### PR TITLE
Remove 'systemctl status' call from devstack plugin

### DIFF
--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -43,7 +43,6 @@ function install_docker {
         sudo cat /lib/systemd/system/docker.service
         sudo systemctl daemon-reload
         sudo systemctl restart docker
-        sudo systemctl status docker
         sudo ifconfig -a
     fi
     docker --version


### PR DESCRIPTION
Calling 'systemctl status' halts execution on systems that have
SYSTEMD_PAGER set or do not use the --no-pager option.

**What this PR does / why we need it**:
Using the k8s-cloud-provider devstack plugin in ubuntu 16.04 (I guess other distributions are affected as well) causes the devstack run to be stuck in a pagination view of `systemctl status docker`.
Since the call shouldn't be needed AFAIK, I propose to remove it.

As an alternative, we could also replace the call with `systemctl --no-pager status docker` to prevent the usage of a pager.