### PR TITLE
Support new annotation for Service

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -277,7 +277,7 @@
     "testhelper/client",
   ]
   pruneopts = "UT"
-  revision = "b18d22ae2c8b9ef046c980e62422369b5aea953f"
+  revision = "f83aee3da90f3f337d024070e2e68b04fb035149"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
**What this PR does / why we need it**:
Support to specify port ID to create Service of LoadBalancer type.

Use case:
Sometimes, we need to know the service IP address before a Service is actually created, so other applications who replies on the Service external IP could be deployed with no dependencies, e.g. the kube-apiserver certificate could be created before the service is actually created.

In order to specify port ID to create Service, a new annotation for Service is introduced, e.g.:
```yaml
annotations:
  loadbalancer.openstack.org/port-id: "849ee2ed-72a6-44a4-911e-6a8be46dbe8e"
```

Please be aware that after the Service is created, port ID cannot be changed.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Introduce a new annotation(`loadbalancer.openstack.org/port-id`) for Service of LoadBalancer type to specify a particular Neutron port for creating the Octavia load balancer.
```