### PR TITLE
Small fixes in controller-manager manifests

### DIFF
--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -23,7 +23,8 @@ spec:
       labels:
         k8s-app: openstack-cloud-controller-manager
     spec:
-      hostNetwork: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       securityContext:
         runAsUser: 1001
       tolerations:

--- a/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ""
   labels:
-    component: kube-controller-manager
+    component: cloud-controller-manager
     tier: control-plane
   name: openstack-cloud-controller-manager
   namespace: kube-system


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix some small issues in controller-manager manifests

DaemonSet manifest:
- Remove double hostNetwork attribute
- Set nodeSelector to only schedule pods on master nodes

Pod manifest:
- Set correct component label