### PR TITLE
Pulling docker for the build

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -12,11 +12,9 @@ parts:
   client-keystone-auth:
     source: .
     plugin: go
+    go-packages:
+      - k8s.io/cloud-provider-openstack/cmd/client-keystone-auth
     go-importpath: k8s.io/cloud-provider-openstack
-    override-build: |
-      docker run -i -v "$PWD":/go/src/k8s.io/cloud-provider-openstack:z \
-        -w /go/src/k8s.io/cloud-provider-openstack \
-        golang:1.10 make build
 
 apps:
   client-keystone-auth:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixing the snap build process. The launchpad builders didn't like using docker, so I switched it out to just build directly.