### PR TITLE
[WIP] Barbican as Key Manager Service for Kubernetes

### DIFF
--- a/cmd/barbican-kms/main.go
+++ b/cmd/barbican-kms/main.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cloud-provider-openstack/pkg/kms/barbican/server"
+)
+
+var (
+	socketpath  string
+	cloudconfig string
+)
+
+func init() {
+	flag.Set("logtostderr", "true")
+}
+
+func main() {
+
+	flag.CommandLine.Parse([]string{})
+
+	cmd := &cobra.Command{
+		Use:   "openstack-key-manager",
+		Short: "Openstack Key Manager Service",
+		Run: func(cmd *cobra.Command, args []string) {
+			handle()
+		},
+	}
+
+	cmd.Flags().AddGoFlagSet(flag.CommandLine)
+
+	cmd.PersistentFlags().StringVar(&socketpath, "socketpath", "", "OpenStack KMS Plugin unix socket endpoint")
+
+	cmd.PersistentFlags().StringVar(&cloudconfig, "cloud-config", "", "OpenStack KMS Plugin cloud config")
+	cmd.MarkPersistentFlagRequired("cloud-config")
+
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s", err.Error())
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}
+
+func handle() {
+	server.Run(cloudconfig, socketpath)
+}

--- a/examples/barbican-kms/encryption-config.yaml
+++ b/examples/barbican-kms/encryption-config.yaml
@@ -1,0 +1,11 @@
+kind: EncryptionConfig
+apiVersion: v1
+resources:
+  - resources:
+    - secrets
+    providers:
+    - identity: {}
+    - kms:
+        name : barbican
+        endpoint: unix:///tmp/socketfile.sock
+        cachesize: 100

