### PR TITLE
Fix up formatting for go 1.11.1

### DIFF
--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -84,7 +84,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 			return nil, err
 		}
 
-		glog.V(4).Infof("Create volume %s in Availability Zone: %s of size %s GiB", resID, resAvailability, resSize)
+		glog.V(4).Infof("Create volume %s in Availability Zone: %s of size %d GiB", resID, resAvailability, resSize)
 
 	}
 

--- a/pkg/identity/keystone/sync.go
+++ b/pkg/identity/keystone/sync.go
@@ -148,7 +148,7 @@ func (s *Syncer) syncData(u *userInfo) error {
 
 	for _, p := range s.syncConfig.ProjectBlackList {
 		if u.Extra["alpha.kubernetes.io/identity/project/id"][0] == p {
-			glog.Infof("Project %v is in black list. Skipping.")
+			glog.Infof("Project %v is in black list. Skipping.", p)
 			return nil
 		}
 	}

--- a/pkg/volume/cinder/cinder_test.go
+++ b/pkg/volume/cinder/cinder_test.go
@@ -195,7 +195,7 @@ func TestPlugin(t *testing.T) {
 
 	// Test Provisioner
 	options := volume.VolumeOptions{
-		PVC: volumetest.CreateTestPVC("100Mi", []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}),
+		PVC:                           volumetest.CreateTestPVC("100Mi", []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}),
 		PersistentVolumeReclaimPolicy: v1.PersistentVolumeReclaimDelete,
 	}
 	provisioner, err := plug.(*cinderPlugin).newProvisionerInternal(options, &fakePDManager{0})


### PR DESCRIPTION
build harness etc have moved to newer go version. We need to switch as well