### PR TITLE
Update kubernetes to v1.14.0-beta.2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -13,20 +13,20 @@
   revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
 
 [[projects]]
-  digest = "1:8e53ab383e902619948eecae0c5e328057905a9a7abbe34ea178fe0a9157a918"
+  digest = "1:af6e785bedb62fc2abb81977c58a7a44e5cf9f7e41b8d3c8dd4d872edea0ce08"
   name = "github.com/NYTimes/gziphandler"
   packages = ["."]
   pruneopts = "UT"
-  revision = "b8a1976e622c1b8052c79219930d64a340ac5fcd"
-  version = "v1.1.0"
+  revision = "dd0439581c7657cb652dfe5c71d7d48baf39541d"
+  version = "v1.1.1"
 
 [[projects]]
-  digest = "1:d1665c44bd5db19aaee18d1b6233c99b0b9a986e8bccb24ef54747547a48027f"
+  digest = "1:a2682518d905d662d984ef9959984ef87cecb777d379bfa9d9fe40e78069b3e4"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
   pruneopts = "UT"
-  revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
-  version = "v1.1.0"
+  revision = "44968752391892e1b0d0b821ee79e9a85fa13049"
+  version = "v1.1.1"
 
 [[projects]]
   branch = "master"
@@ -165,7 +165,7 @@
   version = "v0.18.0"
 
 [[projects]]
-  digest = "1:1f4955627f01f4168c991891aae53ea7c0af139cf2d66bd641978a7bd50da841"
+  digest = "1:33f49b72fdad072a03d13b31a42edfff08088b7c27198f4073b8213a58884f27"
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",
@@ -174,8 +174,8 @@
     "sortkeys",
   ]
   pruneopts = "UT"
-  revision = "4cbf7e384e768b4e01799441fdf2a706a5635ae7"
-  version = "v1.2.0"
+  revision = "ba06b47c162d49f2af050fb4c75bcbc86a159d5c"
+  version = "v1.2.1"
 
 [[projects]]
   branch = "master"
@@ -186,7 +186,7 @@
   revision = "5b532d6fd5efaf7fa130d4e859a2fde0fc3a9e1b"
 
 [[projects]]
-  digest = "1:588beb9f80d2b0afddf05663b32d01c867da419458b560471d81cca0286e76b8"
+  digest = "1:cf0608a4d324260ef753cd04a1977ccca36937b9a6a5544ab08e804325e9cdc0"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -198,8 +198,8 @@
     "ptypes/wrappers",
   ]
   pruneopts = "UT"
-  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
-  version = "v1.2.0"
+  revision = "c823c79ea1570fb5ff454033735a8e68575d1d0f"
+  version = "v1.3.0"
 
 [[projects]]
   branch = "master"
@@ -210,12 +210,12 @@
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
-  digest = "1:236d7e1bdb50d8f68559af37dbcf9d142d56b431c9b2176d41e2a009b664cda8"
+  digest = "1:582b704bebaa06b48c29b0cec224a6058a09c86883aaddabde889cd1a5f73e1b"
   name = "github.com/google/uuid"
   packages = ["."]
   pruneopts = "UT"
-  revision = "9b3b1e0f5f99ae461456d768e7d301a7acdaa2d8"
-  version = "v1.1.0"
+  revision = "0cd6bf5da1e1c83f8b45653022c74f71af0538a4"
+  version = "v1.1.1"
 
 [[projects]]
   digest = "1:65c4414eeb350c47b8de71110150d0ea8a281835b1f386eacaa3ad7325929c21"
@@ -277,7 +277,7 @@
     "testhelper/client",
   ]
   pruneopts = "UT"
-  revision = "f83aee3da90f3f337d024070e2e68b04fb035149"
+  revision = "737db56db180519300c1b7b326e40d431de10206"
 
 [[projects]]
   branch = "master"
@@ -285,7 +285,7 @@
   name = "github.com/gophercloud/utils"
   packages = ["openstack/clientconfig"]
   pruneopts = "UT"
-  revision = "6f24f46ce3c9d3b7de60dad5fef5d87c56657137"
+  revision = "0bcc8e728cb54c9dce9ed46924688b817ab14f31"
 
 [[projects]]
   digest = "1:ca59b1175189b3f0e9f1793d2c350114be36eaabbe5b9f554b35edee1de50aea"
@@ -304,15 +304,15 @@
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:8ec8d88c248041a6df5f6574b87bc00e7e0b493881dad2e7ef47b11dc69093b5"
+  digest = "1:d15ee511aa0f56baacc1eb4c6b922fa1c03b38413b6be18166b996d82a0156ea"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
     "simplelru",
   ]
   pruneopts = "UT"
-  revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
-  version = "v0.5.0"
+  revision = "7087cb70de9f7a8bc0a10c375cb0d2280a8edf9c"
+  version = "v0.5.1"
 
 [[projects]]
   digest = "1:c0d19ab64b32ce9fe5cf4ddceba78d5bc9807f0016db6b1183599da3dcc24d10"
@@ -364,32 +364,20 @@
   version = "v1.0"
 
 [[projects]]
