### PR TITLE
Start using client.authentication.k8s.io/v1beta1 api for the client auth plugin

### DIFF
--- a/cmd/client-keystone-auth/main.go
+++ b/cmd/client-keystone-auth/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -30,23 +29,17 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 
 	kflag "k8s.io/apiserver/pkg/util/flag"
-	"k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1"
 	"k8s.io/cloud-provider-openstack/pkg/identity/keystone"
 )
 
 const errRespTemplate string = `{
-	"apiVersion": "client.authentication.k8s.io/v1alpha1",
+	"apiVersion": "client.authentication.k8s.io/v1beta1",
 	"kind": "ExecCredential",
-	"spec": {
-		"response": {
-			"code": 401,
-			"header": {},
-		},
-	}
+	"status": {}
 }`
 
 const respTemplate string = `{
-	"apiVersion": "client.authentication.k8s.io/v1alpha1",
+	"apiVersion": "client.authentication.k8s.io/v1beta1",
 	"kind": "ExecCredential",
 	"status": {
 		"token": "%v",
@@ -62,13 +55,9 @@ func promptForString(field string, r io.Reader, show bool) (result string, err e
 		_, err = fmt.Fscan(r, &result)
 	} else {
 		var data []byte
-		if terminal.IsTerminal(int(os.Stdin.Fd())) {
-			data, err = terminal.ReadPassword(int(os.Stdin.Fd()))
-			result = string(data)
-			fmt.Fprintf(os.Stderr, "\n")
-		} else {
-			return "", fmt.Errorf("error reading input for %s", field)
-		}
+		data, err = terminal.ReadPassword(int(os.Stdin.Fd()))
+		result = string(data)
+		fmt.Fprintf(os.Stderr, "\n")
 	}
 	return result, err
 }
@@ -125,27 +114,6 @@ func prompt(url string, domain string, user string, project string, password str
 	return options, nil
 }
 
-// KuberneteExecInfo holds information passed to the plugin by the transport. This
-// contains runtime specific information, such as if the session is interactive,
-// auth API version and kind of request.
-type KuberneteExecInfo struct {
-	APIVersion string                      `json:"apiVersion"`
-	Kind       string                      `json:"kind"`
-	Spec       v1alpha1.ExecCredentialSpec `json:"spec"`
-}
-
-func validateKebernetesExecInfo(kei KuberneteExecInfo) error {
-	if kei.APIVersion != v1alpha1.SchemeGroupVersion.String() {
-		return fmt.Errorf("unsupported API version: %v", kei.APIVersion)
-	}
-
-	if kei.Kind != "ExecCredential" {
-		return fmt.Errorf("incorrect request kind: %v", kei.Kind)
-	}
-
-	return nil
-}
-
 func main() {
 	var url string
 	var domain string
@@ -162,28 +130,9 @@ func main() {
 	pflag.StringVar(&password, "password", os.Getenv("OS_PASSWORD"), "Password")
 	kflag.InitFlags()
 
-	keiData := os.Getenv("KUBERNETES_EXEC_INFO")
-	if keiData == "" {
-		fmt.Fprintln(os.Stderr, "KUBERNETES_EXEC_INFO env variable must be set.")
-		os.Exit(1)
-	}
-
-	kei := KuberneteExecInfo{}
-	err = json.Unmarshal([]byte(keiData), &kei)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Failed to parse KUBERNETES_EXEC_INFO value.")
-		os.Exit(1)
-	}
-
-	err = validateKebernetesExecInfo(kei)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "An error occurred: %v\n", err)
-		os.Exit(1)
-	}
-
 	// Generate Gophercloud Auth Options based on input data from stdin
-	// if "intaractive" is set to true, or from env variables otherwise.
-	if !kei.Spec.Interactive {
+	// if IsTerminal returns "true", or from env variables otherwise.
+	if !terminal.IsTerminal(int(os.Stdin.Fd())) {
 		options, err = openstack.AuthOptionsFromEnv()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to read openstack env vars: %s", err)
@@ -201,6 +150,7 @@ func main() {
 	if err != nil {
 		if _, ok := err.(gophercloud.ErrDefault401); ok {
 			fmt.Println(errRespTemplate)
+			os.Stderr.WriteString("Invalid user credentials were provided\n")
 			os.Exit(0)
 		}
 		fmt.Fprintf(os.Stderr, "An error occurred: %v\n", err)

--- a/docs/using-client-keystone-auth.md
+++ b/docs/using-client-keystone-auth.md
@@ -47,7 +47,7 @@ users:
       # resource. Required.
       #
       # The API version returned by the plugin MUST match the version encoded.
-      apiVersion: "client.authentication.k8s.io/v1alpha1"
+      apiVersion: "client.authentication.k8s.io/v1beta1"
 
       # Environment variables to set when executing the plugin. Optional.
       env:
@@ -83,35 +83,27 @@ the binary `/home/jane/bin/client-keystone-auth` is executed.
     exec:
       # Path relative to the directory of the kubeconfig
       command: "./bin/client-keystone-auth"
-      apiVersion: "client.authentication.k8s.io/v1alpha1"
+      apiVersion: "client.authentication.k8s.io/v1beta1"
 ```
 
 ## Input and output formats
 
