### PR TITLE
Support env variables for more arguments

### DIFF
--- a/cmd/k8s-keystone-auth/main.go
+++ b/cmd/k8s-keystone-auth/main.go
@@ -49,11 +49,11 @@ var (
 func main() {
 	flag.CommandLine.Parse([]string{})
 	pflag.StringVar(&listenAddr, "listen", "0.0.0.0:8443", "<address>:<port> to listen on")
-	pflag.StringVar(&tlsCertFile, "tls-cert-file", "", "File containing the default x509 Certificate for HTTPS.")
-	pflag.StringVar(&tlsPrivateKey, "tls-private-key-file", "", "File containing the default x509 private key matching --tls-cert-file.")
+	pflag.StringVar(&tlsCertFile, "tls-cert-file", os.Getenv("TLS_CERT_FILE"), "File containing the default x509 Certificate for HTTPS.")
+	pflag.StringVar(&tlsPrivateKey, "tls-private-key-file", os.Getenv("TLS_PRIVATE_KEY_FILE"), "File containing the default x509 private key matching --tls-cert-file.")
 	pflag.StringVar(&keystoneURL, "keystone-url", os.Getenv("OS_AUTH_URL"), "URL for the OpenStack Keystone API")
-	pflag.StringVar(&keystoneCaFile, "keystone-ca-file", "", "File containing the certificate authority for Keystone Service.")
-	pflag.StringVar(&policyFile, "keystone-policy-file", "", "File containing the policy.")
+	pflag.StringVar(&keystoneCaFile, "keystone-ca-file", os.Getenv("KEYSTONE_CA_FILE"), "File containing the certificate authority for Keystone Service.")
+	pflag.StringVar(&policyFile, "keystone-policy-file", os.Getenv("KEYSTONE_POLICY_FILE"), "File containing the policy.")
 
 	kflag.InitFlags()
 	logs.InitLogs()


### PR DESCRIPTION
Magnum team is try to integrate k8s-keystone-auth when creating
k8s cluster so that user can get keystone authN and authZ for k8s
out of box. However, Magnum is not running kubelet on master(for
flannel network driver) or doesn't allow running workingload on
master(for calico network driver). So we need a good way (env
variables) to pass in those necessary arguments. This patch adds
the env variables support for those must-have arguments.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
