### PR TITLE
Update Cinder CSI Driver to CSI Spec 1.0.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -54,12 +54,12 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
-  digest = "1:a54dc69ec3668e0e57ad159a0a8c0ce1ec571174bb4eb6b3915833a8c21d40f3"
+  digest = "1:94ffc0947c337d618b6ff5ed9abaddc1217b090c1b3a1ae4739b35b7b25851d5"
   name = "github.com/container-storage-interface/spec"
-  packages = ["lib/go/csi/v0"]
+  packages = ["lib/go/csi"]
   pruneopts = "UT"
-  revision = "2178fdeea87f1150a17a63252eee28d4d8141f72"
-  version = "v0.3.0"
+  revision = "ed0bb0e1557548aa028307f48728767cfe8f6345"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:b7e8c5fa66ebd2e6083cd4a6cc515f6d3c651fd04ad18a8276444bbcb172c583"
@@ -227,10 +227,11 @@
   revision = "c65c006176ff7ff98bb916961c7abbc6b0afc0aa"
 
 [[projects]]
-  digest = "1:8f0705fa33e8957018611cc81c65cb373b626c092d39931bb86882489fc4c3f4"
+  digest = "1:588beb9f80d2b0afddf05663b32d01c867da419458b560471d81cca0286e76b8"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
+    "protoc-gen-go/descriptor",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
@@ -1519,7 +1520,8 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/container-storage-interface/spec/lib/go/csi/v0",
+    "github.com/container-storage-interface/spec/lib/go/csi",
+    "github.com/golang/protobuf/ptypes",
     "github.com/gophercloud/gophercloud",
     "github.com/gophercloud/gophercloud/openstack",
     "github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/container-storage-interface/spec"
-  version = "0.3.0"
+  version = "1.0.0"
 
 [[constraint]]
   branch = "master"

--- a/manifests/cinder-csi-plugin/csi-attacher-cinderplugin.yaml
+++ b/manifests/cinder-csi-plugin/csi-attacher-cinderplugin.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccount: csi-attacher
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v0.4.1
+          image: quay.io/k8scsi/csi-attacher:v1.0.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/manifests/cinder-csi-plugin/csi-nodeplugin-cinderplugin.yaml
+++ b/manifests/cinder-csi-plugin/csi-nodeplugin-cinderplugin.yaml
@@ -17,17 +17,21 @@ spec:
       serviceAccount: csi-nodeplugin
       hostNetwork: true
       containers:
-        - name: driver-registrar
-          image: quay.io/k8scsi/driver-registrar:v0.4.1
+        - name: node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/cinder.csi.openstack.org /registration/cinder.csi.openstack.org-reg.sock"]
           env:
             - name: ADDRESS
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
-              value: /var/lib/kubelet/plugins/csi-cinderplugin/csi.sock
+              value: /var/lib/kubelet/plugins/cinder.csi.openstack.org/csi.sock
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -78,11 +82,11 @@ spec:
       volumes:
         - name: socket-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/csi-cinderplugin
+            path: /var/lib/kubelet/plugins/cinder.csi.openstack.org
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/
+            path: /var/lib/kubelet/plugins_registry/
             type: Directory
         - name: pods-mount-dir
           hostPath:

--- a/manifests/cinder-csi-plugin/csi-provisioner-cinderplugin.yaml
+++ b/manifests/cinder-csi-plugin/csi-provisioner-cinderplugin.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccount: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v0.4.1
+          image: quay.io/k8scsi/csi-provisioner:v1.0.1
           args:
             - "--provisioner=csi-cinderplugin"
             - "--csi-address=$(ADDRESS)"

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -18,9 +18,10 @@ package cinder
 
 import (
 	"errors"
-	"time"
 
-	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/golang/protobuf/ptypes"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	ossnapshots "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
 	"github.com/pborman/uuid"
 	"golang.org/x/net/context"
@@ -96,9 +97,10 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
-			Id:            resID,
+			VolumeId:      resID,
 			CapacityBytes: int64(resSize * 1024 * 1024 * 1024),
-			Attributes: map[string]string{
+
+			VolumeContext: map[string]string{
 				"availability": resAvailability,
 			},
 		},
@@ -165,7 +167,7 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 	pvInfo["DevicePath"] = devicePath
 
 	return &csi.ControllerPublishVolumeResponse{
-		PublishInfo: pvInfo,
+		PublishContext: pvInfo,
 	}, nil
 }
 
