### PR TITLE
Install also make if not installed

### DIFF
--- a/tools/install-distro-packages.sh
+++ b/tools/install-distro-packages.sh
@@ -17,7 +17,7 @@ if ! which make; then
     PACKAGES="$PACKAGES make"
 fi
 if [[ -n $PACKAGES ]]; then
-    sudo apt-get -q --assume-yes install virtualenv
+    sudo apt-get -q --assume-yes install $PACKAGES
 fi
 
 # Check for bindep


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes issue that install-distro-packages.sh checks for make but
never installs it.