### PR TITLE
add a check when the volume detach failed,

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -279,7 +279,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:560d4d5c6f31baa5c79d6921a8cbf6056a0e89da5c7bb6558ca6d1b5c640d268"
+  digest = "1:84f4a50111aeb906b336f15cee8837bbabe7c39c378af9bf529c95b15c361cff"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -292,6 +292,7 @@
     "openstack/blockstorage/v3/volumes",
     "openstack/common/extensions",
     "openstack/compute/v2/extensions/attachinterfaces",
+    "openstack/compute/v2/extensions/availabilityzones",
     "openstack/compute/v2/extensions/volumeattach",
     "openstack/compute/v2/flavors",
     "openstack/compute/v2/images",
@@ -1528,6 +1529,7 @@
     "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots",
     "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes",
     "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces",
+    "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones",
     "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach",
     "github.com/gophercloud/gophercloud/openstack/compute/v2/servers",
     "github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/trusts",

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -17,6 +17,7 @@ limitations under the License.
 package openstack
 
 import (
+	"net/http"
 	"os"
 
 	"github.com/gophercloud/gophercloud"
@@ -75,6 +76,20 @@ func (cfg Config) toAuthOptions() gophercloud.AuthOptions {
 		// Persistent service, so we need to be able to renew tokens.
 		AllowReauth: true,
 	}
+}
+
+func isNotFound(err error) bool {
+	if _, ok := err.(gophercloud.ErrDefault404); ok {
+		return true
+	}
+
+	if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
+		if errCode.Actual == http.StatusNotFound {
+			return true
+		}
+	}
+
+	return false
 }
 
 func GetConfigFromFile(configFilePath string) (gophercloud.AuthOptions, gophercloud.EndpointOpts, error) {

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -207,7 +207,9 @@ func (os *OpenStack) WaitDiskAttached(instanceID string, volumeID string) error 
 
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
 		attached, err := os.diskIsAttached(instanceID, volumeID)
-		if err != nil {
+		if err != nil && !isNotFound(err) {
+			// if this is a race condition indicate the volume is deleted
+			// during sleep phase, ignore the error and return attach=false
 			return false, err
 		}
 		return attached, nil


### PR DESCRIPTION
add a check when the volume detach failed, if it's a volume
not found, ignore the error and return false

**What this PR does / why we need it**:
Fix bug 381, add a check for the volume not found error for a race
**Which issue this PR fixes** 
fixes #381 
**Special notes for your reviewer**:

**Release note**:

```release-note
None
```
