### PR TITLE
Allow synchronization between Keystone projects and K8s namespaces

### DIFF
--- a/pkg/identity/keystone/authenticator.go
+++ b/pkg/identity/keystone/authenticator.go
@@ -20,22 +20,94 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
+	"sync"
 
 	"github.com/golang/glog"
 	"github.com/gophercloud/gophercloud"
 
+	"k8s.io/api/core/v1"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/kubernetes"
 )
 
 // Authenticator contacts openstack keystone to validate user's token passed in the request.
 // The keystone endpoint is passed during apiserver startup
 type Authenticator struct {
-	authURL string
-	client  *gophercloud.ServiceClient
+	authURL    string
+	client     *gophercloud.ServiceClient
+	k8sClient  *kubernetes.Clientset
+	syncConfig *syncConfig
+	mu         sync.Mutex
+}
+
+type keystoneResponse struct {
+	Token struct {
+		User struct {
+			ID     string `json:"id"`
+			Name   string `json:"name"`
+			Domain struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"domain"`
+		} `json:"user"`
+		Project struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"project"`
+		Roles []struct {
+			Name string `json:"name"`
+		} `json:"roles"`
+	} `json:"token"`
+}
+
+func (a *Authenticator) syncProjectData(obj *keystoneResponse) error {
+
+	for _, p := range a.syncConfig.ProjectBlackList {
+		if obj.Token.Project.ID == p {
+			glog.Infof("Project %v is in black list. Skipping.")
+			return nil
+		}
+	}
+
+	if a.k8sClient == nil {
+		return errors.New("cannot sync data because k8s client is not initialized")
+	}
+
+	namespaceName := a.syncConfig.formatNamespaceName(
+		obj.Token.Project.ID,
+		obj.Token.Project.Name,
+		obj.Token.User.Domain.ID,
+	)
+
+	_, err := a.k8sClient.CoreV1().Namespaces().Get(namespaceName, metav1.GetOptions{})
+
+	if k8s_errors.IsNotFound(err) {
+		// The required namespace is not found. Create it then.
+		namespace := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespaceName,
+			},
+		}
+		namespace, err = a.k8sClient.CoreV1().Namespaces().Create(namespace)
+		if err != nil {
+			glog.Warningf("Cannot create a namespace for the user: %v", err)
+			return errors.New("Internal server error")
+		}
+	} else if err != nil {
+		// Some other error.
+		glog.Warningf("Cannot get a response from the server: %v", err)
+		return errors.New("Internal server error")
+	}
+
+	return nil
 }
 
 // AuthenticateToken checks the token via Keystone call
 func (a *Authenticator) AuthenticateToken(token string) (user.Info, bool, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 
 	// We can use the Keystone GET /v3/auth/tokens API to validate the token
 	// and get information about the user as well
@@ -61,25 +133,7 @@ func (a *Authenticator) AuthenticateToken(token string) (user.Info, bool, error)
 		return nil, false, errors.New("Failed to authenticate")
 	}
 
-	obj := struct {
-		Token struct {
-			User struct {
-				ID     string `json:"id"`
-				Name   string `json:"name"`
-				Domain struct {
-					ID   string `json:"id"`
-					Name string `json:"name"`
-				} `json:"domain"`
-			} `json:"user"`
-			Project struct {
-				ID   string `json:"id"`
-				Name string `json:"name"`
-			} `json:"project"`
-			Roles []struct {
-				Name string `json:"name"`
-			} `json:"roles"`
-		} `json:"token"`
-	}{}
+	var obj keystoneResponse
 
 	err = json.Unmarshal(bodyBytes, &obj)
 	if err != nil {
@@ -110,6 +164,14 @@ func (a *Authenticator) AuthenticateToken(token string) (user.Info, bool, error)
 		UID:    obj.Token.User.ID,
 		Groups: []string{obj.Token.Project.ID},
 		Extra:  extra,
+	}
+
+	if a.syncConfig != nil {
+		err = a.syncProjectData(&obj)
+		if err != nil {
+			glog.Errorf("an error occurred during data synchronization: %v", err)
+			return nil, false, err
+		}
 	}
 
 	return authenticatedUser, true, nil

--- a/pkg/identity/keystone/authenticator_test.go
+++ b/pkg/identity/keystone/authenticator_test.go
@@ -96,7 +96,7 @@ func TestAuthenticateToken(t *testing.T) {
 		Endpoint:       th.Endpoint(),
 	}
 
-	a := &Authenticator{th.Endpoint(), cli}
+	a := &Authenticator{authURL: th.Endpoint(), client: cli, k8sClient: nil, syncConfig: nil}
 
 	user, ok, err := a.AuthenticateToken("GoodToken")
 	th.AssertEquals(t, "admin", user.GetName())

