### PR TITLE
Add OS_DOMAIN_NAME on the manifest

### DIFF
--- a/manifests/provisioner/deployment.yaml
+++ b/manifests/provisioner/deployment.yaml
@@ -26,3 +26,5 @@ spec:
           value: 522e341dd2884e88a466a5c68ca54aa4
         - name: OS_REGION_NAME
           value: RegionOne
+        - name: OS_DOMAIN_NAME
+          value: Default


### PR DESCRIPTION
**What this PR does / why we need it**:

If not specifying OS_DOMAIN_NAME on standalone-cinder-provisioner
manifest, the deployment is not deployed and the log is like:

  F0810 02:28:02.332034       1 main.go:86] Error creating Cinder
    provisioner: failed to get volume service: You must provide
    exactly one of DomainID or DomainName to authenticate by Username

So this adds the OS_DOMAIN_NAME on the manifest.

**Release note**: NONE
