### PR TITLE
Adds url to log new bug in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ We'd love to accept your patches! Before we can accept them you need to sign Clo
 Refer [getting started](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/getting-started-provider-dev.md)  document to setup development environment
 
 ### Reporting an issue
-If you find a bug or a feature request related to cloud-provider-openstack you can create a new github issue in this repo.
+If you find a bug or a feature request related to cloud-provider-openstack you can create a new github issue in this repo @[kubernetes/cloud-provider-openstack](https://github.com/kubernetes/cloud-provider-openstack/issues).
 
 ### Contributing a Patch
 1. Submit an issue describing your proposed change to the repo.


### PR DESCRIPTION
This commit adds URL for logging new issues related to
cloud-provider-openstack.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds URL for logging new issue in this repository.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
None.
**Special notes for your reviewer**:
None.
**Release note**:
None
