### PR TITLE
Fix t.Errorf() error message

### DIFF
--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -184,7 +184,7 @@ func (mounter *SafeFormatAndMount) FormatAndMount(source string, target string, 
 
 // getMountRefsByDev finds all references to the device provided
 // by mountPath; returns a list of paths.
-// Note that mountPath should be path after the evaluation of any symblolic links.
+// Note that mountPath should be path after the evaluation of any symbolic links.
 func getMountRefsByDev(mounter Interface, mountPath string) ([]string, error) {
 	mps, err := mounter.List()
 	if err != nil {

--- a/pkg/volume/cinder/cinder_block_test.go
+++ b/pkg/volume/cinder/cinder_block_test.go
@@ -140,6 +140,6 @@ func TestGetPodAndPluginMapPaths(t *testing.T) {
 		t.Errorf("Got unexpected pod path: %s, expected %s", gDevicePath, expectedPodPath)
 	}
 	if gVolName != testPVName {
-		t.Errorf("Got unexpected volNamne: %s, expected %s", gVolName, testPVName)
+		t.Errorf("Got unexpected volName: %s, expected %s", gVolName, testPVName)
 	}
 }


### PR DESCRIPTION
1. "symblolic" to "symbolic" in line 187.
2. "volNamne" to "volName" in line 143.