-  digest = "1:3e551bbb3a7c0ab2a2bf4660e7fcad16db089fdcfbb44b0199e62838038623ea"
+  digest = "1:f5a2051c55d05548d2d4fd23d244027b59fbd943217df8aa3b5e170ac2fd6e1b"
   name = "github.com/json-iterator/go"
   packages = ["."]
   pruneopts = "UT"
-  revision = "1624edc4454b8682399def8740d46db5e4362ba4"
-  version = "v1.1.5"
+  revision = "0ff49de124c6f76f8494e194af75bde0f1a49a29"
+  version = "v1.1.6"
 
 [[projects]]
-  digest = "1:0a69a1c0db3591fcefb47f115b224592c8dfa4368b7ba9fae509d5e16cdc95c8"
+  digest = "1:31e761d97c76151dde79e9d28964a812c46efc5baee4085b86f68f0c654450de"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
   pruneopts = "UT"
-  revision = "5c8c8bd35d3832f5d134ae1e1e375b69a4d25242"
-  version = "v1.0.1"
-
-[[projects]]
-  branch = "master"
-  digest = "1:f9fe1a575628740d4ee3077162f439f9876422f617cc30fca96edcda575abdd9"
-  name = "github.com/kubernetes-sigs/sig-storage-lib-external-provisioner"
-  packages = [
-    "controller",
-    "controller/metrics",
-    "util",
-  ]
-  pruneopts = "UT"
-  revision = "6719832875823b66ab4bd0c76e425f659a87e7c5"
+  revision = "f55edac94c9bbba5d6182a4be46d86a2c9b5b50e"
+  version = "v1.0.2"
 
 [[projects]]
   digest = "1:c568d7727aa262c32bdf8a3f7db83614f7af0ed661474b24588de635c20024c7"
@@ -401,7 +389,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:84a5a2b67486d5d67060ac393aa255d05d24ed5ee41daecd5635ec22657b6492"
+  digest = "1:df495c9184b4e6cbb9d55652236dbcbe72c65a1c8b6469da50722628cea474e7"
   name = "github.com/mailru/easyjson"
   packages = [
     "buffer",
@@ -409,7 +397,7 @@
     "jwriter",
   ]
   pruneopts = "UT"
-  revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
+  revision = "1de009706dbeb9d05f18586f0735fcdb7c524481"
 
 [[projects]]
   digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
@@ -420,12 +408,12 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:1b46adc9e3d878cdf38a164cfdac2e19340f4d2662aa5bee88062f6ee08ac9df"
+  digest = "1:4c195ae33dbe8df4eb3485f3357788f47b614547abcd048cbcc59d9025db6b8d"
   name = "github.com/miekg/dns"
   packages = ["."]
   pruneopts = "UT"
-  revision = "8fc2e5773bbd308ca2fcc962fd8d25c1bd0f6743"
-  version = "v1.1.4"
+  revision = "cc8cd02140663157ce797c6650488d6c8563f31f"
+  version = "v1.1.6"
 
 [[projects]]
   digest = "1:5d231480e1c64a726869bc4142d270184c419749d34f167646baa21008eb0a79"
@@ -468,7 +456,7 @@
   revision = "a547fc61f48d567d5b4ec6f8aee5573d8efce11d"
 
 [[projects]]
-  digest = "1:5f4b78246f0bcb105b1e3b2b9e22b52a57cd02f57a8078572fe27c62f4a75ff7"
+  digest = "1:e9c3bb68a6c9470302b8046d4647e0612a2ea6037b9c6a47de60c0a90db504f8"
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
@@ -491,11 +479,11 @@
     "types",
   ]
   pruneopts = "UT"
-  revision = "2e1be8f7d90e9d3e3e58b0ce470f2f14d075406f"
-  version = "v1.7.0"
+  revision = "eea6ad008b96acdaa524f5b409513bf062b500ad"
+  version = "v1.8.0"
 
 [[projects]]
-  digest = "1:7a137fb7718928e473b7d805434ae563ec41790d3d227cdc64e8b14d1cab8a1f"
+  digest = "1:fe167e8f858cbfc10c721f2000f2446140800bb53fa83c088e03d191275611a4"
   name = "github.com/onsi/gomega"
   packages = [
     ".",
@@ -512,8 +500,8 @@
     "types",
   ]
   pruneopts = "UT"
-  revision = "65fb64232476ad9046e57c26cd0bff3d3a8dc6cd"
-  version = "v1.4.3"
+  revision = "90e289841c1ed79b7a598a7cd9959750cb5e89e2"
+  version = "v1.5.0"
 
 [[projects]]
   digest = "1:ee4d4af67d93cc7644157882329023ce9a7bcfce956a079069a9405521c7cc8d"
@@ -581,24 +569,25 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f0bb332b39488b057a8671557f307997426e5c650ee738a634a0697a41e207c5"
+  digest = "1:01cd0cd47758f04c5604daa3be4637e2afa1e0c15af7e08289e95360369e4f48"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
+    "iostats",
     "nfs",
     "xfs",
   ]
   pruneopts = "UT"
