### PR TITLE
octavia-ingress-controller: Add ingress information to openstack resources description

### DIFF
--- a/pkg/ingress/controller/openstack/neutron.go
+++ b/pkg/ingress/controller/openstack/neutron.go
@@ -57,7 +57,7 @@ func (os *OpenStack) getFloatingIPByPortID(portID string) (*floatingips.Floating
 }
 
 // EnsureFloatingIP makes sure a floating IP is allocated for the port
-func (os *OpenStack) EnsureFloatingIP(portID string, floatingIPNetwork string) (string, error) {
+func (os *OpenStack) EnsureFloatingIP(portID string, floatingIPNetwork string, ingName string, ingNamespace string, clusterName string) (string, error) {
 	fip, err := os.getFloatingIPByPortID(portID)
 	if err != nil {
 		if err != ErrNotFound {
@@ -69,6 +69,7 @@ func (os *OpenStack) EnsureFloatingIP(portID string, floatingIPNetwork string) (
 		floatIPOpts := floatingips.CreateOpts{
 			FloatingNetworkID: floatingIPNetwork,
 			PortID:            portID,
+			Description:       fmt.Sprintf("Floating IP for Kubernetes ingress %s in namespace %s from cluster %s", ingName, ingNamespace, clusterName),
 		}
 		fip, err = floatingips.Create(os.neutron, floatIPOpts).Extract()
 		if err != nil {

--- a/pkg/ingress/controller/openstack/octavia.go
+++ b/pkg/ingress/controller/openstack/octavia.go
@@ -302,7 +302,7 @@ func (os *OpenStack) DeleteLoadbalancer(lbID string) error {
 }
 
 // EnsureLoadBalancer creates a loadbalancer in octavia if it does not exist, wait for the loadbalancer to be ACTIVE.
-func (os *OpenStack) EnsureLoadBalancer(name string, subnetID string) (*loadbalancers.LoadBalancer, error) {
+func (os *OpenStack) EnsureLoadBalancer(name string, subnetID string, ingNamespace string, ingName string, clusterName string) (*loadbalancers.LoadBalancer, error) {
 	loadbalancer, err := os.GetLoadbalancerByName(name)
 	if err != nil {
 		if err != ErrNotFound {
@@ -313,7 +313,7 @@ func (os *OpenStack) EnsureLoadBalancer(name string, subnetID string) (*loadbala
 
 		createOpts := loadbalancers.CreateOpts{
 			Name:        name,
-			Description: "Created by Kubernetes",
+			Description: fmt.Sprintf("Kubernetes ingress %s in namespace %s from cluster %s", ingName, ingNamespace, clusterName),
 			VipSubnetID: subnetID,
 			Provider:    "octavia",
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This patch adds the ingress information, e.g. namespace, name and
cluster name into openstack resource description, in order to identify
the corresponding openstack resources created for the ingress and make
it easy to do clean up.

**Which issue this PR fixes** : fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
