### PR TITLE
Add description for the floating ip created for external service

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -279,7 +279,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:84f4a50111aeb906b336f15cee8837bbabe7c39c378af9bf529c95b15c361cff"
+  digest = "1:e2161cf62eb56389630bbcdab989c2656e8808edca3dc7cadf25cffda88d6a16"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -311,6 +311,7 @@
     "openstack/networking/v2/extensions/external",
     "openstack/networking/v2/extensions/layer3/floatingips",
     "openstack/networking/v2/extensions/layer3/routers",
+    "openstack/networking/v2/extensions/lbaas_v2/l7policies",
     "openstack/networking/v2/extensions/lbaas_v2/listeners",
     "openstack/networking/v2/extensions/lbaas_v2/loadbalancers",
     "openstack/networking/v2/extensions/lbaas_v2/monitors",
@@ -327,7 +328,7 @@
     "testhelper/client",
   ]
   pruneopts = "UT"
-  revision = "04bc8f551ef2b34dad9d1d26634aa7a4d565f11f"
+  revision = "cc2dd4edd0609857e53ef6feba69f84e29f5b60f"
 
 [[projects]]
   branch = "master"

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -1060,6 +1060,7 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 			floatIPOpts := floatingips.CreateOpts{
 				FloatingNetworkID: floatingPool,
 				PortID:            portID,
+				Description:       fmt.Sprintf("Floating IP for Kubernetes external service %s from cluster %s", name, clusterName),
 			}
 
 			if loadBalancerIP != "" {

--- a/pkg/ingress/controller/openstack/octavia.go
+++ b/pkg/ingress/controller/openstack/octavia.go
@@ -338,7 +338,7 @@ func (os *OpenStack) EnsureLoadBalancer(name string, subnetID string) (*loadbala
 // UpdateLoadBalancerDescription updates the load balancer description field.
 func (os *OpenStack) UpdateLoadBalancerDescription(lbID string, newDescription string) error {
 	_, err := loadbalancers.Update(os.octavia, lbID, loadbalancers.UpdateOpts{
-		Description: newDescription,
+		Description: &newDescription,
 	}).Extract()
 	if err != nil {
 		return fmt.Errorf("failed to update loadbalancer description: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
fixes #432

**Special notes for your reviewer**:
When creating floating ip for external service, add the cluster and service information in the floating ip description field, so it's easy to query and delete outside of the cluster.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
