### PR TITLE
Remove dependency from csi-common

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -450,14 +450,6 @@
   version = "v1.0.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:c486ed8ec89f0702d16043caada5a9ad0be2f639ca33621665d2614582d32154"
-  name = "github.com/kubernetes-csi/drivers"
-  packages = ["pkg/csi-common"]
-  pruneopts = "UT"
-  revision = "a38ee8520f16657511de3d1063ddbe06aeeee4c6"
-
-[[projects]]
   digest = "1:49926b919c58842fe6ec1e1f3fd46e32071e1f96c7187fb4c38bb85be6c78389"
   name = "github.com/kubernetes-incubator/external-storage"
   packages = [
@@ -1526,10 +1518,8 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-
   input-imports = [
     "github.com/container-storage-interface/spec/lib/go/csi/v0",
-    "github.com/golang/glog",
     "github.com/gophercloud/gophercloud",
     "github.com/gophercloud/gophercloud/openstack",
     "github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions",
@@ -1569,7 +1559,6 @@
     "github.com/gophercloud/gophercloud/testhelper/client",
     "github.com/gophercloud/utils/openstack/clientconfig",
     "github.com/gorilla/mux",
-    "github.com/kubernetes-csi/drivers/pkg/csi-common",
     "github.com/kubernetes-incubator/external-storage/lib/controller",
     "github.com/mitchellh/go-homedir",
     "github.com/mitchellh/mapstructure",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,10 +42,6 @@
   version = "1.6.2"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/kubernetes-csi/drivers"
-
-[[constraint]]
   name = "github.com/kubernetes-incubator/external-storage"
   version = "v5.3.0-alpha.1"
 

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -22,16 +22,17 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi/v0"
 	ossnapshots "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
-	csicommon "github.com/kubernetes-csi/drivers/pkg/csi-common"
 	"github.com/pborman/uuid"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack"
 	"k8s.io/klog"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 )
 
 type controllerServer struct {
-	*csicommon.DefaultControllerServer
+	Driver *CinderDriver
 }
 
 func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
@@ -327,4 +328,22 @@ func (cs *controllerServer) ListSnapshots(ctx context.Context, req *csi.ListSnap
 		Entries: ventries,
 	}, nil
 
+}
+
+// ControllerGetCapabilities implements the default GRPC callout.
+// Default supports all capabilities
+func (cs *controllerServer) ControllerGetCapabilities(ctx context.Context, req *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
+	klog.V(5).Infof("Using default ControllerGetCapabilities")
+
+	return &csi.ControllerGetCapabilitiesResponse{
+		Capabilities: cs.Driver.cscap,
+	}, nil
+}
+
+func (cs *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
+func (cs *controllerServer) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
 }

--- a/pkg/csi/cinder/driver.go
+++ b/pkg/csi/cinder/driver.go
@@ -17,25 +17,14 @@ limitations under the License.
 package cinder
 
 import (
+	"fmt"
+
 	"github.com/container-storage-interface/spec/lib/go/csi/v0"
-	"k8s.io/klog"
-
-	"github.com/kubernetes-csi/drivers/pkg/csi-common"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack"
+	"k8s.io/klog"
 )
