### PR TITLE
Openstack cloud-config as Kubernetes secret

### DIFF
--- a/docs/using-controller-manager-with-kubeadm.md
+++ b/docs/using-controller-manager-with-kubeadm.md
@@ -52,12 +52,10 @@
 
 - Create a secret containing the cloud configuration for cloud-controller-manager.
 
-   Encode your `$CLOUD_CONFIG` file content using base64: `base64 -w 0 $CLOUD_CONFIG`
-
-   Update `cloud.conf` configuration in `manifests/controller-manager/cloud-config-secret.yaml` file
-by using the result of the above command.
+   Update `cloud.conf` configuration in `manifests/controller-manager/cloud-config-secret.yaml`:
 
     ```shell
+    kubectl create secret -n kube-system generic cloud-config --from-literal=cloud.conf="$(cat $CLOUD_CONFIG)" --dry-run -o yaml > manifests/controller-manager/cloud-config-secret.yaml
     kubectl -f manifests/controller-manager/cloud-config-secret.yaml apply
     ```
 

--- a/docs/using-controller-manager-with-kubeadm.md
+++ b/docs/using-controller-manager-with-kubeadm.md
@@ -52,8 +52,13 @@
 
 - Create a configmap containing the cloud configuration for cloud-controller-manager.
 
+   Encode your `cloud.conf` file content using base64: `base64 -w 0 cloud.conf`
+
+   Update `cloud.conf` configuration in `manifests/controller-manager/cloud-config-secret.yaml` file
+by using the result of the above command.
+
     ```shell
-    kubectl create configmap cloud-config --from-file=/etc/kubernetes/cloud-config -n kube-system
+    kubectl -f manifests/controller-manager/cloud-config-secret.yaml apply
     ```
 
 - Create InitializerConfiguration for the cloud-controller-manager to label persistent volumes, see more details [here](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager)

--- a/docs/using-controller-manager-with-kubeadm.md
+++ b/docs/using-controller-manager-with-kubeadm.md
@@ -50,9 +50,9 @@
 
     Then wait for the controller manager to be restarted and running.
 
-- Create a configmap containing the cloud configuration for cloud-controller-manager.
+- Create a secret containing the cloud configuration for cloud-controller-manager.
 
-   Encode your `cloud.conf` file content using base64: `base64 -w 0 cloud.conf`
+   Encode your `$CLOUD_CONFIG` file content using base64: `base64 -w 0 $CLOUD_CONFIG`
 
    Update `cloud.conf` configuration in `manifests/controller-manager/cloud-config-secret.yaml` file
 by using the result of the above command.

--- a/manifests/controller-manager/cloud-config-secret.yaml
+++ b/manifests/controller-manager/cloud-config-secret.yaml
@@ -1,0 +1,10 @@
+# This YAML file contains secret objects,
+# which are necessary to run the cloud-controller-manager.
+
+kind: Secret
+apiVersion: v1
+metadata:
+  name: cloud-config
+  namespace: kube-system
+data:
+  cloud.conf: W0dsb2JhbF0KdXNlcm5hbWU9dXNlcgpwYXNzd29yZD1wYXNzCmF1dGgtdXJsPWh0dHBzOi8vPGtleXN0b25lX2lwPi9pZGVudGl0eS92Mwp0ZW5hbnQtaWQ9Yzg2OTE2OGE4Mjg4NDdmMzlmN2YwNmVkZDczMDU2MzcKZG9tYWluLWlkPTJhNzNiOGY1OTdjMDQ1NTFhMGZkYzhlOTU1NDRiZThhCg==

--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -74,5 +74,5 @@ spec:
           type: DirectoryOrCreate
         name: ca-certs
       - name: cloud-config-volume
-        configMap:
-          name: cloud-config
+        secret:
+          secretName: cloud-config

--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -40,7 +40,7 @@ spec:
           args:
             - /bin/openstack-cloud-controller-manager
             - --v=1
-            - --cloud-config=/etc/cloud/cloud-config
+            - --cloud-config=$(CLOUD_CONFIG)
             - --cloud-provider=openstack
             - --use-service-account-credentials=true
             - --address=127.0.0.1
@@ -51,7 +51,7 @@ spec:
             - mountPath: /etc/ssl/certs
               name: ca-certs
               readOnly: true
-            - mountPath: /etc/cloud
+            - mountPath: /etc/config
               name: cloud-config-volume
               readOnly: true
             - mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
@@ -59,6 +59,9 @@ spec:
           resources:
             requests:
               cpu: 200m
+          env:
+            - name: CLOUD_CONFIG
+              value: /etc/config/cloud.conf
       hostNetwork: true
       volumes:
       - hostPath:

--- a/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
@@ -15,7 +15,7 @@ spec:
       args:
         - /bin/openstack-cloud-controller-manager
         - --v=1
-        - --cloud-config=/etc/cloud/cloud-config
+        - --cloud-config=$(CLOUD_CONFIG)
         - --cloud-provider=openstack
         - --use-service-account-credentials=true
         - --address=127.0.0.1
@@ -28,12 +28,15 @@ spec:
           readOnly: true
         - mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
           name: flexvolume-dir
-        - mountPath: /etc/cloud
+        - mountPath: /etc/config
           name: cloud-config-volume
           readOnly: true
       resources:
         requests:
           cpu: 200m
+      env:
+        - name: CLOUD_CONFIG
+          value: /etc/config/cloud.conf
   hostNetwork: true
   securityContext:
     runAsUser: 1001

--- a/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
@@ -51,5 +51,5 @@ spec:
       type: DirectoryOrCreate
     name: ca-certs
   - name: cloud-config-volume
-    configMap:
-      name: cloud-config
+    secret:
+      secretName: cloud-config


### PR DESCRIPTION
**What this PR does / why we need it**:

The PR changes the Volume type of the Openstack `cloud-config` used by the Openstack-ccm from `ConfigMap` to `Secret` since the configuration file contains sensible data. I know that secrets are not encrypted but at least they are more restrictive from an RBAC perspective.

**Special notes for your reviewer**:
I already use this "patch" in my repo: https://github.com/johscheuer/kubernetes-on-openstack/blob/master/scripts/master.cfg.tpl#L501

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
action required: The volume type for the `cloud-config` used by the `openstack-cloud-controller-mananager` has changed from `ConfigMap` to `Secret`. Ensure that the `Secret exists if you update your Kubernetes manifest.
```
