### PR TITLE
Export some methods in anticipation of a standalone cinder provider

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1578,6 +1578,7 @@
     "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/intstr",
     "k8s.io/apimachinery/pkg/util/net",
     "k8s.io/apimachinery/pkg/util/rand",
     "k8s.io/apimachinery/pkg/util/runtime",

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -173,14 +173,14 @@ type Config struct {
 }
 
 func init() {
-	registerMetrics()
+	RegisterMetrics()
 
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
-		cfg, err := readConfig(config)
+		cfg, err := ReadConfig(config)
 		if err != nil {
 			return nil, err
 		}
-		return newOpenStack(cfg)
+		return NewOpenStack(cfg)
 	})
 }
 
@@ -256,7 +256,7 @@ func configFromEnv() (cfg Config, ok bool) {
 	return
 }
 
-func readConfig(config io.Reader) (Config, error) {
+func ReadConfig(config io.Reader) (Config, error) {
 	if config == nil {
 		return Config{}, fmt.Errorf("no OpenStack cloud provider config file given")
 	}
@@ -330,7 +330,7 @@ func checkOpenStackOpts(openstackOpts *OpenStack) error {
 	return checkMetadataSearchOrder(openstackOpts.metadataOpts.SearchOrder)
 }
 
-func newOpenStack(cfg Config) (*OpenStack, error) {
+func NewOpenStack(cfg Config) (*OpenStack, error) {
 	provider, err := openstack.NewClient(cfg.Global.AuthURL)
 	if err != nil {
 		return nil, err

--- a/pkg/cloudprovider/providers/openstack/openstack_metrics.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_metrics.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package openstack
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 const (
 	openstackSubsystem         = "openstack"
@@ -44,7 +47,11 @@ var (
 	)
 )
 
-func registerMetrics() {
-	prometheus.MustRegister(openstackOperationsLatency)
-	prometheus.MustRegister(openstackAPIRequestErrors)
+func RegisterMetrics() {
+	if err := prometheus.Register(openstackOperationsLatency); err != nil {
+		glog.V(5).Infof("unable to register for latency metrics")
+	}
+	if err := prometheus.Register(openstackAPIRequestErrors); err != nil {
+		glog.V(5).Infof("unable to register for error metrics")
+	}
 }

--- a/pkg/cloudprovider/providers/openstack/openstack_routes_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_routes_test.go
@@ -35,7 +35,7 @@ func TestRoutes(t *testing.T) {
 		t.Skipf("No config found in environment")
 	}
 
-	os, err := newOpenStack(cfg)
+	os, err := NewOpenStack(cfg)
 	if err != nil {
 		t.Fatalf("Failed to construct/authenticate OpenStack: %s", err)
 	}

--- a/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -83,7 +83,7 @@ func WaitForVolumeStatus(t *testing.T, os *OpenStack, volumeName string, status 
 }
 
 func TestReadConfig(t *testing.T) {
-	_, err := readConfig(nil)
+	_, err := ReadConfig(nil)
 	if err == nil {
 		t.Errorf("Should fail when no config is provided: %s", err)
 	}
@@ -99,7 +99,7 @@ func TestReadConfig(t *testing.T) {
 	os.Setenv("OS_TENANT_NAME", "admin")
 	defer os.Unsetenv("OS_TENANT_NAME")
 
-	cfg, err := readConfig(strings.NewReader(`
+	cfg, err := ReadConfig(strings.NewReader(`
  [Global]
  auth-url = http://auth.url
  user-id = user
@@ -613,7 +613,7 @@ func TestNewOpenStack(t *testing.T) {
 		t.Skip("No config found in environment")
 	}
 
-	_, err := newOpenStack(cfg)
+	_, err := NewOpenStack(cfg)
 	if err != nil {
 		t.Fatalf("Failed to construct/authenticate OpenStack: %s", err)
 	}
@@ -631,7 +631,7 @@ func TestLoadBalancer(t *testing.T) {
 		t.Logf("Trying LBVersion = '%s'\n", v)
 		cfg.LoadBalancer.LBVersion = v
 
-		os, err := newOpenStack(cfg)
+		os, err := NewOpenStack(cfg)
 		if err != nil {
 			t.Fatalf("Failed to construct/authenticate OpenStack: %s", err)
 		}
@@ -689,7 +689,7 @@ func TestVolumes(t *testing.T) {
 		t.Skip("No config found in environment")
 	}
 
-	os, err := newOpenStack(cfg)
+	os, err := NewOpenStack(cfg)
 	if err != nil {
 		t.Fatalf("Failed to construct/authenticate OpenStack: %s", err)
 	}


### PR DESCRIPTION
We seem to have a longer runway for removing the cinder in-tree volume
provider. These changes will help us experiment with vendoring code from
cloud-provider-openstack back into kubernetes/kubernetes.

Change-Id: Ie49fe43ebc8b68295bbeb3a192a948dfbe6cd975

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