-  revision = "f8d8b3f739bd91a7c0462cb55235ef63c79c9abc"
+  revision = "d0f344d83b0c80a1bc03b547a2374a9ec6711144"
 
 [[projects]]
-  digest = "1:87c2e02fb01c27060ccc5ba7c5a407cc91147726f8f40b70cceeedbc52b1f3a8"
+  digest = "1:e4c72127d910a96daf869a44f3dd563b86dbe6931a172863a0e99c5ff04b59e4"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = "UT"
-  revision = "e1e72e9de974bd926e5c56f83753fba2df402ce5"
-  version = "v1.3.0"
+  revision = "dae0fa8d5b0c810a8ab733fbd5510c7cae84eca4"
+  version = "v1.4.0"
 
 [[projects]]
   digest = "1:3e39bafd6c2f4bf3c76c3bfd16a2e09e016510ad5db90dc02b88e2f565d6d595"
@@ -628,12 +617,12 @@
   version = "v0.0.3"
 
 [[projects]]
-  digest = "1:68ea4e23713989dc20b1bded5d9da2c5f9be14ff9885beef481848edd18c26cb"
+  digest = "1:1b753ec16506f5864d26a28b43703c58831255059644351bbcb019b843950900"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
   pruneopts = "UT"
-  revision = "4a4406e478ca629068e7768fc33f3f044173c0a6"
-  version = "v1.0.0"
+  revision = "94f6ae3ed3bceceafa716478c5fbf8d29ca601a1"
+  version = "v1.1.0"
 
 [[projects]]
   digest = "1:c1b1102241e7f645bc8e0c22ae352e8f0dc6484b6cb4d132fa9f24174e0119e2"
@@ -644,12 +633,12 @@
   version = "v1.0.3"
 
 [[projects]]
-  digest = "1:de37e343c64582d7026bf8ab6ac5b22a72eac54f3a57020db31524affed9f423"
+  digest = "1:1b773526998f3dbde3a51a4a5881680c4d237d3600f570d900f97ac93c7ba0a8"
   name = "github.com/spf13/viper"
   packages = ["."]
   pruneopts = "UT"
-  revision = "6d33b5a963d922d182c91e8a1c88d81fd150cfd4"
-  version = "v1.3.1"
+  revision = "9e56dacc08fbbf8c9ee2dbc717553c758ce42bc9"
+  version = "v1.3.2"
 
 [[projects]]
   digest = "1:ac83cf90d08b63ad5f7e020ef480d319ae890c208f8524622a2f3136e2686b02"
@@ -672,7 +661,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:fb961be99914b3b93d599cabeaec91736f662e3f706b894668fcd23c0d9aafd7"
+  digest = "1:e33d5efebca6ca5a9bb293b80e8cbd26488e1f9c0fa965b5b0de4b65c2c55e87"
   name = "golang.org/x/crypto"
   packages = [
     "ed25519",
@@ -681,11 +670,11 @@
     "ssh/terminal",
   ]
   pruneopts = "UT"
-  revision = "74369b46fc6756741c016591724fd1cb8e26845f"
+  revision = "a1f597ede03a7bef967a422b5b3a5bd08805a01e"
 
 [[projects]]
   branch = "master"
-  digest = "1:c7351c5151f64a002b9aa7f2a523f466bad50734ba12adf8fe1cc858d48b63f0"
+  digest = "1:889cddec3be451ce69727e48eaa88fee641dd9ae15158cac18dc430ab846cdc7"
   name = "golang.org/x/net"
   packages = [
     "bpf",
@@ -707,29 +696,29 @@
     "websocket",
   ]
   pruneopts = "UT"
-  revision = "3a22650c66bd7f4fb6d1e8072ffd7b75c8a27898"
+  revision = "9f648a60d9775ef5c977e7669d1673a7a67bef33"
 
 [[projects]]
   branch = "master"
-  digest = "1:c664d4451770ebc9ab63d54bccb9e4f2c6106cde7e566ea02889930b836c7d4c"
+  digest = "1:037497a2c592b7aa03789f9d6492d02e7d7d166c0e363c95cb53952cf11c7ab0"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "internal",
   ]
   pruneopts = "UT"
-  revision = "3e8b2be1363542a95c52ea0796d4a40dacfb5b95"
+  revision = "e64efc72b421e893cbf63f17ba2221e7d6d0b0f3"
 
 [[projects]]
   branch = "master"
-  digest = "1:0d703f14f9bbbe1070ff0ce86d749dcbc9d68fb0ae554252c09bd4bb37a072e7"
+  digest = "1:944736317d4f2fb1c1015ef9ca05fd9313b4e19f1128901cc678f636435fa9b0"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "983097b1a8a340cd1cc7df17d735154d89e10b1a"
+  revision = "fead79001313d15903fb4605b4a1b781532cd93e"
 
 [[projects]]
   digest = "1:bb8277a2ca2bcad6ff7f413b939375924099be908cedd1314baa21ecd08df477"
@@ -773,7 +762,7 @@
   name = "golang.org/x/time"
   packages = ["rate"]
   pruneopts = "UT"
