### PR TITLE
Update to use kubernetes-sigs/sig-storage-lib-external-provisioner

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -450,16 +450,16 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:49926b919c58842fe6ec1e1f3fd46e32071e1f96c7187fb4c38bb85be6c78389"
-  name = "github.com/kubernetes-incubator/external-storage"
+  digest = "1:ed7217adfd0a2166b57478acf8adf5eb63244843ef55d2a8d540a5b5c0d8a313"
+  name = "github.com/kubernetes-sigs/sig-storage-lib-external-provisioner"
   packages = [
-    "lib/controller",
-    "lib/controller/metrics",
-    "lib/util",
+    "controller",
+    "controller/metrics",
+    "util",
   ]
   pruneopts = "UT"
-  revision = "a36eb11aa65e1b6890b50db2ee4fd0adb2884a6a"
-  version = "v5.3.0-alpha.1"
+  revision = "eb02dcb0bcd4894de9d7b894c30f2370774d5d1b"
+  version = "v2.1.0"
 
 [[projects]]
   digest = "1:c568d7727aa262c32bdf8a3f7db83614f7af0ed661474b24588de635c20024c7"
@@ -488,6 +488,14 @@
   pruneopts = "UT"
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
+
+[[projects]]
+  digest = "1:1b46adc9e3d878cdf38a164cfdac2e19340f4d2662aa5bee88062f6ee08ac9df"
+  name = "github.com/miekg/dns"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "8fc2e5773bbd308ca2fcc962fd8d25c1bd0f6743"
+  version = "v1.1.4"
 
 [[projects]]
   digest = "1:78bbb1ba5b7c3f2ed0ea1eab57bdd3859aec7e177811563edc41198a760b06af"
@@ -754,9 +762,10 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4b810b02a73d11c884353dcf98ef0541d99cdf8d8c37f656840b13666fc7c683"
+  digest = "1:8ead068f043949c15374a3105a6075fb23216a7bf21abc3b9b07c123f9c41988"
   name = "golang.org/x/net"
   packages = [
+    "bpf",
     "context",
     "context/ctxhttp",
     "html",
@@ -766,7 +775,11 @@
     "http2",
     "http2/hpack",
     "idna",
+    "internal/iana",
+    "internal/socket",
     "internal/timeseries",
+    "ipv4",
+    "ipv6",
     "trace",
     "websocket",
   ]
@@ -1559,7 +1572,7 @@
     "github.com/gophercloud/gophercloud/testhelper/client",
     "github.com/gophercloud/utils/openstack/clientconfig",
     "github.com/gorilla/mux",
-    "github.com/kubernetes-incubator/external-storage/lib/controller",
+    "github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller",
     "github.com/mitchellh/go-homedir",
     "github.com/mitchellh/mapstructure",
     "github.com/onsi/ginkgo",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,8 +42,8 @@
   version = "1.6.2"
 
 [[constraint]]
-  name = "github.com/kubernetes-incubator/external-storage"
-  version = "v5.3.0-alpha.1"
+  name = "github.com/kubernetes-sigs/sig-storage-lib-external-provisioner"
+  version = "v2.1.0"
 
 [[constraint]]
   name = "github.com/mitchellh/go-homedir"

--- a/cmd/cinder-provisioner/main.go
+++ b/cmd/cinder-provisioner/main.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/klog"
 
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/provisioner"
 
 	"k8s.io/apimachinery/pkg/util/wait"

--- a/cmd/manila-provisioner/main.go
+++ b/cmd/manila-provisioner/main.go
@@ -19,7 +19,7 @@ package main
 import (
 	"flag"
 
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"

--- a/pkg/share/manila/manila_test.go
+++ b/pkg/share/manila/manila_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
 	th "github.com/gophercloud/gophercloud/testhelper"
 	fakeclient "github.com/gophercloud/gophercloud/testhelper/client"
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/cloud-provider-openstack/pkg/share/manila/shareoptions"

--- a/pkg/share/manila/provisioner.go
+++ b/pkg/share/manila/provisioner.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/cloud-provider-openstack/pkg/share/manila/sharebackends"

--- a/pkg/share/manila/share.go
+++ b/pkg/share/manila/share.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/share/manila/shareoptions/shareoptions.go
+++ b/pkg/share/manila/shareoptions/shareoptions.go
@@ -19,7 +19,7 @@ package shareoptions
 import (
 	"fmt"
 
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"github.com/pborman/uuid"
 	"k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"

--- a/pkg/volume/cinder/provisioner/iscsi.go
+++ b/pkg/volume/cinder/provisioner/iscsi.go
@@ -17,7 +17,7 @@ limitations under the License.
 package provisioner
 
 import (
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/volumeservice"

--- a/pkg/volume/cinder/provisioner/iscsi_test.go
+++ b/pkg/volume/cinder/provisioner/iscsi_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package provisioner
 
 import (
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/api/core/v1"

--- a/pkg/volume/cinder/provisioner/mapper.go
+++ b/pkg/volume/cinder/provisioner/mapper.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/volumeservice"

--- a/pkg/volume/cinder/provisioner/mapperbroker.go
+++ b/pkg/volume/cinder/provisioner/mapperbroker.go
@@ -17,7 +17,7 @@ limitations under the License.
 package provisioner
 
 import (
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/api/core/v1"
 	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/volumeservice"
 )

--- a/pkg/volume/cinder/provisioner/provisioner.go
+++ b/pkg/volume/cinder/provisioner/provisioner.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes"

--- a/pkg/volume/cinder/provisioner/provisioner_test.go
+++ b/pkg/volume/cinder/provisioner/provisioner_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	volumes_v2 "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/api/core/v1"

--- a/pkg/volume/cinder/provisioner/rbd.go
+++ b/pkg/volume/cinder/provisioner/rbd.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/api/core/v1"
 	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/volumeservice"
 	"k8s.io/klog"

--- a/pkg/volume/cinder/provisioner/rbd_test.go
+++ b/pkg/volume/cinder/provisioner/rbd_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package provisioner
 
 import (
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/api/core/v1"

--- a/pkg/volume/cinder/provisioner/testutils_test.go
+++ b/pkg/volume/cinder/provisioner/testutils_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"errors"
 
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
This commit is to update code to use
kubernetes-sigs/sig-storage-lib-external-provisioner instead of
kubernetes-incubator/external-storage.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #454

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
