### PR TITLE
Add binary file name to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,5 @@ zz_generated.openapi.go
 /k8s-keystone-auth
 /cinder-csi-plugin
 /octavia-ingress-controller
+/client-keystone-auth
+


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

In commit 61f07b188579c2a20b735db06258e3edd973306a we introduced a new binary file `client-keystone-auth` but we forgot to add it to the `.gitignore` like the other binaries


