### PR TITLE
Correct the returned err message

### DIFF
--- a/pkg/flexvolume/flexvolume.go
+++ b/pkg/flexvolume/flexvolume.go
@@ -189,7 +189,7 @@ func (d *FlexVolumeDriver) unmount(targetMountDir string) (map[string]interface{
 
 	// check the target directory
 	if _, err := os.Stat(targetMountDir); os.IsNotExist(err) {
-		return nil, fmt.Errorf("volume directory: %v does not exists", targetMountDir)
+		return nil, fmt.Errorf("volume directory: %v does not exist", targetMountDir)
 	}
 
 	//  initialize FlexVolumeDriver manager by reading cinderConfig from metadata file


### PR DESCRIPTION
Line 192:  return nil, fmt.Errorf("volume directory: %v does not exists", targetMountDir)
does not exists->does not exist