### PR TITLE
Fix the config sort of k8s-keystone-auth

### DIFF
--- a/docs/using-keystone-webhook-authenticator-and-authorizer.md
+++ b/docs/using-keystone-webhook-authenticator-and-authorizer.md
@@ -26,22 +26,22 @@ users:
 
 ## Configuration on K8s master for authentication
 
-- Add the following flags to your Kubernetes api server.
-  * `--authentication-token-webhook-config-file=/path/to/your/webhook.kubeconfig`
-  * `--authorization-mode=Node,RBAC`
 - Start a webhook process (k8s-keystone-auth command) with the following flags
   * `--tls-cert-file /var/run/kubernetes/serving-kube-apiserver.crt`
   * `--tls-private-key-file /var/run/kubernetes/serving-kube-apiserver.key`
   * `--keystone-policy-file examples/webhook/policy.json`
   * `--keystone-url https://my.keystone:5000/v3`
+- Add the following flags to your Kubernetes api server.
+  * `--authentication-token-webhook-config-file=/path/to/your/webhook.kubeconfig`
+  * `--authorization-mode=Node,RBAC`
 
 ## Configuration on K8s master for authorization
 
 - Copy the examples/webhook/policy.json and edit it to your needs.
-- Add the following flags to your Kubernetes api server.
-  * `--authorization-mode=Node,Webhook,RBAC --authorization-webhook-config-file=/path/to/your/webhook.kubeconfig`
 - When you start the webhook process make sure you also have the following flags (in addition to the flags in the case of authentication)
   * `--keystone-policy-file examples/webhook/policy.json`
+- Add the following flags to your Kubernetes api server.
+  * `--authorization-mode=Node,Webhook,RBAC --authorization-webhook-config-file=/path/to/your/webhook.kubeconfig`
 
 ## K8s kubectl Client configuration
 


### PR DESCRIPTION
**What this PR does / why we need it**:

On some environments, kube-apiserver restarts automatically just after
changing the manifest (/etc/kubernetes/manifests/kube-apiserver.yaml, etc).
Before restarting, k8s-keystone-auth process needs to exist.
So this changes the config sort of k8s-keystone-auth to make the condition
easily for readers.

**Release note**: `NONE`
