### PR TITLE
Add cluster info into GetPluginInfo

### DIFF
--- a/pkg/csi/cinder/identityserver.go
+++ b/pkg/csi/cinder/identityserver.go
@@ -39,9 +39,12 @@ func (ids *identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPlugin
 		return nil, status.Error(codes.Unavailable, "Driver is missing version")
 	}
 
+	manifest := map[string]string{"cinder.csi.openstack.org/cluster": ids.Driver.cluster}
+
 	return &csi.GetPluginInfoResponse{
 		Name:          ids.Driver.name,
 		VendorVersion: ids.Driver.version,
+		Manifest:      manifest,
 	}, nil
 }
 

--- a/pkg/csi/cinder/identityserver_test.go
+++ b/pkg/csi/cinder/identityserver_test.go
@@ -34,4 +34,7 @@ func TestGetPluginInfo(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, resp.GetName(), driverName)
 	assert.Equal(t, resp.GetVendorVersion(), vendorVersion)
+	val, err := resp.GetManifest()["cinder.csi.openstack.org/cluster"], err
+	assert.NoError(t, err)
+	assert.Equal(t, val, fakeCluster)
 }


### PR DESCRIPTION
GetPluginInfo can container cluster name for reference
so this patch added the cluster.



**What this PR does / why we need it**:
add cluster info into GetPluginInfo CSI call 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #484 
**Special notes for your reviewer**:

**Release note**:
```release-note
Added the cluster info into CSI call GetPluginInfo 
```
