### PR TITLE
Correct the typos in error messages

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -368,7 +368,7 @@ func waitLoadbalancerActiveProvisioningStatus(client *gophercloud.ServiceClient,
 	})
 
 	if err == wait.ErrWaitTimeout {
-		err = fmt.Errorf("loadbalancer failed to go into ACTIVE provisioning status within alloted time")
+		err = fmt.Errorf("loadbalancer failed to go into ACTIVE provisioning status within allotted time")
 	}
 	return provisioningStatus, err
 }
@@ -391,7 +391,7 @@ func waitLoadbalancerDeleted(client *gophercloud.ServiceClient, loadbalancerID s
 	})
 
 	if err == wait.ErrWaitTimeout {
-		err = fmt.Errorf("loadbalancer failed to delete within the alloted time")
+		err = fmt.Errorf("loadbalancer failed to delete within the allotted time")
 	}
 
 	return err


### PR DESCRIPTION
Fix a typo in message,
Line 371&394:  alloted->allotted