-
-type driver struct {
-	csiDriver   *csicommon.CSIDriver
-	endpoint    string
-	cloudconfig string
-
-	ids *csicommon.DefaultIdentityServer
-	cs  *controllerServer
-	ns  *nodeServer
-
-	cap   []*csi.VolumeCapability_AccessMode
-	cscap []*csi.ControllerServiceCapability
-}
 
 const (
 	driverName = "cinder.csi.openstack.org"
@@ -45,16 +34,33 @@ var (
 	version = "0.3.0"
 )
 
-func NewDriver(nodeID, endpoint string, cloudconfig string) *driver {
+type CinderDriver struct {
+	name        string
+	nodeID      string
+	version     string
+	endpoint    string
+	cloudconfig string
+
+	ids *identityServer
+	cs  *controllerServer
+	ns  *nodeServer
+
+	vcap  []*csi.VolumeCapability_AccessMode
+	cscap []*csi.ControllerServiceCapability
+	nscap []*csi.NodeServiceCapability
+}
+
+func NewDriver(nodeID, endpoint string, cloudconfig string) *CinderDriver {
 	klog.Infof("Driver: %v version: %v", driverName, version)
 
-	d := &driver{}
-
+	d := &CinderDriver{}
+	d.name = driverName
+	d.nodeID = nodeID
+	d.version = version
 	d.endpoint = endpoint
 	d.cloudconfig = cloudconfig
 
-	csiDriver := csicommon.NewCSIDriver(driverName, version, nodeID)
-	csiDriver.AddControllerServiceCapabilities(
+	d.AddControllerServiceCapabilities(
 		[]csi.ControllerServiceCapability_RPC_Type{
 			csi.ControllerServiceCapability_RPC_LIST_VOLUMES,
 			csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
@@ -62,26 +68,54 @@ func NewDriver(nodeID, endpoint string, cloudconfig string) *driver {
 			csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
 			csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS,
 		})
-	csiDriver.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER})
-
-	d.csiDriver = csiDriver
+	d.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER})
 
 	return d
 }
 
-func NewControllerServer(d *driver) *controllerServer {
-	return &controllerServer{
-		DefaultControllerServer: csicommon.NewDefaultControllerServer(d.csiDriver),
+func (d *CinderDriver) AddControllerServiceCapabilities(cl []csi.ControllerServiceCapability_RPC_Type) {
+	var csc []*csi.ControllerServiceCapability
+
+	for _, c := range cl {
+		klog.Infof("Enabling controller service capability: %v", c.String())
+		csc = append(csc, NewControllerServiceCapability(c))
 	}
+
+	d.cscap = csc
+
+	return
 }
 
-func NewNodeServer(d *driver) *nodeServer {
-	return &nodeServer{
-		DefaultNodeServer: csicommon.NewDefaultNodeServer(d.csiDriver),
+func (d *CinderDriver) AddVolumeCapabilityAccessModes(vc []csi.VolumeCapability_AccessMode_Mode) []*csi.VolumeCapability_AccessMode {
+	var vca []*csi.VolumeCapability_AccessMode
+	for _, c := range vc {
+		klog.Infof("Enabling volume access mode: %v", c.String())
+		vca = append(vca, NewVolumeCapabilityAccessMode(c))
 	}
+	d.vcap = vca
+	return vca
 }
 
-func (d *driver) Run() {
+// TODO: Add node caps
+
+func (d *CinderDriver) ValidateControllerServiceRequest(c csi.ControllerServiceCapability_RPC_Type) error {
+	if c == csi.ControllerServiceCapability_RPC_UNKNOWN {
+		return nil
+	}
+
+	for _, cap := range d.cscap {
+		if c == cap.GetRpc().GetType() {
+			return nil
+		}
+	}
+	return status.Error(codes.InvalidArgument, fmt.Sprintf("%s", c))
+}
+
+func (d *CinderDriver) GetVolumeCapabilityAccessModes() []*csi.VolumeCapability_AccessMode {
+	return d.vcap
+}
+
+func (d *CinderDriver) Run() {
 	openstack.InitOpenStackProvider(d.cloudconfig)
-	csicommon.RunControllerandNodePublishServer(d.endpoint, d.csiDriver, NewControllerServer(d), NewNodeServer(d))
+	RunControllerandNodePublishServer(d.endpoint, NewIdentityServer(d), NewControllerServer(d), NewNodeServer(d))
 }

--- a/pkg/csi/cinder/driver_test.go
+++ b/pkg/csi/cinder/driver_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cinder
+
+import (
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	fakeDriverName = "fake"
+)
+
+var (
+	vendorVersion = "0.3.0"
+)
+
+func NewFakeDriver() *CinderDriver {
+
+	driver := NewDriver(fakeNodeID, fakeEndpoint, fakeConfig)
+
+	return driver
+}
+func TestValidateControllerServiceRequest(t *testing.T) {
+	d := NewFakeDriver()
+
+	// Valid requests which require no capabilities
+	err := d.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_UNKNOWN)
+	assert.NoError(t, err)
+
+	// Test controller service publish/unpublish is supported
+	err = d.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME)
+	assert.NoError(t, err)
+
+	// Test controller service create/delete is supported
+	err = d.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME)
+	assert.NoError(t, err)
+
+	// Test controller service list volumes is supported
+	err = d.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_LIST_VOLUMES)
+	assert.NoError(t, err)
+
+	// Test controller service create/delete snapshot is supported
+	err = d.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT)
+	assert.NoError(t, err)
+
+	// Test controller service list snapshot is supported
+	err = d.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS)
+	assert.NoError(t, err)
+}

