### PR TITLE
Remove MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,0 @@
-# Maintainers
-
-* [Angus Lees](https://github.com/anguslees)
-
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/pkg/cloudprovider/providers/openstack/MAINTAINERS.md?pixel)]()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The Kubernetes development community favors OWNERS with approver and reviewer entries over maintainers file and entries. Remove outdated and unmaintained MAINTAINERS.md file.

**Which issue this PR fixes** 

NONE

**Special notes for your reviewer**:

https://github.com/kubernetes/community/blob/master/community-membership.md#maintainer

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```