### PR TITLE
Allow to specify default value in cloud-config for openstack-internal…

### DIFF
--- a/docs/provider-configuration.md
+++ b/docs/provider-configuration.md
@@ -202,6 +202,8 @@ file.
   Where `true` is specified and an Octavia LBaaS V2 entry can not be found, the
   provider will fall back and attempt to find a Neutron LBaaS V2 endpoint
   instead. The default value is `false`.
+* `internal-lb`: Determines whether or not to create an internal load balancer
+  (no floating IP) by default. The default value is `false`.
 
 #### Block Storage
 

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -113,6 +113,7 @@ type LoadBalancerOpts struct {
 	MonitorMaxRetries    uint       `gcfg:"monitor-max-retries"`
 	ManageSecurityGroups bool       `gcfg:"manage-security-groups"`
 	NodeSecurityGroupIDs []string   // Do not specify, get it automatically when enable manage-security-groups. TODO(FengyunPan): move it into cache
+	InternalLB           bool       `gcfg:"internal-lb"` // default false
 }
 
 // BlockStorageOpts is used to talk to Cinder service
@@ -301,6 +302,7 @@ func ReadConfig(config io.Reader) (Config, error) {
 	cfg.Metadata.SearchOrder = fmt.Sprintf("%s,%s", metadata.ConfigDriveID, metadata.MetadataID)
 	cfg.Networking.IPv6SupportDisabled = false
 	cfg.Networking.PublicNetworkName = "public"
+	cfg.LoadBalancer.InternalLB = false
 
 	err := gcfg.FatalOnly(gcfg.ReadInto(&cfg, config))
 	if cfg.Global.UseClouds {


### PR DESCRIPTION
…-load-balancer

Signed-off-by: JrCs <90z7oey02@sneakemail.com>

**What this PR does / why we need it**:
Add on option (`internal-lb`) in the cloud-config configuration file so we can set the default value for openstack-internal-load-balancer