-  revision = "85acf8d2951cb2a3bde7632f9ff273ef0379bcbd"
+  revision = "9d24e82272b4f38b78bc8cff74fa936d31ccd8ef"
 
 [[projects]]
   digest = "1:6f3bd49ddf2e104e52062774d797714371fac1b8bddfd8e124ce78e6b2264a10"
@@ -793,14 +782,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:077c1c599507b3b3e9156d17d36e1e61928ee9b53a5b420f10f28ebd4a0b275c"
+  digest = "1:c3076e7defee87de1236f1814beb588f40a75544c60121e6eb38b3b3721783e2"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
   pruneopts = "UT"
-  revision = "4b09977fb92221987e99d190c8f88f2c92727a29"
+  revision = "5fe7a883aa19554f42890211544aa549836af7b7"
 
 [[projects]]
-  digest = "1:6dfe7f3314a390dc9e21368dd41236169bf40ae69674f42b7bd45db537751a94"
+  digest = "1:73344d5dea2db9e6de56a90125c180b53aa63084edc01a350519f092a88f801e"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -837,8 +826,8 @@
     "tap",
   ]
   pruneopts = "UT"
-  revision = "a02b0774206b209466313a0b525d2c738fe407eb"
-  version = "v1.18.0"
+  revision = "2fdaae294f38ed9a121193c51ec99fecd3b13eb7"
+  version = "v1.19.0"
 
 [[projects]]
   digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
@@ -879,7 +868,7 @@
   version = "v2.1"
 
 [[projects]]
-  digest = "1:a4cde1eec9a17eb2399a50c6e1a9fe3fde039994de058f9dbf6592d157bfe97b"
+  digest = "1:005cbf8b937fcb1694b9dbb845b0aef618627be7faf7bb330eb2490e3f506ef8"
   name = "gopkg.in/square/go-jose.v2"
   packages = [
     ".",
@@ -888,8 +877,8 @@
     "jwt",
   ]
   pruneopts = "UT"
-  revision = "e94fb177d3668d35ab39c61cbb2f311550557e83"
-  version = "v2.2.2"
+  revision = "628223f44a71f715d2881ea69afc795a1e9c01be"
+  version = "v2.3.0"
 
 [[projects]]
   branch = "v1"
@@ -916,7 +905,7 @@
   version = "v2.2.2"
 
 [[projects]]
-  digest = "1:d7893a57cfc6c749265795ab5bd5f4ce050461866beea9a4f615248aef2b0925"
+  digest = "1:baf5a7da864b8f493ff372a9486c2d6a7fae8363699af2dc0ef6dba9a869928f"
   name = "k8s.io/api"
   packages = [
     "admission/v1beta1",
@@ -943,6 +932,8 @@
     "extensions/v1beta1",
     "networking/v1",
     "networking/v1beta1",
+    "node/v1alpha1",
+    "node/v1beta1",
     "policy/v1beta1",
     "rbac/v1",
     "rbac/v1alpha1",
@@ -956,19 +947,19 @@
     "storage/v1beta1",
   ]
   pruneopts = "UT"
-  revision = "75c737d69f92962004c8fdda4c6b2edf12b79327"
-  version = "kubernetes-1.14.0-beta.1"
+  revision = "aed3e58a5946ed43ef2008af9bc6d0d48e0682ea"
+  version = "kubernetes-1.14.0-beta.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:23c21b785665e00bbac1232da678cb271967fd614b9019872a2dcc3966c1fc5e"
+  digest = "1:fa65856d5086d5338e962b3bd409e09cd70cb0ceb110167cdf565edd6920ed2e"
   name = "k8s.io/apiextensions-apiserver"
   packages = ["pkg/features"]
   pruneopts = "UT"
-  revision = "4143c51bc1440efed73d24c8d441439784c4b754"
+  revision = "80ebb0f65ac12d9684d4789ecfd2ba32ceaedc0b"
 
 [[projects]]
-  digest = "1:a7f29291609a7e3506ea5f346e66edf1f5dcdb945fb3d18f80734f0d92d7da83"
+  digest = "1:cdc46545453fa33efc18100f73efec453e2538fe93527a1748c314b94923d844"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -1023,11 +1014,11 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "UT"
-  revision = "bbd8f4d5d07a9d351332af4873b5f2f486f3fca6"
-  version = "kubernetes-1.14.0-beta.1"
+  revision = "52b84f9b724722e77633d2fe022d2d8d57bb16a9"
+  version = "kubernetes-1.14.0-beta.2"
 
 [[projects]]
-  digest = "1:a4fd4ce916dd955997f67f9dd51e9c1648fe7caa5193e0832f153908547f9f79"
+  digest = "1:8e6b0717378aad2ca954012e3b4f75f3e9e564b2da9c5fe1c360f9794ee5393c"
   name = "k8s.io/apiserver"
   packages = [
     "pkg/admission",
@@ -1128,11 +1119,11 @@
     "plugin/pkg/authorizer/webhook",
   ]
   pruneopts = "UT"
-  revision = "35f5a1fb58bea8653891975121f04b809e0325f1"
-  version = "kubernetes-1.14.0-beta.1"
+  revision = "8bbd9f58a9864ed4760c9a7e54d1d5a5e0daa676"
+  version = "kubernetes-1.14.0-beta.2"
 
 [[projects]]
