### PR TITLE
Add internal-network-name networking option

### DIFF
--- a/docs/provider-configuration.md
+++ b/docs/provider-configuration.md
@@ -14,6 +14,8 @@ to the OpenStack Cloud Provider.
       - [Global](#global)
         - [Global Required Parameters](#global-required-parameters)
         - [Global Optional Parameters](#global-optional-parameters)
+      - [Networking](#networking)
+        - [Networking](#networking-optional-parameters)
       - [Load Balancer](#load-balancer)
         - [Load Balancer Optional Parameters](#load-balancer-optional-parameters)
       - [Block Storage](#block-storage)
@@ -135,7 +137,27 @@ file.
 * `Cloud`: Used to specify which named cloud in the clouds.yaml file that you want to use
 
 
+####  Networking
+
+These configuration options for the OpenStack provider pertain to the network
+configuration and should appear in the `[Networking]` section of the `$CLOUD_CONFIG`
+file.
+
+##### Networking Optional Parameters
+
+* `ipv6-support-disabled`: Indicates whether or not to use ipv6 addresses.
+  The default is `false`. When `true` is specified then will ignore any
+  ipv6 addresses assigned to the node.
+* `public-network-name`: Used to specify external network.
+  The default is `public`. Must be a network name, not id.
+* `internal-network-name`: Used to override internal network selection.
+  Where no value is provided automatic detection will select random node interface
+  as internal. This option makes sense and recommended to specify only
+  when you have more than one interface attached to kubernetes nodes.
+  Must be a network name, not id.
+
 ####  Load Balancer
+
 These configuration options for the OpenStack provider pertain to the load
 balancer and should appear in the `[LoadBalancer]` section of the `$CLOUD_CONFIG`
 file.

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -125,6 +125,7 @@ type BlockStorageOpts struct {
 type NetworkingOpts struct {
 	IPv6SupportDisabled bool   `gcfg:"ipv6-support-disabled"`
 	PublicNetworkName   string `gcfg:"public-network-name"`
+	InternalNetworkName string `gcfg:"internal-network-name"`
 }
 
 // RouterOpts is used for Neutron routes
@@ -544,7 +545,12 @@ func nodeAddresses(srv *servers.Server, networkingOpts NetworkingOpts) ([]v1.Nod
 			if props.IPType == "floating" || network == networkingOpts.PublicNetworkName {
 				addressType = v1.NodeExternalIP
 			} else {
-				addressType = v1.NodeInternalIP
+				if networkingOpts.InternalNetworkName == "" || network == networkingOpts.InternalNetworkName {
+					addressType = v1.NodeInternalIP
+				} else {
+					klog.V(5).Infof("Node '%s' address '%s' ignored due to 'internal-network-name' option", srv.Name, props.Addr)
+					continue
+				}
 			}
 
 			isIPv6 := net.ParseIP(props.Addr).To4() == nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This will help in case of multi-nic k8s node deployments.
Previously, cloud provider was assigning all addresses in random
order and k8s was selecting only one of them. But usually,
multi-nic scenario requires to specify which network is
"control" and admins want to bind kubelet listening address only
to that "control" net.

This commit will not affect previous logic until
internal-network-name is specified in cloud-config file.

**Which issue this PR fixes**: fixes #407 

**Special notes for your reviewer**:

**Release note**:
```release-note
```
