### PR TITLE
Add a member number check

### DIFF
--- a/pkg/ingress/controller/openstack/octavia.go
+++ b/pkg/ingress/controller/openstack/octavia.go
@@ -492,6 +492,11 @@ func (os *OpenStack) EnsurePoolMembers(deleted bool, poolName string, lbID strin
 		}
 		members = append(members, member)
 	}
+	// only allow >= 1 members or it will lead to openstack octavia issue
+	if len(members) == 0 {
+		return nil, fmt.Errorf("error because no members in pool: %s", pool.ID)
+	}
+
 	if err := pools.BatchUpdateMembers(os.octavia, pool.ID, members).ExtractErr(); err != nil {
 		return nil, fmt.Errorf("error batch updating members for pool %s: %v", pool.ID, err)
 	}


### PR DESCRIPTION
No members to be updated and calling openstack API will leads to
update error, instead of provide internal error to end user
we can provide more helpful info here.

Closes: #378


**What this PR does / why we need it**:
enhancing log output when no node existing and creating a LB
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #378 
**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
