### PR TITLE
Make usage of CCM cloud-config secret in CSI examples

### DIFF
--- a/docs/using-cinder-csi-plugin.md
+++ b/docs/using-cinder-csi-plugin.md
@@ -21,14 +21,16 @@ Check [kubernetes CSI Docs](https://kubernetes-csi.github.io/docs/) for flag det
 
 ### Deploy
 
+If you already created the `cloud-config` secret used by the [cloud-controller-manager](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/using-controller-manager-with-kubeadm.md#steps) jump directly to the `kubectl apply ...` command.
+
 Encode your ```$CLOUD_CONFIG``` file content using base64.
 
-```base64 -w 0 cloud.conf```
+```base64 -w 0 $CLOUD_CONFIG```
 
 Update ```cloud.conf``` configuration in ```manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml``` file
 by using the result of the above command.
 
-```kubectl -f manifests/cinder-csi-plugin create```
+```kubectl -f manifests/cinder-csi-plugin apply```
 
 This creates a set of cluster roles, cluster role bindings, and statefulsets etc to communicate with openstack(cinder).
 For detailed list of created objects, explore the yaml files in the directory.

--- a/manifests/barbican-kms/pod.yaml
+++ b/manifests/barbican-kms/pod.yaml
@@ -17,7 +17,7 @@ spec:
   volumes:
   - name: config
     hostPath:
-      path: /etc/kubernetes    
+      path: /etc/kubernetes
   - name: socket-dir
     hostPath:
       path: /var/lib/kms/

--- a/manifests/cinder-csi-plugin/csi-attacher-cinderplugin.yaml
+++ b/manifests/cinder-csi-plugin/csi-attacher-cinderplugin.yaml
@@ -5,6 +5,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: csi-attacher-cinderplugin
+  namespace: kube-system
   labels:
     app: csi-attacher-cinderplugin
 spec:
@@ -19,6 +20,7 @@ kind: StatefulSet
 apiVersion: apps/v1beta1
 metadata:
   name: csi-attacher-cinderplugin
+  namespace: kube-system
 spec:
   serviceName: "csi-attacher-cinderplugin"
   replicas: 1
@@ -69,4 +71,4 @@ spec:
           emptyDir:
         - name: secret-cinderplugin
           secret:
-            secretName: csi-secret-cinderplugin
+            secretName: cloud-config

--- a/manifests/cinder-csi-plugin/csi-attacher-rbac.yaml
+++ b/manifests/cinder-csi-plugin/csi-attacher-rbac.yaml
@@ -11,7 +11,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: external-attacher-runner
-  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -28,7 +27,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-attacher-role
-  namespace: kube-system
 subjects:
   - kind: ServiceAccount
     name: csi-attacher

--- a/manifests/cinder-csi-plugin/csi-attacher-rbac.yaml
+++ b/manifests/cinder-csi-plugin/csi-attacher-rbac.yaml
@@ -5,12 +5,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: csi-attacher
-
+  namespace: kube-system
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: external-attacher-runner
+  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -27,10 +28,11 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-attacher-role
+  namespace: kube-system
 subjects:
   - kind: ServiceAccount
     name: csi-attacher
-    namespace: default
+    namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: external-attacher-runner

--- a/manifests/cinder-csi-plugin/csi-nodeplugin-cinderplugin.yaml
+++ b/manifests/cinder-csi-plugin/csi-nodeplugin-cinderplugin.yaml
@@ -5,6 +5,7 @@ kind: DaemonSet
 apiVersion: apps/v1beta2
 metadata:
   name: csi-nodeplugin-cinderplugin
+  namespace: kube-system
 spec:
   selector:
     matchLabels:
@@ -98,4 +99,4 @@ spec:
             type: Directory
         - name: secret-cinderplugin
           secret:
-            secretName: csi-secret-cinderplugin
+            secretName: cloud-config

--- a/manifests/cinder-csi-plugin/csi-nodeplugin-rbac.yaml
+++ b/manifests/cinder-csi-plugin/csi-nodeplugin-rbac.yaml
@@ -10,7 +10,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-nodeplugin
-  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -26,7 +25,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-nodeplugin
-  namespace: kube-system
 subjects:
   - kind: ServiceAccount
     name: csi-nodeplugin

--- a/manifests/cinder-csi-plugin/csi-nodeplugin-rbac.yaml
+++ b/manifests/cinder-csi-plugin/csi-nodeplugin-rbac.yaml
@@ -4,12 +4,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: csi-nodeplugin
-
+  namespace: kube-system
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-nodeplugin
+  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -25,10 +26,11 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-nodeplugin
+  namespace: kube-system
 subjects:
   - kind: ServiceAccount
     name: csi-nodeplugin
-    namespace: default
+    namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: csi-nodeplugin

--- a/manifests/cinder-csi-plugin/csi-provisioner-cinderplugin.yaml
+++ b/manifests/cinder-csi-plugin/csi-provisioner-cinderplugin.yaml
@@ -4,6 +4,7 @@
 kind: Service
 apiVersion: v1
 metadata:
+  namespace: kube-system
   name: csi-provisioner-cinderplugin
   labels:
     app: csi-provisioner-cinderplugin
@@ -19,6 +20,7 @@ kind: StatefulSet
 apiVersion: apps/v1beta1
 metadata:
   name: csi-provisioner-cinderplugin
+  namespace: kube-system
 spec:
   serviceName: "csi-provisioner-cinderplugin"
   replicas: 1
@@ -69,4 +71,4 @@ spec:
           emptyDir:
         - name: secret-cinderplugin
           secret:
-            secretName: csi-secret-cinderplugin
+            secretName: cloud-config

--- a/manifests/cinder-csi-plugin/csi-provisioner-rbac.yaml
+++ b/manifests/cinder-csi-plugin/csi-provisioner-rbac.yaml
@@ -5,12 +5,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: csi-provisioner
-
+  namespace: kube-system
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: external-provisioner-runner
+  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -24,17 +25,16 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-
-    
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-provisioner-role
+  namespace: kube-system
 subjects:
   - kind: ServiceAccount
     name: csi-provisioner
-    namespace: default
+    namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: external-provisioner-runner

--- a/manifests/cinder-csi-plugin/csi-provisioner-rbac.yaml
+++ b/manifests/cinder-csi-plugin/csi-provisioner-rbac.yaml
@@ -11,7 +11,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: external-provisioner-runner
-  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -30,7 +29,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-provisioner-role
-  namespace: kube-system
 subjects:
   - kind: ServiceAccount
     name: csi-provisioner

--- a/manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml
+++ b/manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml
@@ -4,6 +4,7 @@
 kind: Secret
 apiVersion: v1
 metadata:
-  name: csi-secret-cinderplugin
+  name: cloud-config
+  namespace: kube-system
 data:
   cloud.conf: W0dsb2JhbF0KdXNlcm5hbWU9dXNlcgpwYXNzd29yZD1wYXNzCmF1dGgtdXJsPWh0dHBzOi8vPGtleXN0b25lX2lwPi9pZGVudGl0eS92Mwp0ZW5hbnQtaWQ9Yzg2OTE2OGE4Mjg4NDdmMzlmN2YwNmVkZDczMDU2MzcKZG9tYWluLWlkPTJhNzNiOGY1OTdjMDQ1NTFhMGZkYzhlOTU1NDRiZThhCg==


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the same secret like the `cloud-controller-maanger` does to reduce the management overhead of Openstack secrets.

**Special notes for your reviewer**:

Follow up of: https://github.com/kubernetes/cloud-provider-openstack/pull/430

