### PR TITLE
Add Adam Litke to the OWNERS file

### DIFF
--- a/pkg/volume/cinder/OWNERS
+++ b/pkg/volume/cinder/OWNERS
@@ -3,6 +3,7 @@ approvers:
 - anguslees
 - dims
 - FengyunPan2
+- aglitke
 reviewers:
 - anguslees
 - rootfs
@@ -11,3 +12,4 @@ reviewers:
 - jingxu97
 - msau42
 - FengyunPan2
+- aglitke


### PR DESCRIPTION
Hi all.  I just noticed that the standalone-cinder provisioner that I've been maintaining in the kubernetes incubator has been copied over here.  Adding my name to the list of collaborators.

Signed-off-by: Adam Litke <alitke@redhat.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