@@ -217,7 +219,7 @@ func (cs *controllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 	for _, v := range vlist {
 		ventry := csi.ListVolumesResponse_Entry{
 			Volume: &csi.Volume{
-				Id:            v.ID,
+				VolumeId:      v.ID,
 				CapacityBytes: int64(v.Size * 1024 * 1024 * 1024),
 			},
 		}
@@ -266,13 +268,18 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		klog.V(3).Infof("CreateSnapshot %s on %s", name, volumeId)
 	}
 
+	ctime, err := ptypes.TimestampProto(snap.CreatedAt)
+	if err != nil {
+		klog.Errorf("Error to convert time to timestamp: %v", err)
+	}
+
 	// TODO: add snapshot status
 	return &csi.CreateSnapshotResponse{
 		Snapshot: &csi.Snapshot{
-			Id:             snap.ID,
+			SnapshotId:     snap.ID,
 			SizeBytes:      int64(snap.Size * 1024 * 1024 * 1024),
 			SourceVolumeId: snap.VolumeID,
-			CreatedAt:      int64(snap.CreatedAt.UnixNano() / int64(time.Millisecond)),
+			CreationTime:   ctime,
 		},
 	}, nil
 }
@@ -314,12 +321,16 @@ func (cs *controllerServer) ListSnapshots(ctx context.Context, req *csi.ListSnap
 
 	var ventries []*csi.ListSnapshotsResponse_Entry
 	for _, v := range vlist {
+		ctime, err := ptypes.TimestampProto(v.CreatedAt)
+		if err != nil {
+			klog.Errorf("Error to convert time to timestamp: %v", err)
+		}
 		ventry := csi.ListSnapshotsResponse_Entry{
 			Snapshot: &csi.Snapshot{
 				SizeBytes:      int64(v.Size * 1024 * 1024 * 1024),
-				Id:             v.ID,
+				SnapshotId:     v.ID,
 				SourceVolumeId: v.VolumeID,
-				CreatedAt:      int64(v.CreatedAt.UnixNano() / int64(time.Millisecond)),
+				CreationTime:   ctime,
 			},
 		}
 		ventries = append(ventries, &ventry)

--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -20,7 +20,7 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack"
@@ -68,9 +68,9 @@ func TestCreateVolume(t *testing.T) {
 
 	assert.NotNil(actualRes.Volume.CapacityBytes)
 
-	assert.NotEqual(0, len(actualRes.Volume.Id), "Volume Id is nil")
+	assert.NotEqual(0, len(actualRes.Volume.VolumeId), "Volume Id is nil")
 
-	assert.Equal(fakeAvailability, actualRes.Volume.Attributes["availability"])
+	assert.Equal(fakeAvailability, actualRes.Volume.VolumeContext["availability"])
 
 }
 
@@ -100,11 +100,11 @@ func TestCreateVolumeDuplicate(t *testing.T) {
 	// Assert
 	assert.NotNil(actualRes.Volume)
 
-	assert.NotEqual(0, len(actualRes.Volume.Id), "Volume Id is nil")
+	assert.NotEqual(0, len(actualRes.Volume.VolumeId), "Volume Id is nil")
 
-	assert.Equal("nova", actualRes.Volume.Attributes["availability"])
+	assert.Equal("nova", actualRes.Volume.VolumeContext["availability"])
 
-	assert.Equal("261a8b81-3660-43e5-bab8-6470b65ee4e9", actualRes.Volume.Id)
+	assert.Equal("261a8b81-3660-43e5-bab8-6470b65ee4e9", actualRes.Volume.VolumeId)
 }
 
 // Test DeleteVolume
@@ -163,7 +163,7 @@ func TestControllerPublishVolume(t *testing.T) {
 
 	// Expected Result
 	expectedRes := &csi.ControllerPublishVolumeResponse{
-		PublishInfo: map[string]string{
+		PublishContext: map[string]string{
 			"DevicePath": fakeDevicePath,
 		},
 	}
@@ -263,7 +263,7 @@ func TestCreateSnapshot(t *testing.T) {
 	// Assert
 	assert.Equal(fakeVolID, actualRes.Snapshot.SourceVolumeId)
 
-	assert.NotNil(fakeSnapshotID, actualRes.Snapshot.Id)
+	assert.NotNil(fakeSnapshotID, actualRes.Snapshot.SnapshotId)
 }
 
 // Test DeleteSnapshot
@@ -318,5 +318,5 @@ func TestListSnapshots(t *testing.T) {
 	// Assert
 	assert.Equal(fakeVolID, actualRes.Entries[0].Snapshot.SourceVolumeId)
 
-	assert.NotNil(fakeSnapshotID, actualRes.Entries[0].Snapshot.Id)
+	assert.NotNil(fakeSnapshotID, actualRes.Entries[0].Snapshot.SnapshotId)
 }

--- a/pkg/csi/cinder/driver.go
+++ b/pkg/csi/cinder/driver.go
@@ -19,7 +19,7 @@ package cinder
 import (
 	"fmt"
 
-	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack"
@@ -31,7 +31,7 @@ const (
 )
 
 var (
-	version = "0.3.0"
+	version = "1.0.0"
 )
 
 type CinderDriver struct {

--- a/pkg/csi/cinder/driver_test.go
+++ b/pkg/csi/cinder/driver_test.go
@@ -19,7 +19,7 @@ package cinder
 import (
 	"testing"
 
-	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	vendorVersion = "0.3.0"
+	vendorVersion = "1.0.0"
 )
 
 func NewFakeDriver() *CinderDriver {

--- a/pkg/csi/cinder/identityserver.go
+++ b/pkg/csi/cinder/identityserver.go
@@ -17,7 +17,7 @@ limitations under the License.
 package cinder
 
 import (
-	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/pkg/csi/cinder/identityserver_test.go
+++ b/pkg/csi/cinder/identityserver_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -17,7 +17,9 @@ limitations under the License.
 package cinder
 
 import (
-	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"fmt"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -35,7 +37,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	targetPath := req.GetTargetPath()
 	fsType := req.GetVolumeCapability().GetMount().GetFsType()
-	devicePath := req.GetPublishInfo()["DevicePath"]
+	devicePath := req.GetPublishContext()["DevicePath"]
 
 	// Get Mount Provider
 	m, err := mount.GetMountProvider()
@@ -114,18 +116,6 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	return &csi.NodeStageVolumeResponse{}, nil
 }
 
-func (ns *nodeServer) NodeGetId(ctx context.Context, req *csi.NodeGetIdRequest) (*csi.NodeGetIdResponse, error) {
-
-	nodeID, err := getNodeID()
-	if err != nil {
-		return nil, err
-	}
-
-	return &csi.NodeGetIdResponse{
-		NodeId: nodeID,
-	}, nil
-}
-
 func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
 
 	nodeID, err := getNodeID()
@@ -152,6 +142,10 @@ func (ns *nodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetC
 			},
 		},
 	}, nil
+}
+
+func (ns *nodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, fmt.Sprintf("NodeGetVolumeStats is not yet implemented"))
 }
 
 func getNodeIDMountProvider() (string, error) {

--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -20,7 +20,7 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/mount"
@@ -37,36 +37,6 @@ func init() {
 		d := NewDriver(fakeNodeID, fakeEndpoint, fakeConfig)
 		fakeNs = NewNodeServer(d)
 	}
-}
-
-// Test NodeGetId
-func TestNodeGetId(t *testing.T) {
-
-	// mock MountMock
-	mmock := new(mount.MountMock)
-	// GetInstanceID() (string, error)
-	mmock.On("GetInstanceID").Return(fakeNodeID, nil)
-	mount.MInstance = mmock
-
-	// Init assert
-	assert := assert.New(t)
-
-	// Expected Result
-	expectedRes := &csi.NodeGetIdResponse{
-		NodeId: fakeNodeID,
-	}
-
-	// Fake request
-	fakeReq := &csi.NodeGetIdRequest{}
-
-	// Invoke NodeGetId
-	actualRes, err := fakeNs.NodeGetId(fakeCtx, fakeReq)
-	if err != nil {
-		t.Errorf("failed to NodeGetId: %v", err)
-	}
-
-	// Assert
-	assert.Equal(expectedRes, actualRes)
 }
 
 // Test NodeGetInfo
@@ -121,7 +91,7 @@ func TestNodePublishVolume(t *testing.T) {
 	// Fake request
 	fakeReq := &csi.NodePublishVolumeRequest{
 		VolumeId:         fakeVolID,
-		PublishInfo:      map[string]string{"DevicePath": fakeDevicePath},
+		PublishContext:   map[string]string{"DevicePath": fakeDevicePath},
 		TargetPath:       fakeTargetPath,
 		VolumeCapability: nil,
 		Readonly:         false,

--- a/pkg/csi/cinder/server.go
+++ b/pkg/csi/cinder/server.go
@@ -24,7 +24,7 @@ import (
 	"google.golang.org/grpc"
 	"k8s.io/klog"
 
-	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
 // Defines Non blocking GRPC server interfaces

--- a/pkg/csi/cinder/utils.go
+++ b/pkg/csi/cinder/utils.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"k8s.io/klog"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Update cinder csi driver to csi specs 1.0.0

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #365

**Special notes for your reviewer**:
CSI v0.3.0 support is deprecated with kubernetes 1.13 and will be removed in v1.15

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
`NONE`
