### PR TITLE
[Ingress] Add cluster name in the config

### DIFF
--- a/pkg/ingress/cmd/root.go
+++ b/pkg/ingress/cmd/root.go
@@ -106,4 +106,7 @@ func initConfig() {
 	if err := viper.Unmarshal(&conf); err != nil {
 		log.WithFields(log.Fields{"error": err}).Fatal("Unable to decode the configuration")
 	}
+	if conf.ClusterName == "" {
+		log.Fatal("clusterName configuration is required")
+	}
 }

--- a/pkg/ingress/config/config.go
+++ b/pkg/ingress/config/config.go
@@ -22,9 +22,10 @@ import (
 
 // Config struct contains ingress controller configuration
 type Config struct {
-	Kubernetes kubeConfig    `mapstructure:"kubernetes"`
-	OpenStack  osConfig      `mapstructure:"openstack"`
-	Octavia    octaviaConfig `mapstructure:"octavia"`
+	ClusterName string
+	Kubernetes  kubeConfig    `mapstructure:"kubernetes"`
+	OpenStack   osConfig      `mapstructure:"openstack"`
+	Octavia     octaviaConfig `mapstructure:"octavia"`
 }
 
 // Configuration for connecting to Kubernetes API server, either api_host or kubeconfig should be configured.

--- a/pkg/ingress/controller/openstack/client.go
+++ b/pkg/ingress/controller/openstack/client.go
@@ -93,7 +93,7 @@ func NewOpenStack(cfg config.Config) (*OpenStack, error) {
 		config:  cfg,
 	}
 
-	log.Info("openstack client initialized")
+	log.Debug("openstack client initialized")
 
 	return &os, nil
 }

--- a/pkg/ingress/controller/utils.go
+++ b/pkg/ingress/controller/utils.go
@@ -22,16 +22,14 @@ import (
 	"sort"
 
 	apiv1 "k8s.io/api/core/v1"
-	ext_v1beta1 "k8s.io/api/extensions/v1beta1"
 )
 
 func hash(data string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(data)))
 }
 
-func getResourceName(ing *ext_v1beta1.Ingress, suffix string) string {
-	name := fmt.Sprintf("k8s-%s-%s-%s", ing.ObjectMeta.Namespace, ing.ObjectMeta.Name, suffix)
-	return name
+func getResourceName(namespace, name, clusterName string) string {
+	return fmt.Sprintf("k8s_%s_%s_%s", clusterName, namespace, name)
 }
 
 func nodeNames(nodes []*apiv1.Node) []string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adding cluster name in the octavia-ingress-conroller config file.

The cluster name is used for differentiate octavia resources created
for different k8s clusters of different tenants.

**Which issue this PR fixes**:
fixes #324

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
