### PR TITLE
remove filtering by server status

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -116,7 +116,7 @@ func (i *Instances) ExternalID(name types.NodeName) (string, error) {
 	return srv.ID, nil
 }
 
-// InstanceExistsByProviderID returns true if the instance with the given provider id still exists and is running.
+// InstanceExistsByProviderID returns true if the instance with the given provider id still exist.
 // If false is returned with no error, the instance will be immediately deleted by the cloud controller manager.
 func (i *Instances) InstanceExistsByProviderID(providerID string) (bool, error) {
 	instanceID, err := instanceIDFromProviderID(providerID)
@@ -124,17 +124,12 @@ func (i *Instances) InstanceExistsByProviderID(providerID string) (bool, error) 
 		return false, err
 	}
 
-	server, err := servers.Get(i.compute, instanceID).Extract()
+	_, err = servers.Get(i.compute, instanceID).Extract()
 	if err != nil {
 		if isNotFound(err) {
 			return false, nil
 		}
 		return false, err
-	}
-
-	if server.Status != "ACTIVE" {
-		glog.Warningf("the instance %s is not active", instanceID)
-		return false, nil
 	}
 
 	return true, nil


### PR DESCRIPTION
**What this PR does / why we need it**: Originally these filtering was removed in https://github.com/kubernetes/kubernetes/pull/59931 but there is still left one function which is used only in ccm.

**Which issue this PR fixes**: fixes #

**Special notes for your reviewer**: This is little bit stupid now, but I was thinking that we need to have similar behavior in this ccm than what we have in normal controller-manager. So I fixed this function that is used in ccm part. Sorry for making this now, it would have been better to implement in same PR.

So this PR means that kubernetes cluster node is not deleted from cluster if the instance still exist in openstack. If instance is deleted from openstack - the node is deleted from cluster as well

**Release note**:

```release-note
NONE
```

/assign anguslees