### PR TITLE
use occm without root

### DIFF
--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -24,6 +24,8 @@ spec:
         k8s-app: openstack-cloud-controller-manager
     spec:
       hostNetwork: true
+      securityContext:
+        runAsUser: 1001
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"

--- a/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
@@ -39,6 +39,8 @@ spec:
         requests:
           cpu: 200m
   hostNetwork: true
+  securityContext:
+    runAsUser: 1001
   volumes:
   - hostPath:
       path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: default user for cloud controller manager 1001 which is not uid of root.

**Which issue this PR fixes**: fixes #40 partly

**Special notes for your reviewer**: 

**Release note**:
```release-note
```
