### PR TITLE
Use bool type for 'allowed' field in authorization response

### DIFF
--- a/pkg/identity/webhook/webhook.go
+++ b/pkg/identity/webhook/webhook.go
@@ -180,7 +180,7 @@ func (h *WebhookHandler) authorizeToken(w http.ResponseWriter, r *http.Request, 
 
 	delete(data, "spec")
 	data["status"] = map[string]interface{}{
-		"allowed": allowed,
+		"allowed": allowed == authorizer.DecisionAllow,
 	}
 	output, err = json.MarshalIndent(data, "", "  ")
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
To fix the bug in keystone webhook authorization

**Which issue this PR fixes**:
fixes #56

**Special notes for your reviewer**:
The k8s authorizer is expecting a bool type value from WebhookAuthorizer response.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
NONE
