### PR TITLE
Add support for reading clouds.yaml

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -329,6 +329,14 @@
   revision = "04bc8f551ef2b34dad9d1d26634aa7a4d565f11f"
 
 [[projects]]
+  branch = "master"
+  digest = "1:df12b635fdefd90b1d139a70c45716896552051589b004021c745dcbaf0dad96"
+  name = "github.com/gophercloud/utils"
+  packages = ["openstack/clientconfig"]
+  pruneopts = "UT"
+  revision = "34f5991525d116b3832e0d9409492274f1c06bda"
+
+[[projects]]
   digest = "1:c79fb010be38a59d657c48c6ba1d003a8aa651fa56b579d959d74573b7dff8e1"
   name = "github.com/gorilla/context"
   packages = ["."]
@@ -1516,6 +1524,7 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
+
   input-imports = [
     "github.com/container-storage-interface/spec/lib/go/csi/v0",
     "github.com/golang/glog",
@@ -1555,6 +1564,7 @@
     "github.com/gophercloud/gophercloud/pagination",
     "github.com/gophercloud/gophercloud/testhelper",
     "github.com/gophercloud/gophercloud/testhelper/client",
+    "github.com/gophercloud/utils/openstack/clientconfig",
     "github.com/gorilla/mux",
     "github.com/kubernetes-csi/drivers/pkg/csi-common",
     "github.com/kubernetes-incubator/external-storage/lib/controller",

--- a/docs/provider-configuration.md
+++ b/docs/provider-configuration.md
@@ -5,22 +5,24 @@ to the OpenStack Cloud Provider.
 
 ## Contents
 
-* [Supported Services](#supported-services)
-* [Cloud Configuration File](#cloud-configuration-file)
-  * [Sample Configuration](#sample-configuration)
-  * [Configuration Options](#configuration-options)
-    * [Global](#global)
-      * [Global Required Parameters](#global-required-parameters)
-      * [Global Optional Parameters](#global-optional-parameters)
-    * [Block Storage](#block-storage)
-      * [Block Storage Optional Parameters](#block-storage-optional-parameters)
-      * [Block Storage Notes](#block-storage-notes)
-    * [Load Balancer](#load-balancer)
-      * [Load Balancer Optional Parameters](#load-balancer-optional-parameters)
-    * [Metadata](#metadata)
-      * [Metadata Optional Parameters](#metadata-optional-parameters)
-    * [Router](#router)
-      * [Router Optional Parameters](#router-optional-parameters)
+- [OpenStack Cloud Provider Configuration Options](#openstack-cloud-provider-configuration-options)
+  - [Contents](#contents)
+  - [Supported Services](#supported-services)
+  - [Cloud Configuration File](#cloud-configuration-file)
+    - [Sample configuration](#sample-configuration)
+    - [Configuration Options](#configuration-options)
+      - [Global](#global)
+        - [Global Required Parameters](#global-required-parameters)
+        - [Global Optional Parameters](#global-optional-parameters)
+      - [Load Balancer](#load-balancer)
+        - [Load Balancer Optional Parameters](#load-balancer-optional-parameters)
+      - [Block Storage](#block-storage)
+        - [Block Storage Optional Parameters](#block-storage-optional-parameters)
+        - [Block Storage Notes](#block-storage-notes)
+      - [Metadata](#metadata)
+        - [Metadata Optional Parameters](#metadata-optional-parameters)
+      - [Router](#router)
+        - [Router Optional Parameters](#router-optional-parameters)
 
 ## Supported Services
 
@@ -123,6 +125,12 @@ file.
   delegate roles to another user (the trustee), and optionally allow the trustee
   to impersonate the trustor. Available trusts are found under the
   `/v3/OS-TRUST/trusts` endpoint of the Keystone API.
+* `UseClouds`: Set this flag to `true` to get authorization credentials from a clouds.yaml file. Options manually set in the `[Global]` section of cloud.conf will be prioritized over values read from clouds.yaml. The recommended usage is to set the option `CloudsFile` with the path to your clouds.yaml file. However, by default a clouds.yaml file will be looked for in the following locations, in order, if it is not set:
+    1. A file path stored in the environment variable `OS_CLIENT_CONFIG_FILE`
+    2. The directory `pkg/cloudprovider/providers/openstack/`
+    3. The directory `~/.config/openstack`
+    4. The directory `/etc/openstack`
+* `CloudsFile`: Used to specify the path to a clouds.yaml file that you want read authorization data from
 
 
 ####  Load Balancer

--- a/pkg/flexvolume/cinder_client_test.go
+++ b/pkg/flexvolume/cinder_client_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package flexvolume
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadFlexVolumeConfig(t *testing.T) {
+
+	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	if err != nil {
+		t.Error(err)
+	}
+
+	cfgFile := dir + "/test_config"
+	_ = os.Remove(cfgFile)
+
+	var config = `
+ [Global]
+ auth-url = http://auth.url
+ password = mypass
+ user-id = user
+ tenant-name = demo
+ region = RegionOne
+ [RBD]
+ keyring = mykeyring`
+	data := []byte(config)
+	err = ioutil.WriteFile(cfgFile, data, 0644)
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.Remove(cfgFile)
+
+	cfg, err := readConfig(cfgFile)
+	if err != nil {
+		t.Fatalf("Should succeed when a valid config is provided: %s", err)
+	}
+	if cfg.Global.AuthURL != "http://auth.url" {
+		t.Errorf("incorrect IdentityEndpoint: %s", cfg.Global.AuthURL)
+	}
+
+	if cfg.Global.UserID != "user" {
+		t.Errorf("incorrect userid: %s", cfg.Global.UserID)
+	}
+
+	if cfg.Global.Password != "mypass" {
+		t.Errorf("incorrect password: %s", cfg.Global.Password)
+	}
+
+	// config file wins over environment variable
+	if cfg.Global.TenantName != "demo" {
+		t.Errorf("incorrect tenant name: %s", cfg.Global.TenantName)
+	}
+
+	if cfg.Global.Region != "RegionOne" {
+		t.Errorf("incorrect region: %s", cfg.Global.Region)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:  enables use of clouds.yaml in place of environment variables

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: Fixes: https://github.com/kubernetes/cloud-provider-openstack/issues/323



**Special notes for your reviewer**: First pr in this repo :1st_place_medal: 

@flaper87 
