### PR TITLE
manila: added osShareNetworkID option

### DIFF
--- a/docs/using-manila-provisioner.md
+++ b/docs/using-manila-provisioner.md
@@ -27,6 +27,7 @@ Key | Required | Default value | Description
 `osShareID` | No | None | The UUID of an existing share. Used for static provisioning
 `osShareName` | No | None | The name of an existing share. Used for static provisioning
 `osShareAccessID` | No | None | The UUID of an existing access rule to a share. Used for static provisioning
+`osShareNetworkID` | No | None | The UUID of a share network where the share server exists or will be created.
 
 
 **Share-backend specific options**

--- a/pkg/share/manila/share.go
+++ b/pkg/share/manila/share.go
@@ -118,10 +118,11 @@ func buildCreateRequest(
 	shareName := "pvc-" + string(volOptions.PVC.GetUID())
 
 	return &shares.CreateOpts{
-		ShareProto: shareOptions.Protocol,
-		Size:       storageSize,
-		Name:       shareName,
-		ShareType:  shareOptions.Type,
+		ShareProto:     shareOptions.Protocol,
+		ShareNetworkID: shareOptions.OSShareNetworkID,
+		Size:           storageSize,
+		Name:           shareName,
+		ShareType:      shareOptions.Type,
 		Metadata: map[string]string{
 			persistentvolume.CloudVolumeCreatedForClaimNamespaceTag: volOptions.PVC.Namespace,
 			persistentvolume.CloudVolumeCreatedForClaimNameTag:      volOptions.PVC.Name,

--- a/pkg/share/manila/shareoptions/shareoptions.go
+++ b/pkg/share/manila/shareoptions/shareoptions.go
@@ -35,6 +35,8 @@ type ShareOptions struct {
 	OSSecretNamespace    string `name:"osSecretNamespace" value:"default:default"`
 	ShareSecretNamespace string `name:"shareSecretNamespace" value:"default:default"`
 
+	OSShareNetworkID string `name:"osShareNetworkID" value:"optional"`
+
 	OSShareID       string `name:"osShareID" value:"optional" dependsOn:"osShareAccessID"`
 	OSShareName     string `name:"osShareName" value:"optional" dependsOn:"osShareAccessID"`
 	OSShareAccessID string `name:"osShareAccessID" value:"optional" dependsOn:"osShareID|osShareName"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Adds an optional StorageClass field `osShareNetworkID`

**Which issue this PR fixes**
fixes #420

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
manila-provisioner: added a new StorageClass option osShareNetworkID
```
