### PR TITLE
Ensure that authorizer supports core api group validation

### DIFF
--- a/pkg/identity/keystone/authorizer_test.go
+++ b/pkg/identity/keystone/authorizer_test.go
@@ -127,6 +127,15 @@ func TestAuthorizer(t *testing.T) {
 	decision, _, _ = a.Authorize(attrs)
 	th.AssertEquals(t, authorizer.DecisionDeny, decision)
 
+	// Core api group resource match
+	attrs = authorizer.AttributesRecord{User: user1, ResourceRequest: true, Verb: "get", Resource: "core_resource"}
+	decision, _, _ = a.Authorize(attrs)
+	th.AssertEquals(t, authorizer.DecisionAllow, decision)
+
+	attrs = authorizer.AttributesRecord{User: user1, ResourceRequest: true, Verb: "get", Resource: "core_resource", APIGroup: "NonCoreAPIGroup"}
+	decision, _, _ = a.Authorize(attrs)
+	th.AssertEquals(t, authorizer.DecisionDeny, decision)
+
 	// Nonresource user match
 	attrs = authorizer.AttributesRecord{User: user1, ResourceRequest: false, Verb: "get", Path: "/user"}
 	decision, _, _ = a.Authorize(attrs)

--- a/pkg/identity/keystone/authorizer_test_policy.json
+++ b/pkg/identity/keystone/authorizer_test_policy.json
@@ -90,6 +90,18 @@
     }]
   },
   {
+    "resource": {
+      "verbs": ["get"],
+      "resources": ["core_resource"],
+      "version": "",
+      "namespace": "*"
+    },
+    "match": [{
+      "type": "role",
+      "values": ["role1"]
+    }]
+  },
+  {
     "nonresource": {
       "verbs": ["get"],
       "path": "/user"


### PR DESCRIPTION
This patch adds unit tests verifying that if version = "" in the policy file,
then the authorizer must ensure that access is allowed to Core Group API
resources only.

fixes #216 