### PR TITLE
Squash unnecessary ERROR prefixes in logs

### DIFF
--- a/cmd/openstack-cloud-controller-manager/main.go
+++ b/cmd/openstack-cloud-controller-manager/main.go
@@ -51,6 +51,8 @@ func init() {
 
 func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
+
+	goflag.CommandLine.Parse([]string{})
 	s := options.NewCloudControllerManagerOptions()
 	command := &cobra.Command{
 		Use: "cloud-controller-manager",


### PR DESCRIPTION
we were getting some bad prefixes to actual logging because of the way flags are setup. just squash them. 

```
ERROR: logging before flag.Parse: W0411 08:27:21.065165   52319 client_config.go:533] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
ERROR: logging before flag.Parse: W0411 08:27:21.065296   52319 client_config.go:538] error creating inClusterConfig, falling back to default config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PO
```