### PR TITLE
Replace internal provisioner name with external one

### DIFF
--- a/cluster/addons/storage-class/openstack/default.yaml
+++ b/cluster/addons/storage-class/openstack/default.yaml
@@ -7,4 +7,4 @@ metadata:
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists
-provisioner: kubernetes.io/cinder
+provisioner: openstack.org/standalone-cinder

--- a/docs/openstack-kubernetes-integration-options.md
+++ b/docs/openstack-kubernetes-integration-options.md
@@ -11,6 +11,7 @@ command line params. Need to set `--cloud-provider=external` for the other kuber
 
 Also use the `--external-cloud-volume-plugin` command line parameter in `kube-controller-manager` to use the
 in-tree cinder volume plugin. Note that the provisioner name for the in-tree volume plugin is `kubernetes.io/cinder`
+instead of `openstack.org/standalone-cinder` which is the provisioner name for the external cloud-openstack-provider.
 
 ### External OpenStack provider
 

--- a/examples/persistent-volume-provisioning/cinder/cinder-storage-class.yaml
+++ b/examples/persistent-volume-provisioning/cinder/cinder-storage-class.yaml
@@ -2,7 +2,6 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: gold
-provisioner: kubernetes.io/cinder
+provisioner: openstack.org/standalone-cinder
 parameters:
-  type: fast
   availability: nova


### PR DESCRIPTION
**What this PR does / why we need it**:

External provisioner name is "openstack.org/standalone-cinder" which
is hardcoded in this repo. And "kubernetes.io/cinder" is the one of
kubernetes/kubernetes in-tree provisioner which is already deprecated.
So this replaces the old name with a new one which is the external
cloud-provider-openstack to avoid confusion.
In addition, this removes the volume type from the example because
the provisioner cannot create a volume if the volume type doesn't
exist on Cinder side and it is hard to debug it.

**Release note**: NONE
