### PR TITLE
Implement arguments fallback for client-keystone-auth

### DIFF
--- a/cmd/client-keystone-auth/main.go
+++ b/cmd/client-keystone-auth/main.go
@@ -119,6 +119,10 @@ func prompt(url string, domain string, user string, project string, password str
 	return options, nil
 }
 
+// consolidate input and env
+// set env (and a list to rember)
+// after run clean up
+
 func main() {
 	// Glog requires this otherwise it complains.
 	flag.CommandLine.Parse(nil)
@@ -164,10 +168,23 @@ func main() {
 	// Generate Gophercloud Auth Options based on input data from stdin
 	// if IsTerminal returns "true", or from env variables otherwise.
 	if !terminal.IsTerminal(int(os.Stdin.Fd())) {
+		// ToDo
 		options.AuthOptions, err = openstack.AuthOptionsFromEnv()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to read openstack env vars: %s\n", err)
-			os.Exit(1)
+			//os.Exit(1)
+		}
+
+		// Fallback with arguments
+		options.AuthOptions = gophercloud.AuthOptions{
+			IdentityEndpoint:            url,
+			Username:                    user,
+			TenantName:                  project,
+			Password:                    password,
+			DomainName:                  domain,
+			ApplicationCredentialID:     applicationCredentialID,
+			ApplicationCredentialName:   applicationCredentialName,
+			ApplicationCredentialSecret: applicationCredentialSecret,
 		}
 	} else {
 		options.AuthOptions, err = prompt(url, domain, user, project, password, applicationCredentialID, applicationCredentialName, applicationCredentialSecret)

--- a/cmd/client-keystone-auth/main.go
+++ b/cmd/client-keystone-auth/main.go
@@ -119,10 +119,6 @@ func prompt(url string, domain string, user string, project string, password str
 	return options, nil
 }
 
-// consolidate input and env
-// set env (and a list to rember)
-// after run clean up
-
 func main() {
 	// Glog requires this otherwise it complains.
 	flag.CommandLine.Parse(nil)
@@ -173,18 +169,18 @@ func main() {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to read openstack env vars: %s\n", err)
 			//os.Exit(1)
-		}
 
-		// Fallback with arguments
-		options.AuthOptions = gophercloud.AuthOptions{
-			IdentityEndpoint:            url,
-			Username:                    user,
-			TenantName:                  project,
-			Password:                    password,
-			DomainName:                  domain,
-			ApplicationCredentialID:     applicationCredentialID,
-			ApplicationCredentialName:   applicationCredentialName,
-			ApplicationCredentialSecret: applicationCredentialSecret,
+			// Fallback with arguments
+			options.AuthOptions = gophercloud.AuthOptions{
+				IdentityEndpoint:            url,
+				Username:                    user,
+				TenantName:                  project,
+				Password:                    password,
+				DomainName:                  domain,
+				ApplicationCredentialID:     applicationCredentialID,
+				ApplicationCredentialName:   applicationCredentialName,
+				ApplicationCredentialSecret: applicationCredentialSecret,
+			}
 		}
 	} else {
 		options.AuthOptions, err = prompt(url, domain, user, project, password, applicationCredentialID, applicationCredentialName, applicationCredentialSecret)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Without this PR it's not possible to only use arguments in the `client-keystone-auth` and a pipe.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Fixes: https://github.com/kubernetes/cloud-provider-openstack/issues/476
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
client-keystone-auth: change the default behavior to use cli arguments if set otherwise use env variables for authentication
```
