### PR TITLE
Switch to new OpenLab unit test job in release-1.9 branch

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,4 +1,4 @@
 - project:
     check:
       jobs:
-        - openstack-cloud-controller-manager-unittest
+        - cloud-provider-openstack-unittest


### PR DESCRIPTION
**What this PR does / why we need it**:
openstack-cloud-controller-manager-unittest have been deprecated
in OpenLab side, use cloud-provider-openstack-unittest to instead,
all of these job name have been updated in master, only release-1.9
branch should be updated. This change do not impact real code of
cloud-provider-openstack.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Related-Bug: theopenlab/openlab#21

**Special notes for your reviewer**:
@dims 