### PR TITLE
Add volume list functions

### DIFF
--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -210,3 +210,30 @@ func TestControllerUnpublishVolume(t *testing.T) {
 	// Assert
 	assert.Equal(expectedRes, actualRes)
 }
+
+func TestListVolumes(t *testing.T) {
+
+	// mock OpenStack
+	osmock := new(openstack.OpenStackMock)
+
+	osmock.On("ListVolumes").Return(nil)
+
+	openstack.OsInstance = osmock
+
+	// Init assert
+	assert := assert.New(t)
+
+	fakeReq := &csi.ListVolumesRequest{}
+
+	// Expected Result
+	expectedRes := &csi.ListVolumesResponse{}
+
+	// Invoke ListVolumes
+	actualRes, err := fakeCs.ListVolumes(fakeCtx, fakeReq)
+	if err != nil {
+		t.Errorf("failed to ListVolumes: %v", err)
+	}
+
+	// Assert
+	assert.Equal(expectedRes, actualRes)
+}

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -30,6 +30,7 @@ type IOpenStack interface {
 	CreateVolume(name string, size int, vtype, availability string, tags *map[string]string) (string, string, int, error)
 	DeleteVolume(volumeID string) error
 	AttachVolume(instanceID, volumeID string) (string, error)
+	ListVolumes() ([]Volume, error)
 	WaitDiskAttached(instanceID string, volumeID string) error
 	DetachVolume(instanceID, volumeID string) error
 	WaitDiskDetached(instanceID string, volumeID string) error

--- a/pkg/csi/cinder/openstack/openstack_mock.go
+++ b/pkg/csi/cinder/openstack/openstack_mock.go
@@ -259,3 +259,18 @@ func (_m *OpenStackMock) DeleteSnapshot(snapID string) error {
 
 	return r0
 }
+
+// ListVolumes provides a mock function without param
+func (_m *OpenStackMock) ListVolumes() ([]Volume, error) {
+	ret := _m.Called()
+	var vlist []Volume
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return vlist, r0
+}

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -80,6 +80,33 @@ func (os *OpenStack) CreateVolume(name string, size int, vtype, availability str
 	return vol.ID, vol.AvailabilityZone, vol.Size, nil
 }
 
+// ListVolumes list all the volumes
+func (os *OpenStack) ListVolumes() ([]Volume, error) {
+
+	var vlist []Volume
+	opts := volumes.ListOpts{}
+	pages, err := volumes.List(os.blockstorage, opts).AllPages()
+	if err != nil {
+		return vlist, err
+	}
+	vols, err := volumes.ExtractVolumes(pages)
+	if err != nil {
+		return vlist, err
+	}
+
+	for _, v := range vols {
+		volume := Volume{
+			ID:     v.ID,
+			Name:   v.Name,
+			Status: v.Status,
+			AZ:     v.AvailabilityZone,
+			Size:   v.Size,
+		}
+		vlist = append(vlist, volume)
+	}
+	return vlist, nil
+}
+
 // GetVolumesByName is a wrapper around ListVolumes that creates a Name filter to act as a GetByName
 // Returns a list of Volume references with the specified name
 func (os *OpenStack) GetVolumesByName(n string) ([]Volume, error) {


### PR DESCRIPTION
previously volume list will show something like:
not implemented

now it will have

$ csc controller list-volumes  --endpoint tcp://127.0.0.1:10000
"05477623-0355-4229-80d0-dd695f40d748"  2147483648
"c0a0c1da-c4aa-49e0-8900-f67dbfb01dfd"  1073741824




