### PR TITLE
enhance ccm configuration file

### DIFF
--- a/manifests/controller-manager/kubeadm.conf
+++ b/manifests/controller-manager/kubeadm.conf
@@ -1,10 +1,12 @@
 kind: MasterConfiguration
 apiVersion: kubeadm.k8s.io/v1alpha2
 kubernetesVersion: 1.12.3
-unifiedControlPlaneImage: "gcr.io/google_containers/hyperkube-amd64:v1.9.1"
+unifiedControlPlaneImage: "gcr.io/google_containers/hyperkube-amd64:v1.12.3"
 cloudProvider: external
 apiServerExtraArgs:
   enable-admission-plugins: NodeRestriction,Initializers
   runtime-config: admissionregistration.k8s.io/v1alpha1
 controllerManagerExtraArgs:
   external-cloud-volume-plugin: openstack
+networking:
+  podSubnet: 192.168.0.0/24


### PR DESCRIPTION
to make the version consistent
to make the network settings by default



**What this PR does / why we need it**:
to make ccm create have network settings by default
to make sample use consistent version to kubeadm

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

```release-note
None
```
