### PR TITLE
Fix ldflags format for build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,43 +62,43 @@ build: openstack-cloud-controller-manager cinder-provisioner cinder-flex-volume-
 
 openstack-cloud-controller-manager: depend $(SOURCES)
 	CGO_ENABLED=0 GOOS=$(GOOS) go build \
-		-ldflags '$(LDFLAGS)' \
+		-ldflags $(LDFLAGS) \
 		-o openstack-cloud-controller-manager \
 		cmd/openstack-cloud-controller-manager/main.go
 
 cinder-provisioner: depend $(SOURCES)
 	CGO_ENABLED=0 GOOS=$(GOOS) go build \
-		-ldflags '$(LDFLAGS)' \
+		-ldflags $(LDFLAGS) \
 		-o cinder-provisioner \
 		cmd/cinder-provisioner/main.go
 
 cinder-csi-plugin: depend $(SOURCES)
 	CGO_ENABLED=0 GOOS=$(GOOS) go build \
-		-ldflags '$(LDFLAGS)' \
+		-ldflags $(LDFLAGS) \
 		-o cinder-csi-plugin \
 		cmd/cinder-csi-plugin/main.go
 
 cinder-flex-volume-driver: depend $(SOURCES)
 	CGO_ENABLED=0 GOOS=$(GOOS) go build \
-		-ldflags '$(LDFLAGS)' \
+		-ldflags $(LDFLAGS) \
 		-o cinder-flex-volume-driver \
 		cmd/cinder-flex-volume-driver/main.go
 
 k8s-keystone-auth: depend $(SOURCES)
 	CGO_ENABLED=0 GOOS=$(GOOS) go build \
-		-ldflags '$(LDFLAGS)' \
+		-ldflags $(LDFLAGS) \
 		-o k8s-keystone-auth \
 		cmd/k8s-keystone-auth/main.go
 
 client-keystone-auth: depend $(SOURCES)
 	cd $(DEST) && CGO_ENABLED=0 GOOS=$(GOOS) go build \
-		-ldflags '$(LDFLAGS)' \
+		-ldflags $(LDFLAGS) \
 		-o client-keystone-auth \
 		cmd/client-keystone-auth/main.go
 
 octavia-ingress-controller: depend $(SOURCES)
 	cd $(DEST) && CGO_ENABLED=0 GOOS=$(GOOS) go build \
-		-ldflags '$(LDFLAGS)' \
+		-ldflags $(LDFLAGS) \
 		-o octavia-ingress-controller \
 		cmd/octavia-ingress-controller/main.go
 


### PR DESCRIPTION
Currently, make build doesn't work for go1.9.1 and possibly other
older versions, user will see error like below when buiding:

//////////////////////////////////////////////////////////
CGO_ENABLED=0 GOOS=linux go build \
        -ldflags '"-w -s -X 'main.version=c206dbe2'"' \
        -o k8s-keystone-auth \
        cmd/k8s-keystone-auth/main.go
flag provided but not defined: -w -s -X main.version
......
Makefile:88: recipe for target 'k8s-keystone-auth' failed
make: *** [k8s-keystone-auth] Error 2
/////////////////////////////////////////////////////////

It "works" with go1.10. However, with the binary built on go1.10,
when run the command like './k8s-keystone-auth -v 1', you will see
the version is empty, because -ldflags is not well parsed due to
the outer single quotation marks. The patch removes the outer
single quotation mark to make it fully works for different go versions.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
