### PR TITLE
Add document section about csi version compatibility

### DIFF
--- a/docs/using-cinder-csi-plugin.md
+++ b/docs/using-cinder-csi-plugin.md
@@ -2,6 +2,15 @@
 
 ## Kubernetes
 
+### Compatibility
+
+CSI version | CSI Sidecar Version | Cinder CSI Plugin Version | Kubernetes Version
+:------ | :------- | :------------ | :-----------
+v1.0.x | v1.0.x | v1.0.0  docker image: k8scloudprovider/cinder-csi-plugin:latest | v1.13+
+v0.3.0 | v0.3.x, v0.4.x | v0.3.0 docker image: k8scloudprovider/cinder-csi-plugin:1.13.x| v1.11, v1.12, v1.13
+v0.2.0 | v0.2.x | v0.2.0 docker image: k8scloudprovider/cinder-csi-plugin:0.2.0 | v1.10, v1.9
+v0.1.0 | v0.1.0 | v0.1.0 docker image: k8scloudprovider/cinder-csi-plugin:0.1.0| v1.9
+
 ### Requirements
 
 Enable Following features gates for kubernetes cluster running versions lower than v1.10.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Various user facing issues related to compatibility while deploying cinder csi driver 
#486, https://github.com/kubernetes/kubernetes/issues/74162
This PR adds compatibilty tables between cinder csi driver, sidecar and k8s

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
`NONE`
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
