### PR TITLE
Improve security group management for service provision

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -280,7 +280,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e897927dbf8aca8b64ba6c40ae6d750ebda11e1252e65f95724b128ff66f5c04"
+  digest = "1:fe71cbe1db676a11a5ef5a96cbcdf45ca4ae65f3ef663cc0a287d90d60c98ce3"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -309,6 +309,7 @@
     "openstack/loadbalancer/v2/monitors",
     "openstack/loadbalancer/v2/pools",
     "openstack/networking/v2/extensions",
+    "openstack/networking/v2/extensions/attributestags",
     "openstack/networking/v2/extensions/external",
     "openstack/networking/v2/extensions/layer3/floatingips",
     "openstack/networking/v2/extensions/layer3/routers",
@@ -1552,6 +1553,7 @@
     "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors",
     "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools",
     "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions",
+    "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags",
     "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external",
     "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips",
     "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR focuses on the scenario of using Octavia, it does several things:
- When creating service, create a new security group and add rules to allow traffic coming from the load balancer subnet IP address range while going to the service nodeport on the nodes. Associate the security group with all the Neutron ports on the nodes, add a tag to the ports.
- When deleting service, disassociate the security group from the Neutron ports on the nodes before removing.

**Which issue this PR fixes**: 
fixes #490

**Special notes for your reviewer**:
Test process for thie PR:
1. Using image `lingxiankong/openstack-cloud-controller-manager:improve-sg`
1. Configuration
    ```
    [Global]
    auth-url=http://192.168.206.8/identity
    user-id=94a665016c3e4d44a315b14d92f9ef49
    password=password
    tenant-id=cd08a539b7c845ddb92c5d08752101d1
    region=RegionOne
    [LoadBalancer]
    use-octavia=yes
    subnet-id=7e5398da-a77a-4d5a-a2ae-f1273132f869
    create-monitor=no
    manage-security-groups=true
    [BlockStorage]
    bs-version=v2
    ```
1. The security group of the Neutron ports on the nodes only allows the basic traffic within the kubernetes cluster such as 10250. The default port range for service ports is not exposed. 
1. Create a service of LoadBalancer type.
    ```
    $ kubectl run hostname-server --image=lingxiankong/alpine-test --port=8080
    $ kubectl expose deployment hostname-server --type=LoadBalancer --target-port=8080 --port=80 --name hostname-server
    $ kubectl get svc
    NAME              TYPE           CLUSTER-IP   EXTERNAL-IP    PORT(S)        AGE
    hostname-server   LoadBalancer   10.96.74.3   172.24.4.243   80:32760/TCP   44s
    ```
1. A load balancer is created and behaves as expected.
    ```
    $ openstack loadbalancer list
    +--------------------------------------+----------------------------------+----------------------------------+-------------+---------------------+----------+
    | id                                   | name                             | project_id                       | vip_address | provisioning_status | provider |
    +--------------------------------------+----------------------------------+----------------------------------+-------------+---------------------+----------+
    | 5ebd3ef7-8069-4735-bc73-b08f33f715e3 | a8c8af25d342711e98f68fa163e8309a | cd08a539b7c845ddb92c5d08752101d1 | 10.0.0.14   | ACTIVE              | amphora  |
    +--------------------------------------+----------------------------------+----------------------------------+-------------+---------------------+----------+
    $ curl 172.24.4.243
    hostname-server-7857c9b75b-b85mx
    ```
1. Check the security groups rules on the worker node Neutron port.
    ```
    $ openstack port list --device-id 3515c2d9-ce37-439e-b3cb-cc759cac444e
    +--------------------------------------+--------------------+-------------------+--------------------------------------------------------------------------+--------+
    | ID                                   | Name               | MAC Address       | Fixed IP Addresses                                                       | Status |
    +--------------------------------------+--------------------+-------------------+--------------------------------------------------------------------------+--------+
    | 87d41ec1-ba9a-44c1-a371-d833d8a4bf94 | lingxian-k8s-node1 | fa:16:3e:19:a1:60 | ip_address='10.0.0.22', subnet_id='7e5398da-a77a-4d5a-a2ae-f1273132f869' | ACTIVE |
    +--------------------------------------+--------------------+-------------------+--------------------------------------------------------------------------+--------+
    $ openstack port show 87d41ec1-ba9a-44c1-a371-d833d8a4bf94 | grep security
    | port_security_enabled   | True                                                                       |
    | security_group_ids      | bf910fe6-e236-49f3-8eb5-1edc263aa02e, c63a2657-300b-4ab0-9201-65b49e3ba815 |
    $ openstack security group rule list bf910fe6-e236-49f3-8eb5-1edc263aa02e
    +--------------------------------------+-------------+-------------+-------------+-----------------------+
    | ID                                   | IP Protocol | IP Range    | Port Range  | Remote Security Group |
    +--------------------------------------+-------------+-------------+-------------+-----------------------+
    | 4120d44e-cb9b-4ac5-a0eb-15b1ac67f01c | tcp         | 10.0.0.0/26 | 32760:32760 | None                  |
    | 9dfee722-95e8-4b20-a58a-6db7f26eaf7b | None        | None        |             | None                  |
    | e7ec4602-21d4-4d9b-9f12-01f4dd360aa8 | None        | None        |             | None                  |
    +--------------------------------------+-------------+-------------+-------------+-----------------------+
    $ openstack port show 87d41ec1-ba9a-44c1-a371-d833d8a4bf94 | grep tag
    | tags                    | bf910fe6-e236-49f3-8eb5-1edc263aa02e
    ```
1. Delete the service and check again. Make sure the security group has been deleted and the port tag has been removed.
    ```
    $ openstack port show 87d41ec1-ba9a-44c1-a371-d833d8a4bf94 | grep tag
    | tags                    |                                                                          |
    ```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
