### PR TITLE
Fix error output in client-keystone-auth

### DIFF
--- a/cmd/client-keystone-auth/main.go
+++ b/cmd/client-keystone-auth/main.go
@@ -166,13 +166,13 @@ func main() {
 	if !terminal.IsTerminal(int(os.Stdin.Fd())) {
 		options.AuthOptions, err = openstack.AuthOptionsFromEnv()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to read openstack env vars: %s", err)
+			fmt.Fprintf(os.Stderr, "Failed to read openstack env vars: %s\n", err)
 			os.Exit(1)
 		}
 	} else {
 		options.AuthOptions, err = prompt(url, domain, user, project, password, applicationCredentialID, applicationCredentialName, applicationCredentialSecret)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to read data from console: %s", err)
+			fmt.Fprintf(os.Stderr, "Failed to read data from console: %s\n", err)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the error output in `client-keystone-auth`. Before the patch:

```bash
Failed to read openstack env vars: Missing environment variable [OS_AUTH_URL]Failed to read openstack env vars: Missing environment variable [OS_AUTH_URL]Failed to read openstack env vars: Missing environment variable [OS_AUTH_URL]Failed to read openstack env vars: Missing environment variable [OS_AUTH_URL]Failed to read openstack env vars: Missing environment variable [OS_AUTH_URL]Unable to connect to the server: getting credentials: exec: exit status 1
```

after the patch:

```bash
Failed to read openstack env vars: Missing environment variable [OS_AUTH_URL]
Failed to read openstack env vars: Missing environment variable [OS_AUTH_URL]
Failed to read openstack env vars: Missing environment variable [OS_AUTH_URL]
Failed to read openstack env vars: Missing environment variable [OS_AUTH_URL]
Failed to read openstack env vars: Missing environment variable [OS_AUTH_URL]
Unable to connect to the server: getting credentials: exec: exit status 1
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