--- a/pkg/identity/keystone/sync.go
+++ b/pkg/identity/keystone/sync.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keystone
+
+import (
+	"fmt"
+	"io/ioutil"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/golang/glog"
+)
+
+// By now only project syncing is supported
+// TODO(mfedosin): Implement syncing of role assignments, system role assignments, and user groups
+var allowedDataTypesToSync = []string{"projects"}
+
+// syncConfig contains configuration data for synchronization between Keystone and Kubernetes
+type syncConfig struct {
+	// List containing possible data types to sync. Now only "projects" are supported.
+	DataTypesToSync []string `yaml:"data_types_to_sync"`
+
+	// Format of automatically created namespace name. Can contain wildcards %i and %n,
+	// corresponding to project id and project name respectively.
+	NamespaceFormat string `yaml:"namespace_format"`
+
+	// List of project ids to exclude from syncing.
+	ProjectBlackList []string `yaml:"projects_black_list"`
+}
+
+func (sc *syncConfig) validate() error {
+	// Namespace name must contain keystone project id
+	if !strings.Contains(sc.NamespaceFormat, "%i") {
+		return fmt.Errorf("format string should comprise a %%i substring (keystone project id)")
+	}
+
+	// By convention, the names should be up to maximum length of 63 characters and consist of
+	// lower and upper case alphanumeric characters, -, _ and .
+	ts := strings.Replace(sc.NamespaceFormat, "%i", "aa", -1)
+	ts = strings.Replace(ts, "%n", "aa", -1)
+	ts = strings.Replace(ts, "%d", "aa", -1)
+
+	re := regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9_.-]*[a-zA-Z0-9]$")
+	if !re.MatchString(ts) {
+		return fmt.Errorf("namespace name must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character")
+	}
+
+	// Check that only allowed data types are enabled for synchronization
+	for _, dt := range sc.DataTypesToSync {
+		var flag bool
+		for _, a := range allowedDataTypesToSync {
+			if a == dt {
+				flag = true
+				break
+			}
+		}
+		if !flag {
+			return fmt.Errorf(
+				"Unsupported data type to sync: %v. Available values: %v",
+				dt,
+				strings.Join(allowedDataTypesToSync, ","),
+			)
+		}
+	}
+
+	return nil
+}
+
+// formatNamespaceName generates a namespace name, based on format string
+func (sc *syncConfig) formatNamespaceName(id string, name string, domain string) string {
+	res := strings.Replace(sc.NamespaceFormat, "%i", id, -1)
+	res = strings.Replace(res, "%n", name, -1)
+	res = strings.Replace(res, "%d", domain, -1)
+
+	if len(res) > 63 {
+		glog.Warningf("Generated namespace name '%v' exceeds the maximum possible length of 63 characters. Just Keystone project id '%v' will be used as the namespace name.", res, id)
+		return id
+	}
+
+	return res
+}
+
+// newSyncConfig defines the default values for syncConfig
+func newSyncConfig() syncConfig {
+	return syncConfig{
+		// by default namespace name is a string containing just keystone project id
+		NamespaceFormat: "%i",
+		// by default all possible data types are enabled
+		DataTypesToSync: allowedDataTypesToSync,
+	}
+}
+
+// newSyncConfigFromFile loads a sync config from a file
+func newSyncConfigFromFile(path string) (*syncConfig, error) {
+	sc := newSyncConfig()
+
+	yamlFile, err := ioutil.ReadFile(path)
+	if err != nil {
+		glog.Errorf("yamlFile get err   #%v ", err)
+		return nil, err
+	}
+	err = yaml.Unmarshal(yamlFile, &sc)
+	if err != nil {
+		glog.Errorf("Unmarshal: %v", err)
+		return nil, err
+	}
+
+	return &sc, nil
+}

--- a/pkg/identity/keystone/sync_test.go
+++ b/pkg/identity/keystone/sync_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keystone
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestSyncConfigFromFile(t *testing.T) {
+	sc, err := newSyncConfigFromFile("syncconfig.yaml")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "prefix-%d-%n-%i-suffix", sc.NamespaceFormat)
+	th.AssertEquals(t, "id1", sc.ProjectBlackList[0])
+	th.AssertEquals(t, "id2", sc.ProjectBlackList[1])
+}
+
+func TestSyncConfigValidation(t *testing.T) {
+	// Default sync config
+	sc := newSyncConfig()
+	err := sc.validate()
+	th.AssertNoErr(t, err)
+
+	// Forbidden characters in the format string
+	sc.NamespaceFormat = strings.Join([]string{"%i", "!@#$"}, "")
+	err = sc.validate()
+	th.AssertEquals(
+		t,
+		"namespace name must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character",
+		err.Error(),
+	)
+
+	// Format string starts with "-"
+	sc.NamespaceFormat = "-%i"
+	err = sc.validate()
+	th.AssertEquals(
+		t,
+		"namespace name must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character",
+		err.Error(),
+	)
+
+	// NamespaceFormat string doesn't have project id
+	sc.NamespaceFormat = "%n"
+	err = sc.validate()
+	th.AssertEquals(t, "format string should comprise a %i substring (keystone project id)", err.Error())
+
+	sc = newSyncConfig()
+
+	// DataTypesToSync must contain only allowed types
+	sc.DataTypesToSync = []string{"not_allowed_type"}
+	err = sc.validate()
+	th.AssertEquals(
+		t,
+		fmt.Sprintf(
+			"Unsupported data type to sync: not_allowed_type. Available values: %v",
+			strings.Join(allowedDataTypesToSync, ","),
+		),
+		err.Error(),
+	)
+}

--- a/pkg/identity/keystone/syncconfig.yaml
+++ b/pkg/identity/keystone/syncconfig.yaml
@@ -1,0 +1,8 @@
+# In format %d, %n and %i wildcards repesent keystone domain id, project name and id respectively
+namespace_format: "prefix-%d-%n-%i-suffix"
+
+# List of Keystone project ids to omit from syncing
+projects_black_list: ["id1", "id2"]
+
+# List of data types to synchronize
+"data_types_to_sync": ["projects"]


### PR DESCRIPTION
To improve integration between keystone and k8s it's recommended
to add a possibility to synchronize projects/namespaces.

In other words, if the user belongs to the project in Keystone, then, when
he attepts to authenticate in Kubernetes using k8s-keystone-auth, a k8s
namespace with the same name as the project id will automatically be
created for him.

To enable the feature two new arguments were added to the k8s-keystone-auth binary:
"--sync-config-file" - points to a local file with sync configuration.
"--sync-configmap-name" defines a configmap containing the configuration.
If any of them is set, new namespace will be automatically created when the user is
authenticated in Keystone.

fixes: #192 