### PR TITLE
Improve the config option for ingress controller

### DIFF
--- a/pkg/ingress/config/config.go
+++ b/pkg/ingress/config/config.go
@@ -22,29 +22,37 @@ import (
 
 // Config struct contains ingress controller configuration
 type Config struct {
-	Kubernetes kubeConfig
-	OpenStack  osConfig
-	Octavia    octaviaConfig
+	Kubernetes kubeConfig    `mapstructure:"kubernetes"`
+	OpenStack  osConfig      `mapstructure:"openstack"`
+	Octavia    octaviaConfig `mapstructure:"octavia"`
 }
 
+// Configuration for connecting to Kubernetes API server, either api_host or kubeconfig should be configured.
 type kubeConfig struct {
-	ApiserverHost string
-	KubeConfig    string
+	// (Optional)Kubernetes API server host address.
+	ApiserverHost string `mapstructure:"api_host"`
+
+	// (Optional)Kubeconfig file used to connect to Kubernetes cluster.
+	KubeConfig string `mapstructure:"kubeconfig"`
 }
 
+// OpenStack credentials configuration, the section is required.
 type osConfig struct {
 	Username  string
 	Password  string
-	ProjectID string
-	AuthURL   string
+	ProjectID string `mapstructure:"project_id"`
+	AuthURL   string `mapstructure:"auth_url"`
 	Region    string
 }
 
+// Octavia service related configuration
 type octaviaConfig struct {
-	SubnetID           string
-	NodeSubnetID       string
-	AllocateFloatingIP bool
-	FloatingIPNetwork  string
+	// (Required)Subnet ID to create the load balancer.
+	SubnetID string `mapstructure:"subnet_id"`
+
+	// (Optional)Public network to create floating IP.
+	// If empty, no floating IP will be allocated to the load balancer vip.
+	FloatingIPNetwork string `mapstructure:"fip_network"`
 }
 
 // ToAuthOptions gets openstack auth options

--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -477,7 +477,7 @@ func (c *Controller) ensureIngress(ing *ext_v1beta1.Ingress) error {
 
 	var address string
 	address = lb.VipAddress
-	if c.config.Octavia.AllocateFloatingIP {
+	if c.config.Octavia.FloatingIPNetwork != "" {
 		// Allocate floating ip for loadbalancer vip.
 		if address, err = c.osClient.EnsureFloatingIP(lb.VipPortID, c.config.Octavia.FloatingIPNetwork); err != nil {
 			return err


### PR DESCRIPTION
**What this PR does / why we need it**:
Make the ingress controller configuration more readable

**Special notes for your reviewer**:
Before this change, the config file looks like:
```yaml
kubernetes:
    apiserverHost:
    kubeConfig: /etc/kubernetes/ingress-openstack.conf
openStack:
    username: demo
    password: password
    projectID: ${project_id}
    authURL: ${auth_url}/v3
    region: RegionOne
octavia:
    subnetID: ${subnet_id}
    allocateFloatingIP: true
    floatingIPNetwork: ${public_net_id}
```

After this change, it will be:
```yaml
kubernetes:
    apiserverHost:
    kubeconfig: /etc/kubernetes/ingress-openstack.conf
openstack:
    username: demo
    password: password
    project_id: 02c5e04d91b44987bb791d74a36654d4
    auth_url: http://10.0.19.151/identity/v3
    region: RegionOne
octavia:
    subnet_id: bfe392ad-aa5b-464b-acfa-7bb476e66bc6
    fip_network: 6e361672-2e8e-4273-b1cf-fbbef4be59e7
```
