### PR TITLE
Add size into output

### DIFF
--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -73,6 +73,9 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	if len(volumes) == 1 {
 		resID = volumes[0].ID
 		resAvailability = volumes[0].AZ
+		resSize = volumes[0].Size
+
+		glog.V(4).Infof("Volume %s already exists in Availability Zone: %s of size %d GiB", resID, resAvailability, resSize)
 	} else if len(volumes) > 1 {
 		glog.V(3).Infof("found multiple existing volumes with selected name (%s) during create", volName)
 		return nil, errors.New("multiple volumes reported by Cinder with same name")

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -127,6 +127,7 @@ func (os *OpenStack) GetVolumesByName(n string) ([]Volume, error) {
 			ID:     v.ID,
 			Name:   v.Name,
 			Status: v.Status,
+			Size:   v.Size,
 			AZ:     v.AvailabilityZone,
 		}
 		vlist = append(vlist, volume)


### PR DESCRIPTION
when create a volume with name already there,
we don't give the size of the volume in output and lack of log.


**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Fix bug #361 
**Special notes for your reviewer**:

**Release note**:

```release-note
create volume with same name will get the actual size other than 0 now
```
