### PR TITLE
Run depend during `make check`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ k8s-keystone-auth: depend $(SOURCES)
 
 test: unit functional
 
-check: fmt vet lint
+check: depend fmt vet lint
 
 unit: depend
 	cd $(DEST) && go test -tags=unit $(shell glide novendor) $(TESTARGS)


### PR DESCRIPTION
looks like something changed in the CI system, so we need to make sure we pull the dependencies before we run `make check`