### PR TITLE
Manila: trustee authentication + custom CAs

### DIFF
--- a/docs/using-manila-provisioner.md
+++ b/docs/using-manila-provisioner.md
@@ -1,3 +1,4 @@
+
 # Manila external provisioner
 The Manila external provisioner fulfills persistent volume claims by provisioning Manila shares and mapping them to natively supported volume sources represented by Share backends.
 
@@ -24,12 +25,13 @@ Key | Required | Default value | Description
 `osSecretName` | Yes | None | Name of the Secret object containing OpenStack credentials
 `osSecretNamespace` | No | `default` | Namespace of the OpenStack credentials Secret object
 `shareSecretNamespace` | No | value of `osSecretNamespace` | Namespace of the per-share Secret object (contains backend-specific secrets)
-`osShareID` | No | None | The UUID of an existing share. Used during static provisioning
-`osShareName` | No | None | The name of an exisiting share. Used during static provisioning
-`osShareAccessID` | No | None | The UUID of an existing access rule to a share. Used during static provisioning
+`osShareID` | No | None | The UUID of an existing share. Used for static provisioning
+`osShareName` | No | None | The name of an exisiting share. Used for static provisioning
+`osShareAccessID` | No | None | The UUID of an existing access rule to a share. Used for static provisioning
 
 
-**Protocol specific options**  
+**Protocol specific options**
+
 None.
 
 **Share-backend specific options**
@@ -45,20 +47,28 @@ Available Secret parameters: `os-authURL`, `os-region`, `os-certAuthority`, `os-
 
 Parameters `os-authURL` and `os-region` are required for both user and trustee authentication.
 
-Optionally, you can also supply a custom certificate via `os-certAuthority` secret parameter (PEM file contents). By default, the usual TLS verification is performed. To override this behaviour and accept insecure certificates, set `os-TLSInsecure: "true"` (optional, defaults to `false`).
+Optionally, you can supply a custom certificate via `os-certAuthority` secret parameter (PEM file contents). By default, the usual TLS verification is performed. To override this behaviour and accept insecure certificates, set `os-TLSInsecure` to `true` (optional, defaults to `false`).
 
-The recommended way to create a Secret manifest with OpenStack credentials is following:
+**User authentication**
+
+The easiest way to create a Secret manifest with OpenStack user credentials is following:
 ```bash
 $ cd examples/manila-provisioner
 $ ./generate-secrets.sh -n my-manila-secrets | ./filter-secrets.sh > secrets.yaml
 $ kubectl create -f secrets.yaml
 ```
-- `generate-secrets.sh` will read OpenStack variables from the environment and generate a Secrets manifest. It can also parse OpenRC file. Please consult the `-h` option for more details.
-- `filter-secrets.sh` will filter duplicate fields: `*ID` fields will take precedence over `*Name` ones (e.g. `os-projectID` will be chosen over `os-projectName`) - otherwise `gophercloud` would report errors.
+- `generate-secrets.sh` will read OpenStack credentials from the environment variables and generate a Secrets manifest. It can also parse an OpenRC file. Please consult the `-h` option for more details.
+- `filter-secrets.sh` will filter duplicate fields: `*ID` fields will take precedence over `*Name` ones (e.g. `os-projectID` will be chosen over `os-projectName`).
 
-In order to reference the Secret object from Storage Class parameters `osSecretName` and `osSecretNamespace` need to be filled in.
+Required parameters:
 
-Available Secret fields: `os-authURL`, `os-userID`, `os-userName`, `os-password`, `os-projectID`, `os-projectName`, `os-domainID`, `os-domainName`, `os-region`
+- `os-password` and either `os-userID` or `os-userName`
+- either `os-projectID` or `os-projectName`
+- either `os-domainID` or `os-domainName`
+
+**Trustee authentication**
+
+Requires `os-trustID`, `os-trusteeID` and `os-trusteePassword`.
 
 ### Adding a new Share backend
 1. (optional) Add struct fields to `.../manila/shareoptions/backend.go` with appropriate field tags

--- a/docs/using-manila-provisioner.md
+++ b/docs/using-manila-provisioner.md
@@ -22,7 +22,7 @@ Key | Required | Default value | Description
 `protocol` | Yes | None | Protocol used when provisioning a share, options `CEPHFS`,`NFS`
 `backend`  | Yes | None | Share backend used for granting access and creating `PersistentVolumeSource` options `cephfs`,`csi-cephfs`,`nfs`
 `osSecretName` | Yes | None | Name of the Secret object containing OpenStack credentials
-`osSecretNamespace` | Yes | None | Namespace of the OpenStack credentials Secret object
+`osSecretNamespace` | No | `default` | Namespace of the OpenStack credentials Secret object
 `shareSecretNamespace` | No | value of `osSecretNamespace` | Namespace of the per-share Secret object (contains backend-specific secrets)
 `osShareID` | No | None | The UUID of an existing share. Used during static provisioning
 `osShareName` | No | None | The name of an exisiting share. Used during static provisioning

--- a/docs/using-manila-provisioner.md
+++ b/docs/using-manila-provisioner.md
@@ -39,7 +39,13 @@ Key | For backend | For protocol  | Required | Default Value | Description
 `csi-driver` | `csi-cephfs` | `CEPHFS` | Yes | None | Name of the CSI driver
 
 ## Authentication with Manila v2 client
-The provisioner uses `gophercloud` library for talking to the OpenStack Manila service. Authentication credentials are read from Kubernetes Secret object which should contain the same credentials as your OpenRC file.
+The provisioner authenticates to the OpenStack Manila service with the credentials supplied from the Kubernetes Secret object referenced by `osSecretNamespace` : `osSecretName`. One can authenticate either as a user or as a trustee, with each of those having its own set of parameters. Note that if the Secret object is created from a manifest, the Secret's values need to be encoded in base64.
+
+Available Secret parameters: `os-authURL`, `os-region`, `os-certAuthority`, `os-TLSInsecure`, `os-userID`, `os-userName`, `os-password`, `os-projectID`, `os-projectName`, `os-domainID`, `os-domainName`, `os-trustID`, `os-trusteeID` and `os-trusteePassword`.
+
+Parameters `os-authURL` and `os-region` are required for both user and trustee authentication.
+
+Optionally, you can also supply a custom certificate via `os-certAuthority` secret parameter (PEM file contents). By default, the usual TLS verification is performed. To override this behaviour and accept insecure certificates, set `os-TLSInsecure: "true"` (optional, defaults to `false`).
 
 The recommended way to create a Secret manifest with OpenStack credentials is following:
 ```bash

