### PR TITLE
bump csi manifests to v0.2.0

### DIFF
--- a/manifests/cinder-csi-plugin/csi-attacher-cinderplugin.yaml
+++ b/manifests/cinder-csi-plugin/csi-attacher-cinderplugin.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccount: csi-attacher
       containers:
         - name: csi-attacher
-          image: docker.io/k8scsi/csi-attacher
+          image: quay.io/k8scsi/csi-attacher:v0.2.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -53,13 +53,13 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
-              value: unix://plugin/csi.sock
+              value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
               value: /etc/config/cloud.conf
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /plugin
+              mountPath: /csi
             - name: secret-cinderplugin
               mountPath: /etc/config
               readOnly: true

--- a/manifests/cinder-csi-plugin/csi-nodeplugin-cinderplugin.yaml
+++ b/manifests/cinder-csi-plugin/csi-nodeplugin-cinderplugin.yaml
@@ -18,21 +18,21 @@ spec:
       hostNetwork: true
       containers:
         - name: driver-registrar
-          image: docker.io/k8scsi/driver-registrar
+          image: quay.io/k8scsi/driver-registrar:v0.2.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
-              value: /plugin/csi.sock
+              value: /csi/csi.sock
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
-            - name: plugin-dir
-              mountPath: /plugin
+            - name: socket-dir
+              mountPath: /csi
         - name: cinder
           securityContext:
             privileged: true
@@ -50,13 +50,13 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
-              value: unix://plugin/csi.sock
+              value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
               value: /etc/config/cloud.conf
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
-            - name: plugin-dir
-              mountPath: /plugin
+            - name: socket-dir
+              mountPath: /csi
             - name: pods-mount-dir
               mountPath: /var/lib/kubelet/pods
               mountPropagation: "Bidirectional"
@@ -70,7 +70,7 @@ spec:
               mountPath: /etc/config
               readOnly: true
       volumes:
-        - name: plugin-dir
+        - name: socket-dir
           hostPath:
             path: /var/lib/kubelet/plugins/csi-cinderplugin
             type: DirectoryOrCreate

--- a/manifests/cinder-csi-plugin/csi-provisioner-cinderplugin.yaml
+++ b/manifests/cinder-csi-plugin/csi-provisioner-cinderplugin.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccount: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: docker.io/k8scsi/csi-provisioner
+          image: quay.io/k8scsi/csi-provisioner:v0.2.0
           args:
             - "--provisioner=csi-cinderplugin"
             - "--csi-address=$(ADDRESS)"
@@ -53,13 +53,13 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
-              value: unix://plugin/csi.sock
+              value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
               value: /etc/config/cloud.conf
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /plugin
+              mountPath: /csi
             - name: secret-cinderplugin
               mountPath: /etc/config
               readOnly: true


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Since kubernetes csi images has bumped to v0.2.0,
we should update them in csi cinder manifests.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
