### PR TITLE
cinder-csi-plugin: Add cluster argument to the driver

### DIFF
--- a/cmd/cinder-csi-plugin/main.go
+++ b/cmd/cinder-csi-plugin/main.go
@@ -31,6 +31,7 @@ var (
 	endpoint    string
 	nodeID      string
 	cloudconfig string
+	cluster     string
 )
 
 func init() {
@@ -78,6 +79,8 @@ func main() {
 	cmd.PersistentFlags().StringVar(&cloudconfig, "cloud-config", "", "CSI driver cloud config")
 	cmd.MarkPersistentFlagRequired("cloud-config")
 
+	cmd.PersistentFlags().StringVar(&cluster, "cluster", "", "The identifier of the cluster that the plugin is running in.")
+
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%s", err.Error())
 		os.Exit(1)
@@ -87,6 +90,6 @@ func main() {
 }
 
 func handle() {
-	d := cinder.NewDriver(nodeID, endpoint, cloudconfig)
+	d := cinder.NewDriver(nodeID, endpoint, cluster, cloudconfig)
 	d.Run()
 }

--- a/docs/using-cinder-csi-plugin.md
+++ b/docs/using-cinder-csi-plugin.md
@@ -133,10 +133,11 @@ Get ```csc``` tool from https://github.com/thecodeteam/gocsi/tree/master/csc
 
 First, you need to start the plugin as daemon to accept request from csc.
 Following example is starting listening at localhost port 10000 with cloud configuration
-given in /etc/cloud.conf and the node id is CSINodeID.
+given in /etc/cloud.conf and the node id is CSINodeID. ClusterID is the identifier of
+the cluster in which the plugin is running.
 
 ```
-$ sudo cinder-csi-plugin --endpoint tcp://127.0.0.1:10000 --cloud-config /etc/cloud.conf --nodeid CSINodeID
+$ sudo cinder-csi-plugin --endpoint tcp://127.0.0.1:10000 --cloud-config /etc/cloud.conf --nodeid CSINodeID --cluster ClusterID
 ```
 
 #### Get plugin info
@@ -157,14 +158,13 @@ $ csc controller get-capabilities  --endpoint tcp://127.0.0.1:10000
 &{type:CREATE_DELETE_VOLUME }
 &{type:PUBLISH_UNPUBLISH_VOLUME }
 &{type:LIST_VOLUMES }
-
 ```
 
 #### Create a volume
 Following sample creates a volume named ``CSIVolumeName`` and the
 volume id returned is ``8a55f98f-e987-43ab-a9f5-973352bee19c`` with size ``1073741824`` bytes (1Gb)
 ```
-$  csc controller create-volume --endpoint tcp://127.0.0.1:10000 CSIVolumeName
+$ csc controller create-volume --endpoint tcp://127.0.0.1:10000 CSIVolumeName
 "8a55f98f-e987-43ab-a9f5-973352bee19c"  1073741824      "availability"="nova"
 ```
 

--- a/manifests/cinder-csi-plugin/csi-provisioner-cinderplugin.yaml
+++ b/manifests/cinder-csi-plugin/csi-provisioner-cinderplugin.yaml
@@ -47,6 +47,7 @@ spec:
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
+            - "--cluster=$(CLUSTER_NAME)"
             - "--cloud-config=$(CLOUD_CONFIG)"
           env:
             - name: NODE_ID
@@ -57,6 +58,8 @@ spec:
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
               value: /etc/config/cloud.conf
+            - name: CLUSTER_NAME
+              value: kubernetes
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -84,7 +84,8 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, errors.New("multiple volumes reported by Cinder with same name")
 	} else {
 		// Volume Create
-		resID, resAvailability, resSize, err = cloud.CreateVolume(volName, volSizeGB, volType, volAvailability, nil)
+		properties := map[string]string{"cinder.csi.openstack.org/cluster": cs.Driver.cluster}
+		resID, resAvailability, resSize, err = cloud.CreateVolume(volName, volSizeGB, volType, volAvailability, &properties)
 		if err != nil {
 			klog.V(3).Infof("Failed to CreateVolume: %v", err)
 			return nil, err

--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -34,7 +34,7 @@ func init() {
 		// to avoid annoying ERROR: logging before flag.Parse
 		flag.Parse()
 
-		d := NewDriver(fakeNodeID, fakeEndpoint, fakeConfig)
+		d := NewDriver(fakeNodeID, fakeEndpoint, fakeCluster, fakeConfig)
 		fakeCs = NewControllerServer(d)
 	}
 }
@@ -45,7 +45,8 @@ func TestCreateVolume(t *testing.T) {
 	// mock OpenStack
 	osmock := new(openstack.OpenStackMock)
 	// CreateVolume(name string, size int, vtype, availability string, tags *map[string]string) (string, string, int, error)
-	osmock.On("CreateVolume", fakeVolName, mock.AnythingOfType("int"), fakeVolType, fakeAvailability, (*map[string]string)(nil)).Return(fakeVolID, fakeAvailability, fakeCapacityGiB, nil)
+	properties := map[string]string{"cinder.csi.openstack.org/cluster": fakeCluster}
+	osmock.On("CreateVolume", fakeVolName, mock.AnythingOfType("int"), fakeVolType, fakeAvailability, &properties).Return(fakeVolID, fakeAvailability, fakeCapacityGiB, nil)
 	openstack.OsInstance = osmock
 
 	// Init assert
@@ -79,7 +80,8 @@ func TestCreateVolumeDuplicate(t *testing.T) {
 
 	// mock OpenStack
 	osmock := new(openstack.OpenStackMock)
-	osmock.On("CreateVolume", fakeVolName, mock.AnythingOfType("int"), fakeVolType, fakeAvailability, (*map[string]string)(nil)).Return(fakeVolID, fakeAvailability, fakeCapacityGiB, nil)
+	properties := map[string]string{"cinder.csi.openstack.org/cluster": fakeCluster}
+	osmock.On("CreateVolume", fakeVolName, mock.AnythingOfType("int"), fakeVolType, fakeAvailability, &properties).Return(fakeVolID, fakeAvailability, fakeCapacityGiB, nil)
 	openstack.OsInstance = osmock
 
 	// Init assert
@@ -237,7 +239,7 @@ func TestListVolumes(t *testing.T) {
 	assert.Equal(expectedRes, actualRes)
 }
 
-// Test CreateVolume
+// Test CreateSnapshot
 func TestCreateSnapshot(t *testing.T) {
 	// mock OpenStack
 	osmock := new(openstack.OpenStackMock)

--- a/pkg/csi/cinder/driver.go
+++ b/pkg/csi/cinder/driver.go
@@ -40,6 +40,7 @@ type CinderDriver struct {
 	version     string
 	endpoint    string
 	cloudconfig string
+	cluster     string
 
 	ids *identityServer
 	cs  *controllerServer
@@ -50,7 +51,7 @@ type CinderDriver struct {
 	nscap []*csi.NodeServiceCapability
 }
 
-func NewDriver(nodeID, endpoint string, cloudconfig string) *CinderDriver {
+func NewDriver(nodeID, endpoint, cluster, cloudconfig string) *CinderDriver {
 	klog.Infof("Driver: %v version: %v", driverName, version)
 
 	d := &CinderDriver{}
@@ -59,6 +60,7 @@ func NewDriver(nodeID, endpoint string, cloudconfig string) *CinderDriver {
 	d.version = version
 	d.endpoint = endpoint
 	d.cloudconfig = cloudconfig
+	d.cluster = cluster
 
 	d.AddControllerServiceCapabilities(
 		[]csi.ControllerServiceCapability_RPC_Type{

--- a/pkg/csi/cinder/driver_test.go
+++ b/pkg/csi/cinder/driver_test.go
@@ -33,7 +33,7 @@ var (
 
 func NewFakeDriver() *CinderDriver {
 
-	driver := NewDriver(fakeNodeID, fakeEndpoint, fakeConfig)
+	driver := NewDriver(fakeNodeID, fakeEndpoint, fakeCluster, fakeConfig)
 
 	return driver
 }

--- a/pkg/csi/cinder/fake.go
+++ b/pkg/csi/cinder/fake.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack"
 )
 
+var fakeCluster = "cluster"
 var fakeNodeID = "CSINodeID"
 var fakeEndpoint = "tcp://127.0.0.1:10000"
 var fakeConfig = "/etc/cloud.conf"

--- a/pkg/csi/cinder/identityserver_test.go
+++ b/pkg/csi/cinder/identityserver_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestGetPluginInfo(t *testing.T) {
-	d := NewDriver(fakeNodeID, fakeEndpoint, fakeConfig)
+	d := NewDriver(fakeNodeID, fakeEndpoint, fakeCluster, fakeConfig)
 
 	ids := NewIdentityServer(d)
 

--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -34,7 +34,7 @@ func init() {
 		// to avoid annoying ERROR: logging before flag.Parse
 		flag.Parse()
 
-		d := NewDriver(fakeNodeID, fakeEndpoint, fakeConfig)
+		d := NewDriver(fakeNodeID, fakeEndpoint, fakeCluster, fakeConfig)
 		fakeNs = NewNodeServer(d)
 	}
 }

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -41,6 +41,7 @@ const (
 	diskDetachInitDelay      = 1 * time.Second
 	diskDetachFactor         = 1.2
 	diskDetachSteps          = 13
+	volumeDescription        = "Created by OpenStack Cinder CSI driver"
 )
 
 type Volume struct {
@@ -67,6 +68,7 @@ func (os *OpenStack) CreateVolume(name string, size int, vtype, availability str
 		Size:             size,
 		VolumeType:       vtype,
 		AvailabilityZone: availability,
+		Description:      volumeDescription,
 	}
 	if tags != nil {
 		opts.Metadata = *tags


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `cluster` parameter for the driver, admin user could specify the CO's identifier, e.g.  in Magnum, the `cluster` could be the magnum cluster id.

When using cinder-csi-plugin together with kubernetes in the cloud environment, we need some information to recognize the volumes created for the PVs from different kubernetes clusters, which is important for the cloud resource management.

This PR is only adding cluster name to the driver, so that the driver could pass the cluster name to the cinder volume metadata.

**Which issue this PR fixes** : fixes #450

**Special notes for your reviewer**:
This PR is only adding cluster name to the driver, so that the driver could pass the cluster name to the cinder volume metadata.

There are several ways to inject the cluster name to the cinder volume property, e.g. kubernetes admin can provide parameters when creating the StorageClass, the cloud admin could config `volume-name-prefix` to include the cluster as part of cinder volume name, etc. However, in order to support a more flexible and extensible way, I prefer to add all those information to the cinder volume medata.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
cinder-csi-driver supports `--cluster` argument to get the the CO's identifier.
```
