### PR TITLE
First pass at adding templates for keystone auth

### DIFF
--- a/examples/webhook/keystone-apiserver-webhook.yaml
+++ b/examples/webhook/keystone-apiserver-webhook.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Config
+preferences: {}
+clusters:
+  - cluster:
+      insecure-skip-tls-verify: true
+      server: https://{{ keystone-auth-service-ip }}:8443/webhook
+    name: webhook
+users:
+  - name: webhook
+contexts:
+  - context:
+      cluster: webhook
+      user: webhook
+    name: webhook
+current-context: webhook

--- a/examples/webhook/keystone-apiserver-webhook.yaml
+++ b/examples/webhook/keystone-apiserver-webhook.yaml
@@ -4,7 +4,7 @@ preferences: {}
 clusters:
   - cluster:
       insecure-skip-tls-verify: true
-      server: https://{{ keystone-auth-service-ip }}:8443/webhook
+      server: https://{{ keystone_auth_service_ip }}:8443/webhook
     name: webhook
 users:
   - name: webhook

--- a/examples/webhook/keystone-auth-certs-secret.yaml
+++ b/examples/webhook/keystone-auth-certs-secret.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: kube-system
 type: Opaque
 data:
-  cert-file: {{ cert-file }}
-  key-file: {{ key-file }}
+  cert-file: {{ keystone_cert_file }}
+  key-file: {{ keystone_key_file }}

--- a/examples/webhook/keystone-auth-certs-secret.yaml
+++ b/examples/webhook/keystone-auth-certs-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keystone-auth-certs
+  namespace: kube-system
+type: Opaque
+data:
+  cert-file: {{ cert-file }}
+  key-file: {{ key-file }}

--- a/examples/webhook/keystone-deployment.yaml
+++ b/examples/webhook/keystone-deployment.yaml
@@ -28,7 +28,7 @@ spec:
             - --policy-configmap-name
             - k8s-auth-policy
             - --keystone-url
-            - {{ keystone-server-url }}
+            - {{ keystone_server_url }}
           volumeMounts:
             - mountPath: /etc/kubernetes/pki
               name: k8s-certs

--- a/examples/webhook/keystone-deployment.yaml
+++ b/examples/webhook/keystone-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8s-keystone-auth
+  namespace: kube-system
+  labels:
+    app: k8s-keystone-auth
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: k8s-keystone-auth
+  template:
+    metadata:
+      labels:
+        app: k8s-keystone-auth
+    spec:
+      serviceAccountName: k8s-keystone
+      containers:
+        - name: k8s-keystone-auth
+          image: k8scloudprovider/k8s-keystone-auth:latest
+          args:
+            - ./bin/k8s-keystone-auth
+            - --tls-cert-file
+            - /etc/kubernetes/pki/cert-file
+            - --tls-private-key-file
+            - /etc/kubernetes/pki/key-file
+            - --policy-configmap-name
+            - k8s-auth-policy
+            - --keystone-url
+            - {{ keystone-server-url }}
+          volumeMounts:
+            - mountPath: /etc/kubernetes/pki
+              name: k8s-certs
+              readOnly: true
+          ports:
+            - containerPort: 8443
+      volumes:
+      - name: k8s-certs
+        secret:
+          secretName: keystone-auth-certs

--- a/examples/webhook/keystone-policy-configmap.yaml
+++ b/examples/webhook/keystone-policy-configmap.yaml
@@ -1,0 +1,39 @@
+# This file lays out the policies of the cluster. It is only used
+# if using Keystone for authorization. Note the difference between
+# authentication and authorization.
+
+# This configmap allows the users in the project 'demo' that have
+# the 'k8s-viewer' role in Keystone to query the pod information
+# from all the namespaces. The configmap is in the kube-system
+# namespace due to the k8s-keystone-auth service existing in
+# the kube-system namespace.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-auth-policy
+  namespace: kube-system
+  labels:
+    k8s-app: k8s-keystone-auth
+data:
+  policies: |
+    [
+      {
+        "resource": {
+          "verbs": ["get", "list", "watch"],
+          "resources": ["pods"],
+          "version": "*",
+          "namespace": "default"
+        },
+        "match": [
+          {
+            "type": "role",
+            "values": ["k8s-viewer"]
+          },
+          {
+            "type": "project",
+            "values": ["demo"]
+          }
+        ]
+      }
+    ]

--- a/examples/webhook/keystone-rbac.yaml
+++ b/examples/webhook/keystone-rbac.yaml
@@ -1,0 +1,36 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    k8s-app: k8s-keystone-auth
+  name: k8s-keystone-auth
+  namespace: kube-system
+rules:
+  # Allow k8s-keystone-auth to get k8s-auth-policy configmap
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["k8s-auth-policy"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8s-keystone-auth
+  namespace: kube-system
+  labels:
+    k8s-app: k8s-keystone-auth
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8s-keystone-auth
+subjects:
+- kind: ServiceAccount
+  name: k8s-keystone
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8s-keystone
+  namespace: kube-system
+

--- a/examples/webhook/keystone-service.yaml
+++ b/examples/webhook/keystone-service.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: k8s-keystone-auth-service
+  namespace: kube-system
+spec:
+  selector:
+    app: k8s-keystone-auth
+  ports:
+    - protocol: TCP
+      port: 8443
+      targetPort: 8443


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding templates from the documentation(with some rbac changes). This makes it easier for people to deploy by cloning the repo.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/kubernetes/cloud-provider-openstack/issues/271
**Special notes for your reviewer**:
RBAC changes to create a new service account specifically for keystone auth. Not sure where the tests are or if you want to use these templates in those tests.
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added keystone auth templates to examples/webhook.
```
