### PR TITLE
Tolerate unknown sections / variables

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -270,7 +270,7 @@ func readConfig(config io.Reader) (Config, error) {
 	cfg.Networking.IPv6SupportDisabled = false
 	cfg.Networking.PublicNetworkName = "public"
 
-	err := gcfg.ReadInto(&cfg, config)
+	err := gcfg.FatalOnly(gcfg.ReadInto(&cfg, config))
 	return cfg, err
 }
 

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -84,7 +84,7 @@ func GetConfigFromFile(configFilePath string) (gophercloud.AuthOptions, gophercl
 
 	// Read configuration
 	var cfg Config
-	err = gcfg.ReadInto(&cfg, config)
+	err = gcfg.FatalOnly(gcfg.ReadInto(&cfg, config))
 	if err != nil {
 		glog.V(3).Infof("Failed to read OpenStack configuration file: %v", err)
 		return authOpts, epOpts, err

--- a/pkg/flexvolume/cinder_client.go
+++ b/pkg/flexvolume/cinder_client.go
@@ -71,7 +71,7 @@ func readConfig(configFile string) (openStackConfig, error) {
 	}
 
 	var cfg openStackConfig
-	err = gcfg.ReadInto(&cfg, config)
+	err = gcfg.FatalOnly(gcfg.ReadInto(&cfg, config))
 	return cfg, err
 }
 

--- a/pkg/volume/cinder/volumeservice/connection.go
+++ b/pkg/volume/cinder/volumeservice/connection.go
@@ -118,7 +118,7 @@ func getConfig(configFilePath string) (cinderConfig, error) {
 
 		defer configFile.Close()
 
-		err = gcfg.ReadInto(&config, configFile)
+		err = gcfg.FatalOnly(gcfg.ReadInto(&config, configFile))
 		if err != nil {
 			glog.Fatalf("Couldn't read configuration: %#v", err)
 			return cinderConfig{}, err


### PR DESCRIPTION
We have a few data structures to load Configuration, until we have
a single package, let's make sure we can read a cloud conf file with
extra sections. (example cinder csi plugin fails when we feed it a
cloud.conf with LoadBalancer section)
