### PR TITLE
Provide a hack a script to run make in a Container

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ Here are some examples of how you could leverage `openstack-cloud-controller-man
 
 `make` will build, test, and package this project. This project uses trash Glide for dependency management.
 
+If you don't have a Go Environment setup, we also offer the ability to run make
+in a Docker Container.  The only requirement for this is that you have Docker
+installed and configured (of course).  You don't need to have a Golang
+environment setup, and you don't need to follow rules in terms of directory
+structure for the code checkout.
+
+To use this method, just call the `hack/make.sh` script with the desired argument:
+    `hack/make.sh build`  for example will run `make build` in a container.
+
+NOTE You MUST run the script from the root source directory as shown above,
+attempting to do something like `cd hack && make.sh build` will not work
+because we won't bind mount the source files into the container.
+
 ## License
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Simple script to offer the ability to run the make directives in a Docker Container.
+# In other words you don't need a Go env on your system to run Make (build, test etc)
+# This script will just bind-mount the source directory into a container under the correct
+# GOPATH and handle all of the Go ENV stuff for you.  All you need is Docker
+docker run -it -v "$PWD":/go/src/k8s.io/cloud-provider-openstack:z \
+	-w /go/src/k8s.io/cloud-provider-openstack \
+	golang:1.10 make $1


### PR DESCRIPTION
**What this PR does / why we need it**:

This just adds a simple hack/make.sh script to run make directives in a
Docker container.  This means you can run build, test, vet etc on a
repod checked out into any directory on any machine that has Docker.
You aren't required to have a Golang environment or dev environment
setup on your system.

Some may find this useful to simplify the development and test process. 
It's not as useful for dev environments because you presumably will need
a proper Go env to do any dev work, but it's a very lightweight and easy
way to provide a testing environment or to generate builds without any
pre-requisites.
