### PR TITLE
Fix reliability of TestRoutes and TestVolumes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ BASE_DIR := $(shell basename $(PWD))
 # Keep an existing GOPATH, make a private one if it is undefined
 GOPATH_DEFAULT := $(PWD)/.go
 export GOPATH ?= $(GOPATH_DEFAULT)
+TESTARGS_DEFAULT := "-v"
+export TESTARGS ?= $(TESTARGS_DEFAULT)
 PKG := $(shell awk  '/^package: / { print $$2 }' glide.yaml)
 DEST := $(GOPATH)/src/$(GIT_HOST)/$(BASE_DIR)
 DEST := $(GOPATH)/src/$(PKG)
@@ -74,7 +76,7 @@ k8s-keystone-auth: depend $(SOURCES)
 
 test: unit functional
 
-check: fmt vet lint
+check: depend fmt vet lint
 
 unit: depend
 	cd $(DEST) && go test -tags=unit $(shell glide novendor) $(TESTARGS)

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -275,7 +275,7 @@ func readInstanceID(searchOrder string) (string, error) {
 		instanceID := string(idBytes)
 		instanceID = strings.TrimSpace(instanceID)
 		glog.V(3).Infof("Got instance id from %s: %s", instanceIDFile, instanceID)
-		if instanceID != "" {
+		if instanceID != "" && instanceID != "iid-datasource-none" {
 			return instanceID, nil
 		}
 		// Fall through to metadata server lookup

--- a/pkg/cloudprovider/providers/openstack/openstack_routes_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_routes_test.go
@@ -87,7 +87,10 @@ func TestRoutes(t *testing.T) {
 
 func getServers(os *OpenStack) []servers.Server {
 	c, err := os.NewComputeV2()
-	allPages, err := servers.List(c, servers.ListOpts{}).AllPages()
+	opts := servers.ListOpts{
+		Status: "ACTIVE",
+	}
+	allPages, err := servers.List(c, opts).AllPages()
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/volume/cinder/attacher.go
+++ b/pkg/volume/cinder/attacher.go
@@ -231,7 +231,10 @@ func (attacher *cinderDiskAttacher) WaitForAttach(spec *volume.Spec, devicePath 
 			probeAttachedVolume()
 			if !attacher.cinderProvider.ShouldTrustDevicePath() {
 				// Using the Cinder volume ID, find the real device path (See Issue #33128)
-				devicePath = attacher.cinderProvider.GetDevicePath(volumeID)
+				devicePath, err = attacher.cinderProvider.GetDevicePath(volumeID)
+				if err != nil {
+					return "", err
+				}
 			}
 			exists, err := volumeutil.PathExists(devicePath)
 			if exists && err == nil {

--- a/pkg/volume/cinder/attacher_test.go
+++ b/pkg/volume/cinder/attacher_test.go
@@ -619,8 +619,8 @@ func (testcase *testcase) CreateVolume(name string, size int, vtype, availabilit
 	return "", "", false, errors.New("Not implemented")
 }
 
-func (testcase *testcase) GetDevicePath(volumeID string) string {
-	return ""
+func (testcase *testcase) GetDevicePath(volumeID string) (string, error) {
+	return "", nil
 }
 
 func (testcase *testcase) InstanceID() (string, error) {

--- a/pkg/volume/cinder/cinder.go
+++ b/pkg/volume/cinder/cinder.go
@@ -53,7 +53,7 @@ type BlockStorageProvider interface {
 	DetachDisk(instanceID, volumeID string) error
 	DeleteVolume(volumeID string) error
 	CreateVolume(name string, size int, vtype, availability string, tags *map[string]string) (string, string, bool, error)
-	GetDevicePath(volumeID string) string
+	GetDevicePath(volumeID string) (string, error)
 	InstanceID() (string, error)
 	GetAttachmentDiskPath(instanceID, volumeID string) (string, error)
 	OperationPending(diskName string) (bool, string, error)

--- a/pkg/volume/cinder/cinder_util.go
+++ b/pkg/volume/cinder/cinder_util.go
@@ -62,7 +62,10 @@ func (util *DiskUtil) AttachDisk(b *cinderVolumeMounter, globalPDPath string) er
 	var devicePath string
 	numTries := 0
 	for {
-		devicePath = cloud.GetDevicePath(diskid)
+		devicePath, err = cloud.GetDevicePath(diskid)
+		if err != nil {
+			return err
+		}
 		probeAttachedVolume()
 
 		_, err := os.Stat(devicePath)


### PR DESCRIPTION
In TestRoutes, let's make sure we get an active instance and use
that. If the instance is not active, then it will not have an ip address
and hence fail.

In TestVolumes, we should actually wait for a total of 30 seconds. We
are bailing out in one second right now. Make sure we sleep for the
initial delay before we start as well.
