### PR TITLE
Add lingxiankong to the OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ approvers:
 - FengyunPan2
 - flaper87
 - hogepodge
+- lingxiankong
 - NickrenREN
 - rootfs
 - zetaab


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Add myself to the cloud-provider-openstack owners. I've been contributing the repo for almost half a year, the motivation of my contribution comes from the adoption of CPO(as part of Kubernetes as a Service) in our public cloud. I'm also the author of octavia-ingress-controller and maintainer of k8s-keystone-auth service. Being one of the owners doesn't mean more power but more responsibilities.

**Which issue this PR fixes**: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
