### PR TITLE
[WIP]Pip quiet install in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ work: $(GOBIN)
 
 depend: work
 ifndef HAS_MERCURIAL
-	pip install Mercurial
+	pip install --quiet Mercurial
 endif
 ifndef HAS_DEP
 	curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh


### PR DESCRIPTION
**What this PR does / why we need it**:
Add "--quiet" option for pip install Mercurial to avoid
stdio to be interrupted, that cause incompleteness of OpenLab log.

**Special notes for your reviewer**:
@dims 