--- a/pkg/share/manila/client.go
+++ b/pkg/share/manila/client.go
@@ -17,7 +17,10 @@ limitations under the License.
 package manila
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -51,7 +54,7 @@ func splitMicroversion(microversion string) (major, minor int) {
 
 func validateMicroversion(microversion string) error {
 	if !microversionRegexp.MatchString(microversion) {
-		return fmt.Errorf("Invalid microversion format in %q", microversion)
+		return fmt.Errorf("invalid microversion format in %q", microversion)
 	}
 
 	return nil
@@ -64,14 +67,44 @@ func compareVersionsLessThan(a, b string) bool {
 	return aMaj < bMaj || (aMaj == bMaj && aMin < bMin)
 }
 
-// NewManilaV2Client Creates Manila v2 client
-// Authenticates to the Manila service with credentials passed in env variables
-func NewManilaV2Client(osOptions *shareoptions.OpenStackOptions) (*gophercloud.ServiceClient, error) {
-	// Authenticate
+func createHTTPclient(o *shareoptions.OpenStackOptions) (http.Client, error) {
+	if o.OSCertAuthority == "" {
+		return http.Client{}, nil
+	}
 
-	provider, err := openstack.NewClient(osOptions.OSAuthURL)
+	if o.OSTLSInsecure == "" {
+		o.OSTLSInsecure = "false"
+	}
+
+	allowInsecure, err := strconv.ParseBool(o.OSTLSInsecure)
+	if err != nil {
+		return http.Client{}, fmt.Errorf("failed to parse parameter os-insecureTLS: %v", err)
+	}
+
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM([]byte(o.OSCertAuthority))
+
+	tlsConfig := &tls.Config{
+		RootCAs:            caCertPool,
+		InsecureSkipVerify: allowInsecure,
+	}
+
+	tlsConfig.BuildNameToCertificate()
+
+	return http.Client{
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
+	}, nil
+}
+
+func authenticateClient(o *shareoptions.OpenStackOptions) (*gophercloud.ProviderClient, error) {
+	provider, err := openstack.NewClient(o.OSAuthURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Keystone client: %v", err)
+	}
+
+	provider.HTTPClient, err = createHTTPclient(o)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP client: %v", err)
 	}
 
 	const (
@@ -86,13 +119,13 @@ func NewManilaV2Client(osOptions *shareoptions.OpenStackOptions) (*gophercloud.S
 
 	switch chosenVersion.ID {
 	case v2:
-		if osOptions.OSTrustID != "" {
-			return nil, fmt.Errorf("Keystone %s does not support trustee authentication", chosenVersion.ID)
+		if o.OSTrustID != "" {
+			return nil, fmt.Errorf("Keystone %s does not support trustee authentication", v2)
 		}
 
-		err = openstack.AuthenticateV2(provider, *osOptions.ToAuthOptions(), gophercloud.EndpointOpts{})
+		err = openstack.AuthenticateV2(provider, *o.ToAuthOptions(), gophercloud.EndpointOpts{})
 	case v3:
-		err = openstack.AuthenticateV3(provider, *osOptions.ToAuthOptionsExt(), gophercloud.EndpointOpts{})
+		err = openstack.AuthenticateV3(provider, *o.ToAuthOptionsExt(), gophercloud.EndpointOpts{})
 	default:
 		return nil, fmt.Errorf("unrecognized Keystone version: %s", chosenVersion.ID)
 	}
@@ -101,7 +134,45 @@ func NewManilaV2Client(osOptions *shareoptions.OpenStackOptions) (*gophercloud.S
 		return nil, fmt.Errorf("failed to authenticate with Keystone: %v", err)
 	}
 
-	client, err := openstack.NewSharedFileSystemV2(provider, gophercloud.EndpointOpts{Region: osOptions.OSRegionName})
+	return provider, nil
+}
+
+func validateManilaClient(c *gophercloud.ServiceClient) error {
+	serverVersion, err := apiversions.Get(c, "v2").Extract()
+	if err != nil {
+		return fmt.Errorf("failed to get Manila v2 API microversions: %v", err)
+	}
+
+	if err = validateMicroversion(serverVersion.MinVersion); err != nil {
+		return fmt.Errorf("server's minimum microversion is invalid: %v", err)
+	}
+
+	if err = validateMicroversion(serverVersion.Version); err != nil {
+		return fmt.Errorf("server's maximum microversion is invalid: %v", err)
+	}
+
+	if compareVersionsLessThan(c.Microversion, serverVersion.MinVersion) {
+		return fmt.Errorf("client's microversion %s is lower than server's minimum microversion %s", c.Microversion, serverVersion.MinVersion)
+	}
+
+	if compareVersionsLessThan(serverVersion.Version, c.Microversion) {
+		return fmt.Errorf("client's microversion %s is higher than server's highest supported microversion %s", c.Microversion, serverVersion.Version)
+	}
+
+	return nil
+}
+
+// NewManilaV2Client Creates Manila v2 client
+// Authenticates to the Manila service with credentials passed in shareoptions.OpenStackOptions
+func NewManilaV2Client(o *shareoptions.OpenStackOptions) (*gophercloud.ServiceClient, error) {
+	// Authenticate and create Manila v2 client
+
+	provider, err := authenticateClient(o)
+	if err != nil {
+		return nil, fmt.Errorf("failed to authenticate: %v", err)
+	}
+
+	client, err := openstack.NewSharedFileSystemV2(provider, gophercloud.EndpointOpts{Region: o.OSRegionName})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Manila v2 client: %v", err)
 	}
@@ -109,26 +180,8 @@ func NewManilaV2Client(osOptions *shareoptions.OpenStackOptions) (*gophercloud.S
 	// Check client's and server's versions for compatibility
 
 	client.Microversion = minimumManilaVersion
-
-	serverVersion, err := apiversions.Get(client, "v2").Extract()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get Manila v2 API microversions: %v", err)
-	}
-
-	if err = validateMicroversion(serverVersion.MinVersion); err != nil {
-		return nil, fmt.Errorf("server's minimum microversion is invalid: %v", err)
-	}
-
-	if err = validateMicroversion(serverVersion.Version); err != nil {
-		return nil, fmt.Errorf("server's maximum microversion is invalid: %v", err)
-	}
-
-	if compareVersionsLessThan(client.Microversion, serverVersion.MinVersion) {
-		return nil, fmt.Errorf("client's microversion %s is lower than server's minimum microversion %s", client.Microversion, serverVersion.MinVersion)
-	}
-
-	if compareVersionsLessThan(serverVersion.Version, client.Microversion) {
-		return nil, fmt.Errorf("client's microversion %s is higher than server's highest supported microversion %s", client.Microversion, serverVersion.Version)
+	if err = validateManilaClient(client); err != nil {
+		return nil, fmt.Errorf("failed to validate Manila v2 client: %v", err)
 	}
 
 	return client, nil

--- a/pkg/share/manila/provisioner.go
+++ b/pkg/share/manila/provisioner.go
@@ -161,7 +161,7 @@ func (p *Provisioner) Delete(pv *v1.PersistentVolume) error {
 		return fmt.Errorf("failed to get provision type for volume %s: %v", pv.GetName(), err)
 	}
 
-	osOptions, err := shareoptions.NewOpenStackOptions(p.clientset, osSecretRef)
+	osOptions, err := shareoptions.NewOpenStackOptionsFromSecret(p.clientset, osSecretRef)
 	if err != nil {
 		return fmt.Errorf("failed to create OpenStack options for share %s: %v", shareID, err)
 	}

--- a/pkg/share/manila/shareoptions/common.go
+++ b/pkg/share/manila/shareoptions/common.go
@@ -24,7 +24,7 @@ type CommonOptions struct {
 	Backend  string `name:"backend"`
 
 	OSSecretName         string `name:"osSecretName"`
-	OSSecretNamespace    string `name:"osSecretNamespace"`
+	OSSecretNamespace    string `name:"osSecretNamespace" value:"default=default"`
 	ShareSecretNamespace string `name:"shareSecretNamespace" value:"coalesce=osSecretNamespace"`
 
 	OSShareID       string `name:"osShareID" value:"requires=osShareAccessID"`

--- a/pkg/share/manila/shareoptions/openstack.go
+++ b/pkg/share/manila/shareoptions/openstack.go
@@ -25,18 +25,23 @@ import (
 
 // OpenStackOptions contains fields used for authenticating to OpenStack
 type OpenStackOptions struct {
-	// Mandatory options
+	// Common options
 
 	OSAuthURL    string `name:"os-authURL" value:"alwaysRequires=os-password|os-trustID"`
 	OSRegionName string `name:"os-region"`
 
+	OSCertAuthority string `name:"os-certAuthority" value:"optional"`
+	OSTLSInsecure   string `name:"os-TLSInsecure" value:"requires=os-certAuthority"`
+
 	// User authentication
 
-	OSPassword    string `name:"os-password" value:"requires=os-domainID|os-domainName,os-projectID|os-projectName,os-userID|os-userName"`
-	OSUserID      string `name:"os-userID" value:"requires=os-password"`
-	OSUsername    string `name:"os-userName" value:"requires=os-password"`
-	OSDomainID    string `name:"os-domainID" value:"requires=os-password"`
-	OSDomainName  string `name:"os-domainName" value:"requires=os-password"`
+	OSPassword string `name:"os-password" value:"requires=os-domainID|os-domainName,os-projectID|os-projectName,os-userID|os-userName"`
+	OSUserID   string `name:"os-userID" value:"requires=os-password"`
+	OSUsername string `name:"os-userName" value:"requires=os-password"`
+
+	OSDomainID   string `name:"os-domainID" value:"requires=os-password"`
+	OSDomainName string `name:"os-domainName" value:"requires=os-password"`
+
 	OSProjectID   string `name:"os-projectID" value:"requires=os-password"`
 	OSProjectName string `name:"os-projectName" value:"requires=os-password"`
 
@@ -45,8 +50,6 @@ type OpenStackOptions struct {
 	OSTrustID         string `name:"os-trustID" value:"requires=os-trusteeID,os-trusteePassword"`
 	OSTrusteeID       string `name:"os-trusteeID" value:"requires=os-trustID"`
 	OSTrusteePassword string `name:"os-trusteePassword" value:"requires=os-trustID"`
-	// TODO:
-	// OSCertAuthority   string `name:"os-certAuthority" value:"requires=os-trustID"`
 }
 
 // NewOpenStackOptionsFromSecret reads k8s secrets, validates and populates OpenStackOptions

--- a/pkg/share/manila/shareoptions/shareoptions.go
+++ b/pkg/share/manila/shareoptions/shareoptions.go
@@ -44,6 +44,7 @@ func init() {
 	processStruct(&CommonOptions{})
 	processStruct(&ProtocolOptions{})
 	processStruct(&BackendOptions{})
+	processStruct(&OpenStackOptions{})
 }
 
 // NewShareOptions creates new share options
@@ -95,11 +96,15 @@ func NewShareOptions(volOptions *controller.VolumeOptions, c clientset.Interface
 
 	// Retrieve and parse secrets
 
-	err = buildOpenStackOptionsTo(c, &opts.OpenStackOptions, &v1.SecretReference{
+	sec, err := readSecrets(c, &v1.SecretReference{
 		Name:      opts.OSSecretName,
 		Namespace: opts.OSSecretNamespace,
 	})
 	if err != nil {
+		return nil, err
+	}
+
+	if err = buildOpenStackOptionsTo(&opts.OpenStackOptions, sec); err != nil {
 		return nil, err
 	}
 

--- a/pkg/share/manila/shareoptions/util.go
+++ b/pkg/share/manila/shareoptions/util.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shareoptions
+
+import (
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+func readSecrets(c clientset.Interface, secretRef *v1.SecretReference) (map[string]string, error) {
+	secrets, err := c.CoreV1().Secrets(secretRef.Namespace).Get(secretRef.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	secretsData := make(map[string]string)
+	for k, v := range secrets.Data {
+		secretsData[k] = string(v)
+	}
+
+	return secretsData, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Adds support for trustee authentication and supplying custom CAs.
The OpenStack Secret may now contain:
- `os-trustID`, `os-trusteeID` and `os-trusteePassword` for trustee auth
- `os-certAuthority` and `os-TLSInsecure` for supplying a custom CA, and optionally allowing it to be insecure

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/cc @dims @hogepodge @flaper87 
