### PR TITLE
Get NodeID from Metadata Service as fallback

### DIFF
--- a/pkg/csi/cinder/openstack/openstack_metadata.go
+++ b/pkg/csi/cinder/openstack/openstack_metadata.go
@@ -1,0 +1,50 @@
+package openstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+const (
+	defaultMetadataVersion = "2012-08-10"
+	metadataURLTemplate    = "http://169.254.169.254/openstack/%s/meta_data.json"
+)
+
+type metadata struct {
+	UUID string
+}
+
+func getMetadata(metadataURL string) ([]byte, error) {
+	resp, err := http.Get(metadataURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, err
+	}
+
+	md, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return md, nil
+}
+
+// GetInstanceID from metadata service
+func GetInstanceID() (string, error) {
+	metadataURL := fmt.Sprintf(metadataURLTemplate, defaultMetadataVersion)
+	md, err := getMetadata(metadataURL)
+	if err != nil {
+		return "", err
+	}
+	var m metadata
+	err = json.Unmarshal(md, &m)
+	if err != nil {
+		return "", err
+	}
+
+	return m.UUID, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Currently cinder csi plugin gets nodeID from cloud-init mounted data, but the plugin fails if the instance image does not have cloud-init or data is at some other location, This commit adds to get the data from metadata service as a fallback option.

**Which issue this PR fixes** : fixes #325 

**Special notes for your reviewer**:
As of now separate code is written in cinder-csi-plugin to get metadata from openstack metadata service, In future we should import some common functionality from provider/openstack 

**Release note**:
`NONE`
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
