### PR TITLE
Trivial: Fix the path of policy.json

### DIFF
--- a/docs/using-keystone-webhook-authenticator-and-authorizer.md
+++ b/docs/using-keystone-webhook-authenticator-and-authorizer.md
@@ -32,16 +32,16 @@ users:
 - Start webhook process with the following flags
   * `--tls-cert-file /var/run/kubernetes/serving-kube-apiserver.crt`
   * `--tls-private-key-file /var/run/kubernetes/serving-kube-apiserver.key`
-  * `--keystone-policy-file examples/policy.json`
+  * `--keystone-policy-file examples/webhook/policy.json`
   * `--keystone-url https://my.keystone:5000/v3`
 
 ## Configuration on K8s master for authorization
 
-- Copy the examples/policy.json and edit it to your needs.
+- Copy the examples/webhook/policy.json and edit it to your needs.
 - Add the following flags to your Kubernetes api server.
   * `--authorization-mode=Node,Webhook,RBAC --authorization-webhook-config-file=/path/to/your/webhook.kubeconfig`
 - When you start the webhook process make sure you also have the following flags (in addition to the flags in the case of authentication)
-  * `--keystone-policy-file examples/policy.json`
+  * `--keystone-policy-file examples/webhook/policy.json`
 
 ## K8s kubectl Client configuration
 


### PR DESCRIPTION
**What this PR does / why we need it**:

policy.json exists under examples/webhook/, not examples directly.
This fixes the path for avoiding confusion.

**Release note**: `NONE`