-  digest = "1:b484822590d656b050fcb1259ace44aff1578250917f32179acec3c5b5fd7994"
+  digest = "1:76a2d5629d0b96fa300cbf1b650bc63888fbcf211bc20e5c157a06c940394e41"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1169,6 +1160,9 @@
     "informers/networking",
     "informers/networking/v1",
     "informers/networking/v1beta1",
+    "informers/node",
+    "informers/node/v1alpha1",
+    "informers/node/v1beta1",
     "informers/policy",
     "informers/policy/v1beta1",
     "informers/rbac",
@@ -1234,6 +1228,10 @@
     "kubernetes/typed/networking/v1/fake",
     "kubernetes/typed/networking/v1beta1",
     "kubernetes/typed/networking/v1beta1/fake",
+    "kubernetes/typed/node/v1alpha1",
+    "kubernetes/typed/node/v1alpha1/fake",
+    "kubernetes/typed/node/v1beta1",
+    "kubernetes/typed/node/v1beta1/fake",
     "kubernetes/typed/policy/v1beta1",
     "kubernetes/typed/policy/v1beta1/fake",
     "kubernetes/typed/rbac/v1",
@@ -1275,6 +1273,8 @@
     "listers/extensions/v1beta1",
     "listers/networking/v1",
     "listers/networking/v1beta1",
+    "listers/node/v1alpha1",
+    "listers/node/v1beta1",
     "listers/policy/v1beta1",
     "listers/rbac/v1",
     "listers/rbac/v1alpha1",
@@ -1319,11 +1319,11 @@
     "util/workqueue",
   ]
   pruneopts = "UT"
-  revision = "ed8db5ef46ecb88fff367d20c75ba51b41bd8067"
-  version = "kubernetes-1.14.0-beta.1"
+  revision = "94c2b28f7daad3bd8a35083cc4f8cbe93f027cb3"
+  version = "kubernetes-1.14.0-beta.2"
 
 [[projects]]
-  digest = "1:79516a8260b66bf2809b75bf2af90cf8b78fd6ed6ed2a6dbb750d5aaec3a42fb"
+  digest = "1:1a96ad6cfdcfd87d45308f5ab00a79d79b70c737f6f3906b122a8f0b96002129"
   name = "k8s.io/cloud-provider"
   packages = [
     ".",
@@ -1333,8 +1333,8 @@
     "volume/helpers",
   ]
   pruneopts = "UT"
-  revision = "584a0655c79d4fe1f3dc0e34ac0c15c826b076da"
-  version = "kubernetes-1.14.0-beta.1"
+  revision = "4ee83c7903ee568380d31b984d285fb386253a61"
+  version = "kubernetes-1.14.0-beta.2"
 
 [[projects]]
   digest = "1:c5f6808d3fa257c7e9d2e7f81a123c16c69fbaeeb841fc748480da7939fad181"
@@ -1347,21 +1347,19 @@
     "logs",
   ]
   pruneopts = "UT"
-  revision = "f9f76e4701c2c16d3e9db359016d9c4505290fac"
-  version = "kubernetes-1.14.0-beta.1"
+  revision = "923e373b2c7ebc95cf3dc5444798c4995ff780b7"
+  version = "kubernetes-1.14.0-beta.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:e79eeb85f6f9636d4a9f1c36f1bdab1b2684db3621d7feea1d087edab281154c"
-  name = "k8s.io/csi-api"
+  digest = "1:20626caf143d25c06c8cabd9aae7a6c55a738ba660c795b1104661eb90be6f32"
+  name = "k8s.io/csi-translation-lib"
   packages = [
-    "pkg/apis/csi/v1alpha1",
-    "pkg/client/clientset/versioned",
-    "pkg/client/clientset/versioned/scheme",
-    "pkg/client/clientset/versioned/typed/csi/v1alpha1",
+    ".",
+    "plugins",
   ]
   pruneopts = "UT"
-  revision = "912199f9a195058f50bc3dd1968727d4cb1c64a8"
+  revision = "7f5cabc6aac80cb6cdcf30c37d23947401f26a21"
 
 [[projects]]
   digest = "1:72fd56341405f53c745377e0ebc4abeff87f1a048e0eea6568a20212650f5a82"
@@ -1377,11 +1375,11 @@
   name = "k8s.io/kube-controller-manager"
   packages = ["config/v1alpha1"]
   pruneopts = "UT"
-  revision = "58144a281884b4871146ed52d775a74e6272a3ae"
+  revision = "d2b16a081e75e1b7cb93c8e9750694ccef282490"
 
 [[projects]]
   branch = "master"
-  digest = "1:f5fbd3559e339e10dc9f8593abdbf88f1c05d72442142cc0f6baf9c992669ce3"
+  digest = "1:ab234c6da57e24e48a2a180aa06ee9540c0333642cb41a49a7362cedc2a4db2e"
   name = "k8s.io/kube-openapi"
   packages = [
     "pkg/builder",
@@ -1392,10 +1390,10 @@
     "pkg/util/proto",
   ]
   pruneopts = "UT"
