### PR TITLE
Add support for selecting a specific cloud from clouds.yaml

### DIFF
--- a/docs/provider-configuration.md
+++ b/docs/provider-configuration.md
@@ -131,6 +131,7 @@ file.
     3. The directory `~/.config/openstack`
     4. The directory `/etc/openstack`
 * `CloudsFile`: Used to specify the path to a clouds.yaml file that you want read authorization data from
+* `Cloud`: Used to specify which named cloud in the clouds.yaml file that you want to use
 
 
 ####  Load Balancer

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -172,6 +172,7 @@ type Config struct {
 		CAFile     string `gcfg:"ca-file"`
 		UseClouds  bool   `gcfg:"use-clouds"`
 		CloudsFile string `gcfg:"clouds-file,omitempty"`
+		Cloud      string `gcfg:"cloud,omitempty"`
 	}
 	LoadBalancer LoadBalancerOpts
 	BlockStorage BlockStorageOpts
@@ -306,6 +307,9 @@ func replaceEmpty(a string, b string) string {
 // Allows the cloud-config to have priority
 func ReadClouds(cfg *Config) error {
 	co := new(clientconfig.ClientOpts)
+	if cfg.Global.Cloud != "" {
+		co.Cloud = cfg.Global.Cloud
+	}
 	cloud, err := clientconfig.GetCloudFromYAML(co)
 	if err != nil && err.Error() != "unable to load clouds.yaml: no clouds.yaml file found" {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
clouds.yaml files can contain more than one cloud entry. Allow a user
to configure the named cloud from the file explicitly.
