### PR TITLE
Fix CSI CI (Update CSI Sidecar versions)

### DIFF
--- a/manifests/cinder-csi-plugin/csi-attacher-cinderplugin.yaml
+++ b/manifests/cinder-csi-plugin/csi-attacher-cinderplugin.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccount: csi-attacher
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:canary
+          image: quay.io/k8scsi/csi-attacher:v0.4.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/manifests/cinder-csi-plugin/csi-nodeplugin-cinderplugin.yaml
+++ b/manifests/cinder-csi-plugin/csi-nodeplugin-cinderplugin.yaml
@@ -18,7 +18,7 @@ spec:
       hostNetwork: true
       containers:
         - name: driver-registrar
-          image: quay.io/k8scsi/driver-registrar:canary
+          image: quay.io/k8scsi/driver-registrar:v0.4.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/manifests/cinder-csi-plugin/csi-provisioner-cinderplugin.yaml
+++ b/manifests/cinder-csi-plugin/csi-provisioner-cinderplugin.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccount: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:canary
+          image: quay.io/k8scsi/csi-provisioner:v0.4.1
           args:
             - "--provisioner=csi-cinderplugin"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Cinder CSI is breaking with sidecar containers update to CSIv1.0.0
Using older version until cinder driver updated to 1.0.0

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
`NONE`
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
