### PR TITLE
Add octavia-ingress-controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ endif
 depend-update: work
 	dep ensure -update
 
-build: openstack-cloud-controller-manager cinder-provisioner cinder-flex-volume-driver cinder-csi-plugin k8s-keystone-auth client-keystone-auth
+build: openstack-cloud-controller-manager cinder-provisioner cinder-flex-volume-driver cinder-csi-plugin k8s-keystone-auth client-keystone-auth octavia-ingress-controller
 
 openstack-cloud-controller-manager: depend $(SOURCES)
 	CGO_ENABLED=0 GOOS=$(GOOS) go build \
@@ -88,6 +88,12 @@ client-keystone-auth: depend $(SOURCES)
 		-ldflags "-X 'main.version=${VERSION}'" \
 		-o client-keystone-auth \
 		cmd/client-keystone-auth/main.go
+
+octavia-ingress-controller: depend $(SOURCES)
+	cd $(DEST) && CGO_ENABLED=0 GOOS=$(GOOS) go build \
+		-ldflags "-X 'main.version=${VERSION}'" \
+		-o octavia-ingress-controller \
+		cmd/octavia-ingress-controller/main.go
 
 test: unit functional
 
@@ -155,7 +161,7 @@ install-distro-packages:
 	tools/install-distro-packages.sh
 
 clean:
-	rm -rf .bindep openstack-cloud-controller-manager cinder-flex-volume-driver cinder-provisioner cinder-csi-plugin k8s-keystone-auth client-keystone-auth
+	rm -rf .bindep openstack-cloud-controller-manager cinder-flex-volume-driver cinder-provisioner cinder-csi-plugin k8s-keystone-auth client-keystone-auth octavia-ingress-controller
 
 realclean: clean
 	rm -rf vendor

--- a/cmd/octavia-ingress-controller/main.go
+++ b/cmd/octavia-ingress-controller/main.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "k8s.io/cloud-provider-openstack/pkg/ingress/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/pkg/ingress/cmd/root.go
+++ b/pkg/ingress/cmd/root.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	homedir "github.com/mitchellh/go-homedir"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"k8s.io/cloud-provider-openstack/pkg/ingress/config"
+	"k8s.io/cloud-provider-openstack/pkg/ingress/controller"
+)
+
+var (
+	cfgFile string
+	conf    config.Config
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "ingress-openstack",
+	Short: "Ingress controller for OpenStack",
+	Long:  `Ingress controller for OpenStack`,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		osIngress := controller.NewController(conf)
+		osIngress.Start()
+
+		sigterm := make(chan os.Signal, 1)
+		signal.Notify(sigterm, syscall.SIGTERM)
+		signal.Notify(sigterm, syscall.SIGINT)
+		<-sigterm
+	},
+}
+
+// Execute adds all child commands to the root command sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
+}
+
+func init() {
+	log.SetOutput(os.Stdout)
+	log.SetLevel(log.DebugLevel)
+
+	cobra.OnInitialize(initConfig)
+
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.ingress_openstack.yaml)")
+}
+
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if cfgFile != "" {
+		// Use config file from the flag.
+		viper.SetConfigFile(cfgFile)
+	} else {
+		// Find home directory.
+		home, err := homedir.Dir()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		// Search config in home directory with name ".ingress_openstack" (without extension).
+		viper.AddConfigPath(home)
+		viper.SetConfigName(".ingress_openstack")
+	}
+
+	viper.AutomaticEnv() // read in environment variables that match
+
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err != nil {
+		log.WithFields(log.Fields{"error": err}).Fatal("Failed to read config file")
+	}
+
+	log.WithFields(log.Fields{"file": viper.ConfigFileUsed()}).Info("Using config file")
+
+	if err := viper.Unmarshal(&conf); err != nil {
+		log.WithFields(log.Fields{"error": err}).Fatal("Unable to decode the configuration")
+	}
+}

--- a/pkg/ingress/config/config.go
+++ b/pkg/ingress/config/config.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// Config struct contains ingress controller configuration
+type Config struct {
+	Kubernetes kubeConfig
+	OpenStack  osConfig
+	Octavia    octaviaConfig
+}
+
+type kubeConfig struct {
+	ApiserverHost string
+	KubeConfig    string
+}
+
+type osConfig struct {
+	Username  string
+	Password  string
+	ProjectID string
+	AuthURL   string
+	Region    string
+}
+
+type octaviaConfig struct {
+	SubnetID           string
+	NodeSubnetID       string
+	AllocateFloatingIP bool
+	FloatingIPNetwork  string
+}
+
+// ToAuthOptions gets openstack auth options
+func (cfg Config) ToAuthOptions() gophercloud.AuthOptions {
+	return gophercloud.AuthOptions{
+		IdentityEndpoint: cfg.OpenStack.AuthURL,
+		Username:         cfg.OpenStack.Username,
+		Password:         cfg.OpenStack.Password,
+		TenantID:         cfg.OpenStack.ProjectID,
+		DomainName:       "default",
+		AllowReauth:      true,
+	}
+}

