### PR TITLE
Enhance event of ingress

### DIFF
--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -432,27 +432,27 @@ func (c *Controller) processItem(event Event) error {
 		if err := c.ensureIngress(ing); err != nil {
 			utilruntime.HandleError(fmt.Errorf("failed to create openstack resources for ingress %s: %v", key, err))
 			c.recorder.Event(ing, apiv1.EventTypeWarning, "Failed", fmt.Sprintf("Failed to create openstack resources for ingress %s: %v", key, err))
+		} else {
+			c.recorder.Event(ing, apiv1.EventTypeNormal, "Created", fmt.Sprintf("Ingress %s", key))
 		}
-
-		c.recorder.Event(ing, apiv1.EventTypeNormal, "Created", fmt.Sprintf("Ingress %s", key))
 	case UpdateEvent:
 		log.WithFields(log.Fields{"ingress": key}).Info("ingress updated, will update openstack resources")
 
 		if err := c.ensureIngress(ing); err != nil {
 			utilruntime.HandleError(fmt.Errorf("failed to update openstack resources for ingress %s: %v", key, err))
 			c.recorder.Event(ing, apiv1.EventTypeWarning, "Failed", fmt.Sprintf("Failed to update openstack resources for ingress %s: %v", key, err))
+		} else {
+			c.recorder.Event(ing, apiv1.EventTypeNormal, "Updated", fmt.Sprintf("Ingress %s", key))
 		}
-
-		c.recorder.Event(ing, apiv1.EventTypeNormal, "Updated", fmt.Sprintf("Ingress %s", key))
 	case DeleteEvent:
 		log.WithFields(log.Fields{"ingress": key}).Info("ingress has been deleted, will delete openstack resources")
 
 		if err := c.deleteIngress(ing.Namespace, ing.Name); err != nil {
 			utilruntime.HandleError(fmt.Errorf("failed to delete openstack resources for ingress %s: %v", key, err))
 			c.recorder.Event(ing, apiv1.EventTypeWarning, "Failed", fmt.Sprintf("Failed to delete openstack resources for ingress %s: %v", key, err))
+		} else {
+			c.recorder.Event(ing, apiv1.EventTypeNormal, "Deleted", fmt.Sprintf("Ingress %s", key))
 		}
-
-		c.recorder.Event(ing, apiv1.EventTypeNormal, "Deleted", fmt.Sprintf("Ingress %s", key))
 	}
 
 	return nil


### PR DESCRIPTION
when failed to update, still get a 'updated' event
28s         Normal    Updating   Ingress   Ingress default/test-ingress1
28s         Warning   Failed     Ingress   Failed to update openstack.....
28s         Normal    Updated    Ingress   Ingress default/test-ingress1

**What this PR does / why we need it**:
avoid incorrect event generation

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
minor changes
**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