-When executing the command, `k8s.io/client-go` sets the `KUBERNETES_EXEC_INFO` environment
-variable to a JSON serialized [`ExecCredential`](
-https://github.com/kubernetes/client-go/blob/master/pkg/apis/clientauthentication/v1alpha1/types.go)
-resource.
+The executed command prints an `ExecCredential` object to `stdout`. `k8s.io/client-go`
+authenticates against the Kubernetes API using the returned credentials in the `status`.
 
-```
-KUBERNETES_EXEC_INFO='{
-  "apiVersion": "client.authentication.k8s.io/v1alpha1",
-  "kind": "ExecCredential",
-  "spec": {
-    "interactive": true
-  }
-}'
-```
-
-If the variable is not set or its format is invalid, then the executable fails immediately.
+When run from an interactive session, `stdin` is exposed directly to the plugin. The plugin uses a
+[TTY check](https://godoc.org/golang.org/x/crypto/ssh/terminal#IsTerminal) to determine if it's
+appropriate to prompt a user interactively.
 
 When the plugin is executed from an interactive session, `stdin` and `stderr` are directly
 exposed to the plugin so it can prompt the user for input for interactive logins.
 
 To authenticate in Keystone from an interactive session, the user needs to provide the address
-domain name, user name and his password. These values can be specified using environment variables
-(`OS_AUTH_URL`, `OS_DOMAIN_NAME`, `OS_USERNAME` and `OS_PASSWORD`), or through command arguments
-(`--keystone-url`, `--domain-name`, `--user-name` and `--password`), respectively.
+domain name, user name, password, and, optionally, a project name. These values can be specified
+using environment variables
+(`OS_AUTH_URL`, `OS_DOMAIN_NAME`, `OS_USERNAME`, `OS_PASSWORD` and `OS_PROJECT_NAME`), or through command
+arguments
+(`--keystone-url`, `--domain-name`, `--user-name`, `--password` and `--project-name`), respectively.
 If they are not specified, the user will be prompted to enter them at the time of the interactive
 session.
 
@@ -120,7 +112,7 @@ include metadata about the response.
 
 ```json
 {
-  "apiVersion": "client.authentication.k8s.io/v1alpha1",
+  "apiVersion": "client.authentication.k8s.io/v1beta1",
   "kind": "ExecCredential",
   "spec": {
     "response": {
@@ -139,7 +131,7 @@ Kubernetes API.
 
 ```json
 {
-  "apiVersion": "client.authentication.k8s.io/v1alpha1",
+  "apiVersion": "client.authentication.k8s.io/v1beta1",
   "kind": "ExecCredential",
   "status": {
     "token": "my-bearer-token",


### PR DESCRIPTION
Recently client authentication api was updated from v1alpha1 to v1beta1.
https://github.com/kubernetes/client-go/commit/f58a8f4fd079a6e2d027afeba4eb8c2ef3a233f5

This commit switches keystone-client-auth on the new api and removes the outdated
one.

The difference between two versions is that in alpha interactive mode was checked
in client-go and provided to the plugin with the environment variable
KUBERNETES_EXEC_INFO. In beta the plugin uses a TTY check to determine if it's
appropriate to prompt a user interactively. That's why KUBERNETES_EXEC_INFO is
not used anymore and can be removed.

Another change is that ExecCredentialSpec struct doesn't contain any fields now,
which means the plugin shouldn't write anything in this section during printing
response output.

https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins
