### PR TITLE
[Ingress] Do not recreate octavia resources when the controller restarts

### DIFF
--- a/pkg/ingress/cmd/root.go
+++ b/pkg/ingress/cmd/root.go
@@ -33,6 +33,7 @@ import (
 
 var (
 	cfgFile string
+	isDebug bool
 	conf    config.Config
 )
 
@@ -64,11 +65,15 @@ func Execute() {
 
 func init() {
 	log.SetOutput(os.Stdout)
-	log.SetLevel(log.DebugLevel)
 
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.ingress_openstack.yaml)")
+	rootCmd.PersistentFlags().BoolVar(&isDebug, "debug", false, "Print more detailed information.")
+
+	if isDebug {
+		log.SetLevel(log.DebugLevel)
+	}
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/pkg/ingress/controller/openstack/neutron.go
+++ b/pkg/ingress/controller/openstack/neutron.go
@@ -63,7 +63,8 @@ func (os *OpenStack) EnsureFloatingIP(portID string, floatingIPNetwork string) (
 		if err != ErrNotFound {
 			return "", fmt.Errorf("error getting floating ip for port %s: %v", portID, err)
 		}
-		log.WithFields(log.Fields{"portID": portID}).Info("creating floating ip for port")
+
+		log.WithFields(log.Fields{"portID": portID}).Debug("creating floating ip for port")
 
 		floatIPOpts := floatingips.CreateOpts{
 			FloatingNetworkID: floatingIPNetwork,
@@ -87,7 +88,10 @@ func (os *OpenStack) DeleteFloatingIP(portID string) error {
 		if err != ErrNotFound {
 			return fmt.Errorf("error getting floating ip for port %s: %v", portID, err)
 		}
-		log.WithFields(log.Fields{"portID": portID}).Info("floating ip not exists")
+
+		log.WithFields(log.Fields{"portID": portID}).Debug("floating ip not exists")
+
+		return nil
 	}
 
 	err = floatingips.Delete(os.neutron, fip.ID).ExtractErr()
@@ -96,5 +100,6 @@ func (os *OpenStack) DeleteFloatingIP(portID string) error {
 	}
 
 	log.WithFields(log.Fields{"floatingip": fip.FloatingIP}).Info("floating ip deleted")
+
 	return nil
 }

--- a/pkg/ingress/controller/utils.go
+++ b/pkg/ingress/controller/utils.go
@@ -34,41 +34,6 @@ func getResourceName(ing *ext_v1beta1.Ingress, suffix string) string {
 	return name
 }
 
-func loadBalancerStatusDeepCopy(lb *apiv1.LoadBalancerStatus) *apiv1.LoadBalancerStatus {
-	c := &apiv1.LoadBalancerStatus{}
-	c.Ingress = make([]apiv1.LoadBalancerIngress, len(lb.Ingress))
-	for i := range lb.Ingress {
-		c.Ingress[i] = lb.Ingress[i]
-	}
-	return c
-}
-
-func loadBalancerStatusEqual(l, r *apiv1.LoadBalancerStatus) bool {
-	return ingressSliceEqual(l.Ingress, r.Ingress)
-}
-
-func ingressSliceEqual(lhs, rhs []apiv1.LoadBalancerIngress) bool {
-	if len(lhs) != len(rhs) {
-		return false
-	}
-	for i := range lhs {
-		if !ingressEqual(&lhs[i], &rhs[i]) {
-			return false
-		}
-	}
-	return true
-}
-
-func ingressEqual(lhs, rhs *apiv1.LoadBalancerIngress) bool {
-	if lhs.IP != rhs.IP {
-		return false
-	}
-	if lhs.Hostname != rhs.Hostname {
-		return false
-	}
-	return true
-}
-
 func nodeNames(nodes []*apiv1.Node) []string {
 	ret := make([]string, len(nodes))
 	for i, node := range nodes {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
If the ingress resource doesn't change, nothing needs to do when the
ingress controller restarts. In order to do that we need to store
the ingress resource version information in the load balancer's
description field.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #311

**Special notes for your reviewer**:
With this PR, when the ingress controller restarts, for existing ingress that not changed, you can see the log below:
```
INFO[0000] ingress created or updated, will create or update octavia resources  ingress=default/test-octavia-ingress
DEBU[0000] loadbalancer exists                           name=k8s-default-test-octavia-ingress-lb
INFO[0000] loadbalancer active                           id=d15108bd-1f4a-49d5-8e8a-5c5fb80720d9 name=k8s-default-test-octavia-ingress-lb
INFO[0000] ingress not change                            ingress=test-octavia-ingress
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
The octavia ingress controller stores the ingress ResourceVersion in the description field of the load balancer in Octavia in order to avoid any change unnecessarily.
```
