### PR TITLE
Run conformance periodic jobs on specific branches for master

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -34,6 +34,10 @@
         - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.11
     periodic:
       jobs:
-        - cloud-provider-openstack-acceptance-test-e2e-conformance
-        - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.10
-        - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.11
+        - cloud-provider-openstack-acceptance-test-e2e-conformance:
+            branches: master
+        - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.10:
+            branches: release-1.10
+        - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.11:
+            #TODO: change branch to release-1.11 when we have it
+            branches: release-1.10


### PR DESCRIPTION
**What this PR does / why we need it**:
It is not necessary to run both master and release 1.10 branch
cloud-provider-openstack to test against k8s master, v1.10 and v1.11
in OpenLab periodic jobs, that allocate lots of testing vm resources.
Add branches option into job define in order to limiting specific job
just run on specific branch.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
