### PR TITLE
Allow to read username and password from env variables

### DIFF
--- a/docs/using-client-keystone-auth.md
+++ b/docs/using-client-keystone-auth.md
@@ -51,13 +51,15 @@ users:
 
       # Environment variables to set when executing the plugin. Optional.
       env:
-      - name: "OS_AUTH_URL"
-        value: "https://127.0.0.1/identity"
+      - name: "OS_USERNAME"
+        value: "admin"
+      - name: "OS_PASSWORD"
+        value: "passw0rd"
 
       # Arguments to pass when executing the plugin. Optional.
       args:
-      - "--domain-name default"
-      - "--keystone-url https://127.0.0.1/identity"
+      - "--domain-name=default"
+      - "--keystone-url=https://127.0.0.1/identity"
 clusters:
 - name: my-cluster
   cluster:
@@ -107,10 +109,11 @@ When the plugin is executed from an interactive session, `stdin` and `stderr` ar
 exposed to the plugin so it can prompt the user for input for interactive logins.
 
 To authenticate in Keystone from an interactive session, the user needs to provide the address
-and domain name. These values can be specified using environment variables
-(`OS_AUTH_URL` and `OS_DOMAIN_NAME`), or through command arguments
-(`--keystone-url` and `--domain-name`), respectively. If they are not specified, the user
-will be prompted to enter them at the time of the interactive session.
+domain name, user name and his password. These values can be specified using environment variables
+(`OS_AUTH_URL`, `OS_DOMAIN_NAME`, `OS_USERNAME` and `OS_PASSWORD`), or through command arguments
+(`--keystone-url`, `--domain-name`, `--user-name` and `--password`), respectively.
+If they are not specified, the user will be prompted to enter them at the time of the interactive
+session.
 
 When responding to a 401 HTTP status code (indicating invalid credentials), this object will
 include metadata about the response.


### PR DESCRIPTION
Now, in case of interactive session, users have to enter their
logins and passwords every time in the interactive sessions.
This is not very convenient, so it's better to allow to store
this data in env variables and ask to enter the values only if
they are unset.

This commit adds two new flags for the client-keystone-auth executable:
--user-name and --password, which are defaulted to OS_USERNAME and
OS_PASSWORD respectively.

Addtionally, this commit fixes several small issues:
1. Since Stdout is redirected the executable cannot write data there,
   when the user is asked for his login or password. Therefore, Stderr
   should be used for the output in the interactive sessions.
2. The Exec plugin expects to get expiresAt data in RFC3339Nano format,
   otherwise it is ignored. So the executable converts it before printing.
3. Domain name was defaulted to the string "default". But it's better to
   get this value from OS_DOMAIN_NAME env variable.
