### PR TITLE
Add Support for Running CSI Sanity Tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -380,6 +380,17 @@
   version = "v1.0.2"
 
 [[projects]]
+  digest = "1:c9ba37d3709f57185b60f587a6282378feaff2aa3cddc28a56770704e3f96b98"
+  name = "github.com/kubernetes-csi/csi-test"
+  packages = [
+    "pkg/sanity",
+    "utils",
+  ]
+  pruneopts = "UT"
+  revision = "5b1e3786b7c8f7ca514b40e882a0b5dc36e4c842"
+  version = "v1.1.0"
+
+[[projects]]
   digest = "1:c568d7727aa262c32bdf8a3f7db83614f7af0ed661474b24588de635c20024c7"
   name = "github.com/magiconair/properties"
   packages = ["."]
@@ -1563,6 +1574,7 @@
     "github.com/gophercloud/gophercloud/testhelper/client",
     "github.com/gophercloud/utils/openstack/clientconfig",
     "github.com/gorilla/mux",
+    "github.com/kubernetes-csi/csi-test/pkg/sanity",
     "github.com/mitchellh/go-homedir",
     "github.com/mitchellh/mapstructure",
     "github.com/onsi/ginkgo",

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ test: unit functional
 check: depend fmt vet lint import-boss
 
 unit: depend
-	go test -tags=unit $(shell go list ./...) $(TESTARGS)
+	go test -tags=unit $(shell go list ./... | sed -e '/sanity/ { N; d; }') $(TESTARGS)
 
 functional:
 	@echo "$@ not yet implemented"

--- a/cmd/cinder-csi-plugin/main.go
+++ b/cmd/cinder-csi-plugin/main.go
@@ -24,6 +24,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder"
+	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/mount"
+	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack"
 	"k8s.io/component-base/logs"
 	"k8s.io/klog"
 )
@@ -94,6 +96,29 @@ func main() {
 }
 
 func handle() {
-	d := cinder.NewDriver(nodeID, endpoint, cluster, cloudconfig)
+	d := cinder.NewDriver(nodeID, endpoint, cluster)
+
+	//Intiliaze mount
+	mount, err := mount.GetMountProvider()
+	if err != nil {
+		klog.V(3).Infof("Failed to GetMountProvider: %v", err)
+	}
+
+	//Intiliaze Metadatda
+	metadatda, err := openstack.GetMetadataProvider()
+	if err != nil {
+		klog.V(3).Infof("Failed to GetMetadataProvider: %v", err)
+	}
+
+	// Initiliaze cloud
+	openstack.InitOpenStackProvider(cloudconfig)
+	cloud, err := openstack.GetOpenStackProvider()
+
+	if err != nil {
+		klog.V(3).Infof("Failed to GetOpenStackProvider: %v", err)
+		return
+	}
+
+	d.SetupDriver(cloud, mount, metadatda)
 	d.Run()
 }

