### PR TITLE
Update defaultMetadataVersion to latest

### DIFF
--- a/pkg/cloudprovider/providers/openstack/metadata.go
+++ b/pkg/cloudprovider/providers/openstack/metadata.go
@@ -38,7 +38,7 @@ const (
 	// It's a hardcoded IPv4 link-local address as documented in "User Documentation"
 	// section "Metadata service
 	// https://docs.openstack.org/nova/latest/user/metadata-service.html
-	defaultMetadataVersion = "2012-08-10"
+	defaultMetadataVersion = "latest"
 	metadataURLTemplate    = "http://169.254.169.254/openstack/%s/meta_data.json"
 
 	// metadataID is used as an identifier on the metadata search order configuration.

--- a/pkg/csi/cinder/openstack/openstack_metadata.go
+++ b/pkg/csi/cinder/openstack/openstack_metadata.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	defaultMetadataVersion = "2012-08-10"
+	defaultMetadataVersion = "latest"
 	metadataURLTemplate    = "http://169.254.169.254/openstack/%s/meta_data.json"
 )
 


### PR DESCRIPTION
Currently defaultMetadataVersion is set to 2012-08-10 which is
very old. This commit updates the same.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
