### PR TITLE
Set e2e to master until cpo 1.12 branch/tag is cut

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -45,4 +45,4 @@
             branches: release-1.11
         - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.12:
             #TODO: change branch to release-1.12 when we have it
-            branches: release-1.11
+            branches: master


### PR DESCRIPTION
Signed-off-by: Melvin Hillsman <mrhillsman@gmail.com>

**What this PR does / why we need it**:
Update periodic job runs to use master branch since there is not a 1.12 branch/tag yet. Currently the 1.12 conformance does not run due to branch 1.11 being used.

@dims 