-  revision = "d7c86cdc46e3a4fcf892b32dd7bc3aa775e0870e"
+  revision = "15615b16d372105f0c69ff47dfe7402926a65aaa"
 
 [[projects]]
-  digest = "1:4fd52930f2c138feae008e585bfb5f4bf15a937ef3a46905632310f5d2d638f4"
+  digest = "1:8ffd84dd7473a5bdda51af5378c3f14eb8fe3f89fd79c5efd13cc0179d47b9c4"
   name = "k8s.io/kubernetes"
   packages = [
     "cmd/cloud-controller-manager/app",
@@ -1408,7 +1406,6 @@
     "cmd/controller-manager/app/options",
     "pkg/api/legacyscheme",
     "pkg/api/service",
-    "pkg/api/v1/node",
     "pkg/api/v1/pod",
     "pkg/apis/apps",
     "pkg/apis/autoscaling",
@@ -1429,6 +1426,7 @@
     "pkg/controller/cloud",
     "pkg/controller/route",
     "pkg/controller/service",
+    "pkg/controller/util/node",
     "pkg/controller/volume/events",
     "pkg/controller/volume/persistentvolume",
     "pkg/controller/volume/persistentvolume/metrics",
@@ -1436,6 +1434,7 @@
     "pkg/fieldpath",
     "pkg/kubelet/apis",
     "pkg/kubelet/types",
+    "pkg/kubelet/util/format",
     "pkg/master/ports",
     "pkg/scheduler/api",
     "pkg/security/apparmor",
@@ -1459,16 +1458,17 @@
     "pkg/volume/util",
     "pkg/volume/util/fs",
     "pkg/volume/util/recyclerclient",
+    "pkg/volume/util/subpath",
     "pkg/volume/util/types",
     "pkg/volume/util/volumepathhandler",
   ]
   pruneopts = "UT"
-  revision = "6c7afd1222ebf2cb91567364471d74ac056437b7"
-  version = "v1.14.0-beta.1"
+  revision = "b1e389e6f7bd798a8dd162f82b918f509ac5291b"
+  version = "v1.14.0-beta.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:c61ea8146319684fb681b00f0092ef1def069dbdfcf27066646329cdcb3c15fe"
+  digest = "1:34acf6e67e51ad9e51ae948b3b3055490526e2b64091c2828f5c6af551faeea8"
   name = "k8s.io/utils"
   packages = [
     "buffer",
@@ -1484,10 +1484,22 @@
     "trace",
   ]
   pruneopts = "UT"
-  revision = "cdba02414f767c89d729b1b9e61d9891f4e82b35"
+  revision = "21c4ce38f2a793ec01e925ddc31216500183b773"
 
 [[projects]]
-  digest = "1:060c1112d3b1639a0cfc6cceb2c90e61b902ddf1897c2ffbdbe2bf067661242c"
+  branch = "master"
+  digest = "1:17ea996b5b90aeef13bb306bbf46ae1e6a572fa058528177d57cc6b537233132"
+  name = "sigs.k8s.io/sig-storage-lib-external-provisioner"
+  packages = [
+    "controller",
+    "controller/metrics",
+    "util",
+  ]
+  pruneopts = "UT"
+  revision = "0fcd2a19e047b6a1e9203b8ed3511ed8679b23f4"
+
+[[projects]]
+  digest = "1:fef5992ddf85e9ccad899b11338339858936a10fbce96b9d5c43767669d95398"
   name = "sigs.k8s.io/structured-merge-diff"
   packages = [
     "fieldpath",
@@ -1497,7 +1509,7 @@
     "value",
   ]
   pruneopts = "UT"
-  revision = "e5e029740eb81ee0217ecf9d950c25a0eeb9688a"
+  revision = "e85c7b244fd2cc57bb829d73a061f93a441e63ce"
 
 [[projects]]
   digest = "1:7719608fe0b52a4ece56c2dde37bedd95b938677d1ab0f84b8a7852e4c59f849"
@@ -1551,7 +1563,6 @@
     "github.com/gophercloud/gophercloud/testhelper/client",
     "github.com/gophercloud/utils/openstack/clientconfig",
     "github.com/gorilla/mux",
-    "github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller",
     "github.com/mitchellh/go-homedir",
     "github.com/mitchellh/mapstructure",
     "github.com/onsi/ginkgo",
@@ -1631,6 +1642,7 @@
     "k8s.io/utils/exec",
     "k8s.io/utils/keymutex",
     "k8s.io/utils/strings",
+    "sigs.k8s.io/sig-storage-lib-external-provisioner/controller",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,7 +24,6 @@
 #   go-tests = true
 #   unused-packages = true
 
-
 [[constraint]]
   branch = "master"
   name = "github.com/gophercloud/gophercloud"
@@ -32,10 +31,6 @@
 [[constraint]]
   branch = "master"
   name = "github.com/gophercloud/utils"
-
-[[constraint]]
-  name = "github.com/kubernetes-sigs/sig-storage-lib-external-provisioner"
-  branch = "master"
 
 [[constraint]]
   name = "golang.org/x/crypto"
@@ -55,36 +50,40 @@
 
 [[constraint]]
   name = "k8s.io/api"
