### PR TITLE
Fix part of bug 372, try to use metadata to retrieve data first

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -287,6 +287,13 @@ func (c *caller) call(f func()) {
 }
 
 func readInstanceID(searchOrder string) (string, error) {
+	// First, try to get data from metadata service because local
+	// data might be changed by accident
+	md, err := getMetadata(searchOrder)
+	if err == nil {
+		return md.UUID, nil
+	}
+
 	// Try to find instance ID on the local filesystem (created by cloud-init)
 	const instanceIDFile = "/var/lib/cloud/data/instance-id"
 	idBytes, err := ioutil.ReadFile(instanceIDFile)
@@ -297,15 +304,9 @@ func readInstanceID(searchOrder string) (string, error) {
 		if instanceID != "" && instanceID != "iid-datasource-none" {
 			return instanceID, nil
 		}
-		// Fall through to metadata server lookup
 	}
 
-	md, err := getMetadata(searchOrder)
-	if err != nil {
-		return "", err
-	}
-
-	return md.UUID, nil
+	return "", err
 }
 
 // check opts for OpenStack


### PR DESCRIPTION
first, let's try use metadata to retrieve data then use cloud-init data
after all, the data in metadata/config drive won't be changed but
it's likely the data in cloud-init generated might be changed.




**What this PR does / why we need it**:
use metadata/config drive first then cloud-init generated data

**Which issue this PR fixes** *
fixes #372 
**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
