### PR TITLE
Avoid ERROR: logging before flag.Parse in UT

### DIFF
--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cinder
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi/v0"
@@ -30,6 +31,9 @@ var fakeCs *controllerServer
 // Init Controller Server
 func init() {
 	if fakeCs == nil {
+		// to avoid annoying ERROR: logging before flag.Parse
+		flag.Parse()
+
 		d := NewDriver(fakeNodeID, fakeEndpoint, fakeConfig)
 		fakeCs = NewControllerServer(d)
 	}

--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cinder
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi/v0"
@@ -30,6 +31,9 @@ var fakeNs *nodeServer
 // Init Node Server
 func init() {
 	if fakeNs == nil {
+		// to avoid annoying ERROR: logging before flag.Parse
+		flag.Parse()
+
 		d := NewDriver(fakeNodeID, fakeEndpoint, fakeConfig)
 		fakeNs = NewNodeServer(d)
 	}


### PR DESCRIPTION
Try to avoid those error in UT output:

ok      k8s.io/cloud-provider-openstack/pkg/cloudprovider/providers/openstack   (cached)
ERROR: logging before flag.Parse: I0920 15:25:14.382972   31350 driver.go:49] Driver: csi-cinderplugin version: 0.3.0
ERROR: logging before flag.Parse: I0920 15:25:14.383122   31350 driver.go:80] Enabling controller service capability: CREATE_DELETE_VOLUME
ERROR: logging before flag.Parse: I0920 15:25:14.383135   31350 driver.go:80] Enabling controller service capability: PUBLISH_UNPUBLISH_VOLUME
ERROR: logging before flag.Parse: I0920 15:25:14.383147   31350 driver.go:92] Enabling volume access mode: SINGLE_NODE_WRITER
ERROR: logging before flag.Parse: I0920 15:25:14.383161   31350 driver.go:49] Driver: csi-cinderplugin version: 0.3.0
ERROR: logging before flag.Parse: I0920 15:25:14.383170   31350 driver.go:80] Enabling controller service capability: CREATE_DELETE_VOLUME
ERROR: logging before flag.Parse: I0920 15:25:14.383192   31350 driver.go:80] Enabling controller service capability: PUBLISH_UNPUBLISH_VOLUME
ERROR: logging before flag.Parse: I0920 15:25:14.383202   31350 driver.go:92] Enabling volume access mode: SINGLE_NODE_WRITER

