### PR TITLE
Add barbican-kms-plugin to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ zz_generated.openapi.go
 /octavia-ingress-controller
 /client-keystone-auth
 /manila-provisioner
+/barbican-kms-plugin
 
 # snap temp files
 /parts


### PR DESCRIPTION
make build generates barbican-kms-plugin binary , which comes
under untracked files. Make git to ignore the same.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