--- a/pkg/csi/cinder/identityserver.go
+++ b/pkg/csi/cinder/identityserver.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cinder
+
+import (
+	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/klog"
+)
+
+type identityServer struct {
+	Driver *CinderDriver
+}
+
+func (ids *identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
+	klog.V(5).Infof("Using default GetPluginInfo")
+
+	if ids.Driver.name == "" {
+		return nil, status.Error(codes.Unavailable, "Driver name not configured")
+	}
+
+	if ids.Driver.version == "" {
+		return nil, status.Error(codes.Unavailable, "Driver is missing version")
+	}
+
+	return &csi.GetPluginInfoResponse{
+		Name:          ids.Driver.name,
+		VendorVersion: ids.Driver.version,
+	}, nil
+}
+
+func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
+	return &csi.ProbeResponse{}, nil
+}
+
+func (ids *identityServer) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
+	klog.V(5).Infof("Using default capabilities")
+	return &csi.GetPluginCapabilitiesResponse{
+		Capabilities: []*csi.PluginCapability{
+			{
+				Type: &csi.PluginCapability_Service_{
+					Service: &csi.PluginCapability_Service{
+						Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/pkg/csi/cinder/identityserver_test.go
+++ b/pkg/csi/cinder/identityserver_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cinder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPluginInfo(t *testing.T) {
+	d := NewDriver(fakeNodeID, fakeEndpoint, fakeConfig)
+
+	ids := NewIdentityServer(d)
+
+	req := csi.GetPluginInfoRequest{}
+	resp, err := ids.GetPluginInfo(context.Background(), &req)
+	assert.NoError(t, err)
+	assert.Equal(t, resp.GetName(), driverName)
+	assert.Equal(t, resp.GetVendorVersion(), vendorVersion)
+}

--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -23,13 +23,12 @@ import (
 	"google.golang.org/grpc/status"
 	"k8s.io/klog"
 
-	csicommon "github.com/kubernetes-csi/drivers/pkg/csi-common"
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/mount"
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack"
 )
 
 type nodeServer struct {
-	*csicommon.DefaultNodeServer
+	Driver *CinderDriver
 }
 
 func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
@@ -122,14 +121,9 @@ func (ns *nodeServer) NodeGetId(ctx context.Context, req *csi.NodeGetIdRequest) 
 		return nil, err
 	}
 
-	if len(nodeID) > 0 {
-		return &csi.NodeGetIdResponse{
-			NodeId: nodeID,
-		}, nil
-	}
-
-	// Using default function
-	return ns.DefaultNodeServer.NodeGetId(ctx, req)
+	return &csi.NodeGetIdResponse{
+		NodeId: nodeID,
+	}, nil
 }
 
 func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
@@ -139,14 +133,9 @@ func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 		return nil, err
 	}
 
-	if len(nodeID) > 0 {
-		return &csi.NodeGetInfoResponse{
-			NodeId: nodeID,
-		}, nil
-	}
-
-	// Using default function
-	return ns.DefaultNodeServer.NodeGetInfo(ctx, req)
+	return &csi.NodeGetInfoResponse{
+		NodeId: nodeID,
+	}, nil
 }
 
 func (ns *nodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {

--- a/pkg/csi/cinder/server.go
+++ b/pkg/csi/cinder/server.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cinder
+
+import (
+	"net"
+	"os"
+	"sync"
+
+	"google.golang.org/grpc"
+	"k8s.io/klog"
+
+	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+)
+
+// Defines Non blocking GRPC server interfaces
+type NonBlockingGRPCServer interface {
+	// Start services at the endpoint
+	Start(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer)
+	// Waits for the service to stop
+	Wait()
+	// Stops the service gracefully
+	Stop()
+	// Stops the service forcefully
+	ForceStop()
+}
+
+func NewNonBlockingGRPCServer() NonBlockingGRPCServer {
+	return &nonBlockingGRPCServer{}
+}
+
+// NonBlocking server
+type nonBlockingGRPCServer struct {
+	wg     sync.WaitGroup
+	server *grpc.Server
+}
+
+func (s *nonBlockingGRPCServer) Start(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer) {
+
+	s.wg.Add(1)
+
+	go s.serve(endpoint, ids, cs, ns)
+
+	return
+}
+
+func (s *nonBlockingGRPCServer) Wait() {
+	s.wg.Wait()
+}
+
+func (s *nonBlockingGRPCServer) Stop() {
+	s.server.GracefulStop()
+}
+
+func (s *nonBlockingGRPCServer) ForceStop() {
+	s.server.Stop()
+}
+
+func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer) {
+
+	proto, addr, err := ParseEndpoint(endpoint)
+	if err != nil {
+		klog.Fatal(err.Error())
+	}
+
+	if proto == "unix" {
+		addr = "/" + addr
+		if err := os.Remove(addr); err != nil && !os.IsNotExist(err) {
+			klog.Fatalf("Failed to remove %s, error: %s", addr, err.Error())
+		}
+	}
+
+	listener, err := net.Listen(proto, addr)
+	if err != nil {
+		klog.Fatalf("Failed to listen: %v", err)
+	}
+
+	opts := []grpc.ServerOption{
+		grpc.UnaryInterceptor(logGRPC),
+	}
+	server := grpc.NewServer(opts...)
+	s.server = server
+
+	if ids != nil {
+		csi.RegisterIdentityServer(server, ids)
+	}
+	if cs != nil {
+		csi.RegisterControllerServer(server, cs)
+	}
+	if ns != nil {
+		csi.RegisterNodeServer(server, ns)
+	}
+
+	klog.Infof("Listening for connections on address: %#v", listener.Addr())
+
+	server.Serve(listener)
+
+}

--- a/pkg/csi/cinder/utils.go
+++ b/pkg/csi/cinder/utils.go
@@ -1,0 +1,72 @@
+package cinder
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"k8s.io/klog"
+)
+
+func NewControllerServiceCapability(cap csi.ControllerServiceCapability_RPC_Type) *csi.ControllerServiceCapability {
+	return &csi.ControllerServiceCapability{
+		Type: &csi.ControllerServiceCapability_Rpc{
+			Rpc: &csi.ControllerServiceCapability_RPC{
+				Type: cap,
+			},
+		},
+	}
+}
+
+func NewVolumeCapabilityAccessMode(mode csi.VolumeCapability_AccessMode_Mode) *csi.VolumeCapability_AccessMode {
+	return &csi.VolumeCapability_AccessMode{Mode: mode}
+}
+
+func NewControllerServer(d *CinderDriver) *controllerServer {
+	return &controllerServer{
+		Driver: d,
+	}
+}
+
+func NewIdentityServer(d *CinderDriver) *identityServer {
+	return &identityServer{
+		Driver: d,
+	}
+}
+
+func NewNodeServer(d *CinderDriver) *nodeServer {
+	return &nodeServer{
+		Driver: d,
+	}
+}
+
+func RunControllerandNodePublishServer(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer) {
+
+	s := NewNonBlockingGRPCServer()
+	s.Start(endpoint, ids, cs, ns)
+	s.Wait()
+}
+
+func ParseEndpoint(ep string) (string, string, error) {
+	if strings.HasPrefix(strings.ToLower(ep), "unix://") || strings.HasPrefix(strings.ToLower(ep), "tcp://") {
+		s := strings.SplitN(ep, "://", 2)
+		if s[1] != "" {
+			return s[0], s[1], nil
+		}
+	}
+	return "", "", fmt.Errorf("Invalid endpoint: %v", ep)
+}
+
+func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	klog.V(3).Infof("GRPC call: %s", info.FullMethod)
+	klog.V(5).Infof("GRPC request: %+v", req)
+	resp, err := handler(ctx, req)
+	if err != nil {
+		klog.Errorf("GRPC error: %v", err)
+	} else {
+		klog.V(5).Infof("GRPC response: %+v", resp)
+	}
+	return resp, err
+}

