### PR TITLE
manila-provisioner: added mounter option for csi-cephfs backend

### DIFF
--- a/docs/using-manila-provisioner.md
+++ b/docs/using-manila-provisioner.md
@@ -39,6 +39,7 @@ None.
 Key | For backend | For protocol  | Required | Default Value | Description
 --- | ----------- | ------------- | ------------- | ----------- |---------
 `csi-driver` | `csi-cephfs` | `CEPHFS` | Yes | None | Name of the CSI driver
+`mounter` | `csi-cephfs` | `CEPHFS` | No | `fuse` | Mounter to use in. Available options are `fuse` and `kernel`. Please consult the [csi-cephfs docs](https://github.com/ceph/ceph-csi/blob/master/docs/deploy-cephfs.md#configuration) for more info
 `nfs-share-client` | `nfs` | `NFS` | No | `0.0.0.0` | Default NFS client for the share
 
 ## Authentication with Manila v2 client

--- a/pkg/share/manila/sharebackends/csicephfs.go
+++ b/pkg/share/manila/sharebackends/csicephfs.go
@@ -17,6 +17,8 @@ limitations under the License.
 package sharebackends
 
 import (
+	"fmt"
+
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
 	"k8s.io/api/core/v1"
 )
@@ -36,6 +38,10 @@ func (CSICephFS) BuildSource(args *BuildSourceArgs) (*v1.PersistentVolumeSource,
 		return nil, err
 	}
 
+	if args.Options.CSICEPHFSmounter != "fuse" && args.Options.CSICEPHFSmounter != "kernel" {
+		return nil, fmt.Errorf("unrecognized mounter option '%s'", args.Options.CSICEPHFSmounter)
+	}
+
 	return &v1.PersistentVolumeSource{
 		CSI: &v1.CSIPersistentVolumeSource{
 			Driver:       args.Options.CSICEPHFSdriver,
@@ -44,7 +50,7 @@ func (CSICephFS) BuildSource(args *BuildSourceArgs) (*v1.PersistentVolumeSource,
 			VolumeAttributes: map[string]string{
 				"monitors":        monitors,
 				"rootPath":        rootPath,
-				"mounter":         "fuse",
+				"mounter":         args.Options.CSICEPHFSmounter,
 				"provisionVolume": "false",
 			},
 			NodeStageSecretRef: &args.Options.ShareSecretRef,

--- a/pkg/share/manila/sharebackends/sharebackend_test.go
+++ b/pkg/share/manila/sharebackends/sharebackend_test.go
@@ -72,6 +72,7 @@ func TestCSICephFSBuildSource(t *testing.T) {
 	}
 
 	args.Options.CSICEPHFSdriver = "csi-cephfs"
+	args.Options.CSICEPHFSmounter = "fuse"
 	args.Options.OSSecretNamespace = "default"
 
 	source, err := b.BuildSource(&args)

--- a/pkg/share/manila/sharebackends/sharebackend_test.go
+++ b/pkg/share/manila/sharebackends/sharebackend_test.go
@@ -71,38 +71,43 @@ func TestCSICephFSBuildSource(t *testing.T) {
 		},
 	}
 
-	args.Options.CSICEPHFSdriver = "csi-cephfs"
-	args.Options.CSICEPHFSmounter = "fuse"
-	args.Options.OSSecretNamespace = "default"
+	testBuild := func(mounter string) {
+		args.Options.CSICEPHFSdriver = "csi-cephfs"
+		args.Options.CSICEPHFSmounter = mounter
+		args.Options.OSSecretNamespace = "default"
 
-	source, err := b.BuildSource(&args)
+		source, err := b.BuildSource(&args)
 
-	if err != nil {
-		t.Errorf("failed to build PV source: %v	", err)
-	}
+		if err != nil {
+			t.Errorf("failed to build PV source: %v	", err)
+		}
 
-	expected := v1.PersistentVolumeSource{
-		CSI: &v1.CSIPersistentVolumeSource{
-			Driver:       "csi-cephfs",
-			VolumeHandle: args.Options.ShareName,
-			VolumeAttributes: map[string]string{
-				"monitors":        "192.168.2.1:6789,192.168.2.2:6789",
-				"rootPath":        "/shares/011d21e2-fbc3-4e4a-9993-9ea223f73264",
-				"mounter":         "fuse",
-				"provisionVolume": "false",
+		expected := v1.PersistentVolumeSource{
+			CSI: &v1.CSIPersistentVolumeSource{
+				Driver:       "csi-cephfs",
+				VolumeHandle: args.Options.ShareName,
+				VolumeAttributes: map[string]string{
+					"monitors":        "192.168.2.1:6789,192.168.2.2:6789",
+					"rootPath":        "/shares/011d21e2-fbc3-4e4a-9993-9ea223f73264",
+					"mounter":         mounter,
+					"provisionVolume": "false",
+				},
+				NodeStageSecretRef: &v1.SecretReference{
+					Name:      "manila-011d21e2-fbc3-4e4a-9993-9ea223f73264",
+					Namespace: "default",
+				},
 			},
-			NodeStageSecretRef: &v1.SecretReference{
-				Name:      "manila-011d21e2-fbc3-4e4a-9993-9ea223f73264",
-				Namespace: "default",
-			},
-		},
+		}
+
+		eq := reflect.DeepEqual(source, &expected)
+
+		if !eq {
+			t.Errorf("unexpected PV source contents: got %+v, expected %+v", source, &expected)
+		}
 	}
 
-	eq := reflect.DeepEqual(source, &expected)
-
-	if !eq {
-		t.Errorf("unexpected PV source contents: got %+v, expected %+v", source, &expected)
-	}
+	testBuild("fuse")
+	testBuild("kernel")
 }
 
 func TestCSICephFSGrantAccess(t *testing.T) {

--- a/pkg/share/manila/shareoptions/backend.go
+++ b/pkg/share/manila/shareoptions/backend.go
@@ -18,7 +18,10 @@ package shareoptions
 
 // BackendOptions contains backend-specific options
 type BackendOptions struct {
-	CSICEPHFSdriver string `name:"csi-driver" backend:"csi-cephfs" protocol:"CEPHFS"`
-	NFSShareClient  string `name:"nfs-share-client" backend:"nfs" protocol:"NFS" value:"default=0.0.0.0"`
+	CSICEPHFSdriver  string `name:"csi-driver" backend:"csi-cephfs" protocol:"CEPHFS"`
+	CSICEPHFSmounter string `name:"mounter" backend:"csi-cephfs" protocol:"CEPHFS" value:"default=fuse"`
+
+	NFSShareClient string `name:"nfs-share-client" backend:"nfs" protocol:"NFS" value:"default=0.0.0.0"`
+
 	// Add more backend options here
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a new StorageClass param for the csi-cephfs backend, users can now choose whether to use the Ceph kernel client or Ceph FUSE driver for mounting.

```release-note
Manila provisioner recognizes a new StorageClass option to specify mount tool for csi-cephfs backend
```