-  version = "kubernetes-1.14.0-beta.1"
+  version = "kubernetes-1.14.0-beta.2"
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  version = "kubernetes-1.14.0-beta.1"
+  version = "kubernetes-1.14.0-beta.2"
 
 [[constraint]]
   name = "k8s.io/apiserver"
-  version = "kubernetes-1.14.0-beta.1"
+  version = "kubernetes-1.14.0-beta.2"
 
 [[constraint]]
   name = "k8s.io/client-go"
-  version = "kubernetes-1.14.0-beta.1"
+  version = "kubernetes-1.14.0-beta.2"
 
 [[constraint]]
   name = "k8s.io/cloud-provider"
-  version = "kubernetes-1.14.0-beta.1"
+  version = "kubernetes-1.14.0-beta.2"
 
 [[constraint]]
   name = "k8s.io/component-base"
-  version = "kubernetes-1.14.0-beta.1"
+  version = "kubernetes-1.14.0-beta.2"
 
 [[constraint]]
   name = "k8s.io/kubernetes"
-  version = "v1.14.0-beta.1"
+  version = "v1.14.0-beta.2"
+
+[[constraint]]
+  name = "sigs.k8s.io/sig-storage-lib-external-provisioner"
+  branch = "master"
 
 # Picked up from k/k Godeps/Godeps.json
 [[override]]
 name = "sigs.k8s.io/structured-merge-diff"
-revision = "e5e029740eb81ee0217ecf9d950c25a0eeb9688a"
+revision = "e85c7b244fd2cc57bb829d73a061f93a441e63ce"
 
 # Picked up from k/k Godeps/Godeps.json
 # "v21.3.0"

--- a/cmd/cinder-provisioner/main.go
+++ b/cmd/cinder-provisioner/main.go
@@ -21,8 +21,8 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/klog"
 
-	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/provisioner"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"

