### PR TITLE
Cinder provisioner fixes

### DIFF
--- a/pkg/volume/cinder/provisioner/clusterbroker.go
+++ b/pkg/volume/cinder/provisioner/clusterbroker.go
@@ -31,7 +31,7 @@ type k8sClusterBroker struct {
 	clusterBroker
 }
 
-func (k8sClusterBroker) createSecret(p *cinderProvisioner, ns string, secret *v1.Secret) error {
+func (*k8sClusterBroker) createSecret(p *cinderProvisioner, ns string, secret *v1.Secret) error {
 	_, err := p.Client.CoreV1().Secrets(ns).Create(secret)
 	if err != nil {
 		glog.Errorf("Failed to create chap secret in namespace %s: %v", ns, err)

--- a/pkg/volume/cinder/provisioner/iscsi.go
+++ b/pkg/volume/cinder/provisioner/iscsi.go
@@ -25,6 +25,7 @@ import (
 )
 
 const iscsiType = "iscsi"
+const initiatorName = "iqn.2018-01.io.k8s:a13fc3d1cc22"
 
 type iscsiMapper struct {
 	volumeMapper
@@ -39,9 +40,10 @@ func getChapSecretName(connection volumeservice.VolumeConnection, options contro
 }
 
 func (m *iscsiMapper) BuildPVSource(conn volumeservice.VolumeConnection, options controller.VolumeOptions) (*v1.PersistentVolumeSource, error) {
+	initiator := initiatorName[:]
 	ret := &v1.PersistentVolumeSource{
 		ISCSI: &v1.ISCSIPersistentVolumeSource{
-			// TODO: Need some way to specify the initiator name
+			InitiatorName:   &initiator,
 			TargetPortal:    conn.Data.TargetPortal,
 			IQN:             conn.Data.TargetIqn,
 			Lun:             conn.Data.TargetLun,

--- a/pkg/volume/cinder/provisioner/iscsi_test.go
+++ b/pkg/volume/cinder/provisioner/iscsi_test.go
@@ -201,22 +201,3 @@ func createIscsiConnectionInfo() volumeservice.VolumeConnection {
 		},
 	}
 }
-
-type fakeClusterBroker struct {
-	clusterBroker
-	CreatedSecret *v1.Secret
-	DeletedSecret string
-	Namespace     string
-}
-
-func (cb *fakeClusterBroker) createSecret(p *cinderProvisioner, ns string, secret *v1.Secret) error {
-	cb.CreatedSecret = secret
-	cb.Namespace = ns
-	return nil
-}
-
-func (cb *fakeClusterBroker) deleteSecret(p *cinderProvisioner, ns string, secretName string) error {
-	cb.DeletedSecret = secretName
-	cb.Namespace = ns
-	return nil
-}

--- a/pkg/volume/cinder/provisioner/mapper.go
+++ b/pkg/volume/cinder/provisioner/mapper.go
@@ -73,8 +73,8 @@ func buildPV(m volumeMapper, p *cinderProvisioner, options controller.VolumeOpti
 			Name:      options.PVName,
 			Namespace: options.PVC.Namespace,
 			Annotations: map[string]string{
-				ProvisionerIDAnn: p.Identity,
-				CinderVolumeID:   volumeID,
+				ProvisionerIDAnn:  p.Identity,
+				CinderVolumeIDAnn: volumeID,
 			},
 		},
 		Spec: v1.PersistentVolumeSpec{

--- a/pkg/volume/cinder/provisioner/mapper_test.go
+++ b/pkg/volume/cinder/provisioner/mapper_test.go
@@ -167,8 +167,8 @@ var _ = Describe("Mapper", func() {
 
 		It("should yield a valid PV associated with this provisioner", func() {
 			annotations := map[string]string{
-				ProvisionerIDAnn: "identity",
-				CinderVolumeID:   "volumeid",
+				ProvisionerIDAnn:  "identity",
+				CinderVolumeIDAnn: "volumeid",
 			}
 			accessModes := []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
 			quantity, parseErr := resource.ParseQuantity("1Gi")

--- a/pkg/volume/cinder/provisioner/provisioner.go
+++ b/pkg/volume/cinder/provisioner/provisioner.go
@@ -39,8 +39,8 @@ const (
 	// ProvisionerIDAnn is an annotation to identify a particular instance of this provisioner
 	ProvisionerIDAnn = "standaloneCinderProvisionerIdentity"
 
-	// CinderVolumeID is an annotation to store the ID of the associated cinder volume
-	CinderVolumeID = "cinderVolumeId"
+	// CinderVolumeIDAnn is an annotation to store the ID of the associated cinder volume
+	CinderVolumeIDAnn = "cinderVolumeId"
 )
 
 type cinderProvisioner struct {
@@ -215,9 +215,9 @@ func (p *cinderProvisioner) Delete(pv *v1.PersistentVolume) error {
 	// TODO when beta is removed, have to check kube version and pick v1/beta
 	// accordingly: maybe the controller lib should offer a function for that
 
-	volumeID, ok := pv.Annotations[CinderVolumeID]
+	volumeID, ok := pv.Annotations[CinderVolumeIDAnn]
 	if !ok {
-		return errors.New(CinderVolumeID + " annotation not found on PV")
+		return errors.New(CinderVolumeIDAnn + " annotation not found on PV")
 	}
 
 	mapper, err := p.mb.newVolumeMapperFromPV(pv)

--- a/pkg/volume/cinder/provisioner/provisioner.go
+++ b/pkg/volume/cinder/provisioner/provisioner.go
@@ -142,7 +142,7 @@ func (p *cinderProvisioner) Provision(options controller.VolumeOptions) (*v1.Per
 		goto ERROR_DELETE
 	}
 
-	connection, err = p.vsb.connectCinderVolume(p.VolumeService, volumeID)
+	connection, err = p.vsb.connectCinderVolume(p.VolumeService, initiatorName, volumeID)
 	if err != nil {
 		glog.Errorf("Failed to connect volume %s: %v", volumeID, err)
 		goto ERROR_UNRESERVE
@@ -179,7 +179,7 @@ ERROR_DETACH:
 		glog.Errorf("Failed to detach volume %s: %v", volumeID, cleanupErr)
 	}
 ERROR_DISCONNECT:
-	cleanupErr = p.vsb.disconnectCinderVolume(p.VolumeService, volumeID)
+	cleanupErr = p.vsb.disconnectCinderVolume(p.VolumeService, initiatorName, volumeID)
 	if cleanupErr != nil {
 		glog.Errorf("Failed to disconnect volume %s: %v", volumeID, cleanupErr)
 	}
@@ -234,7 +234,7 @@ func (p *cinderProvisioner) Delete(pv *v1.PersistentVolume) error {
 		return err
 	}
 
-	err = p.vsb.disconnectCinderVolume(p.VolumeService, volumeID)
+	err = p.vsb.disconnectCinderVolume(p.VolumeService, initiatorName, volumeID)
 	if err != nil {
 		glog.Errorf("Failed to disconnect volume %s: %v", volumeID, err)
 		return err

--- a/pkg/volume/cinder/provisioner/provisioner.go
+++ b/pkg/volume/cinder/provisioner/provisioner.go
@@ -19,13 +19,17 @@ package provisioner
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/gophercloud/gophercloud"
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/volumeservice"
+
+	volumes_v2 "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
 )
 
 const (
@@ -71,9 +75,39 @@ func NewCinderProvisioner(client kubernetes.Interface, id, configFilePath string
 	}, nil
 }
 
+func getCreateOptions(options controller.VolumeOptions) (volumes_v2.CreateOpts, error) {
+	name := fmt.Sprintf("cinder-dynamic-pvc-%s", uuid.NewUUID())
+	capacity := options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
+	sizeBytes := capacity.Value()
+	// Cinder works with gigabytes, convert to GiB with rounding up
+	sizeGB := int((sizeBytes + 1024*1024*1024 - 1) / (1024 * 1024 * 1024))
+	volType := ""
+	availability := "nova"
+	// Apply ProvisionerParameters (case-insensitive). We leave validation of
+	// the values to the cloud provider.
+	for k, v := range options.Parameters {
+		switch strings.ToLower(k) {
+		case "type":
+			volType = v
+		case "availability":
+			availability = v
+		default:
+			return volumes_v2.CreateOpts{}, fmt.Errorf("invalid option %q", k)
+		}
+	}
+
+	return volumes_v2.CreateOpts{
+		Name:             name,
+		Size:             sizeGB,
+		VolumeType:       volType,
+		AvailabilityZone: availability,
+	}, nil
+}
+
 // Provision creates a storage asset and returns a PV object representing it.
 func (p *cinderProvisioner) Provision(options controller.VolumeOptions) (*v1.PersistentVolume, error) {
 	var (
+		volumeID   string
 		connection volumeservice.VolumeConnection
 		mapper     volumeMapper
 		pv         *v1.PersistentVolume
@@ -85,8 +119,12 @@ func (p *cinderProvisioner) Provision(options controller.VolumeOptions) (*v1.Per
 	}
 
 	// TODO: Check access mode
-
-	volumeID, err := p.vsb.createCinderVolume(p.VolumeService, options)
+	createOptions, err := getCreateOptions(options)
+	if err != nil {
+		glog.Error(err)
+		goto ERROR
+	}
+	volumeID, err = p.vsb.createCinderVolume(p.VolumeService, createOptions)
 	if err != nil {
 		glog.Errorf("Failed to create volume")
 		goto ERROR

--- a/pkg/volume/cinder/provisioner/provisioner_test.go
+++ b/pkg/volume/cinder/provisioner/provisioner_test.go
@@ -344,7 +344,7 @@ func (vsb *fakeVolumeServiceBroker) reserveCinderVolume(vs *gophercloud.ServiceC
 	return vsb.mightFail.ret("reserveCinderVolume")
 }
 
-func (vsb *fakeVolumeServiceBroker) connectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (volumeservice.VolumeConnection, error) {
+func (vsb *fakeVolumeServiceBroker) connectCinderVolume(vs *gophercloud.ServiceClient, initiator string, volumeID string) (volumeservice.VolumeConnection, error) {
 	if vsb.mightFail.isSet("connectCinderVolume") {
 		return volumeservice.VolumeConnection{}, errors.New("injected error for testing")
 	}
@@ -359,7 +359,7 @@ func (vsb *fakeVolumeServiceBroker) detachCinderVolume(vs *gophercloud.ServiceCl
 	return vsb.mightFail.logRet("detachCinderVolume")
 }
 
-func (vsb *fakeVolumeServiceBroker) disconnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
+func (vsb *fakeVolumeServiceBroker) disconnectCinderVolume(vs *gophercloud.ServiceClient, initiator string, volumeID string) error {
 	return vsb.mightFail.logRet("disconnectCinderVolume")
 }
 

--- a/pkg/volume/cinder/provisioner/provisioner_test.go
+++ b/pkg/volume/cinder/provisioner/provisioner_test.go
@@ -269,7 +269,7 @@ var _ = Describe("Provisioner", func() {
 
 		Context("when the cinder volume ID annotation is missing from the PV", func() {
 			BeforeEach(func() {
-				delete(pv.Annotations, CinderVolumeID)
+				delete(pv.Annotations, CinderVolumeIDAnn)
 			})
 
 			It("should fail", func() {

--- a/pkg/volume/cinder/provisioner/provisioner_test.go
+++ b/pkg/volume/cinder/provisioner/provisioner_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 
 	"github.com/gophercloud/gophercloud"
+	volumes_v2 "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -30,6 +31,48 @@ import (
 )
 
 var _ = Describe("Provisioner", func() {
+	Describe("Create volume options parsing", func() {
+		var (
+			err           error
+			options       controller.VolumeOptions
+			createOptions volumes_v2.CreateOpts
+		)
+		BeforeEach(func() {
+			options = createVolumeOptions()
+		})
+		JustBeforeEach(func() {
+			createOptions, err = getCreateOptions(options)
+		})
+
+		Context("when an unrecognized option is specified in the storage class", func() {
+			BeforeEach(func() {
+				options.Parameters = map[string]string{
+					"foo": "bar",
+				}
+			})
+
+			It("should fail", func() {
+				Expect(createOptions).To(Equal(volumes_v2.CreateOpts{}))
+				Expect(err).ToNot(BeNil())
+			})
+		})
+
+		Context("when recognized options are used", func() {
+			BeforeEach(func() {
+				options.Parameters = map[string]string{
+					"type":         "gold",
+					"availability": "zone",
+				}
+			})
+
+			It("should be reflected in the create options", func() {
+				Expect(err).To(BeNil())
+				Expect(createOptions.AvailabilityZone).To(Equal("zone"))
+				Expect(createOptions.VolumeType).To(Equal("gold"))
+			})
+		})
+	})
+
 	Describe("A provision operation", func() {
 		var (
 			pv      *v1.PersistentVolume
@@ -62,6 +105,19 @@ var _ = Describe("Provisioner", func() {
 		Context("when a claim selector is specified", func() {
 			BeforeEach(func() {
 				options.PVC.Spec.Selector = &metav1.LabelSelector{}
+			})
+
+			It("should fail", func() {
+				Expect(pv).To(BeNil())
+				Expect(err).To(Not(BeNil()))
+			})
+		})
+
+		Context("when an unrecognized option is specified in the storage class", func() {
+			BeforeEach(func() {
+				options.Parameters = map[string]string{
+					"foo": "bar",
+				}
 			})
 
 			It("should fail", func() {
@@ -263,7 +319,7 @@ type fakeVolumeServiceBroker struct {
 	volumeServiceBroker
 }
 
-func (vsb *fakeVolumeServiceBroker) createCinderVolume(vs *gophercloud.ServiceClient, options controller.VolumeOptions) (string, error) {
+func (vsb *fakeVolumeServiceBroker) createCinderVolume(vs *gophercloud.ServiceClient, options volumes_v2.CreateOpts) (string, error) {
 	if vsb.mightFail.isSet("createCinderVolume") {
 		return "", errors.New("injected error for testing")
 	}

--- a/pkg/volume/cinder/provisioner/testutils_test.go
+++ b/pkg/volume/cinder/provisioner/testutils_test.go
@@ -28,31 +28,37 @@ import (
 	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/volumeservice"
 )
 
-func createVolumeOptions() controller.VolumeOptions {
+func createPVC(name string, size string) *v1.PersistentVolumeClaim {
 	var storageClass = "storageclass"
 
 	capacity, err := resource.ParseQuantity("1Gi")
 	if err != nil {
 		glog.Error("Programmer error, cannot parse quantity string")
-		return controller.VolumeOptions{}
+		return &v1.PersistentVolumeClaim{}
 	}
-
-	return controller.VolumeOptions{
-		PVName: "testpv",
-		PVC: &v1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "testns",
-			},
-			Spec: v1.PersistentVolumeClaimSpec{
-				StorageClassName: &storageClass,
-				AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
-				Resources: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
-						v1.ResourceName(v1.ResourceStorage): capacity,
-					},
+	return &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "testns",
+			Annotations: make(map[string]string),
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClass,
+			AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): capacity,
 				},
 			},
 		},
+	}
+}
+
+func createVolumeOptions() controller.VolumeOptions {
+	return controller.VolumeOptions{
+		PVName:                        "testpv",
+		PVC:                           createPVC("curPVC", "1G"),
+		Parameters:                    make(map[string]string),
 		PersistentVolumeReclaimPolicy: v1.PersistentVolumeReclaimDelete,
 	}
 }

--- a/pkg/volume/cinder/provisioner/testutils_test.go
+++ b/pkg/volume/cinder/provisioner/testutils_test.go
@@ -139,3 +139,22 @@ func (m *fakeMapper) AuthSetup(p *cinderProvisioner, options controller.VolumeOp
 func (m *fakeMapper) AuthTeardown(p *cinderProvisioner, pv *v1.PersistentVolume) error {
 	return m.mightFail.ret("AuthTeardown")
 }
+
+type fakeClusterBroker struct {
+	clusterBroker
+	CreatedSecret *v1.Secret
+	DeletedSecret string
+	Namespace     string
+}
+
+func (cb *fakeClusterBroker) createSecret(p *cinderProvisioner, ns string, secret *v1.Secret) error {
+	cb.CreatedSecret = secret
+	cb.Namespace = ns
+	return nil
+}
+
+func (cb *fakeClusterBroker) deleteSecret(p *cinderProvisioner, ns string, secretName string) error {
+	cb.DeletedSecret = secretName
+	cb.Namespace = ns
+	return nil
+}

--- a/pkg/volume/cinder/provisioner/testutils_test.go
+++ b/pkg/volume/cinder/provisioner/testutils_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package provisioner
 
 import (
+	"bytes"
 	"errors"
+
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
 	"k8s.io/api/core/v1"
@@ -79,31 +81,41 @@ func createCinderProvisioner() *cinderProvisioner {
 }
 
 type failureInjector struct {
-	failOn map[string]bool
+	operationLog bytes.Buffer
+	failOn       map[string]bool
 }
 
-func (vsb *failureInjector) set(method string) {
-	if vsb.failOn == nil {
-		vsb.failOn = make(map[string]bool)
+func (fi *failureInjector) set(method string) {
+	if fi.failOn == nil {
+		fi.failOn = make(map[string]bool)
 	}
-	vsb.failOn[method] = true
+	fi.failOn[method] = true
 }
 
-func (vsb *failureInjector) isSet(method string) bool {
-	if vsb.failOn == nil {
+func (fi *failureInjector) isSet(method string) bool {
+	if fi.failOn == nil {
 		return false
 	}
-	value, ok := vsb.failOn[method]
+	value, ok := fi.failOn[method]
 	if !ok {
 		return false
 	}
 	return value
 }
 
-func (vsb *failureInjector) ret(method string) error {
-	if vsb.isSet(method) {
+func (fi *failureInjector) ret(method string) error {
+	if fi.isSet(method) {
 		return errors.New("injected error for testing")
 	}
+	return nil
+}
+
+func (fi *failureInjector) logRet(fn string) error {
+	if fi.isSet(fn) {
+		return errors.New("injected error for testing")
+	}
+	fi.operationLog.WriteString(fn)
+	fi.operationLog.WriteString(".")
 	return nil
 }
 

--- a/pkg/volume/cinder/provisioner/testutils_test.go
+++ b/pkg/volume/cinder/provisioner/testutils_test.go
@@ -61,8 +61,8 @@ func createPersistentVolume() *v1.PersistentVolume {
 	return &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				ProvisionerIDAnn: "identity",
-				CinderVolumeID:   "cinderVolumeID",
+				ProvisionerIDAnn:  "identity",
+				CinderVolumeIDAnn: "cinderVolumeID",
 			},
 		},
 		Spec: v1.PersistentVolumeSpec{

--- a/pkg/volume/cinder/provisioner/vsbroker.go
+++ b/pkg/volume/cinder/provisioner/vsbroker.go
@@ -28,6 +28,8 @@ type volumeServiceBroker interface {
 	waitForAvailableCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	reserveCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	connectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (volumeservice.VolumeConnection, error)
+	attachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
+	detachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	disconnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	unreserveCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	deleteCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
@@ -51,6 +53,14 @@ func (vsb *gophercloudBroker) reserveCinderVolume(vs *gophercloud.ServiceClient,
 
 func (vsb *gophercloudBroker) connectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (volumeservice.VolumeConnection, error) {
 	return volumeservice.ConnectCinderVolume(vs, volumeID)
+}
+
+func (vsb *gophercloudBroker) attachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
+	return volumeservice.AttachCinderVolume(vs, volumeID)
+}
+
+func (vsb *gophercloudBroker) detachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
+	return volumeservice.DetachCinderVolume(vs, volumeID)
 }
 
 func (vsb *gophercloudBroker) disconnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {

--- a/pkg/volume/cinder/provisioner/vsbroker.go
+++ b/pkg/volume/cinder/provisioner/vsbroker.go
@@ -27,10 +27,10 @@ type volumeServiceBroker interface {
 	createCinderVolume(vs *gophercloud.ServiceClient, options volumes_v2.CreateOpts) (string, error)
 	waitForAvailableCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	reserveCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
-	connectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (volumeservice.VolumeConnection, error)
+	connectCinderVolume(vs *gophercloud.ServiceClient, initiator string, volumeID string) (volumeservice.VolumeConnection, error)
 	attachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	detachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
-	disconnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
+	disconnectCinderVolume(vs *gophercloud.ServiceClient, initiator string, volumeID string) error
 	unreserveCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	deleteCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	getCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (*volumes_v2.Volume, error)
@@ -52,8 +52,8 @@ func (vsb *gophercloudBroker) reserveCinderVolume(vs *gophercloud.ServiceClient,
 	return volumeservice.ReserveCinderVolume(vs, volumeID)
 }
 
-func (vsb *gophercloudBroker) connectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (volumeservice.VolumeConnection, error) {
-	return volumeservice.ConnectCinderVolume(vs, volumeID)
+func (vsb *gophercloudBroker) connectCinderVolume(vs *gophercloud.ServiceClient, initiator string, volumeID string) (volumeservice.VolumeConnection, error) {
+	return volumeservice.ConnectCinderVolume(vs, initiator, volumeID)
 }
 
 func (vsb *gophercloudBroker) attachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
@@ -64,8 +64,8 @@ func (vsb *gophercloudBroker) detachCinderVolume(vs *gophercloud.ServiceClient, 
 	return volumeservice.DetachCinderVolume(vs, volumeID)
 }
 
-func (vsb *gophercloudBroker) disconnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
-	return volumeservice.DisconnectCinderVolume(vs, volumeID)
+func (vsb *gophercloudBroker) disconnectCinderVolume(vs *gophercloud.ServiceClient, initiator string, volumeID string) error {
+	return volumeservice.DisconnectCinderVolume(vs, initiator, volumeID)
 }
 
 func (vsb *gophercloudBroker) unreserveCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {

--- a/pkg/volume/cinder/provisioner/vsbroker.go
+++ b/pkg/volume/cinder/provisioner/vsbroker.go
@@ -18,13 +18,13 @@ package provisioner
 
 import (
 	"github.com/gophercloud/gophercloud"
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	volumes_v2 "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
 	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/volumeservice"
 )
 
 // volumeServiceBroker provides a mechanism for tests to override calls to cinder with mocks.
 type volumeServiceBroker interface {
-	createCinderVolume(vs *gophercloud.ServiceClient, options controller.VolumeOptions) (string, error)
+	createCinderVolume(vs *gophercloud.ServiceClient, options volumes_v2.CreateOpts) (string, error)
 	waitForAvailableCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	reserveCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	connectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (volumeservice.VolumeConnection, error)
@@ -37,7 +37,7 @@ type gophercloudBroker struct {
 	volumeServiceBroker
 }
 
-func (vsb *gophercloudBroker) createCinderVolume(vs *gophercloud.ServiceClient, options controller.VolumeOptions) (string, error) {
+func (vsb *gophercloudBroker) createCinderVolume(vs *gophercloud.ServiceClient, options volumes_v2.CreateOpts) (string, error) {
 	return volumeservice.CreateCinderVolume(vs, options)
 }
 

--- a/pkg/volume/cinder/provisioner/vsbroker.go
+++ b/pkg/volume/cinder/provisioner/vsbroker.go
@@ -33,6 +33,7 @@ type volumeServiceBroker interface {
 	disconnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	unreserveCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	deleteCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
+	getCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (*volumes_v2.Volume, error)
 }
 
 type gophercloudBroker struct {
@@ -73,4 +74,8 @@ func (vsb *gophercloudBroker) unreserveCinderVolume(vs *gophercloud.ServiceClien
 
 func (vsb *gophercloudBroker) deleteCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
 	return volumeservice.DeleteCinderVolume(vs, volumeID)
+}
+
+func (vsb *gophercloudBroker) getCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (*volumes_v2.Volume, error) {
+	return volumeservice.GetCinderVolume(vs, volumeID)
 }

--- a/pkg/volume/cinder/volumeservice/actions.go
+++ b/pkg/volume/cinder/volumeservice/actions.go
@@ -29,7 +29,6 @@ import (
 const attachMountPoint = "/k8s.io/standalone-cinder"
 const attachHostName = "standalone-cinder.k8s.io"
 
-const initiatorName = "iqn.1994-05.com.redhat:a13fc3d1cc22"
 const pollInterval = 3 * time.Second
 const pollTimeout = 60 * time.Second
 
@@ -96,11 +95,11 @@ func ReserveCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
 // ConnectCinderVolume retrieves connection information for a cinder volume.
 // Depending on the type of volume, cinder may perform setup on a storage server
 // such as mapping a LUN to a particular ISCSI initiator.
-func ConnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (VolumeConnection, error) {
+func ConnectCinderVolume(vs *gophercloud.ServiceClient, initiator string, volumeID string) (VolumeConnection, error) {
 	opt := volumeactions.InitializeConnectionOpts{
 		Host:      "localhost",
 		IP:        "127.0.0.1",
-		Initiator: initiatorName,
+		Initiator: initiator,
 	}
 	var rcv rcvVolumeConnection
 	err := volumeactions.InitializeConnection(vs, volumeID, &opt).ExtractInto(&rcv)
@@ -129,11 +128,11 @@ func DetachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
 // DisconnectCinderVolume removes a connection to a cinder volume.  Depending on
 // the volume type, this may cause cinder to clean up the connection at a
 // storage server (i.e. remove a LUN mapping).
-func DisconnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
+func DisconnectCinderVolume(vs *gophercloud.ServiceClient, initiator string, volumeID string) error {
 	opt := volumeactions.TerminateConnectionOpts{
 		Host:      "localhost",
 		IP:        "127.0.0.1",
-		Initiator: initiatorName,
+		Initiator: initiator,
 	}
 
 	err := volumeactions.TerminateConnection(vs, volumeID, &opt).Result.Err

--- a/pkg/volume/cinder/volumeservice/actions.go
+++ b/pkg/volume/cinder/volumeservice/actions.go
@@ -17,17 +17,12 @@ limitations under the License.
 package volumeservice
 
 import (
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions"
 	volumes_v2 "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
-	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/uuid"
 )
 
 const initiatorName = "iqn.1994-05.com.redhat:a13fc3d1cc22"
@@ -65,38 +60,10 @@ type rcvVolumeConnection struct {
 }
 
 // CreateCinderVolume creates a new volume in cinder according to the PVC specifications
-func CreateCinderVolume(vs *gophercloud.ServiceClient, options controller.VolumeOptions) (string, error) {
-	name := fmt.Sprintf("cinder-dynamic-pvc-%s", uuid.NewUUID())
-	capacity := options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
-	sizeBytes := capacity.Value()
-	// Cinder works with gigabytes, convert to GiB with rounding up
-	sizeGB := int((sizeBytes + 1024*1024*1024 - 1) / (1024 * 1024 * 1024))
-	volType := ""
-	availability := ""
-	// Apply ProvisionerParameters (case-insensitive). We leave validation of
-	// the values to the cloud provider.
-	for k, v := range options.Parameters {
-		switch strings.ToLower(k) {
-		case "type":
-			volType = v
-		case "availability":
-			availability = v
-		default:
-			return "", fmt.Errorf("invalid option %q", k)
-		}
-	}
-
-	opts := volumes_v2.CreateOpts{
-		Name:             name,
-		Size:             sizeGB,
-		VolumeType:       volType,
-		AvailabilityZone: availability,
-	}
-
-	vol, err := volumes_v2.Create(vs, &opts).Extract()
-
+func CreateCinderVolume(vs *gophercloud.ServiceClient, options volumes_v2.CreateOpts) (string, error) {
+	vol, err := volumes_v2.Create(vs, &options).Extract()
 	if err != nil {
-		glog.Errorf("Failed to create a %d GiB volume: %v", sizeGB, err)
+		glog.Errorf("Failed to create a %d GiB volume: %v", options.Size, err)
 		return "", err
 	}
 

--- a/pkg/volume/cinder/volumeservice/actions.go
+++ b/pkg/volume/cinder/volumeservice/actions.go
@@ -25,6 +25,9 @@ import (
 	volumes_v2 "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
 )
 
+const attachMountPoint = "/k8s.io/standalone-cinder"
+const attachHostName = "standalone-cinder.k8s.io"
+
 const initiatorName = "iqn.1994-05.com.redhat:a13fc3d1cc22"
 
 // VolumeConnectionDetails represent the type-specific values for a given
@@ -106,6 +109,20 @@ func ConnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (Volume
 	}
 	glog.V(3).Infof("Received connection info: %v", rcv)
 	return rcv.ConnectionInfo, nil
+}
+
+// AttachCinderVolume marks the volume as attached in the cinder database.
+func AttachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
+	opts := volumeactions.AttachOpts{
+		MountPoint: attachMountPoint,
+		HostName:   attachHostName,
+		Mode:       volumeactions.ReadWrite,
+	}
+	return volumeactions.Attach(vs, volumeID, opts).ExtractErr()
+}
+
+func DetachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
+	return volumeactions.Detach(vs, volumeID, volumeactions.DetachOpts{}).ExtractErr()
 }
 
 // DisconnectCinderVolume removes a connection to a cinder volume.  Depending on

--- a/pkg/volume/cinder/volumeservice/actions.go
+++ b/pkg/volume/cinder/volumeservice/actions.go
@@ -23,12 +23,15 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions"
 	volumes_v2 "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const attachMountPoint = "/k8s.io/standalone-cinder"
 const attachHostName = "standalone-cinder.k8s.io"
 
 const initiatorName = "iqn.1994-05.com.redhat:a13fc3d1cc22"
+const pollInterval = 3 * time.Second
+const pollTimeout = 60 * time.Second
 
 // VolumeConnectionDetails represent the type-specific values for a given
 // DriverVolumeType.  Depending on the volume type, fields may be absent or
@@ -78,12 +81,10 @@ func CreateCinderVolume(vs *gophercloud.ServiceClient, options volumes_v2.Create
 // become available.  The connection information cannot be retrieved from cinder
 // until the volume is available.
 func WaitForAvailableCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
-	// TODO: Implement proper polling instead of brain-dead timers
-	c := make(chan error)
-	go time.AfterFunc(5*time.Second, func() {
-		c <- nil
+	return wait.Poll(pollInterval, pollTimeout, func() (bool, error) {
+		volume, err := GetCinderVolume(vs, volumeID)
+		return volume.Status == "available", err
 	})
-	return <-c
 }
 
 // ReserveCinderVolume marks the volume as 'Attaching' in cinder.  This prevents
@@ -159,4 +160,14 @@ func DeleteCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
 	}
 
 	return err
+}
+
+// GetCinderVolume retrieves a volume from the cinder API.
+func GetCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (*volumes_v2.Volume, error) {
+	volume, err := volumes_v2.Get(vs, volumeID).Extract()
+	if err != nil {
+		glog.Errorf("Failed to get volume:%v ", volumeID)
+		return nil, err
+	}
+	return volume, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Apply a few fixes that have been queued while the provisioner code was moved to this repo from the kubernetes-incubator.  I would like to focus my development effort now on this repository instead of the old location.

**Which issue this PR fixes**: This PR fixes the provisioning flow when cinder.create takes longer than 5 seconds.  It also makes it easier to use certain iscsi storage where initiatorName is verified during volume attachment.  The rest of the commits make small fixes and refactors to prepare for the addition of cloning support.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Usability and reliability improvements to the cinder-provisioner.
```