--- a/pkg/csi/cinder/utils_test.go
+++ b/pkg/csi/cinder/utils_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cinder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseEndpoint(t *testing.T) {
+
+	//Valid unix domain socket endpoint
+	sockType, addr, err := ParseEndpoint("unix://fake.sock")
+	assert.NoError(t, err)
+	assert.Equal(t, sockType, "unix")
+	assert.Equal(t, addr, "fake.sock")
+
+	sockType, addr, err = ParseEndpoint("unix:///fakedir/fakedir/fake.sock")
+	assert.NoError(t, err)
+	assert.Equal(t, sockType, "unix")
+	assert.Equal(t, addr, "/fakedir/fakedir/fake.sock")
+
+	//Valid unix domain socket with uppercase
+	sockType, addr, err = ParseEndpoint("UNIX://fake.sock")
+	assert.NoError(t, err)
+	assert.Equal(t, sockType, "UNIX")
+	assert.Equal(t, addr, "fake.sock")
+
+	//Valid TCP endpoint with ip
+	sockType, addr, err = ParseEndpoint("tcp://127.0.0.1:80")
+	assert.NoError(t, err)
+	assert.Equal(t, sockType, "tcp")
+	assert.Equal(t, addr, "127.0.0.1:80")
+
+	//Valid TCP endpoint with uppercase
+	sockType, addr, err = ParseEndpoint("TCP://127.0.0.1:80")
+	assert.NoError(t, err)
+	assert.Equal(t, sockType, "TCP")
+	assert.Equal(t, addr, "127.0.0.1:80")
+
+	//Valid TCP endpoint with hostname
+	sockType, addr, err = ParseEndpoint("tcp://fakehost:80")
+	assert.NoError(t, err)
+	assert.Equal(t, sockType, "tcp")
+	assert.Equal(t, addr, "fakehost:80")
+
+	_, _, err = ParseEndpoint("unix:/fake.sock/")
+	assert.NotNil(t, err)
+
+	_, _, err = ParseEndpoint("fake.sock")
+	assert.NotNil(t, err)
+
+	_, _, err = ParseEndpoint("unix://")
+	assert.NotNil(t, err)
+
+	_, _, err = ParseEndpoint("://")
+	assert.NotNil(t, err)
+
+	_, _, err = ParseEndpoint("")
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR removes dependency of cinder csi driver from
https://github.com/kubernetes-csi/drivers/tree/master/pkg/csi-common.
This is necessary to have own identity rpc plugin.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #359
partialfixes: #301 

**Special notes for your reviewer**:

**Release note**:
`NONE`
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