--- a/cmd/manila-provisioner/main.go
+++ b/cmd/manila-provisioner/main.go
@@ -19,13 +19,13 @@ package main
 import (
 	"flag"
 
-	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/cloud-provider-openstack/pkg/share/manila"
 	"k8s.io/klog"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 )
 
 var (

--- a/cmd/openstack-cloud-controller-manager/main.go
+++ b/cmd/openstack-cloud-controller-manager/main.go
@@ -151,7 +151,6 @@ func newControllerInitializers() map[string]initFunc {
 	controllers := map[string]initFunc{}
 	controllers["cloud-node"] = startCloudNodeController
 	controllers["cloud-node-lifecycle"] = startCloudNodeLifecycleController
-	controllers["persistentvolume-binder"] = startPersistentVolumeLabelController
 	controllers["service"] = startServiceController
 	controllers["route"] = startRouteController
 	return controllers
@@ -186,17 +185,6 @@ func startCloudNodeLifecycleController(ctx *cloudcontrollerconfig.CompletedConfi
 	}
 
 	go cloudNodeLifecycleController.Run(stopCh)
-
-	return nil, true, nil
-}
-
-func startPersistentVolumeLabelController(ctx *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface, stopCh <-chan struct{}) (http.Handler, bool, error) {
-	// Start the PersistentVolumeLabelController
-	pvlController := cloudcontrollers.NewPersistentVolumeLabelController(
-		ctx.ClientBuilder.ClientOrDie("pvl-controller"),
-		cloud,
-	)
-	go pvlController.Run(5, stopCh)
 
 	return nil, true, nil
 }

--- a/pkg/identity/keystone/sync.go
+++ b/pkg/identity/keystone/sync.go
@@ -211,7 +211,7 @@ func (s *Syncer) syncProjectData(u *userInfo, namespaceName string) error {
 
 func (s *Syncer) syncRoleAssignmentsData(u *userInfo, namespaceName string) error {
 	// TODO(mfedosin): add a field separator to filter out unnecessary roles bindings at an early stage
-	roleBindings, err := s.k8sClient.Rbac().RoleBindings(namespaceName).List(metav1.ListOptions{})
+	roleBindings, err := s.k8sClient.RbacV1().RoleBindings(namespaceName).List(metav1.ListOptions{})
 	if err != nil {
 		klog.Warningf("Cannot get a list of role bindings from the server: %v", err)
 		return errors.New("Internal server error")
@@ -234,7 +234,7 @@ func (s *Syncer) syncRoleAssignmentsData(u *userInfo, namespaceName string) erro
 			}
 		}
 		if !keepRoleBinding {
-			err = s.k8sClient.Rbac().RoleBindings(namespaceName).Delete(roleBinding.Name, &metav1.DeleteOptions{})
+			err = s.k8sClient.RbacV1().RoleBindings(namespaceName).Delete(roleBinding.Name, &metav1.DeleteOptions{})
 			if err != nil {
 				klog.Warningf("Cannot delete a role binding from the server: %v", err)
 				return errors.New("Internal server error")
@@ -276,7 +276,7 @@ func (s *Syncer) syncRoleAssignmentsData(u *userInfo, namespaceName string) erro
 				Name:     roleName,
 			},
 		}
-		roleBinding, err = s.k8sClient.Rbac().RoleBindings(namespaceName).Create(roleBinding)
+		roleBinding, err = s.k8sClient.RbacV1().RoleBindings(namespaceName).Create(roleBinding)
 		if err != nil {
 			klog.Warningf("Cannot create a role binding for the user: %v", err)
 			return errors.New("Internal server error")

--- a/pkg/share/manila/manila_test.go
+++ b/pkg/share/manila/manila_test.go
@@ -25,11 +25,11 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
 	th "github.com/gophercloud/gophercloud/testhelper"
 	fakeclient "github.com/gophercloud/gophercloud/testhelper/client"
-	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cloud-provider-openstack/pkg/share/manila/shareoptions"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 )
 
 func TestChooseExportLocation(t *testing.T) {

--- a/pkg/share/manila/provisioner.go
+++ b/pkg/share/manila/provisioner.go
@@ -20,13 +20,13 @@ import (
 	"fmt"
 
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
-	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"github.com/pborman/uuid"
 	"k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/cloud-provider-openstack/pkg/share/manila/sharebackends"
 	"k8s.io/cloud-provider-openstack/pkg/share/manila/shareoptions"
 	"k8s.io/klog"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 )
 
 // Provisioner struct, implements controller.Provisioner interface

--- a/pkg/share/manila/share.go
+++ b/pkg/share/manila/share.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
-	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +28,7 @@ import (
 	"k8s.io/cloud-provider-openstack/pkg/share/manila/sharebackends"
 	"k8s.io/cloud-provider-openstack/pkg/share/manila/shareoptions"
 	"k8s.io/kubernetes/pkg/controller/volume/persistentvolume"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 )
 
 const (

--- a/pkg/share/manila/shareoptions/shareoptions.go
+++ b/pkg/share/manila/shareoptions/shareoptions.go
@@ -18,9 +18,9 @@ package shareoptions
 
 import (
 	"fmt"
-	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/cloud-provider-openstack/pkg/share/manila/shareoptions/validator"
 	"k8s.io/cloud-provider/volume/helpers"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 )
 
 // ShareOptions contains options for provisioning and attaching a share

--- a/pkg/volume/cinder/provisioner/iscsi.go
+++ b/pkg/volume/cinder/provisioner/iscsi.go
@@ -17,11 +17,11 @@ limitations under the License.
 package provisioner
 
 import (
-	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/volumeservice"
 	"k8s.io/klog"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 )
 
 const iscsiType = "iscsi"

--- a/pkg/volume/cinder/provisioner/iscsi_test.go
+++ b/pkg/volume/cinder/provisioner/iscsi_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package provisioner
 
 import (
-	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/api/core/v1"
 	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/volumeservice"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 )
 
 var _ = Describe("Iscsi Mapper", func() {

--- a/pkg/volume/cinder/provisioner/mapper.go
+++ b/pkg/volume/cinder/provisioner/mapper.go
@@ -20,11 +20,11 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/volumeservice"
 	"k8s.io/klog"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 )
 
 type volumeMapper interface {

--- a/pkg/volume/cinder/provisioner/mapperbroker.go
+++ b/pkg/volume/cinder/provisioner/mapperbroker.go
@@ -17,9 +17,9 @@ limitations under the License.
 package provisioner
 
 import (
-	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/api/core/v1"
 	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/volumeservice"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 )
 
 type mapperBroker interface {

--- a/pkg/volume/cinder/provisioner/provisioner.go
+++ b/pkg/volume/cinder/provisioner/provisioner.go
@@ -22,12 +22,12 @@ import (
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
-	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/volumeservice"
 	"k8s.io/klog"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 
 	volumes_v2 "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
 )

--- a/pkg/volume/cinder/provisioner/provisioner_test.go
+++ b/pkg/volume/cinder/provisioner/provisioner_test.go
@@ -21,12 +21,12 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	volumes_v2 "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
-	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/volumeservice"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 )
 
 var _ = Describe("Provisioner", func() {

--- a/pkg/volume/cinder/provisioner/rbd.go
+++ b/pkg/volume/cinder/provisioner/rbd.go
@@ -21,10 +21,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/api/core/v1"
 	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/volumeservice"
 	"k8s.io/klog"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 )
 
 const rbdType = "rbd"

--- a/pkg/volume/cinder/provisioner/rbd_test.go
+++ b/pkg/volume/cinder/provisioner/rbd_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package provisioner
 
 import (
-	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/api/core/v1"
 	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/volumeservice"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 )
 
 var _ = Describe("Rbd Mapper", func() {

--- a/pkg/volume/cinder/provisioner/testutils_test.go
+++ b/pkg/volume/cinder/provisioner/testutils_test.go
@@ -20,12 +20,12 @@ import (
 	"bytes"
 	"errors"
 
-	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/volumeservice"
 	"k8s.io/klog"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 )
 
 func createPVC(name string, size string) *v1.PersistentVolumeClaim {


### PR DESCRIPTION
This PR updates the k8s version to v1.14.0-beta.2 
and also updates to use vanity url of sig-storage-lib-external-provisioner
Ref: https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/pull/31

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #522

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
