### PR TITLE
Track coverage using codecov.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .idea
 .DS_Store
 vendor
+coverage.txt
 
 # OSX leaves these everywhere on SMB shares
 ._*

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,18 @@ vet:
 
 cover: depend
 	go test -tags=unit $(shell go list ./...) -cover
+	@rm -rf coverage.txt
+	@for d in `go list ./... | grep -v vendor`; do \
+		t=$$(date +%s); \
+		go test -coverprofile=cover.out -covermode=atomic $$d || exit 1; \
+		echo "Coverage test $$d took $$(($$(date +%s)-t)) seconds"; \
+		if [ -f cover.out ]; then \
+			cat cover.out >> coverage.txt; \
+			rm cover.out; \
+		fi; \
+	done
+	@echo "Uploading coverage results..."
+	@curl -s https://codecov.io/bash | bash
 
 docs:
 	@echo "$@ not yet implemented"


### PR DESCRIPTION
We don't really have a good idea about the code coverage using our unit tests. The first step is to update the Makefile, need to figure out how to add support to our Zuul v3 jobs to talk to codecov.io