### PR TITLE
fix GetLabelsForVolume to handle only Cinder volumes

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -718,6 +718,11 @@ func (os *OpenStack) ShouldTrustDevicePath() bool {
 
 // GetLabelsForVolume implements PVLabeler.GetLabelsForVolume
 func (os *OpenStack) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVolume) (map[string]string, error) {
+	// Ignore if not Cinder.
+	if pv.Spec.Cinder == nil {
+		return nil, nil
+	}
+
 	// Ignore any volumes that are being provisioned
 	if pv.Spec.Cinder.VolumeID == k8s_volume.ProvisionedVolumeName {
 		return nil, nil


### PR DESCRIPTION
**What this PR does / why we need it**: 
When the `openstack-cloud-controller-manager` is running with PV label initializing controller
and NFS volume is created, it causes nill reference error.

**Which issue this PR fixes** 
`OpenStack` version of kubernetes/kubernetes#68996

**Special notes for your reviewer**:
This is a cherry-pick of kubernetes/kubernetes#70459

**Release note**:
```release-note
NONE
```
