### PR TITLE
Enter DEST dir before running dep ensure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ endif
 ifndef HAS_DEP
 	curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 endif
-	dep ensure
+	cd $(DEST) && dep ensure
 
 depend-update: work
-	dep ensure -update
+	cd $(DEST) && dep ensure -update
 
 build: openstack-cloud-controller-manager cinder-provisioner cinder-flex-volume-driver cinder-csi-plugin k8s-keystone-auth
 
@@ -140,7 +140,7 @@ $(GOBIN):
 
 $(DEST): $(GOPATH)
 	mkdir -p $(shell dirname $(DEST))
-	ln -s $(PWD) $(DEST)
+	ln -sf $(PWD) $(DEST)
 
 .bindep:
 	virtualenv .bindep


### PR DESCRIPTION
If we don't enter the `$(DEST)` dir, `dep` will fail saying that the `cloud-provider-openstack` dir is not in one of the known `GOPATH/src` paths.

This commit also forces the creation of the symlink, otherwise it'll fail saying that a symlink exists already.