### PR TITLE
Add readable and configurable loadbalancer naming

### DIFF
--- a/pkg/cloudprovider/providers/openstack/OWNERS
+++ b/pkg/cloudprovider/providers/openstack/OWNERS
@@ -8,3 +8,4 @@ reviewers:
 - NickrenREN
 - dims
 - FengyunPan2
+- imdigitaljim


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently LB's are named in Neutron based on what Google and AWS needs by using an in-tree cloudprovider function. Since this driver is now out of tree, we can make this a feature improve the experience for users on Horizon and API's and correlate the loadbalancer name and description in a more meaningful way.