--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -1,0 +1,548 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	apiv1 "k8s.io/api/core/v1"
+	ext_v1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	ext_listers "k8s.io/client-go/listers/extensions/v1beta1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/workqueue"
+
+	"k8s.io/cloud-provider-openstack/pkg/ingress/config"
+	"k8s.io/cloud-provider-openstack/pkg/ingress/controller/openstack"
+)
+
+const (
+	// High enough QPS to fit all expected use cases. QPS=0 is not set here, because
+	// client code is overriding it.
+	defaultQPS = 1e6
+	// High enough Burst to fit all expected use cases. Burst=0 is not set here, because
+	// client code is overriding it.
+	defaultBurst = 1e6
+
+	maxRetries = 5
+
+	// IngressKey picks a specific "class" for the Ingress.
+	// The controller only processes Ingresses with this annotation either
+	// unset, or set to either the configured value or the empty string.
+	IngressKey = "kubernetes.io/ingress.class"
+
+	// IngressClass menas accept ingresses with the annotation
+	IngressClass = "openstack"
+
+	// LabelNodeRoleMaster specifies that a node is a master
+	// It's copied over to kubeadm until it's merged in core: https://github.com/kubernetes/kubernetes/pull/39112
+	LabelNodeRoleMaster = "node-role.kubernetes.io/master"
+)
+
+var (
+	nodePort int
+)
+
+// Controller ...
+type Controller struct {
+	stopCh              chan struct{}
+	knownNodes          []*apiv1.Node
+	queue               workqueue.RateLimitingInterface
+	informer            informers.SharedInformerFactory
+	ingressLister       ext_listers.IngressLister
+	ingressListerSynced cache.InformerSynced
+	serviceLister       corelisters.ServiceLister
+	serviceListerSynced cache.InformerSynced
+	nodeLister          corelisters.NodeLister
+	nodeListerSynced    cache.InformerSynced
+	osClient            *openstack.OpenStack
+	kubeClient          kubernetes.Interface
+	config              config.Config
+}
+
+// IsValid returns true if the given Ingress either doesn't specify
+// the ingress.class annotation, or it's set to the configured in the
+// ingress controller.
+func IsValid(ing *ext_v1beta1.Ingress) bool {
+	ingress, ok := ing.GetAnnotations()[IngressKey]
+	if !ok {
+		log.WithFields(log.Fields{
+			"ingress_name": ing.Name, "ingress_ns": ing.Namespace,
+		}).Info("annotation not present in ingress")
+		return false
+	}
+
+	return ingress == IngressClass
+}
+
+func createApiserverClient(apiserverHost string, kubeConfig string) (*kubernetes.Clientset, error) {
+	cfg, err := clientcmd.BuildConfigFromFlags(apiserverHost, kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg.QPS = defaultQPS
+	cfg.Burst = defaultBurst
+	cfg.ContentType = "application/vnd.kubernetes.protobuf"
+
+	log.Info("creating kubernetes API client")
+
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	v, err := client.Discovery().ServerVersion()
+	if err != nil {
+		return nil, err
+	}
+	log.WithFields(log.Fields{
+		"version": fmt.Sprintf("v%v.%v", v.Major, v.Minor),
+	}).Info("kubernetes API client created")
+
+	return client, nil
+}
+
+func getNodeConditionPredicate() corelisters.NodeConditionPredicate {
+	return func(node *apiv1.Node) bool {
+		// We add the master to the node list, but its unschedulable.  So we use this to filter
+		// the master.
+		if node.Spec.Unschedulable {
+			return false
+		}
+
+		// As of 1.6, we will taint the master, but not necessarily mark it unschedulable.
+		// Recognize nodes labeled as master, and filter them also, as we were doing previously.
+		if _, hasMasterRoleLabel := node.Labels[LabelNodeRoleMaster]; hasMasterRoleLabel {
+			return false
+		}
+
+		// If we have no info, don't accept
+		if len(node.Status.Conditions) == 0 {
+			return false
+		}
+		for _, cond := range node.Status.Conditions {
+			// We consider the node for load balancing only when its NodeReady condition status
+			// is ConditionTrue
+			if cond.Type == apiv1.NodeReady && cond.Status != apiv1.ConditionTrue {
+				log.WithFields(log.Fields{"name": node.Name, "status": cond.Status}).Info("ignoring node")
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// NewController creates a new OpenStack Ingress controller.
+func NewController(conf config.Config) *Controller {
+	// initialize k8s client
+	kubeClient, err := createApiserverClient(conf.Kubernetes.ApiserverHost, conf.Kubernetes.KubeConfig)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"api_server":  conf.Kubernetes.ApiserverHost,
+			"kuberconfig": conf.Kubernetes.KubeConfig,
+			"error":       err,
+		}).Fatal("failed to initialize kubernetes client")
+	}
+
+	// initialize openstack client
+	var osClient *openstack.OpenStack
+	osClient, err = openstack.NewOpenStack(conf)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+		}).Fatal("failed to initialize openstack client")
+	}
+
+	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, time.Second*30)
+	serviceInformer := kubeInformerFactory.Core().V1().Services()
+	nodeInformer := kubeInformerFactory.Core().V1().Nodes()
+	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	controller := &Controller{
+		config:              conf,
+		queue:               queue,
+		stopCh:              make(chan struct{}),
+		informer:            kubeInformerFactory,
+		serviceLister:       serviceInformer.Lister(),
+		serviceListerSynced: serviceInformer.Informer().HasSynced,
+		nodeLister:          nodeInformer.Lister(),
+		nodeListerSynced:    nodeInformer.Informer().HasSynced,
+		knownNodes:          []*apiv1.Node{},
+		osClient:            osClient,
+		kubeClient:          kubeClient,
+	}
+
+	ingInformer := kubeInformerFactory.Extensions().V1beta1().Ingresses()
+	ingInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: controller.enqueueIng,
+		UpdateFunc: func(old, new interface{}) {
+			newIng := new.(*ext_v1beta1.Ingress)
+			oldIng := old.(*ext_v1beta1.Ingress)
+			if newIng.ResourceVersion == oldIng.ResourceVersion {
+				// Periodic resync will send update events for all known Ingresses.
+				// Two different versions of the same Ingress will always have different RVs.
+				return
+			}
+			if reflect.DeepEqual(newIng.Spec, oldIng.Spec) {
+				return
+			}
+			controller.enqueueIng(new)
+		},
+		DeleteFunc: controller.enqueueIng,
+	})
+
+	controller.ingressLister = ingInformer.Lister()
+	controller.ingressListerSynced = ingInformer.Informer().HasSynced
+
+	return controller
+}
+
+// Start starts the openstack ingress controller.
+func (c *Controller) Start() {
+	defer close(c.stopCh)
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	log.Info("starting Ingress controller")
+	go c.informer.Start(c.stopCh)
+
+	// wait for the caches to synchronize before starting the worker
+	if !cache.WaitForCacheSync(c.stopCh, c.ingressListerSynced, c.serviceListerSynced, c.nodeListerSynced) {
+		utilruntime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
+		return
+	}
+	log.Info("ingress controller synced and ready")
+
+	newNodes, err := c.nodeLister.ListWithPredicate(getNodeConditionPredicate())
+	if err != nil {
+		log.Errorf("Failed to retrieve current set of nodes from node lister: %v", err)
+		return
+	}
+	c.knownNodes = newNodes
+
+	go wait.Until(c.runWorker, time.Second, c.stopCh)
+	go wait.Until(c.nodeSyncLoop, 60*time.Second, c.stopCh)
+
+	<-c.stopCh
+}
+
+// obj could be an *v1.Ingress, or a DeletionFinalStateUnknown marker item.
+func (c *Controller) enqueueIng(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err, "object": obj}).Error("Couldn't get key for object")
+		return
+	}
+
+	c.queue.Add(key)
+}
+
+// nodeSyncLoop handles updating the hosts pointed to by all load
+// balancers whenever the set of nodes in the cluster changes.
+func (c *Controller) nodeSyncLoop() {
+	newNodes, err := c.nodeLister.ListWithPredicate(getNodeConditionPredicate())
+	if err != nil {
+		log.Errorf("Failed to retrieve current set of nodes from node lister: %v", err)
+		return
+	}
+	if nodeSlicesEqualForLB(newNodes, c.knownNodes) {
+		return
+	}
+
+	log.Infof("Detected change in list of current cluster nodes. New node set: %v", nodeNames(newNodes))
+
+	ings := new(ext_v1beta1.IngressList)
+	// TODO: only take ingresses without ip address into consideration
+	opts := apimeta_v1.ListOptions{}
+	if ings, err = c.kubeClient.ExtensionsV1beta1().Ingresses("").List(opts); err != nil {
+		log.Errorf("Failed to retrieve current set of ingresses: %v", err)
+		return
+	}
+
+	// Update each ingress
+	for _, ing := range ings.Items {
+		log.WithFields(log.Fields{"ingress": ing.ObjectMeta.Name}).Info("Starting to handle ingress")
+
+		lbName := getResourceName(&ing, "lb")
+		loadbalancer, err := c.osClient.GetLoadbalancerByName(lbName)
+		if err != nil {
+			if err != openstack.ErrNotFound {
+				log.WithFields(log.Fields{"name": lbName}).Errorf("Failed to retrieve loadbalancer from OpenStack: %v", err)
+			}
+
+			// If lb doesn't exist or error occured, continue
+			continue
+		}
+
+		if err = c.osClient.UpdateLoadbalancerMembers(loadbalancer.ID, newNodes); err != nil {
+			log.WithFields(log.Fields{"ingress": ing.ObjectMeta.Name}).Errorf("Failed to handle ingress")
+			continue
+		}
+
+		log.WithFields(log.Fields{"ingress": ing.ObjectMeta.Name}).Info("Finished to handle ingress")
+	}
+
+	c.knownNodes = newNodes
+}
+
+func (c *Controller) runWorker() {
+	for c.processNextItem() {
+		// continue looping
+	}
+}
+
+func (c *Controller) processNextItem() bool {
+	key, quit := c.queue.Get()
+
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	err := c.processItem(key.(string))
+	if err == nil {
+		// No error, reset the ratelimit counters
+		c.queue.Forget(key)
+	} else if c.queue.NumRequeues(key) < maxRetries {
+		log.WithFields(log.Fields{"key": key, "error": err}).Error("Failed to process key (will retry)")
+		c.queue.AddRateLimited(key)
+	} else {
+		// err != nil and too many retries
+		log.WithFields(log.Fields{"key": key, "error": err}).Error("Failed to process key (giving up)")
+		c.queue.Forget(key)
+		utilruntime.HandleError(err)
+	}
+
+	return true
+}
+
+func (c *Controller) processItem(key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+
+	ing, err := c.ingressLister.Ingresses(namespace).Get(name)
+	switch {
+	case errors.IsNotFound(err):
+		log.WithFields(log.Fields{"key": key}).Info("ingress has been deleted, will delete octavia resources")
+		err = c.deleteIngress(namespace, name)
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("failed to delete openstack resources for ingress %s: %v", key, err))
+		}
+	case err != nil:
+		return fmt.Errorf("error fetching object with key %s from store: %v", key, err)
+	default:
+		if !IsValid(ing) {
+			log.WithFields(log.Fields{"key": key}).Info("ignore ingress")
+			return nil
+		}
+
+		log.WithFields(log.Fields{"key": key, "ingress": ing}).Info("ingress created or updated, will create or update octavia resources")
+
+		err = c.ensureIngress(ing)
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("failed to create openstack resources for ingress %s: %v", key, err))
+		}
+	}
+
+	return nil
+}
+
+func (c *Controller) deleteIngress(namespace, name string) error {
+	lbName := fmt.Sprintf("k8s-%s-%s-lb", namespace, name)
+	loadbalancer, err := c.osClient.GetLoadbalancerByName(lbName)
+	if err != nil {
+		if err != openstack.ErrNotFound {
+			return fmt.Errorf("error getting loadbalancer %s: %v", name, err)
+		}
+		log.WithFields(log.Fields{"lbName": lbName, "ingressName": name, "ingressNamespace": namespace}).Info("loadbalancer for ingress deleted")
+		return nil
+	}
+
+	if err = c.osClient.DeleteFloatingIP(loadbalancer.VipPortID); err != nil {
+		return err
+	}
+
+	return c.osClient.DeleteLoadbalancer(loadbalancer.ID)
+}
+
+func (c *Controller) ensureIngress(ing *ext_v1beta1.Ingress) error {
+	var lbName = getResourceName(ing, "lb")
+	lb, err := c.osClient.EnsureLoadBalancer(lbName, c.config.Octavia.SubnetID)
+	if err != nil {
+		return err
+	}
+
+	var listenerName = getResourceName(ing, "listener")
+	listener, err := c.osClient.EnsureListener(listenerName, lb.ID)
+	if err != nil {
+		return err
+	}
+
+	// get nodes information
+	nodeObjs, err := c.nodeLister.ListWithPredicate(getNodeConditionPredicate())
+	if err != nil {
+		return err
+	}
+
+	// Add default pool for the listener if 'backend' is defined
+	defaultPoolName := listenerName + "-pool"
+	if ing.Spec.Backend != nil {
+		serviceName := fmt.Sprintf("%s/%s", ing.ObjectMeta.Namespace, ing.Spec.Backend.ServiceName)
+		nodePort, err := c.getServiceNodePort(serviceName, ing.Spec.Backend.ServicePort.IntValue())
+		if err != nil {
+			return err
+		}
+
+		if _, err = c.osClient.EnsurePoolMembers(false, defaultPoolName, "", listener.ID, &nodePort, nodeObjs); err != nil {
+			return err
+		}
+	} else {
+		// Delete default pool and its members
+		if _, err = c.osClient.EnsurePoolMembers(true, defaultPoolName, lb.ID, listener.ID, nil, nil); err != nil {
+			return err
+		}
+	}
+
+	// Delete all existing policies
+	existingPolicies, err := c.osClient.GetL7policies(listener.ID)
+	if err != nil {
+		return err
+	}
+	for _, p := range existingPolicies {
+		c.osClient.DeleteL7policy(p.ID, lb.ID)
+	}
+
+	// Delete all existing shared pools
+	existingSharedPools, err := c.osClient.GetPools(lb.ID, true)
+	if err != nil {
+		return err
+	}
+	for _, sp := range existingSharedPools {
+		c.osClient.DeletePool(sp.ID, lb.ID)
+	}
+
+	// Add l7 load balancing rules. Each host and path combination is mapped to a l7 policy in octavia,
+	// which contains two rules(with type 'HOST_NAME' and 'PATH' respectively)
+	for _, rule := range ing.Spec.Rules {
+		host := rule.Host
+
+		for _, path := range rule.HTTP.Paths {
+			// make the pool name unique
+			poolName := hash(fmt.Sprintf("%s+%s", path.Backend.ServiceName, path.Backend.ServicePort.String()))
+			serviceName := fmt.Sprintf("%s/%s", ing.ObjectMeta.Namespace, path.Backend.ServiceName)
+			nodePort, err := c.getServiceNodePort(serviceName, path.Backend.ServicePort.IntValue())
+			if err != nil {
+				return err
+			}
+
+			poolID, err := c.osClient.EnsurePoolMembers(false, poolName, lb.ID, "", &nodePort, nodeObjs)
+			if err != nil {
+				return err
+			}
+
+			// make the policy name unique
+			policyName := hash(fmt.Sprintf("%s+%s", host, path.Path))
+			if err = c.osClient.EnsurePolicyRules(false, policyName, lb.ID, listener.ID, *poolID, host, path.Path); err != nil {
+				return err
+			}
+		}
+	}
+
+	var address string
+	address = lb.VipAddress
+	if c.config.Octavia.AllocateFloatingIP {
+		// Allocate floating ip for loadbalancer vip.
+		if address, err = c.osClient.EnsureFloatingIP(lb.VipPortID, c.config.Octavia.FloatingIPNetwork); err != nil {
+			return err
+		}
+	}
+
+	// Update ingress status
+	if err = c.updateIngressStatus(ing, address); err != nil {
+		return err
+	}
+
+	log.Info("openstack resources for ingress created")
+	return nil
+}
+
+func (c *Controller) updateIngressStatus(ing *ext_v1beta1.Ingress, vip string) error {
+	previousState := loadBalancerStatusDeepCopy(&ing.Status.LoadBalancer)
+
+	newState := new(apiv1.LoadBalancerStatus)
+	newState.Ingress = []apiv1.LoadBalancerIngress{{IP: vip}}
+	newIng := ing.DeepCopy()
+	newIng.Status.LoadBalancer = *newState
+
+	// This is to make sure we don't send duplicate update event.
+	if !loadBalancerStatusEqual(previousState, newState) {
+		if _, err := c.kubeClient.ExtensionsV1beta1().Ingresses(newIng.Namespace).UpdateStatus(newIng); err != nil {
+			return err
+		}
+		log.Info("ingress status updated")
+	}
+
+	return nil
+}
+
+func (c *Controller) getService(key string) (*apiv1.Service, error) {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	service, err := c.serviceLister.Services(namespace).Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return service, nil
+}
+
+func (c *Controller) getServiceNodePort(name string, port int) (int, error) {
+	svc, err := c.getService(name)
+	if err != nil {
+		return 0, err
+	}
+
+	var nodePort int
+	ports := svc.Spec.Ports
+	for _, p := range ports {
+		if int(p.Port) == port {
+			nodePort = int(p.NodePort)
+		}
+	}
+
+	if nodePort == 0 {
+		return 0, fmt.Errorf("failed to find service node port")
+	}
+
+	return nodePort, nil
+}

