### PR TITLE
Move loadbalancer annotations to the service

### DIFF
--- a/examples/loadbalancers/external-http-nginx.yaml
+++ b/examples/loadbalancers/external-http-nginx.yaml
@@ -3,9 +3,6 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: external-http-nginx-deployment
-  annotations:
-    service.beta.kubernetes.io/openstack-internal-load-balancer: "false"
-    loadbalancer.openstack.org/floating-network-id: "9be23551-38e2-4d27-b5ea-ea2ea1321bd6"
 spec:
   replicas: 2
   template:
@@ -23,6 +20,9 @@ kind: Service
 apiVersion: v1
 metadata:
   name: external-http-nginx-service
+  annotations:
+    service.beta.kubernetes.io/openstack-internal-load-balancer: "false"
+    loadbalancer.openstack.org/floating-network-id: "9be23551-38e2-4d27-b5ea-ea2ea1321bd6"
 spec:
   selector:
     app: nginx

--- a/examples/loadbalancers/internal-http-nginx.yaml
+++ b/examples/loadbalancers/internal-http-nginx.yaml
@@ -3,8 +3,6 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: internal-http-nginx-deployment
-  annotations:
-    service.beta.kubernetes.io/openstack-internal-load-balancer: "true"
 spec:
   replicas: 2
   template:
@@ -22,6 +20,8 @@ kind: Service
 apiVersion: v1
 metadata:
   name: internal-http-nginx-service
+  annotations:
+    service.beta.kubernetes.io/openstack-internal-load-balancer: "true"
 spec:
   selector:
     app: nginx


### PR DESCRIPTION
For the loadbalancer annotations to have any effect, they need to be in
the service definition not in the deployment.

**What this PR does / why we need it**:

It moves the loadbalancer annotations in the loadbalancers examples to the right resource. These annotations hint to the provider if the loadbalancer should grab a floating IP for the loadbalancer or if its meant to remain internal.

**Which issue this PR fixes**:
 fixes #375 