--- a/pkg/csi/cinder/driver_test.go
+++ b/pkg/csi/cinder/driver_test.go
@@ -33,7 +33,7 @@ var (
 
 func NewFakeDriver() *CinderDriver {
 
-	driver := NewDriver(fakeNodeID, fakeEndpoint, fakeCluster, fakeConfig)
+	driver := NewDriver(FakeNodeID, FakeEndpoint, FakeCluster)
 
 	return driver
 }

--- a/pkg/csi/cinder/fake.go
+++ b/pkg/csi/cinder/fake.go
@@ -22,36 +22,45 @@ import (
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack"
 )
 
-var fakeCluster = "cluster"
-var fakeNodeID = "CSINodeID"
-var fakeEndpoint = "tcp://127.0.0.1:10000"
-var fakeConfig = "/etc/cloud.conf"
-var fakeCtx = context.Background()
-var fakeVolName = "CSIVolumeName"
-var fakeVolID = "CSIVolumeID"
-var fakeSnapshotName = "CSISnapshotName"
-var fakeSnapshotID = "261a8b81-3660-43e5-bab8-6470b65ee4e8"
-var fakeCapacityGiB = 1
-var fakeVolType = ""
-var fakeAvailability = "nova"
-var fakeDevicePath = "/dev/xxx"
-var fakeTargetPath = "/mnt/cinder"
-var fakeStagingTargetPath = "/mnt/globalmount"
-var fakeVol1 = openstack.Volume{
+var FakeCluster = "cluster"
+var FakeNodeID = "CSINodeID"
+var FakeEndpoint = "tcp://127.0.0.1:10000"
+var FakeConfig = "/etc/cloud.conf"
+var FakeCtx = context.Background()
+var FakeVolName = "CSIVolumeName"
+var FakeVolID = "CSIVolumeID"
+var FakeSnapshotName = "CSISnapshotName"
+var FakeSnapshotID = "261a8b81-3660-43e5-bab8-6470b65ee4e8"
+var FakeCapacityGiB = 1
+var FakeVolType = ""
+var FakeAvailability = "nova"
+var FakeDevicePath = "/dev/xxx"
+var FakeTargetPath = "/mnt/cinder"
+var FakeStagingTargetPath = "/mnt/globalmount"
+var FakeVol1 = openstack.Volume{
 	ID:     "261a8b81-3660-43e5-bab8-6470b65ee4e9",
 	Name:   "fake-duplicate",
 	Status: "available",
 	AZ:     "",
 }
-var fakeVol2 = openstack.Volume{
+var FakeVol2 = openstack.Volume{
 	ID:     "261a8b81-3660-43e5-bab8-6470b65ee4e9",
 	Name:   "fake-duplicate",
 	Status: "available",
 	AZ:     "",
 }
-var fakeSnapshotRes = snapshots.Snapshot{
-	ID:       fakeSnapshotID,
+var FakeVol3 = openstack.Volume{
+	ID:     "261a8b81-3660-43e5-bab8-6470b65ee4e9",
+	Name:   "fake-3",
+	Status: "available",
+	AZ:     "",
+}
+var FakeSnapshotRes = snapshots.Snapshot{
+	ID:       FakeSnapshotID,
 	Name:     "fake-snapshot",
-	VolumeID: fakeVolID,
+	VolumeID: FakeVolID,
 }
-var fakeSnapshotsRes = []snapshots.Snapshot{fakeSnapshotRes}
+
+var FakeSnapshotsRes = []snapshots.Snapshot{FakeSnapshotRes}
+var FakeVolList = []openstack.Volume{FakeVol1, FakeVol3}
+var FakeInstanceID = "321a8b81-3660-43e5-bab8-6470b65ee4e8"

--- a/pkg/csi/cinder/identityserver_test.go
+++ b/pkg/csi/cinder/identityserver_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestGetPluginInfo(t *testing.T) {
-	d := NewDriver(fakeNodeID, fakeEndpoint, fakeCluster, fakeConfig)
+	d := NewDriver(FakeNodeID, FakeEndpoint, FakeCluster)
 
 	ids := NewIdentityServer(d)
 

--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 var fakeNs *nodeServer
+var mmock *mount.MountMock
+var metamock *openstack.OpenStackMock
 
 // Init Node Server
 func init() {
@@ -35,38 +37,40 @@ func init() {
 		// to avoid annoying ERROR: logging before flag.Parse
 		flag.Parse()
 
-		d := NewDriver(fakeNodeID, fakeEndpoint, fakeCluster, fakeConfig)
-		fakeNs = NewNodeServer(d)
+		d := NewDriver(FakeNodeID, FakeEndpoint, FakeCluster)
+
+		// mock MountMock
+		mmock = new(mount.MountMock)
+		mount.MInstance = mmock
+
+		metamock = new(openstack.OpenStackMock)
+		openstack.MetadataService = metamock
+		fakeNs = NewNodeServer(d, mount.MInstance, openstack.MetadataService)
 	}
 }
 
 // Test NodeGetInfo
 func TestNodeGetInfo(t *testing.T) {
 
-	// mock MountMock
-	mmock := new(mount.MountMock)
 	// GetInstanceID() (string, error)
-	mmock.On("GetInstanceID").Return(fakeNodeID, nil)
-	mount.MInstance = mmock
+	mmock.On("GetInstanceID").Return(FakeNodeID, nil)
 
-	osmock := new(openstack.OpenStackMock)
-	osmock.On("GetAvailabilityZone").Return(fakeAvailability, nil)
-	openstack.MetadataService = osmock
+	metamock.On("GetAvailabilityZone").Return(FakeAvailability, nil)
 
 	// Init assert
 	assert := assert.New(t)
 
 	// Expected Result
 	expectedRes := &csi.NodeGetInfoResponse{
-		NodeId:             fakeNodeID,
-		AccessibleTopology: &csi.Topology{Segments: map[string]string{topologyKey: fakeAvailability}},
+		NodeId:             FakeNodeID,
+		AccessibleTopology: &csi.Topology{Segments: map[string]string{topologyKey: FakeAvailability}},
 	}
 
 	// Fake request
 	fakeReq := &csi.NodeGetInfoRequest{}
 
 	// Invoke NodeGetId
-	actualRes, err := fakeNs.NodeGetInfo(fakeCtx, fakeReq)
+	actualRes, err := fakeNs.NodeGetInfo(FakeCtx, fakeReq)
 	if err != nil {
 		t.Errorf("failed to NodeGetInfo: %v", err)
 	}
@@ -78,15 +82,12 @@ func TestNodeGetInfo(t *testing.T) {
 // Test NodePublishVolume
 func TestNodePublishVolume(t *testing.T) {
 
-	// mock MountMock
-	mmock := new(mount.MountMock)
 	// ScanForAttach(devicePath string) error
-	mmock.On("ScanForAttach", fakeDevicePath).Return(nil)
+	mmock.On("ScanForAttach", FakeDevicePath).Return(nil)
 	// IsLikelyNotMountPointAttach(targetpath string) (bool, error)
-	mmock.On("IsLikelyNotMountPointAttach", fakeTargetPath).Return(true, nil)
+	mmock.On("IsLikelyNotMountPointAttach", FakeTargetPath).Return(true, nil)
 	// Mount(source string, target string, fstype string, options []string) error
-	mmock.On("Mount", fakeStagingTargetPath, fakeTargetPath, mock.AnythingOfType("string"), []string{"bind", "rw"}).Return(nil)
-	mount.MInstance = mmock
+	mmock.On("Mount", FakeStagingTargetPath, FakeTargetPath, mock.AnythingOfType("string"), []string{"bind", "rw"}).Return(nil)
 
 	// Init assert
 	assert := assert.New(t)
@@ -103,16 +104,16 @@ func TestNodePublishVolume(t *testing.T) {
 	}
 	// Fake request
 	fakeReq := &csi.NodePublishVolumeRequest{
-		VolumeId:          fakeVolID,
-		PublishContext:    map[string]string{"DevicePath": fakeDevicePath},
-		TargetPath:        fakeTargetPath,
-		StagingTargetPath: fakeStagingTargetPath,
+		VolumeId:          FakeVolID,
+		PublishContext:    map[string]string{"DevicePath": FakeDevicePath},
+		TargetPath:        FakeTargetPath,
+		StagingTargetPath: FakeStagingTargetPath,
 		VolumeCapability:  stdVolCap,
 		Readonly:          false,
 	}
 
 	// Invoke NodePublishVolume
-	actualRes, err := fakeNs.NodePublishVolume(fakeCtx, fakeReq)
+	actualRes, err := fakeNs.NodePublishVolume(FakeCtx, fakeReq)
 	if err != nil {
 		t.Errorf("failed to NodePublishVolume: %v", err)
 	}
@@ -124,15 +125,12 @@ func TestNodePublishVolume(t *testing.T) {
 // Test NodeStageVolume
 func TestNodeStageVolume(t *testing.T) {
 
-	// mock MountMock
-	mmock := new(mount.MountMock)
 	// ScanForAttach(devicePath string) error
-	mmock.On("ScanForAttach", fakeDevicePath).Return(nil)
+	mmock.On("ScanForAttach", FakeDevicePath).Return(nil)
 	// IsLikelyNotMountPointAttach(targetpath string) (bool, error)
-	mmock.On("IsLikelyNotMountPointAttach", fakeStagingTargetPath).Return(true, nil)
+	mmock.On("IsLikelyNotMountPointAttach", FakeStagingTargetPath).Return(true, nil)
 	// FormatAndMount(source string, target string, fstype string, options []string) error
-	mmock.On("FormatAndMount", fakeDevicePath, fakeStagingTargetPath, "ext4", []string(nil)).Return(nil)
-	mount.MInstance = mmock
+	mmock.On("FormatAndMount", FakeDevicePath, FakeStagingTargetPath, "ext4", []string(nil)).Return(nil)
 
 	// Init assert
 	assert := assert.New(t)
@@ -150,14 +148,14 @@ func TestNodeStageVolume(t *testing.T) {
 
 	// Fake request
 	fakeReq := &csi.NodeStageVolumeRequest{
-		VolumeId:          fakeVolID,
-		PublishContext:    map[string]string{"DevicePath": fakeDevicePath},
-		StagingTargetPath: fakeStagingTargetPath,
+		VolumeId:          FakeVolID,
+		PublishContext:    map[string]string{"DevicePath": FakeDevicePath},
+		StagingTargetPath: FakeStagingTargetPath,
 		VolumeCapability:  stdVolCap,
 	}
 
 	// Invoke NodeStageVolume
-	actualRes, err := fakeNs.NodeStageVolume(fakeCtx, fakeReq)
+	actualRes, err := fakeNs.NodeStageVolume(FakeCtx, fakeReq)
 	if err != nil {
 		t.Errorf("failed to NodeStageVolume: %v", err)
 	}
@@ -169,14 +167,10 @@ func TestNodeStageVolume(t *testing.T) {
 // Test NodeUnpublishVolume
 func TestNodeUnpublishVolume(t *testing.T) {
 
-	// mock MountMock
-	mmock := new(mount.MountMock)
-
 	// IsLikelyNotMountPointDetach(targetpath string) (bool, error)
-	mmock.On("IsLikelyNotMountPointDetach", fakeTargetPath).Return(false, nil)
+	mmock.On("IsLikelyNotMountPointDetach", FakeTargetPath).Return(false, nil)
 	// UnmountPath(mountPath string) error
-	mmock.On("UnmountPath", fakeTargetPath).Return(nil)
-	mount.MInstance = mmock
+	mmock.On("UnmountPath", FakeTargetPath).Return(nil)
 
 	// Init assert
 	assert := assert.New(t)
@@ -186,12 +180,12 @@ func TestNodeUnpublishVolume(t *testing.T) {
 
 	// Fake request
 	fakeReq := &csi.NodeUnpublishVolumeRequest{
-		VolumeId:   fakeVolID,
-		TargetPath: fakeTargetPath,
+		VolumeId:   FakeVolID,
+		TargetPath: FakeTargetPath,
 	}
 
 	// Invoke NodeUnpublishVolume
-	actualRes, err := fakeNs.NodeUnpublishVolume(fakeCtx, fakeReq)
+	actualRes, err := fakeNs.NodeUnpublishVolume(FakeCtx, fakeReq)
 	if err != nil {
 		t.Errorf("failed to NodeUnpublishVolume: %v", err)
 	}
@@ -203,14 +197,10 @@ func TestNodeUnpublishVolume(t *testing.T) {
 // Test NodeUnstageVolume
 func TestNodeUnstageVolume(t *testing.T) {
 
-	// mock MountMock
-	mmock := new(mount.MountMock)
-
 	// IsLikelyNotMountPointDetach(targetpath string) (bool, error)
-	mmock.On("IsLikelyNotMountPointDetach", fakeStagingTargetPath).Return(false, nil)
+	mmock.On("IsLikelyNotMountPointDetach", FakeStagingTargetPath).Return(false, nil)
 	// UnmountPath(mountPath string) error
-	mmock.On("UnmountPath", fakeStagingTargetPath).Return(nil)
-	mount.MInstance = mmock
+	mmock.On("UnmountPath", FakeStagingTargetPath).Return(nil)
 
 	// Init assert
 	assert := assert.New(t)
@@ -220,12 +210,12 @@ func TestNodeUnstageVolume(t *testing.T) {
 
 	// Fake request
 	fakeReq := &csi.NodeUnstageVolumeRequest{
-		VolumeId:          fakeVolID,
-		StagingTargetPath: fakeStagingTargetPath,
+		VolumeId:          FakeVolID,
+		StagingTargetPath: FakeStagingTargetPath,
 	}
 
 	// Invoke NodeUnstageVolume
-	actualRes, err := fakeNs.NodeUnstageVolume(fakeCtx, fakeReq)
+	actualRes, err := fakeNs.NodeUnstageVolume(FakeCtx, fakeReq)
 	if err != nil {
 		t.Errorf("failed to NodeUnstageVolume: %v", err)
 	}

--- a/pkg/csi/cinder/sanity/fakecloud.go
+++ b/pkg/csi/cinder/sanity/fakecloud.go
@@ -1,0 +1,75 @@
+package sanity
+
+import (
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
+	"k8s.io/cloud-provider-openstack/pkg/csi/cinder"
+	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack"
+)
+
+type cloud struct {
+}
+
+// Fake Cloud
+func (cloud *cloud) CreateVolume(name string, size int, vtype, availability string, snapshotID string, tags *map[string]string) (string, string, int, error) {
+
+	return cinder.FakeVolID, cinder.FakeAvailability, cinder.FakeCapacityGiB, nil
+}
+
+func (cloud *cloud) DeleteVolume(volumeID string) error {
+	return nil
+
+}
+
+func (cloud *cloud) AttachVolume(instanceID, volumeID string) (string, error) {
+	return cinder.FakeVolID, nil
+}
+
+func (cloud *cloud) ListVolumes() ([]openstack.Volume, error) {
+	return cinder.FakeVolList, nil
+
+}
+
+func (cloud *cloud) WaitDiskAttached(instanceID string, volumeID string) error {
+	return nil
+
+}
+
+func (cloud *cloud) DetachVolume(instanceID, volumeID string) error {
+	return nil
+
+}
+
+func (cloud *cloud) WaitDiskDetached(instanceID string, volumeID string) error {
+	return nil
+
+}
+func (cloud *cloud) GetAttachmentDiskPath(instanceID, volumeID string) (string, error) {
+	return cinder.FakeDevicePath, nil
+
+}
+func (cloud *cloud) GetVolumesByName(name string) ([]openstack.Volume, error) {
+
+	return cinder.FakeVolList, nil
+
+}
+func (cloud *cloud) CreateSnapshot(name, volID, description string, tags *map[string]string) (*snapshots.Snapshot, error) {
+	return &cinder.FakeSnapshotRes, nil
+}
+func (cloud *cloud) ListSnapshots(limit, offset int, filters map[string]string) ([]snapshots.Snapshot, error) {
+	return cinder.FakeSnapshotsRes, nil
+}
+func (cloud *cloud) DeleteSnapshot(snapID string) error {
+	return nil
+
+}
+func (cloud *cloud) GetSnapshotByNameAndVolumeID(n string, volumeId string) ([]snapshots.Snapshot, error) {
+	return cinder.FakeSnapshotsRes, nil
+}
+
+func (cloud *cloud) GetSnapshotByID(snapshotID string) (*snapshots.Snapshot, error) {
+	return &cinder.FakeSnapshotRes, nil
+}
+
+func (cloud *cloud) WaitSnapshotReady(snapshotID string) error {
+	return nil
+}

--- a/pkg/csi/cinder/sanity/fakemetadata.go
+++ b/pkg/csi/cinder/sanity/fakemetadata.go
@@ -1,0 +1,16 @@
+package sanity
+
+import "k8s.io/cloud-provider-openstack/pkg/csi/cinder"
+
+type fakemetadata struct {
+}
+
+// fake metadata
+
+func (m *fakemetadata) GetInstanceID() (string, error) {
+	return cinder.FakeInstanceID, nil
+}
+
+func (m *fakemetadata) GetAvailabilityZone() (string, error) {
+	return cinder.FakeAvailability, nil
+}

--- a/pkg/csi/cinder/sanity/fakemount.go
+++ b/pkg/csi/cinder/sanity/fakemount.go
@@ -1,0 +1,37 @@
+package sanity
+
+import "k8s.io/cloud-provider-openstack/pkg/csi/cinder"
+
+type fakemount struct {
+}
+
+// fake mount
+
+func (m *fakemount) ScanForAttach(devicePath string) error {
+	return nil
+}
+
+func (m *fakemount) IsLikelyNotMountPointAttach(targetpath string) (bool, error) {
+	return true, nil
+}
+
+func (m *fakemount) FormatAndMount(source string, target string, fstype string, options []string) error {
+	return nil
+}
+
+func (m *fakemount) IsLikelyNotMountPointDetach(targetpath string) (bool, error) {
+	return true, nil
+}
+
+func (m *fakemount) Mount(source string, target string, fstype string, options []string) error {
+	return nil
+
+}
+
+func (m *fakemount) UnmountPath(mountPath string) error {
+	return nil
+}
+
+func (m *fakemount) GetInstanceID() (string, error) {
+	return cinder.FakeInstanceID, nil
+}

--- a/pkg/csi/cinder/sanity/sanity_test.go
+++ b/pkg/csi/cinder/sanity/sanity_test.go
@@ -1,0 +1,51 @@
+package sanity
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"k8s.io/cloud-provider-openstack/pkg/csi/cinder"
+
+	"github.com/kubernetes-csi/csi-test/pkg/sanity"
+)
+
+//start sanity test for driver
+func TestDriver(t *testing.T) {
+
+	socket := "/tmp/csi.sock"
+	endpoint := "unix://" + socket
+	cluster := "kubernetes"
+	nodeID := "45678"
+
+	d := cinder.NewDriver(nodeID, endpoint, cluster)
+	c := &cloud{}
+	fakemnt := &fakemount{}
+	fakemet := &fakemetadata{}
+
+	d.SetupDriver(c, fakemnt, fakemet)
+
+	//TODO: Stop call
+
+	go d.Run()
+
+	mntDir, err := ioutil.TempDir("", "mnt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(mntDir)
+
+	mntStageDir, err := ioutil.TempDir("", "mnt-stage")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(mntStageDir)
+
+	config := &sanity.Config{
+		TargetPath:  mntDir,
+		StagingPath: mntStageDir,
+		Address:     endpoint,
+	}
+
+	sanity.Test(t, config)
+}

--- a/pkg/csi/cinder/utils.go
+++ b/pkg/csi/cinder/utils.go
@@ -7,6 +7,8 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/mount"
+	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack"
 	"k8s.io/klog"
 )
 
@@ -34,9 +36,10 @@ func NewVolumeCapabilityAccessMode(mode csi.VolumeCapability_AccessMode_Mode) *c
 	return &csi.VolumeCapability_AccessMode{Mode: mode}
 }
 
-func NewControllerServer(d *CinderDriver) *controllerServer {
+func NewControllerServer(d *CinderDriver, cloud openstack.IOpenStack) *controllerServer {
 	return &controllerServer{
 		Driver: d,
+		Cloud:  cloud,
 	}
 }
 
@@ -46,9 +49,11 @@ func NewIdentityServer(d *CinderDriver) *identityServer {
 	}
 }
 
-func NewNodeServer(d *CinderDriver) *nodeServer {
+func NewNodeServer(d *CinderDriver, mount mount.IMount, metadata openstack.IMetadata) *nodeServer {
 	return &nodeServer{
-		Driver: d,
+		Driver:   d,
+		Mount:    mount,
+		Metadata: metadata,
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR adds support for running csi sanity tests, from csi-test/sanity, It adds a package sanity which provides fake cloud provider, fake metadata and fake mount
and instantiate cinder csi driver for running sanity tests.

This PR does not fix sanity test failures, for this a separate PR will be created. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #469

**Special notes for your reviewer**:
Using Existing mock package for cloud provider, metadata and mount was not possible as mock function arguments comes csi-test/sanity package, and also it does not support conditional mocking.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
`None.`