--- a/pkg/ingress/controller/openstack/client.go
+++ b/pkg/ingress/controller/openstack/client.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/cloud-provider-openstack/pkg/ingress/config"
+)
+
+// OpenStack is an implementation of cloud provider Interface for OpenStack.
+type OpenStack struct {
+	octavia *gophercloud.ServiceClient
+	nova    *gophercloud.ServiceClient
+	neutron *gophercloud.ServiceClient
+	config  config.Config
+}
+
+func isNotFound(err error) bool {
+	if _, ok := err.(gophercloud.ErrDefault404); ok {
+		return true
+	}
+
+	if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
+		if errCode.Actual == http.StatusNotFound {
+			return true
+		}
+	}
+
+	return false
+}
+
+// NewOpenStack gets openstack struct
+func NewOpenStack(cfg config.Config) (*OpenStack, error) {
+	provider, err := openstack.NewClient(cfg.OpenStack.AuthURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = openstack.Authenticate(provider, cfg.ToAuthOptions()); err != nil {
+		return nil, err
+	}
+
+	// get octavia service client
+	var lb *gophercloud.ServiceClient
+	lb, err = openstack.NewLoadBalancerV2(provider, gophercloud.EndpointOpts{
+		Region: cfg.OpenStack.Region,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to find octavia endpoint for region %s: %v", cfg.OpenStack.Region, err)
+	}
+
+	// get neutron service client
+	var network *gophercloud.ServiceClient
+	network, err = openstack.NewNetworkV2(provider, gophercloud.EndpointOpts{
+		Region: cfg.OpenStack.Region,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to find neutron endpoint for region %s: %v", cfg.OpenStack.Region, err)
+	}
+
+	// get nova service client
+	var compute *gophercloud.ServiceClient
+	compute, err = openstack.NewComputeV2(provider, gophercloud.EndpointOpts{
+		Region: cfg.OpenStack.Region,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to find compute v2 endpoint for region %s: %v", cfg.OpenStack.Region, err)
+	}
+
+	os := OpenStack{
+		octavia: lb,
+		nova:    compute,
+		neutron: network,
+		config:  cfg,
+	}
+
+	log.Info("openstack client initialized")
+
+	return &os, nil
+}

--- a/pkg/ingress/controller/openstack/neutron.go
+++ b/pkg/ingress/controller/openstack/neutron.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
+	"github.com/gophercloud/gophercloud/pagination"
+	log "github.com/sirupsen/logrus"
+)
+
+func (os *OpenStack) getFloatingIPByPortID(portID string) (*floatingips.FloatingIP, error) {
+	floatingIPList := make([]floatingips.FloatingIP, 0, 1)
+	opts := floatingips.ListOpts{
+		PortID: portID,
+	}
+	pager := floatingips.List(os.neutron, opts)
+
+	err := pager.EachPage(func(page pagination.Page) (bool, error) {
+		f, err := floatingips.ExtractFloatingIPs(page)
+		if err != nil {
+			return false, err
+		}
+		floatingIPList = append(floatingIPList, f...)
+		if len(floatingIPList) > 1 {
+			return false, ErrMultipleResults
+		}
+		return true, nil
+	})
+	if err != nil {
+		if isNotFound(err) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	if len(floatingIPList) == 0 {
+		return nil, ErrNotFound
+	}
+
+	return &floatingIPList[0], nil
+}
+
+// EnsureFloatingIP makes sure a floating IP is allocated for the port
+func (os *OpenStack) EnsureFloatingIP(portID string, floatingIPNetwork string) (string, error) {
+	fip, err := os.getFloatingIPByPortID(portID)
+	if err != nil {
+		if err != ErrNotFound {
+			return "", fmt.Errorf("error getting floating ip for port %s: %v", portID, err)
+		}
+		log.WithFields(log.Fields{"portID": portID}).Info("creating floating ip for port")
+
+		floatIPOpts := floatingips.CreateOpts{
+			FloatingNetworkID: floatingIPNetwork,
+			PortID:            portID,
+		}
+		fip, err = floatingips.Create(os.neutron, floatIPOpts).Extract()
+		if err != nil {
+			return "", fmt.Errorf("error creating floating ip for port %s: %v", portID, err)
+		}
+
+		log.WithFields(log.Fields{"portID": portID, "floatingip": fip.FloatingIP}).Info("floating ip for port created")
+	}
+
+	return fip.FloatingIP, nil
+}
+
+// DeleteFloatingIP deletes floating ip for the port
+func (os *OpenStack) DeleteFloatingIP(portID string) error {
+	fip, err := os.getFloatingIPByPortID(portID)
+	if err != nil {
+		if err != ErrNotFound {
+			return fmt.Errorf("error getting floating ip for port %s: %v", portID, err)
+		}
+		log.WithFields(log.Fields{"portID": portID}).Info("floating ip not exists")
+	}
+
+	err = floatingips.Delete(os.neutron, fip.ID).ExtractErr()
+	if err != nil && !isNotFound(err) {
+		return fmt.Errorf("error deleting floating ip %s: %v", fip.ID, err)
+	}
+
+	log.WithFields(log.Fields{"floatingip": fip.FloatingIP}).Info("floating ip deleted")
+	return nil
+}

--- a/pkg/ingress/controller/openstack/octavia.go
+++ b/pkg/ingress/controller/openstack/octavia.go
@@ -1,0 +1,675 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
+	"github.com/gophercloud/gophercloud/pagination"
+	log "github.com/sirupsen/logrus"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type empty struct{}
+
+const (
+	loadbalancerActiveInitDealy = 5 * time.Second
+	loadbalancerActiveFactor    = 1
+	loadbalancerActiveSteps     = 240
+
+	activeStatus = "ACTIVE"
+	errorStatus  = "ERROR"
+)
+
+var (
+	// ErrNotFound is used to inform that the object is missing
+	ErrNotFound = errors.New("failed to find object")
+
+	// ErrMultipleResults is used when we unexpectedly get back multiple results
+	ErrMultipleResults = errors.New("multiple results where only one expected")
+)
+
+func getNodeAddressForLB(node *apiv1.Node) (string, error) {
+	addrs := node.Status.Addresses
+	if len(addrs) == 0 {
+		return "", errors.New("no address found for host")
+	}
+
+	for _, addr := range addrs {
+		if addr.Type == apiv1.NodeInternalIP {
+			return addr.Address, nil
+		}
+	}
+
+	return addrs[0].Address, nil
+}
+
+func (os *OpenStack) waitLoadbalancerActiveProvisioningStatus(loadbalancerID string) (string, error) {
+	backoff := wait.Backoff{
+		Duration: loadbalancerActiveInitDealy,
+		Factor:   loadbalancerActiveFactor,
+		Steps:    loadbalancerActiveSteps,
+	}
+
+	var provisioningStatus string
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		loadbalancer, err := loadbalancers.Get(os.octavia, loadbalancerID).Extract()
+		if err != nil {
+			return false, err
+		}
+		provisioningStatus = loadbalancer.ProvisioningStatus
+		if loadbalancer.ProvisioningStatus == activeStatus {
+			return true, nil
+		} else if loadbalancer.ProvisioningStatus == errorStatus {
+			return true, fmt.Errorf("loadbalancer has gone into ERROR state")
+		} else {
+			return false, nil
+		}
+
+	})
+
+	if err == wait.ErrWaitTimeout {
+		err = fmt.Errorf("loadbalancer failed to go into ACTIVE provisioning status within alloted time")
+	}
+	return provisioningStatus, err
+}
+
+// GetLoadbalancerByName retrieves loadbalancer object
+func (os *OpenStack) GetLoadbalancerByName(name string) (*loadbalancers.LoadBalancer, error) {
+	opts := loadbalancers.ListOpts{
+		Name: name,
+	}
+	pager := loadbalancers.List(os.octavia, opts)
+	loadbalancerList := make([]loadbalancers.LoadBalancer, 0, 1)
+
+	err := pager.EachPage(func(page pagination.Page) (bool, error) {
+		v, err := loadbalancers.ExtractLoadBalancers(page)
+		if err != nil {
+			return false, err
+		}
+		loadbalancerList = append(loadbalancerList, v...)
+		if len(loadbalancerList) > 1 {
+			return false, ErrMultipleResults
+		}
+		return true, nil
+	})
+	if err != nil {
+		if isNotFound(err) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	if len(loadbalancerList) == 0 {
+		return nil, ErrNotFound
+	}
+
+	return &loadbalancerList[0], nil
+}
+
+func (os *OpenStack) getListenerByName(name string, lbID string) (*listeners.Listener, error) {
+	opts := listeners.ListOpts{
+		Name:           name,
+		LoadbalancerID: lbID,
+	}
+	pager := listeners.List(os.octavia, opts)
+	listenerList := make([]listeners.Listener, 0, 1)
+
+	err := pager.EachPage(func(page pagination.Page) (bool, error) {
+		v, err := listeners.ExtractListeners(page)
+		if err != nil {
+			return false, err
+		}
+		listenerList = append(listenerList, v...)
+		if len(listenerList) > 1 {
+			return false, ErrMultipleResults
+		}
+		return true, nil
+	})
+	if err != nil {
+		if isNotFound(err) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	if len(listenerList) == 0 {
+		return nil, ErrNotFound
+	}
+
+	return &listenerList[0], nil
+}
+
+func (os *OpenStack) getPoolByName(name string, lbID string) (*pools.Pool, error) {
+	listenerPools := make([]pools.Pool, 0, 1)
+	opts := pools.ListOpts{
+		Name:           name,
+		LoadbalancerID: lbID,
+	}
+	err := pools.List(os.octavia, opts).EachPage(func(page pagination.Page) (bool, error) {
+		v, err := pools.ExtractPools(page)
+		if err != nil {
+			return false, err
+		}
+		listenerPools = append(listenerPools, v...)
+		if len(listenerPools) > 1 {
+			return false, ErrMultipleResults
+		}
+		return true, nil
+	})
+	if err != nil {
+		if isNotFound(err) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	if len(listenerPools) == 0 {
+		return nil, ErrNotFound
+	} else if len(listenerPools) > 1 {
+		return nil, ErrMultipleResults
+	}
+
+	return &listenerPools[0], nil
+}
+
+// GetPools retrives the pools belong to the loadbalancer.
+func (os *OpenStack) GetPools(lbID string, shared bool) ([]pools.Pool, error) {
+	var lbPools []pools.Pool
+
+	opts := pools.ListOpts{
+		LoadbalancerID: lbID,
+	}
+	err := pools.List(os.octavia, opts).EachPage(func(page pagination.Page) (bool, error) {
+		v, err := pools.ExtractPools(page)
+		if err != nil {
+			return false, err
+		}
+		for _, p := range v {
+			if shared && len(p.Listeners) != 0 {
+				continue
+			}
+			lbPools = append(lbPools, p)
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return lbPools, nil
+}
+
+// GetMembers retrieve all the members of the specified pool
+func (os *OpenStack) GetMembers(poolID string) ([]pools.Member, error) {
+	var members []pools.Member
+
+	opts := pools.ListMembersOpts{}
+	err := pools.ListMembers(os.octavia, poolID, opts).EachPage(func(page pagination.Page) (bool, error) {
+		v, err := pools.ExtractMembers(page)
+		if err != nil {
+			return false, err
+		}
+		members = append(members, v...)
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return members, nil
+}
+
+// DeletePool deletes a pool
+func (os *OpenStack) DeletePool(poolID string, lbID string) error {
+	if err := pools.Delete(os.octavia, poolID).ExtractErr(); err != nil {
+		return fmt.Errorf("failed to delete pool %s: %v", poolID, err)
+	}
+
+	_, err := os.waitLoadbalancerActiveProvisioningStatus(lbID)
+	if err != nil {
+		return fmt.Errorf("failed to wait for loadbalancer to be active: %v", err)
+	}
+
+	return nil
+}
+
+// GetL7policies retrieves all l7 policies for the given listener.
+func (os *OpenStack) GetL7policies(listenerID string) ([]l7policies.L7Policy, error) {
+	var policies []l7policies.L7Policy
+	opts := l7policies.ListOpts{
+		ListenerID: listenerID,
+	}
+	err := l7policies.List(os.octavia, opts).EachPage(func(page pagination.Page) (bool, error) {
+		v, err := l7policies.ExtractL7Policies(page)
+		if err != nil {
+			return false, err
+		}
+		policies = append(policies, v...)
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return policies, nil
+}
+
+func (os *OpenStack) getL7policy(name string, listenerID, poolID string) (*l7policies.L7Policy, error) {
+	policies := make([]l7policies.L7Policy, 0, 1)
+	opts := l7policies.ListOpts{
+		Name:           name,
+		ListenerID:     listenerID,
+		RedirectPoolID: poolID,
+	}
+	err := l7policies.List(os.octavia, opts).EachPage(func(page pagination.Page) (bool, error) {
+		v, err := l7policies.ExtractL7Policies(page)
+		if err != nil {
+			return false, err
+		}
+		policies = append(policies, v...)
+		if len(policies) > 1 {
+			return false, ErrMultipleResults
+		}
+		return true, nil
+	})
+	if err != nil {
+		if isNotFound(err) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	if len(policies) == 0 {
+		return nil, ErrNotFound
+	}
+
+	return &policies[0], nil
+}
+
+// DeleteL7policy deletes a l7 policy
+func (os *OpenStack) DeleteL7policy(policyID string, lbID string) error {
+	if err := l7policies.Delete(os.octavia, policyID).ExtractErr(); err != nil {
+		return fmt.Errorf("failed to delete l7 policy: %v", err)
+	}
+
+	_, err := os.waitLoadbalancerActiveProvisioningStatus(lbID)
+	if err != nil {
+		return fmt.Errorf("failed to wait for loadbalancer to be active: %v", err)
+	}
+
+	return nil
+}
+
+// DeleteLoadbalancer deletes a loadbalancer with all its child objects.
+func (os *OpenStack) DeleteLoadbalancer(lbID string) error {
+	log.WithFields(log.Fields{"lbID": lbID}).Info("deleting loadbalancer with all child objects")
+
+	err := loadbalancers.Delete(os.octavia, lbID, loadbalancers.DeleteOpts{Cascade: true}).ExtractErr()
+	if err != nil && !isNotFound(err) {
+		return fmt.Errorf("error deleting loadbalancer %s: %v", lbID, err)
+	}
+
+	log.WithFields(log.Fields{"lbID": lbID}).Info("loadbalancer deleted")
+	return nil
+}
+
+// EnsureLoadBalancer creates a loadbalancer in octavia if it does not exist, wait for the loadbalancer to be ACTIVE.
+func (os *OpenStack) EnsureLoadBalancer(name string, subnetID string) (*loadbalancers.LoadBalancer, error) {
+	loadbalancer, err := os.GetLoadbalancerByName(name)
+	if err != nil {
+		if err != ErrNotFound {
+			return nil, fmt.Errorf("error getting loadbalancer %s: %v", name, err)
+		}
+
+		log.WithFields(log.Fields{"name": name}).Info("creating loadbalancer")
+
+		createOpts := loadbalancers.CreateOpts{
+			Name:        name,
+			Description: "Created by Kubernetes",
+			VipSubnetID: subnetID,
+			Provider:    "octavia",
+		}
+		loadbalancer, err = loadbalancers.Create(os.octavia, createOpts).Extract()
+		if err != nil {
+			return nil, fmt.Errorf("error creating loadbalancer %v: %v", createOpts, err)
+		}
+	} else {
+		log.WithFields(log.Fields{"name": name}).Info("loadbalancer exists")
+	}
+
+	_, err = os.waitLoadbalancerActiveProvisioningStatus(loadbalancer.ID)
+	if err != nil {
+		return nil, fmt.Errorf("error creating loadbalancer: %v", err)
+	}
+
+	log.WithFields(log.Fields{"name": name, "id": loadbalancer.ID}).Info("loadbalancer created")
+	return loadbalancer, nil
+}
+
+// EnsureListener creates a loadbalancer listener in octavia if it does not exist, wait for the loadbalancer to be ACTIVE.
+func (os *OpenStack) EnsureListener(name string, lbID string) (*listeners.Listener, error) {
+	listener, err := os.getListenerByName(name, lbID)
+	if err != nil {
+		if err != ErrNotFound {
+			return nil, fmt.Errorf("error getting listener %s: %v", name, err)
+		}
+
+		log.WithFields(log.Fields{"lb": lbID, "listenerName": name}).Info("creating listener")
+
+		listener, err = listeners.Create(os.octavia, listeners.CreateOpts{
+			Name:           name,
+			Protocol:       "HTTP",
+			ProtocolPort:   80, // Ingress Controller only supports http/https for now
+			LoadbalancerID: lbID,
+		}).Extract()
+		if err != nil {
+			return nil, fmt.Errorf("error creating listener: %v", err)
+		}
+	}
+
+	_, err = os.waitLoadbalancerActiveProvisioningStatus(lbID)
+	if err != nil {
+		return nil, fmt.Errorf("error creating listener: %v", err)
+	}
+
+	log.WithFields(log.Fields{"lb": lbID, "listenerName": name}).Info("listener created")
+	return listener, nil
+}
+
+// EnsurePoolMembers deletes the old pool with its members, then creates a new pool with members if deleted flag is not set.
+func (os *OpenStack) EnsurePoolMembers(deleted bool, poolName, lbID, listenerID string, servicePort *int, nodes []*apiv1.Node) (*string, error) {
+	pool, err := os.getPoolByName(poolName, lbID)
+	if err != nil {
+		if err != ErrNotFound {
+			return nil, fmt.Errorf("error getting pool %s: %v", poolName, err)
+		}
+
+		if deleted {
+			return nil, nil
+		}
+	} else {
+		// Delete the existing pool, members will be deleted automatically
+		err = pools.Delete(os.octavia, pool.ID).ExtractErr()
+		if err != nil && !isNotFound(err) {
+			return nil, fmt.Errorf("error deleting pool %s: %v", pool.ID, err)
+		}
+
+		_, err = os.waitLoadbalancerActiveProvisioningStatus(lbID)
+		if err != nil {
+			return nil, fmt.Errorf("error waiting for loadbalancer %s to be active: %v", lbID, err)
+		}
+
+		if deleted {
+			log.WithFields(log.Fields{"name": poolName, "ID": pool.ID}).Info("pool deleted")
+			return nil, nil
+		}
+	}
+
+	// Creates new pool
+	log.WithFields(log.Fields{"lb": lbID, "listenserID": listenerID, "poolName": poolName}).Info("creating pool")
+
+	var opts pools.CreateOptsBuilder
+	if lbID != "" {
+		opts = pools.CreateOpts{
+			Name:           poolName,
+			Protocol:       "HTTP",
+			LBMethod:       pools.LBMethodRoundRobin,
+			LoadbalancerID: lbID,
+			Persistence:    nil,
+		}
+	} else {
+		opts = pools.CreateOpts{
+			Name:        poolName,
+			Protocol:    "HTTP",
+			LBMethod:    pools.LBMethodRoundRobin,
+			ListenerID:  listenerID,
+			Persistence: nil,
+		}
+	}
+	pool, err = pools.Create(os.octavia, opts).Extract()
+	if err != nil {
+		return nil, fmt.Errorf("error creating pool for listener %s: %v", listenerID, err)
+	}
+
+	_, err = os.waitLoadbalancerActiveProvisioningStatus(lbID)
+	if err != nil {
+		return nil, fmt.Errorf("error waiting for loadbalancer %s to be active: %v", lbID, err)
+	}
+
+	log.WithFields(log.Fields{"lb": lbID, "listenserID": listenerID, "poolName": poolName, "pooID": pool.ID}).Info("pool created")
+
+	// Adds members to the new pool
+	for _, node := range nodes {
+		addr, err := getNodeAddressForLB(node)
+		if err != nil {
+			// Node failure, do not create member
+			log.WithFields(log.Fields{"node": node.Name, "poolName": poolName, "error": err}).Warn("failed to create LB pool member for node")
+			continue
+		}
+
+		log.WithFields(log.Fields{"addr": addr, "poolID": pool.ID, "port": *servicePort}).Info("adding new member to pool")
+
+		_, err = pools.CreateMember(os.octavia, pool.ID, pools.CreateMemberOpts{
+			ProtocolPort: *servicePort,
+			Address:      addr,
+		}).Extract()
+		if err != nil {
+			return nil, fmt.Errorf("error creating pool member %s: %v", addr, err)
+		}
+
+		_, err = os.waitLoadbalancerActiveProvisioningStatus(lbID)
+		if err != nil {
+			return nil, fmt.Errorf("error waiting for loadbalancer %s to be active: %v", lbID, err)
+		}
+
+		log.WithFields(log.Fields{"addr": addr, "poolID": pool.ID, "port": *servicePort}).Info("member added to pool")
+	}
+
+	return &pool.ID, nil
+}
+
+// EnsurePolicyRules creates l7 policy with rules for listener or delete policy if deleted flag is set.
+// For policy creation, the old policy will be deleted anyway.
+func (os *OpenStack) EnsurePolicyRules(deleted bool, policyName, lbID, listenerID, poolID, host, path string) error {
+	policy, err := os.getL7policy(policyName, listenerID, poolID)
+	if err != nil {
+		if err != ErrNotFound {
+			return fmt.Errorf("error getting policy %s: %v", policyName, err)
+		}
+
+		if deleted {
+			log.WithFields(log.Fields{"lb": lbID, "listenserID": listenerID, "policyName": policyName}).Info("policy not exists")
+			return nil
+		}
+	} else {
+		// Delete old policy first
+		err = l7policies.Delete(os.octavia, policy.ID).ExtractErr()
+		if err != nil && !isNotFound(err) {
+			return fmt.Errorf("error deleting policy %s: %v", policy.ID, err)
+		}
+
+		_, err = os.waitLoadbalancerActiveProvisioningStatus(lbID)
+		if err != nil {
+			return fmt.Errorf("error waiting for loadbalancer %s to be active: %v", lbID, err)
+		}
+
+		if deleted {
+			log.WithFields(log.Fields{"lb": lbID, "listenserID": listenerID, "policyName": policyName}).Info("policy deleted")
+			return nil
+		}
+	}
+
+	// Create new policy with rules
+	log.WithFields(log.Fields{"lb": lbID, "listenserID": listenerID, "policyName": policyName}).Info("creating policy")
+
+	policy, err = l7policies.Create(os.octavia, l7policies.CreateOpts{
+		Name:           policyName,
+		ListenerID:     listenerID,
+		Action:         l7policies.ActionRedirectToPool,
+		Description:    "Created by kubernetes ingress",
+		RedirectPoolID: poolID,
+	}).Extract()
+	if err != nil {
+		return fmt.Errorf("error creating l7policy: %v", err)
+	}
+
+	_, err = os.waitLoadbalancerActiveProvisioningStatus(lbID)
+	if err != nil {
+		return fmt.Errorf("error waiting for loadbalancer %s to be active: %v", lbID, err)
+	}
+
+	log.WithFields(log.Fields{"lb": lbID, "listenserID": listenerID, "policyName": policyName}).Info("policy created")
+
+	if host != "" {
+		log.WithFields(log.Fields{"type": l7policies.TypeHostName, "host": host, "policyName": policyName}).Info("creating policy rule")
+
+		// Create HOST_NAME type rule
+		_, err = l7policies.CreateRule(os.octavia, policy.ID, l7policies.CreateRuleOpts{
+			RuleType:    l7policies.TypeHostName,
+			CompareType: l7policies.CompareTypeEqual,
+			Value:       host,
+		}).Extract()
+		if err != nil {
+			return fmt.Errorf("error creating l7 rule: %v", err)
+		}
+
+		_, err = os.waitLoadbalancerActiveProvisioningStatus(lbID)
+		if err != nil {
+			return fmt.Errorf("error waiting for loadbalancer %s to be active: %v", lbID, err)
+		}
+
+		log.WithFields(log.Fields{"type": l7policies.TypeHostName, "host": host, "policyName": policyName}).Info("policy rule created")
+	}
+
+	if path != "" {
+		log.WithFields(log.Fields{"type": l7policies.TypePath, "path": path, "policyName": policyName}).Info("creating policy rule")
+
+		// Create PATH type rule
+		_, err = l7policies.CreateRule(os.octavia, policy.ID, l7policies.CreateRuleOpts{
+			RuleType:    l7policies.TypePath,
+			CompareType: l7policies.CompareTypeStartWith,
+			Value:       path,
+		}).Extract()
+		if err != nil {
+			return fmt.Errorf("error creating l7 rule: %v", err)
+		}
+
+		_, err = os.waitLoadbalancerActiveProvisioningStatus(lbID)
+		if err != nil {
+			return fmt.Errorf("error waiting for loadbalancer %s to be active: %v", lbID, err)
+		}
+
+		log.WithFields(log.Fields{"type": l7policies.TypePath, "path": path, "policyName": policyName}).Info("policy rule created")
+	}
+
+	return nil
+}
+
+// UpdateLoadbalancerMembers update members for all the pools in the specified loadbalancer.
+func (os *OpenStack) UpdateLoadbalancerMembers(lbID string, nodes []*apiv1.Node) error {
+	lbPools, err := os.GetPools(lbID, false)
+	if err != nil {
+		return err
+	}
+
+	addrs := map[string]empty{}
+	for _, node := range nodes {
+		addr, err := getNodeAddressForLB(node)
+		if err != nil {
+			log.WithFields(log.Fields{"name": node.ObjectMeta.Name}).Warningf("Failed to get node address: %v", err)
+			continue
+		}
+		addrs[addr] = empty{}
+	}
+
+	for _, pool := range lbPools {
+		log.WithFields(log.Fields{"poolID": pool.ID}).Info("Starting to update pool members")
+
+		members, err := os.GetMembers(pool.ID)
+		if err != nil {
+			log.WithFields(log.Fields{"poolID": pool.ID}).Errorf("Failed to get pool members: %v", err)
+			continue
+		}
+
+		// Members have the same ProtocolPort
+		servicePort := members[0].ProtocolPort
+
+		addrMemberMapping := make(map[string]pools.Member)
+		for _, member := range members {
+			addrMemberMapping[member.Address] = member
+		}
+
+		// Add any new members for this port
+		for addr := range addrs {
+			if _, ok := addrMemberMapping[addr]; ok {
+				continue
+			}
+
+			log.WithFields(log.Fields{"poolID": pool.ID, "memberAddress": addr}).Info("Adding new member to the pool")
+
+			// This is a new node joined to the cluster
+			if _, err = pools.CreateMember(os.octavia, pool.ID, pools.CreateMemberOpts{
+				ProtocolPort: servicePort,
+				Address:      addr,
+			}).Extract(); err != nil {
+				return err
+			}
+
+			log.WithFields(log.Fields{"poolID": pool.ID, "memberAddress": addr}).Info("Finished to add new member to the pool")
+
+			_, err = os.waitLoadbalancerActiveProvisioningStatus(lbID)
+			if err != nil {
+				return fmt.Errorf("error waiting for loadbalancer %s to be active: %v", lbID, err)
+			}
+		}
+
+		// Remove any old members
+		for _, member := range addrMemberMapping {
+			if _, ok := addrs[member.Address]; ok {
+				continue
+			}
+
+			log.WithFields(log.Fields{"poolID": pool.ID, "memberAddress": member.Address}).Info("Deleting old member from the pool")
+
+			err = pools.DeleteMember(os.octavia, pool.ID, member.ID).ExtractErr()
+			if err != nil && !isNotFound(err) {
+				log.WithFields(log.Fields{"poolID": pool.ID, "memberAddress": member.Address}).Error("Failed to delete old member from the pool")
+				return err
+			}
+
+			log.WithFields(log.Fields{"poolID": pool.ID, "memberAddress": member.Address}).Info("Finished to delete old member from the pool")
+
+			_, err = os.waitLoadbalancerActiveProvisioningStatus(lbID)
+			if err != nil {
+				return fmt.Errorf("error waiting for loadbalancer %s to be active: %v", lbID, err)
+			}
+		}
+
+		log.WithFields(log.Fields{"poolID": pool.ID}).Info("Finished to update pool members")
+	}
+
+	return nil
+}

--- a/pkg/ingress/controller/utils.go
+++ b/pkg/ingress/controller/utils.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"sort"
+
+	apiv1 "k8s.io/api/core/v1"
+	ext_v1beta1 "k8s.io/api/extensions/v1beta1"
+)
+
+func hash(data string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(data)))
+}
+
+func getResourceName(ing *ext_v1beta1.Ingress, suffix string) string {
+	name := fmt.Sprintf("k8s-%s-%s-%s", ing.ObjectMeta.Namespace, ing.ObjectMeta.Name, suffix)
+	return name
+}
+
+func loadBalancerStatusDeepCopy(lb *apiv1.LoadBalancerStatus) *apiv1.LoadBalancerStatus {
+	c := &apiv1.LoadBalancerStatus{}
+	c.Ingress = make([]apiv1.LoadBalancerIngress, len(lb.Ingress))
+	for i := range lb.Ingress {
+		c.Ingress[i] = lb.Ingress[i]
+	}
+	return c
+}
+
+func loadBalancerStatusEqual(l, r *apiv1.LoadBalancerStatus) bool {
+	return ingressSliceEqual(l.Ingress, r.Ingress)
+}
+
+func ingressSliceEqual(lhs, rhs []apiv1.LoadBalancerIngress) bool {
+	if len(lhs) != len(rhs) {
+		return false
+	}
+	for i := range lhs {
+		if !ingressEqual(&lhs[i], &rhs[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func ingressEqual(lhs, rhs *apiv1.LoadBalancerIngress) bool {
+	if lhs.IP != rhs.IP {
+		return false
+	}
+	if lhs.Hostname != rhs.Hostname {
+		return false
+	}
+	return true
+}
+
+func nodeNames(nodes []*apiv1.Node) []string {
+	ret := make([]string, len(nodes))
+	for i, node := range nodes {
+		ret[i] = node.Name
+	}
+	return ret
+}
+
+func nodeSlicesEqualForLB(x, y []*apiv1.Node) bool {
+	if len(x) != len(y) {
+		return false
+	}
+	return stringSlicesEqual(nodeNames(x), nodeNames(y))
+}
+
+func stringSlicesEqual(x, y []string) bool {
+	if len(x) != len(y) {
+		return false
+	}
+	if !sort.StringsAreSorted(x) {
+		sort.Strings(x)
+	}
+	if !sort.StringsAreSorted(y) {
+		sort.Strings(y)
+	}
+	for i := range x {
+		if x[i] != y[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
An ingress controller implementation based on OpenStack Octavia service. A demo: <https://youtu.be/ASSUMDvH_aE>

**Which issue this PR fixes**: 
fixes #114

**Special notes for your reviewer**:
This is the initial commit that can only be used for PoC purpose, a lot of things need to be improved such as:

- Add documentation for how to deploy and test the ingress controller.
- The unit test is missing
- Add functional test
- TLS support
- Service name support

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add OpenStack(Octavia) based ingress controller implementation.
```
