### PR TITLE
Fix get SyncConfigMapName in config.go bug

### DIFF
--- a/pkg/identity/keystone/config.go
+++ b/pkg/identity/keystone/config.go
@@ -89,6 +89,6 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.PolicyFile, "keystone-policy-file", c.PolicyFile, "File containing the policy, if provided, it takes precedence over the policy configmap.")
 	fs.StringVar(&c.PolicyConfigMapName, "policy-configmap-name", c.PolicyConfigMapName, "ConfigMap in kube-system namespace containing the policy configuration, the ConfigMap data must contain the key 'policies'")
 	fs.StringVar(&c.SyncConfigFile, "sync-config-file", c.SyncConfigFile, "File containing config values for data synchronization beetween Keystone and Kubernetes.")
-	fs.StringVar(&c.SyncConfigFile, "sync-configmap-name", "", "ConfigMap in kube-system namespace containing config values for data synchronization beetween Keystone and Kubernetes.")
+	fs.StringVar(&c.SyncConfigMapName, "sync-configmap-name", "", "ConfigMap in kube-system namespace containing config values for data synchronization beetween Keystone and Kubernetes.")
 	fs.StringVar(&c.Kubeconfig, "kubeconfig", c.Kubeconfig, "Kubeconfig file used to connect to Kubernetes API to get policy configmap. If the service is running inside the pod, this option is not necessary, will use in-cluster config instead.")
 }

--- a/pkg/identity/keystone/keystone.go
+++ b/pkg/identity/keystone/keystone.go
@@ -175,7 +175,9 @@ func (k *KeystoneAuth) updateSyncConfig(cm *apiv1.ConfigMap, key string) {
 	klog.Info("ConfigMap created or updated, will update the sync configuration.")
 
 	var sc *syncConfig
-	if err := json.Unmarshal([]byte(cm.Data["syncConfig"]), sc); err != nil {
+	newConfig := newSyncConfig()
+	sc = &newConfig
+	if err := yaml.Unmarshal([]byte(cm.Data["syncConfig"]), sc); err != nil {
 		runtimeutil.HandleError(fmt.Errorf("failed to parse sync config defined in the configmap %s: %v", key, err))
 	}
 
@@ -435,6 +437,8 @@ func NewKeystoneAuth(c *Config) (*KeystoneAuth, error) {
 			return nil, fmt.Errorf("failed to get configmap %s: %v", c.SyncConfigMapName, err)
 		}
 
+		newConfig := newSyncConfig()
+		sc = &newConfig
 		if err := yaml.Unmarshal([]byte(cm.Data["syncConfig"]), sc); err != nil {
 			klog.Errorf("Unmarshal: %v", err)
 			return nil, fmt.Errorf("failed to parse sync config defined in the configmap %s: %v", c.SyncConfigMapName, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

This PR fix an obvious bug in keystone config.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

when set parameter like this:
`  - ./bin/k8s-keystone-auth
            - --v=10
            - --tls-cert-file
            - /etc/kubernetes/pki/cert-file
            - --tls-private-key-file
            - /etc/kubernetes/pki/key-file
            - --sync-configmap-name
            - k8s-sync-config`

I got eorrors like this:
`I0211 06:17:47.079308       1 keystone.go:544] Kubernetes API client created, server version v1.13`
`E0211 06:17:47.079361       1 sync.go:126] yamlFile get err   #open k8s-sync-config: no such file or directory`
`E0211 06:17:47.079384       1 main.go:60] failed to extract data from sync config file k8s-sync-config: open k8s-sync-config: no such file or directory
`
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