--- a/pkg/kms/barbican/barbican.go
+++ b/pkg/kms/barbican/barbican.go
@@ -1,0 +1,107 @@
+package barbican
+
+import (
+	"encoding/base64"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/keymanager/v1/secrets"
+)
+
+func (cfg Config) toAuthOptions() gophercloud.AuthOptions {
+	return gophercloud.AuthOptions{
+		IdentityEndpoint: cfg.Global.AuthURL,
+		Username:         cfg.Global.Username,
+		UserID:           cfg.Global.UserID,
+		Password:         cfg.Global.Password,
+		TenantID:         cfg.Global.TenantID,
+		TenantName:       cfg.Global.TenantName,
+		DomainID:         cfg.Global.DomainID,
+		DomainName:       cfg.Global.DomainName,
+
+		// Persistent service, so we need to be able to renew tokens.
+		AllowReauth: true,
+	}
+}
+
+//Config to read config options
+type Config struct {
+	Global struct {
+		AuthURL    string `gcfg:"auth-url"`
+		Username   string
+		UserID     string `gcfg:"user-id"`
+		Password   string
+		TenantID   string `gcfg:"tenant-id"`
+		TenantName string `gcfg:"tenant-name"`
+		DomainID   string `gcfg:"domain-id"`
+		DomainName string `gcfg:"domain-name"`
+		Region     string
+	}
+}
+
+// Barbican is gophercloud service client
+type Barbican struct {
+	Client *gophercloud.ServiceClient
+}
+
+// NewBarbicanClient creates new BarbicanClient
+func NewBarbicanClient(cfg *Config) (*Barbican, error) {
+
+	provider, err := openstack.AuthenticatedClient(cfg.toAuthOptions())
+
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := openstack.NewKeyManagerV1(provider, gophercloud.EndpointOpts{
+		Region: cfg.Global.Region,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &Barbican{Client: client}, nil
+}
+
+// CreateSecret creates a secret from payload
+func (client *Barbican) CreateSecret(data []byte) ([]byte, error) {
+
+	//TODO:add prefix with name or data
+	encode := base64.StdEncoding.EncodeToString(data)
+
+	opts := secrets.CreateOpts{
+		Payload:                encode,
+		PayloadContentType:     "application/octet-stream",
+		SecretType:             "symmetric",
+		PayloadContentEncoding: "base64",
+	}
+
+	// we are storing data encryption key id from barbican
+	// we will store encrypted dek, once the bp gets implemented
+	response, err := secrets.Create(client.Client, opts).Extract()
+	if err != nil {
+		return nil, err
+	}
+
+	href := response.SecretRef
+	id := strings.Split(href, "/")
+
+	return []byte(id[5]), nil
+}
+
+// GetSecret gets unencrypted secret
+func (client *Barbican) GetSecret(data []byte) ([]byte, error) {
+
+	opts := secrets.GetPayloadOpts{
+		PayloadContentType: "application/octet-stream",
+	}
+
+	plain, err := secrets.GetPayload(client.Client, string(data), opts).Extract()
+	if err != nil {
+		return nil, err
+	}
+
+	return plain, nil
+}

--- a/pkg/kms/barbican/client/client.go
+++ b/pkg/kms/barbican/client/client.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	pb "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1"
+	"os"
+)
+
+//This client is for test purpose only, Kubernetes api server will call to kms plugin grpc server
+
+func main() {
+
+	connection, err := grpc.Dial("unix:///tmp/socketfile.sock", grpc.WithInsecure())
+	defer connection.Close()
+	if err != nil {
+		fmt.Printf("\nConnection to KMS plugin failed, error: %v", err)
+	}
+
+	kmsClient := pb.NewKeyManagementServiceClient(connection)
+	request := &pb.VersionRequest{Version: "v1beta1"}
+	_, err = kmsClient.Version(context.TODO(), request)
+
+	if err != nil {
+		fmt.Printf("\nError in getting version from KMS Plugin: %v", err)
+	}
+
+	secretBytes := []byte("mypassword")
+
+	//Encryption Request to KMS Plugin
+	encRequest := &pb.EncryptRequest{
+		Version: "v1beta1",
+		Plain:   secretBytes}
+	encResponse, err := kmsClient.Encrypt(context.TODO(), encRequest)
+
+	if err != nil {
+		fmt.Printf("\nEncrypt Request Failed: %v", err)
+		os.Exit(1)
+	}
+
+	cipher := string(encResponse.Cipher)
+	fmt.Println("cipher:", cipher)
+
+	//Decryption Request to KMS plugin
+	decRequest := &pb.DecryptRequest{
+		Version: "v1beta1",
+		Cipher:  encResponse.Cipher,
+	}
+
+	decResponse, err := kmsClient.Decrypt(context.TODO(), decRequest)
+
+	fmt.Printf("\n\ndecryption response %v", decResponse)
+}

--- a/pkg/kms/barbican/server/kmsserver.go
+++ b/pkg/kms/barbican/server/kmsserver.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"net"
+	"os"
+	"syscall"
+
+	"github.com/golang/glog"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	gcfg "gopkg.in/gcfg.v1"
+	pb "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1"
+	"k8s.io/cloud-provider-openstack/pkg/kms/barbican"
+)
+
+const (
+	// Unix Domain Socket
+	netProtocol    = "unix"
+	version        = "v1beta1"
+	runtimename    = "barbican"
+	runtimeversion = "0.0.1"
+)
+
+type server struct{}
+
+var cfg barbican.Config
+
+func initConfig(configFilePath string) error {
+
+	config, err := os.Open(configFilePath)
+	defer config.Close()
+	if err != nil {
+		glog.V(3).Infof("Failed to open OpenStack configuration file: %v", err)
+		return err
+	}
+
+	err = gcfg.FatalOnly(gcfg.ReadInto(&cfg, config))
+
+	if err != nil {
+		glog.V(3).Infof("Failed to read OpenStack configuration file: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+// Run Grpc server for barbican KMS
+func Run(configFilePath string, socketpath string) {
+
+	glog.Infof("Barbican KMS Plugin Starting Version: %s, RunTimeVersion: %s", version, runtimeversion)
+
+	if err := initConfig(configFilePath); err != nil {
+		glog.V(4).Infof("Error in Getting Config File: %v", err)
+	}
+
+	// unlink the unix socket
+	if err := syscall.Unlink(socketpath); err != nil {
+		glog.V(4).Infof("Error to unlink unix socket: %v", err)
+	}
+
+	listener, err := net.Listen(netProtocol, socketpath)
+	if err != nil {
+		glog.Fatalf("Failed to Listen: %v", err)
+	}
+
+	s := grpc.NewServer()
+	pb.RegisterKeyManagementServiceServer(s, &server{})
+
+	if err := s.Serve(listener); err != nil {
+		glog.Fatalf("failed to serve: %v", err)
+	}
+}
+
+func (s *server) Version(ctx context.Context, req *pb.VersionRequest) (*pb.VersionResponse, error) {
+
+	glog.V(4).Infof("Version Information Requested by Kubernetes api server")
+
+	res := &pb.VersionResponse{
+		Version:        version,
+		RuntimeName:    runtimename,
+		RuntimeVersion: runtimeversion,
+	}
+
+	return res, nil
+}
+
+func (s *server) Decrypt(ctx context.Context, req *pb.DecryptRequest) (*pb.DecryptResponse, error) {
+
+	glog.V(4).Infof("Decrypt Request by Kubernetes api server")
+
+	barbicanClient, err := barbican.NewBarbicanClient(&cfg)
+	if err != nil {
+		glog.V(4).Infof("Failed to get Barbican client %v: ", err)
+		return nil, err
+	}
+
+	plain, err := barbicanClient.GetSecret(req.Cipher)
+	if err != nil {
+		glog.V(4).Infof("Failed to get secret %v: ", err)
+		return nil, err
+	}
+
+	return &pb.DecryptResponse{Plain: plain}, nil
+}
+
+func (s *server) Encrypt(ctx context.Context, req *pb.EncryptRequest) (*pb.EncryptResponse, error) {
+
+	glog.V(4).Infof("Encrypt Request by Kubernetes api server")
+
+	barbicanClient, err := barbican.NewBarbicanClient(&cfg)
+	if err != nil {
+		glog.V(4).Infof("Failed to get Barbican client %v: ", err)
+		return nil, err
+	}
+
+	cipher, err := barbicanClient.CreateSecret(req.Plain)
+	if err != nil {
+		glog.V(4).Infof("Failed to create secret %v: ", err)
+		return nil, err
+	}
+
+	return &pb.EncryptResponse{Cipher: cipher}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds Feature to use Barbican as Key manager service for kubernetes

**Which issue this PR fixes**: 
fixes #44 

**Special notes for your reviewer**:
This Plugin cannot be used in production until[1] in barbican gets implemented.
As per Kubernetes documents[2], we need to return encrypted dek to kubernetes, It stores encrypted dek in etcd, only kek is stored in Key Manager Service. OpenStack Barbican currently does not support to return encrypted secret, It only returns secret id. This Plugin returns the secret id to Kubernetes rather than encrypted secret. It results in problem of storing encrypted data at two different locations and since there is no notification from kuberenetes about secret deletion, user has to manually delete secrets stored in barbican. Once feature[1] gets implemented barbican needs to store only single kek and encrypted secret will be stored in kubernetes etcd only.
[1] https://review.openstack.org/#/c/598389/
[2] https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
`NONE`.

