### PR TITLE
Add information about user's domain to the Extra data

### DIFF
--- a/pkg/identity/keystone/authenticator.go
+++ b/pkg/identity/keystone/authenticator.go
@@ -64,11 +64,15 @@ func (a *Authenticator) AuthenticateToken(token string) (user.Info, bool, error)
 	obj := struct {
 		Token struct {
 			User struct {
-				Id   string `json:"id"`
-				Name string `json:"name"`
+				ID     string `json:"id"`
+				Name   string `json:"name"`
+				Domain struct {
+					ID   string `json:"id"`
+					Name string `json:"name"`
+				} `json:"domain"`
 			} `json:"user"`
 			Project struct {
-				Id   string `json:"id"`
+				ID   string `json:"id"`
 				Name string `json:"name"`
 			} `json:"project"`
 			Roles []struct {
@@ -94,15 +98,17 @@ func (a *Authenticator) AuthenticateToken(token string) (user.Info, bool, error)
 	}
 
 	extra := map[string][]string{
-		"alpha.kubernetes.io/identity/roles":        roles,
-		"alpha.kubernetes.io/identity/project/id":   {obj.Token.Project.Id},
-		"alpha.kubernetes.io/identity/project/name": {obj.Token.Project.Name},
+		"alpha.kubernetes.io/identity/roles":            roles,
+		"alpha.kubernetes.io/identity/project/id":       {obj.Token.Project.ID},
+		"alpha.kubernetes.io/identity/project/name":     {obj.Token.Project.Name},
+		"alpha.kubernetes.io/identity/user/domain/id":   {obj.Token.User.Domain.ID},
+		"alpha.kubernetes.io/identity/user/domain/name": {obj.Token.User.Domain.Name},
 	}
 
 	authenticatedUser := &user.DefaultInfo{
 		Name:   obj.Token.User.Name,
-		UID:    obj.Token.User.Id,
-		Groups: []string{obj.Token.Project.Id},
+		UID:    obj.Token.User.ID,
+		Groups: []string{obj.Token.Project.ID},
 		Extra:  extra,
 	}
 

--- a/pkg/identity/keystone/authenticator_test.go
+++ b/pkg/identity/keystone/authenticator_test.go
@@ -47,6 +47,20 @@ func TestAuthenticateToken(t *testing.T) {
 						"name": "admin",
 						"password_expires_at": null
 					},
+					"project": {
+						"id": "74a4e7d5f4e24a4c9cd01b8deec4bee5",
+						"name": "the_project"
+					},
+					"roles": [
+						{
+							"id": "51cc68287d524c759f47c811e6463340",
+							"name": "admin"
+						},
+						{
+							"id": "5af76e3aec294349929db2a0a27d3192",
+							"name": "developer"
+						}
+					],
 					"audit_ids": [
 						"mAjXQhiYRyKwkB4qygdLVg"
 					],
@@ -89,6 +103,13 @@ func TestAuthenticateToken(t *testing.T) {
 	th.AssertEquals(t, "10a2e6e717a245d9acad3e5f97aeca3d", user.GetUID())
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, ok, true)
+
+	th.AssertEquals(t, "74a4e7d5f4e24a4c9cd01b8deec4bee5", user.GetExtra()["alpha.kubernetes.io/identity/project/id"][0])
+	th.AssertEquals(t, "the_project", user.GetExtra()["alpha.kubernetes.io/identity/project/name"][0])
+	th.AssertEquals(t, "default", user.GetExtra()["alpha.kubernetes.io/identity/user/domain/id"][0])
+	th.AssertEquals(t, "Default", user.GetExtra()["alpha.kubernetes.io/identity/user/domain/name"][0])
+	th.AssertEquals(t, "admin", user.GetExtra()["alpha.kubernetes.io/identity/roles"][0])
+	th.AssertEquals(t, "developer", user.GetExtra()["alpha.kubernetes.io/identity/roles"][1])
 
 	_, ok, err = a.AuthenticateToken("WrongToken")
 	th.AssertEquals(t, (err != nil), true)


### PR DESCRIPTION
When user authenticates there is no information about his domain,
but having it could be useful for data synchronization. For instance,
when admin may want to disable the synchronization for some specific
domains.

This patch adds information about user's domain to the Extra data,
that can be found by "alpha.kubernetes.io/identity/user/domain/id" and
"alpha.kubernetes.io/identity/user/domain/name" keys respectively.

Also missing unit tests were added to check unmarshaling of keystone
responses.