### PR TITLE
Adding snap building support to client-keystone-auth plugin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,8 @@ zz_generated.openapi.go
 /octavia-ingress-controller
 /client-keystone-auth
 
+# snap temp files
+/parts
+/snap
+/prime
+*.snap

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: client-keystone-auth
+version: git
+summary: Client plugin for kubectl to enable keystone authentication.
+description: |
+  client-keystone-auth is a plugin for kubectl. It allows kubectl to get an
+  auth token from Keystone and use that to authenticate to the Kubernetes
+  api server.
+grade: stable
+confinement: strict
+
+parts:
+  client-keystone-auth:
+    source: .
+    plugin: go
+    go-importpath: k8s.io/cloud-provider-openstack
+    override-build: |
+      docker run -i -v "$PWD":/go/src/k8s.io/cloud-provider-openstack:z \
+        -w /go/src/k8s.io/cloud-provider-openstack \
+        golang:1.10 make build
+
+apps:
+  client-keystone-auth:
+    command: client-keystone-auth
+    plugs: [ network ]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adds snap building to build a snap for the client-keystone-auth plugin. [Snaps](https://snapcraft.io) are a new package system by Ubuntu. Snaps will run on almost any distro and it's super easy to update them. Snaps will update on the user's machine periodically, so the users will always have the latest version that you publish.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
I have also created a [launchpad team](https://launchpad.net/~cloud-provider-openstack) and a [snap store snap](https://dashboard.snapcraft.io/snaps/client-keystone-auth/) for this. The team owns the [launchpad project](https://launchpad.net/cloud-provider-openstack) which watches the github repo and builds snaps automagically. I will finish setting this up once the snapcraft.yaml is in the repo. Another option is to bail on the launchpad builders and use travis to build the snap, which you can read about [here](https://docs.snapcraft.io/build-snaps/ci-integration). The launchpad builders will release the snap to the edge channel only. It is up to something(travis?) to validate those snaps and release them to the stable channel.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added snap support for the client-keystone-auth binary
```
