### PR TITLE
fix kubernetes hostnames if those contain dot

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -390,7 +390,6 @@ func checkOpenStackOpts(openstackOpts *OpenStack) error {
 	return checkMetadataSearchOrder(openstackOpts.metadataOpts.SearchOrder)
 }
 
-
 func getClusterName() string {
 	return os.Getenv("KUBERNETES_CLUSTER")
 }
@@ -484,7 +483,7 @@ func mapServerToNodeName(server *servers.Server) types.NodeName {
 
 	serverLower := strings.ToLower(server.Name)
 	if getClusterName() == "" {
-	    return types.NodeName(serverLower)
+		return types.NodeName(serverLower)
 	}
 	splitted := strings.Split(serverLower, ".")
 	if len(splitted) > 0 {
@@ -516,7 +515,7 @@ func getServerByName(client *gophercloud.ServiceClient, name types.NodeName) (*S
 	servername := mapNodeNameToServerName(name)
 	clusterName := getClusterName()
 	if clusterName != "" {
-		servername = mapNodeNameToServerName(name)+"."+clusterName
+		servername = mapNodeNameToServerName(name) + "." + clusterName
 	}
 
 	opts := servers.ListOpts{

--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -70,7 +70,7 @@ func (i *Instances) CurrentNodeName(ctx context.Context, hostname string) (types
 	}
 
 	if getClusterName() == "" {
-	    return types.NodeName(md.Name), nil
+		return types.NodeName(md.Name), nil
 	}
 	splitted := strings.Split(md.Name, ".")
 	if len(splitted) > 0 {

--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
@@ -66,6 +67,14 @@ func (i *Instances) CurrentNodeName(ctx context.Context, hostname string) (types
 	md, err := getMetadata(i.opts.SearchOrder)
 	if err != nil {
 		return "", err
+	}
+
+	if getClusterName() == "" {
+	    return types.NodeName(md.Name), nil
+	}
+	splitted := strings.Split(md.Name, ".")
+	if len(splitted) > 0 {
+		return types.NodeName(splitted[0]), nil
 	}
 	return types.NodeName(md.Name), nil
 }


### PR DESCRIPTION

**What this PR does / why we need it**: https://serverfault.com/questions/229331/can-i-have-dots-in-a-hostname the recommendation is that we should not use dots in linux hostnames. If we do not have dots in linux hostnames, we should not have those either in kubernetes nodenames because then `nodename` does not match to `hostname`. This makes huge issues if we are using external cloudprovider plugin and when bootstrapping it.


issue in kops https://github.com/kubernetes/kops/issues/6441