### PR TITLE
CSI Manila driver

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -186,9 +186,10 @@
   revision = "5b532d6fd5efaf7fa130d4e859a2fde0fc3a9e1b"
 
 [[projects]]
-  digest = "1:cf0608a4d324260ef753cd04a1977ccca36937b9a6a5544ab08e804325e9cdc0"
+  digest = "1:09042989768a0c57341402f9991359808ad998d07ddb824393833a7c35fd3d10"
   name = "github.com/golang/protobuf"
   packages = [
+    "descriptor",
     "proto",
     "protoc-gen-go/descriptor",
     "ptypes",
@@ -378,6 +379,18 @@
   pruneopts = "UT"
   revision = "f55edac94c9bbba5d6182a4be46d86a2c9b5b50e"
   version = "v1.0.2"
+
+[[projects]]
+  digest = "1:b09c9ac14d93f481c768e73a12d4e8527ac25232d593f2ad918ffe462901b654"
+  name = "github.com/kubernetes-csi/csi-lib-utils"
+  packages = [
+    "connection",
+    "protosanitizer",
+  ]
+  pruneopts = "UT"
+  revision = "b8b7a89535d80e12f2c0f4c53cfb981add8aaca2"
+  source = "https://github.com/kubernetes-csi/csi-lib-utils"
+  version = "v0.6.1"
 
 [[projects]]
   digest = "1:c9ba37d3709f57185b60f587a6282378feaff2aa3cddc28a56770704e3f96b98"
@@ -1574,6 +1587,8 @@
     "github.com/gophercloud/gophercloud/testhelper/client",
     "github.com/gophercloud/utils/openstack/clientconfig",
     "github.com/gorilla/mux",
+    "github.com/kubernetes-csi/csi-lib-utils/connection",
+    "github.com/kubernetes-csi/csi-lib-utils/protosanitizer",
     "github.com/kubernetes-csi/csi-test/pkg/sanity",
     "github.com/mitchellh/go-homedir",
     "github.com/mitchellh/mapstructure",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -84,6 +84,10 @@
   name = "sigs.k8s.io/sig-storage-lib-external-provisioner"
   branch = "master"
 
+[[constraint]]
+name = "github.com/kubernetes-csi/csi-lib-utils"
+source = "https://github.com/kubernetes-csi/csi-lib-utils"
+
 # Picked up from k/k Godeps/Godeps.json
 [[override]]
 name = "sigs.k8s.io/structured-merge-diff"

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,12 @@ manila-provisioner: depend $(SOURCES)
 		-o manila-provisioner \
 		cmd/manila-provisioner/main.go
 
+manila-csi-plugin: depend $(SOURCES)
+	cd $(DEST) && CGO_ENABLED=0 GOOS=$(GOOS) go build \
+		-ldflags $(LDFLAGS) \
+		-o manila-csi-plugin \
+		cmd/manila-csi-plugin/main.go
+
 barbican-kms-plugin: depend $(SOURCES)
 	cd $(DEST) && CGO_ENABLED=0 GOOS=$(GOOS) go build \
 		-ldflags $(LDFLAGS) \
@@ -191,7 +197,7 @@ install-distro-packages:
 	tools/install-distro-packages.sh
 
 clean:
-	rm -rf _dist .bindep openstack-cloud-controller-manager cinder-flex-volume-driver cinder-provisioner cinder-csi-plugin k8s-keystone-auth client-keystone-auth octavia-ingress-controller manila-provisioner
+	rm -rf _dist .bindep openstack-cloud-controller-manager cinder-flex-volume-driver cinder-provisioner cinder-csi-plugin k8s-keystone-auth client-keystone-auth octavia-ingress-controller manila-provisioner manila-csi-plugin
 
 realclean: clean
 	rm -rf vendor
@@ -202,7 +208,7 @@ realclean: clean
 shell:
 	$(SHELL) -i
 
-images: image-controller-manager image-flex-volume-driver image-provisioner image-csi-plugin image-k8s-keystone-auth image-octavia-ingress-controller image-manila-provisioner image-kms-plugin
+images: image-controller-manager image-flex-volume-driver image-provisioner image-csi-plugin image-k8s-keystone-auth image-octavia-ingress-controller image-manila-provisioner image-manila-csi-plugin image-kms-plugin
 
 image-controller-manager: depend openstack-cloud-controller-manager
 ifeq ($(GOOS),linux)
@@ -267,6 +273,15 @@ else
 	$(error Please set GOOS=linux for building the image)
 endif
 
+image-manila-csi-plugin: depend manila-csi-plugin
+ifeq ($(GOOS),linux)
+	cp manila-csi-plugin cluster/images/manila-csi-plugin
+	docker build -t $(REGISTRY)/manila-csi-plugin:$(VERSION) cluster/images/manila-csi-plugin
+	rm cluster/images/manila-csi-plugin/manila-csi-plugin
+else
+	$(error Please set GOOS=linux for building the image)
+endif
+
 image-kms-plugin: depend barbican-kms-plugin
 ifeq ($(GOOS), linux)
 	cp barbican-kms-plugin cluster/images/barbican-kms-plugin
@@ -286,6 +301,7 @@ upload-images: images
 	docker push $(REGISTRY)/k8s-keystone-auth:$(VERSION)
 	docker push $(REGISTRY)/octavia-ingress-controller:$(VERSION)
 	docker push $(REGISTRY)/manila-provisioner:$(VERSION)
+	docker push $(REGISTRY)/manila-csi-plugin:$(VERSION)
 
 version:
 	@echo ${VERSION}
@@ -304,6 +320,7 @@ endif
 	CGO_ENABLED=0 gox -parallel=$(GOX_PARALLEL) -output="_dist/{{.OS}}-{{.Arch}}/{{.Dir}}" -osarch='$(TARGETS)' $(GOFLAGS) $(if $(TAGS),-tags '$(TAGS)',) -ldflags '$(LDFLAGS)' $(GIT_HOST)/$(BASE_DIR)/cmd/client-keystone-auth/
 	CGO_ENABLED=0 gox -parallel=$(GOX_PARALLEL) -output="_dist/{{.OS}}-{{.Arch}}/{{.Dir}}" -osarch='$(TARGETS)' $(GOFLAGS) $(if $(TAGS),-tags '$(TAGS)',) -ldflags '$(LDFLAGS)' $(GIT_HOST)/$(BASE_DIR)/cmd/octavia-ingress-controller/
 	CGO_ENABLED=0 gox -parallel=$(GOX_PARALLEL) -output="_dist/{{.OS}}-{{.Arch}}/{{.Dir}}" -osarch='$(TARGETS)' $(GOFLAGS) $(if $(TAGS),-tags '$(TAGS)',) -ldflags '$(LDFLAGS)' $(GIT_HOST)/$(BASE_DIR)/cmd/manila-provisioner/
+	CGO_ENABLED=0 gox -parallel=$(GOX_PARALLEL) -output="_dist/{{.OS}}-{{.Arch}}/{{.Dir}}" -osarch='$(TARGETS)' $(GOFLAGS) $(if $(TAGS),-tags '$(TAGS)',) -ldflags '$(LDFLAGS)' $(GIT_HOST)/$(BASE_DIR)/cmd/manila-csi-plugin/
 
 .PHONY: dist
 dist: build-cross

--- a/cluster/images/manila-csi-plugin/Dockerfile
+++ b/cluster/images/manila-csi-plugin/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.7
+LABEL maintainers="Kubernetes Authors"
+LABEL description="Manila CSI Plugin"
+
+ADD manila-csi-plugin /bin/
+
+ENTRYPOINT ["/bin/manila-csi-plugin"]

--- a/cmd/manila-csi-plugin/main.go
+++ b/cmd/manila-csi-plugin/main.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila"
+	"k8s.io/klog"
+)
+
+var (
+	endpoint      = flag.String("endpoint", "unix://tmp/csi.sock", "CSI endpoint")
+	driverName    = flag.String("drivername", "manila.csi.openstack.org", "name of the driver")
+	nodeID        = flag.String("nodeid", "", "this node's ID")
+	protoSelector = flag.String("share-protocol-selector", "", "specifies which Manila share protocol to use")
+	fwdEndpoint   = flag.String("fwdendpoint", "", "CSI Node Plugin endpoint to which all Node Service RPCs are forwarded. Must be able to handle the file-system specified in share-protocol-selector")
+)
+
+func main() {
+	klog.InitFlags(nil)
+	if err := flag.Set("logtostderr", "true"); err != nil {
+		klog.Exitf("failed to set logtostderr flag: %v", err)
+	}
+	flag.Parse()
+
+	d, err := manila.NewDriver(*nodeID, *driverName, *endpoint, *fwdEndpoint, *protoSelector)
+	if err != nil {
+		klog.Fatalf("driver initialization failed: %v", err)
+	}
+
+	d.Run()
+}

--- a/docs/developers-csi-manila.md
+++ b/docs/developers-csi-manila.md
@@ -1,0 +1,144 @@
+# CSI Manila developer's guide
+
+## Share adapters
+
+A share adapter is an interface found here `pkg/csi/manila/shareadapters/shareadapter.go` that forms an adapter between a Manila share and a CSI plugin.
+
+### Adding support for more share protocols
+
+As of writing this document, CSI Manila supports only NFS and CephFS shares. If you'd like to expand on this set and contribute with a new adapter for a share protocol, keep reading!
+
+1. Create a new file `some-protocol.go` under `pkg/csi/manila/shareadapters`
+2. Create a new struct that implements the `ShareAdapter` interface
+3. Add a case block in `getShareAdapter()` function in `pkg/csi/manila/util.go`. The condition string must match one of Manila's supported share protocols.
+4. Add the protocol name to the `matches` expression (regexp syntax) inside `ControllerVolumeContext.Protocol` field tags in `pkg/csi/manila/options/shareoptions.go`. Again, it must match one of Manila's supported share protocols.
+5. Update the docs in `docs/using-manila-csi-plugin.md`, namely any parameters that the protocol or node plugin may use. There's also a dedicated section "Share protocols support matrix" at the bottom of the document which needs to be updated: name of the share protocol, link to the proxy'd CSI driver and its supported version(s).
+
+### Passing volume options to share adapters
+
+Usually, shares / share adapters offer a set of options which users may want to configure. Those options can be specified in `pkg/csi/manila/options/shareoptions.go`, in either `ControllerVolumeContext` or `NodeVolumeContext` structs, or both. Each struct field must contain `name` field tag which is then used for parsing input values. It's highly recommended that, if necessary, you use validator tags instead of hard-coding validation checks in share adapters. See `pkg/share/manila/shareoptions/validator/validator.go` for info on supported validator tags.
+
+## Service capabilities
+
+**Controller Service:**
+* `CREATE_DELETE_VOLUME`
+* ~~`CREATE_DELETE_SNAPSHOT`~~ planned as a part of GSoC 2019
+
+Availability Zones are not supported yet.
+
+**Node Service:**
+
+Node Service capabilities of the proxy'd Node Plugin
+
+## Notes on design...
+
+**Problem 1:**
+
+OpenStack Manila supports NFS, CIFS, GLUSTERFS, HDFS, CEPHFS and MAPRFS share protocols. Implementing support for all of those backends within a single CSI driver doesn't scale very well because:
+* a dedicated CSI driver for each of those file-systems already exists - or eventually will
+* not reusing those existing drivers means more maintenance for devs, possible fragmented/missing features between drivers
+* mounting the file-systems mentioned above requires tools that are not usually present on the host system and they'd need to be built into the container image
+
+**Solution:**
+
+CSI Manila's Controller Plugin deals with Manila and nothing else. All node-related operations (attachments, mounts) are carried out by *another CSI driver* dedicated for that particular filesystem, effectively offloading all FS-specific code out of CSI Manila. This is achieved by Node Plugin acting only as a proxy and forwarding CSI RPCs to the other CSI driver.
+
+For example, creating and mounting a CephFS Manila share would go like this:
+
+(1) CO requests a volume provisioning with `CreateVolume`:
+
+```
+                        +--------------------+
+                        |       MASTER       |
++------+  CreateVolume  |  +--------------+  |
+|  CO  +------------------>+  csi-manila  |  |
++------+                |  +--------------+  |
+                        +--------------------+
+
+1. Authenticate with Manila v2 client
+2. Create a CephFS share
+3. Create a cephx access rule
+```
+
+(2) And when CO publishes the volume onto a node with `NodePublishVolume`:
+```
+                             +--------------------------------------+
+                             |                 NODE                 |
++------+  NodePublishVolume  |  +--------------+                    |
+|  CO  +----------------------->+  csi-manila  |                    |
++------+                     |  +------+-------+                    |
+                             |         |                            |
+                             |         | FORWARD NodePublishVolume  |
+                             |         V                            |
+                             |  +------+-------+                    |
+                             |  |  csi-cephfs  |                    |
+                             |  +--------------+                    |
+                             +--------------------------------------+
+
+1. Authenticate with Manila v2 client
+2. Retrieve the CephFS share
+3. Retrieve the cephx access rule
+4. Connect to csi-cephfs socket
+5. Call csi-cephfs's NodePublishVolume, return its response
+```
+
+The initial idea was to encompass all Manila share protocols within a single instance of csi-manila. Due to limitations of CSI, this cannot be achieved and there have to be multiple instances of csi-manila running in order to serve multiple share protocols, one for each. There are couple of RPCs in Node Service that don't bring enough context to decide which proxy'd driver that particular RPC should be forwarded to (e.g. `NodeGetCapabilities` would be ambiguous and we can't know which proxy'd driver should answer) => therefore with current design, there may be only a single proxy'd driver per csi-manila instance, i.e. one share protocol per csi-manila instance.
+
+**Problem 2:**
+
+The CSI spec allows COs to retry RPCs for any reason, e.g. as a part of timeout-handling mechanism. Such situation may occur even during the execution of operations that would otherwise return with success, but are simply taking too long to complete. This results in multiple operations being executed for the same resource in parallel, placing unnecessary load on Manila.
+
+**Solution:**
+
+Using a simple synchronization with a mutex for each resource would result in this:
+```
+  R req1             req2             req3
+T -----------------+----------------+----------------+
+01| LOCK           |                |                |
+02| op1            |                |                |
+03| op2            | LOCK...wait    |                |
+04| op3            | wait...        |                |
+05| UNLOCK         | wait...        | LOCK...wait    |
+06| RETURN success + LOCK           | wait...        |
+07|                  op1            | wait...        |
+08|                  op2            | wait...        |
+09|                  op3            | wait...        |
+21|                  UNLOCK         | wait...        |
+22|                  RETURN success + LOCK           |
+23|                                   op1            |
+24|                                   op2            |
+25|                                   op3            |
+26|                                   UNLOCK         |
+27|                                   RETURN SUCCESS +
+
+T - time
+R - request (e.g. CreateVolume); requests may be running in parallel
+LOCK/UNLOCK - locking/unlocking a mutex for this resource (e.g. volume ID)
+opN - some long running operation
+```
+The first request  `req1`  locks the mutex and launches a long running operation  `op`  (taking up 3 time units). The call times out, so the CO decides to retry with  `req2`  but needs to wait till  `req1`  finishes so that  `req2`  may acquire the lock. This pattern may repeat until the call doesn't time-out. There are two problems here: (a) it may take a long time till CO is satisfied with the answer, (b) the long running operation  `op`  is being run in all of those retries sequentially, wasting resources.
+
+`pkg/csi/manila/responsebroker`  tries to tackle the problem (b), and hopes to mitigate (a):
+```
+  R req1                                             req2                          req3
+T -------------------------------------------------+-----------------------------+-----------------------------+
+01| LOCK(acq-or-create)                            |                             |                             |
+02| op1                                            |                             |                             |
+03| op2                                            | LOCK(acq-or-create)...wait  |                             |
+04| op3                                            | wait...                     |                             |
+05| UNLOCK, write success, wait till all Rs finish | wait...                     | LOCK(acq-or-create)...wait  |
+06| wait...                                        | LOCK, read response:success | wait...                     |
+07| wait...                                        | UNLOCK                      | wait...                     |
+08| wait...                                        | RETURN SUCCESS              + LOCK, read response:success |
+09| RETURN SUCCESS                                 +                               UNLOCK                      |
+10|                                                                                RETURN SUCCESS              +
+```
+
+The same scenario as above:  `req1`  locks the mutex and runs the long running operation  `op`  and times-out.  `req2`  will block till it can acquire the lock, but instead of running  `op`  again, it reads the response from  `req1`  and if it's successful, it immediately exits with success. The  `responsebroker`  basically caches the result of an operation and propagates it to multiple readers.
+
+Notes on using `responsebroker`:
+* locking should be done at a per-resource granularity (e.g. a single volume) using a unique identifier of the resource as a key (e.g. volume ID)
+* acquire the lock before launching the long-running operation using `ResponseBroker.Acquire(key)`
+* if this is a new request (`Acquire` returned `true`) or the previous request failed (`ResponseHandle.Read()` returned a non-nil error), continue normally. Once the operation is done, you must call `ResponseHandle.Write(responseData, operationError)` which publishes the result of the operation and releases the lock. If the operation finished successfully, call `ResponseBroker.Done(key)` which waits till everyone has `Read()` the response
+* otherwise (i.e. this is either an existing request or `Read()` returned a nil error) call `ResponseHandle.Release()` which releases the lock and return the response data you've read
+

--- a/docs/using-manila-csi-plugin.md
+++ b/docs/using-manila-csi-plugin.md
@@ -1,0 +1,133 @@
+# CSI Manila driver
+
+The CSI Manila driver is able to create and mount OpenStack Manila shares.
+
+###### Table of contents
+
+* [Configuration](#configuration)
+  * [Command line arguments](#command-line-arguments)
+  * [Controller Service volume parameters](#controller-service-volume-parameters)
+  * [Node Service volume context](#node-service-volume-context)
+  * [Secrets, authentication](#secrets-authentication)
+* [Deployment](#deployment)
+  * [Kubernetes 1.13+](#kubernetes-113)
+    * [Verifying the deployment](#verifying-the-deployment)
+* [Share protocol support matrix](#share-protocol-support-matrix)
+* [For developers](#for-developers)
+
+## Configuration
+
+### Command line arguments
+
+Option | Default value | Description
+-------|---------------|------------
+`--endpoint` | `unix://tmp/csi.sock` | CSI Manila's CSI endpoint
+`--drivername` | `manila.csi.openstack.org` | Name of this driver
+`--nodeid` | _none_ | ID of this node
+`--share-protocol-selector` | _none_ | Specifies which Manila share protocol to use for this instance of the driver. See [supported protocols](#share-protocol-support-matrix) for valid values.
+`--fwdendpoint` | _none_ | [CSI Node Plugin](https://github.com/container-storage-interface/spec/blob/master/spec.md#rpc-interface) endpoint to which all Node Service RPCs are forwarded. Must be able to handle the file-system specified in `share-protocol-selector`. Check out the [Deployment](#deployment) section to see why this is necessary.
+
+### Controller Service volume parameters
+
+Parameter | Required | Description
+----------|----------|------------
+`type` | _yes_ | Manila [share type](https://wiki.openstack.org/wiki/Manila/Concepts#share_type)
+`shareNetworkID` | _no_ | Manila [share network ID](https://wiki.openstack.org/wiki/Manila/Concepts#share_network)
+`cephfs-mounter` | _no_ | Relevant for CephFS Manila shares. Specifies which mounting method to use with the CSI CephFS driver. Available options are `kernel` and `fuse`, defaults to `fuse`. See [CSI CephFS docs](https://github.com/ceph/ceph-csi/blob/csi-v1.0/docs/deploy-cephfs.md#configuration) for further information.
+`nfs-shareClient` | _no_ | Relevant for NFS Manila shares. Specifies what address has access to the NFS share. Defaults to `0.0.0.0/0`, i.e. anyone. 
+
+### Node Service volume context
+
+Parameter | Required | Description
+----------|----------|------------
+`shareID` | if `shareName` is not given | The UUID of the share
+`shareName` | if `shareID` is not given | The name of the share
+`shareAccessID` | _yes_ | The UUID of the access rule for the share
+`cephfs-mounter` | _no_ | Relevant for CephFS Manila shares. Specifies which mounting method to use with the CSI CephFS driver. Available options are `kernel` and `fuse`, defaults to `fuse`. See [CSI CephFS docs](https://github.com/ceph/ceph-csi/blob/csi-v1.0/docs/deploy-cephfs.md#configuration) for further information.
+
+_Note that the Node Plugin of CSI Manila doesn't care about the origin of a share. As long as the share protocol is supported, CSI Manila is able to consume dynamically provisioned as well as pre-provisioned shares (e.g. shares created manually)._
+
+### Secrets, authentication
+
+Authentication with OpenStack may be done using either user or trustee credentials.
+
+Mandatory secrets: `os-authURL`, `os-region`.
+
+Mandatory secrets for _user authentication:_ `os-password`, `os-userID` or `os-userName`, `os-domainID` or `os-domainName`, `os-projectID` or `os-projectName`.
+
+Mandatory secrets for _trustee authentication:_ `os-trustID`, `os-trusteeID`, `os-trusteePassword`.
+
+Optionally, a custom certificate may be sourced via `os-certAuthorityPath` (path to a PEM file inside the plugin container). By default, the usual TLS verification is performed. To override this behavior and accept insecure certificates, set `os-TLSInsecure` to `true` (defaults to `false`).
+
+## Deployment
+
+The Manila CSI driver deals with the Manila service only. All node-related operations (attachments, mounts) are performed by a dedicated CSI Node Plugin, to which all Node Service RPCs are forwarded. This means that the operator is expected to already have a working deployment of that dedicated CSI Node Plugin.
+
+A single instance of the driver may serve only a single Manila share protocol. To serve multiple share protocols, multiple deployments of the driver need to be made. In order to avoid deployment collisions, each instance of the driver should be named differently, e.g. `csi-manila-cephfs`, `csi-manila-nfs`.
+
+### Kubernetes 1.13+
+
+Required feature gates: `CSIDriverRegistry`, `CSINodeInfo`
+
+All Kubernetes YAML manifests are located in `manifests/manila-csi-plugin`.
+
+Deploy the RBACs for the external-provisioner, external-provisioner and Manila CSI driver:
+```
+kubectl create -f csi-provisioner-rbac.yaml
+kubectl create -f csi-attacher-rbac.yaml
+kubectl create -f csi-nodeplugin-rbac.yaml
+```
+
+Deploy the StatefulSets for the external-provisioner and external-provisioner:
+```
+kubectl create -f csi-provisioner-manilaplugin.yaml
+kubectl create -f csi-attacher-manilaplugin.yaml
+```
+
+Before continuing, `csi-nodeplugin-manilaplugin.yaml` needs to be modified first: `fwd-plugin-dir` needs to point to the correct path containing the `.sock` file of the other CSI driver.
+Next, `MANILA_SHARE_PROTO` and `FWD_CSI_ENDPOINT` environment variables must be set. Consult `--share-protocol-selector` and `--fwdendpoint` [command line flags](#command-line-arguments) for valid values.
+
+After performing the necessary changes, deploy the DaemonSet for Manila CSI driver:
+```
+kubectl create -f csi-nodeplugin-manilaplugin.yaml
+```
+
+#### Verifying the deployment
+
+Successful deployment should look similar to this:
+
+```
+$ kubectl get all
+NAME                                       READY   STATUS    RESTARTS   AGE
+pod/csi-attacher-manilaplugin-0            1/1     Running   0          37s
+pod/csi-nodeplugin-manilaplugin-5c7l4      2/2     Running   0          20s
+pod/csi-provisioner-manilaplugin-0         1/1     Running   0          38s
+
+NAME                                         TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)     AGE
+service/csi-attacher-manilaplugin            ClusterIP   10.107.213.186   <none>        12345/TCP   39s
+service/csi-provisioner-manilaplugin         ClusterIP   10.110.66.17     <none>        12345/TCP   41s
+
+NAME                                         DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
+daemonset.apps/csi-nodeplugin-manilaplugin   1         1         1       1            1           <none>          22s
+
+NAME                                                  READY   AGE
+statefulset.apps/csi-attacher-manilaplugin            1/1     39s
+statefulset.apps/csi-provisioner-manilaplugin         1/1     40s
+
+...
+```
+
+To test the deployment further, see `examples/csi-manila-plugin`.
+
+## Share protocol support matrix
+
+The table below shows Manila share protocols currently supported by CSI Manila and their corresponding CSI Node Plugins which must be deployed alongside CSI Manila.
+
+Manila share protocol | CSI Node Plugin
+----------------------|----------------
+`CEPHFS` | [CSI CephFS](https://github.com/ceph/ceph-csi) : v1.0.0
+`NFS` | [CSI NFS](https://github.com/kubernetes-csi/csi-driver-nfs) : v1.0.0
+
+## For developers
+
+If you'd like to contribute to CSI Manila, check out `docs/developers-csi-manila.md` to get you started.

--- a/examples/manila-csi-plugin/README.md
+++ b/examples/manila-csi-plugin/README.md
@@ -1,0 +1,16 @@
+## Example CSI Manila CephFS usage
+
+1. Deploy CSI CephFS driver
+2. Deploy CSI Manila driver with `--share-protocol-selector=CEPHFS` and `--fwdendpoint=unix:///csi/csi-cephfsplugin/csi.sock` (or similar, based on your environment)
+3. Modify `secrets.yaml` to suite your OpenStack cloud environment. Refer to the _"Secrets, authentication"_ section of CSI Manila docs. You may also use helper scripts from `examples/manila-provisioner` to generate the Secrets manifest.
+4. Deploy OpenStack secrets
+5. Create a persistent volume:
+  5.1 **If you want to provision a new share:**
+    5.1.1 Modify `storageclass.yaml` to reflect your environment. Refer to the _"Controller Service volume parameters"_ section of CSI Manila docs.
+    5.1.2 Deploy the `csi-manila-cephfs` storage class `storageclass.yaml`
+    5.1.3 Deploy the persistent volume claim `pvc.yaml`
+  5.2 **OR you want to use an existing share:**
+    5.2.1 Modify `preprovisioned-pvc.yaml` to reflect your environment. Refer to the _"Node Service volume context"_ section of CSI Manila docs.
+    5.2.2 Deploy the PV+PVC
+6. Deploy `pod.yaml` which creates a Pod that mounts the share you've prepared in the steps above
+7. You should see `pod/csicephfs-demo-pod` with status _Running_ soon

--- a/examples/manila-csi-plugin/exec-bash.sh
+++ b/examples/manila-csi-plugin/exec-bash.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+CONTAINER_NAME=csi-nodeplugin-manilaplugin
+POD_NAME=$(kubectl get pods -l app=$CONTAINER_NAME -o=name | head -n 1)
+
+function get_pod_status() {
+	echo -n "$(kubectl get "$POD_NAME" -o jsonpath="{.status.phase}")"
+}
+
+while [[ "$(get_pod_status)" != "Running" ]]; do
+	sleep 1
+	echo "Waiting for $POD_NAME (status $(get_pod_status))"
+done
+
+kubectl exec -it "${POD_NAME#*/}" -c "$CONTAINER_NAME" bash

--- a/examples/manila-csi-plugin/logs.sh
+++ b/examples/manila-csi-plugin/logs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+POD_NAME=$(kubectl get pods -l app=csi-nodeplugin-manilaplugin -o=name | head -n 1)
+
+function get_pod_status() {
+	echo -n $(kubectl get $POD_NAME -o jsonpath="{.status.phase}")
+}
+
+while [[ $(get_pod_status) != "Running" ]]; do
+	sleep 1
+	echo "Waiting for $POD_NAME (status $(get_pod_status))"
+done
+
+
+kubectl logs -f $POD_NAME -c csi-nodeplugin-manilaplugin

--- a/examples/manila-csi-plugin/pod.yaml
+++ b/examples/manila-csi-plugin/pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: csicephfs-demo-pod
+spec:
+  containers:
+    - name: web-server
+      image: nginx
+      imagePullPolicy: IfNotPresent
+      volumeMounts:
+        - name: mypvc
+          mountPath: /var/lib/www
+  volumes:
+    - name: mypvc
+      persistentVolumeClaim:
+        claimName: csi-manila-cephfs-pvc
+        readOnly: false

--- a/examples/manila-csi-plugin/preprovisioned-pvc.yaml
+++ b/examples/manila-csi-plugin/preprovisioned-pvc.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: preprovisioned-manila-cephfs-share
+  labels:
+    name: preprovisioned-manila-cephfs-share
+spec:
+  accessModes:
+  - ReadWriteMany
+  capacity:
+    storage: 1Gi
+  csi:
+    driver: manila.csi.openstack.org
+    volumeHandle: preprovisioned-manila-cephfs-share
+    nodeStageSecretRef:
+      name: csi-manila-secrets
+      namespace: default
+    nodePublishSecretRef:
+      name: csi-manila-secrets
+      namespace: default
+    volumeAttributes:
+      shareID: SHARE-UUID-GOES-HERE
+      shareAccessID: ACCESS-UUID-OF-THE-SHARE
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: csi-manila-cephfs-pvc
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+  selector:
+    matchExpressions:
+    - key: name
+      operator: In
+      values: ["preprovisioned-manila-cephfs-share"]

--- a/examples/manila-csi-plugin/pvc.yaml
+++ b/examples/manila-csi-plugin/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: csi-manila-cephfs-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: csi-manila-cephfs
+

--- a/examples/manila-csi-plugin/secrets.yaml
+++ b/examples/manila-csi-plugin/secrets.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: csi-manila-secrets
+  namespace: default
+data:
+  # Mandatory
+  os-authURL: "BASE64-ENCODED-STRING"
+  os-region: "BASE64-ENCODED-STRING"
+
+  # Authentication using user credentials
+  os-userName: "BASE64-ENCODED-STRING"
+  os-password: "BASE64-ENCODED-STRING"
+  os-projectName: "BASE64-ENCODED-STRING"
+  os-domainID: "BASE64-ENCODED-STRING"
+
+  # Authentication using trustee credentials
+  os-trustID: "BASE64-ENCODED-STRING"
+  os-trusteeID: "BASE64-ENCODED-STRING"
+  os-trusteePassword: "BASE64-ENCODED-STRING"

--- a/examples/manila-csi-plugin/storageclass.yaml
+++ b/examples/manila-csi-plugin/storageclass.yaml
@@ -1,0 +1,15 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-manila-cephfs
+provisioner: manila.csi.openstack.org
+parameters:
+  type: cephfstype
+  
+  csi.storage.k8s.io/provisioner-secret-name: csi-manila-secrets
+  csi.storage.k8s.io/provisioner-secret-namespace: default
+  csi.storage.k8s.io/node-stage-secret-name: csi-manila-secrets
+  csi.storage.k8s.io/node-stage-secret-namespace: default
+  csi.storage.k8s.io/node-publish-secret-name: csi-manila-secrets
+  csi.storage.k8s.io/node-publish-secret-namespace: default
+

--- a/manifests/manila-csi-plugin/csi-attacher-manilaplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-attacher-manilaplugin.yaml
@@ -1,0 +1,47 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-attacher-manilaplugin
+  labels:
+    app: csi-attacher-manilaplugin
+spec:
+  selector:
+    app: csi-attacher-manilaplugin
+  ports:
+    - name: dummy
+      port: 12345
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-attacher-manilaplugin
+spec:
+  serviceName: csi-attacher-manilaplugin
+  selector:
+    matchLabels:
+      app: csi-attacher-manilaplugin
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: csi-attacher-manilaplugin
+    spec:
+      serviceAccount: cephfs-csi-attacher
+      containers:
+        - name: csi-attacher
+          image: quay.io/k8scsi/csi-attacher:v1.1.0
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+          env:
+            - name: ADDRESS
+              value: /var/lib/kubelet/plugins/csi-nodeplugin-manilaplugin/csi.sock
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/kubelet/plugins/csi-nodeplugin-manilaplugin
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi-nodeplugin-manilaplugin
+            type: DirectoryOrCreate

--- a/manifests/manila-csi-plugin/csi-attacher-rbac.yaml
+++ b/manifests/manila-csi-plugin/csi-attacher-rbac.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cephfs-csi-attacher
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cephfs-external-attacher-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cephfs-csi-attacher-role
+subjects:
+  - kind: ServiceAccount
+    name: cephfs-csi-attacher
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cephfs-external-attacher-runner
+  apiGroup: rbac.authorization.k8s.io

--- a/manifests/manila-csi-plugin/csi-nodeplugin-manilaplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin-manilaplugin.yaml
@@ -1,0 +1,87 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-nodeplugin-manilaplugin
+spec:
+  selector:
+    matchLabels:
+      app: csi-nodeplugin-manilaplugin
+  template:
+    metadata:
+      labels:
+        app: csi-nodeplugin-manilaplugin
+    spec:
+      serviceAccount: manila-csi-nodeplugin
+      hostNetwork: true
+      containers:
+        - name: driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          args:
+            - "--v=5"
+            - "--csi-address=/csi/csi.sock"
+            - "--kubelet-registration-path=/var/lib/kubelet/plugins/csi-nodeplugin-manilaplugin/csi.sock"
+          lifecycle:
+            preStop:
+              exec:
+                command: [
+                  "/bin/sh", "-c",
+                  "rm -rf /registration/csi-nodeplugin-manilaplugin /registration/csi-nodeplugin-manilaplugin-reg.sock"
+                ]
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+        - name: csi-nodeplugin-manilaplugin
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: manila-csi-plugin
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--drivername=manila.csi.openstack.org"
+            - "--nodeid=$(NODE_ID)"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--share-protocol-selector=$(MANILA_SHARE_PROTO)"
+            - "--fwdendpoint=$(FWD_CSI_ENDPOINT)"
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi-nodeplugin-manilaplugin/csi.sock
+            - name: MANILA_SHARE_PROTO
+              value: >>>Share protocol goes here<<<
+            - name: FWD_CSI_ENDPOINT
+              value: unix://>>>Absolute path to proxy'd plugin .sock file<<<
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi/csi-nodeplugin-manilaplugin
+            - name: fwd-plugin-dir
+              mountPath: >>>Path to the directory containing .sock file of the proxy'd plugin<<<
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi-nodeplugin-manilaplugin
+            type: DirectoryOrCreate
+        - name: fwd-plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/>>>The other CSI plugin<<<
+            type: Directory

--- a/manifests/manila-csi-plugin/csi-nodeplugin-rbac.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin-rbac.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: manila-csi-nodeplugin
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manila-csi-nodeplugin
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "update"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manila-csi-nodeplugin
+subjects:
+  - kind: ServiceAccount
+    name: manila-csi-nodeplugin
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: manila-csi-nodeplugin
+  apiGroup: rbac.authorization.k8s.io

--- a/manifests/manila-csi-plugin/csi-provisioner-manilaplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-provisioner-manilaplugin.yaml
@@ -1,0 +1,47 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-provisioner-manilaplugin
+  labels:
+    app: csi-provisioner-manilaplugin
+spec:
+  selector:
+    app: csi-provisioner-manilaplugin
+  ports:
+    - name: dummy
+      port: 12345
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-provisioner-manilaplugin
+spec:
+  serviceName: csi-provisioner-manilaplugin
+  selector:
+    matchLabels:
+      app: csi-provisioner-manilaplugin
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: csi-provisioner-manilaplugin
+    spec:
+      serviceAccount: manila-csi-provisioner
+      containers:
+        - name: csi-provisioner
+          image: quay.io/k8scsi/csi-provisioner:v1.1.0
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+          env:
+            - name: ADDRESS
+              value: /var/lib/kubelet/plugins/csi-nodeplugin-manilaplugin/csi.sock
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/kubelet/plugins/csi-nodeplugin-manilaplugin
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi-nodeplugin-manilaplugin
+            type: DirectoryOrCreate

--- a/manifests/manila-csi-plugin/csi-provisioner-rbac.yaml
+++ b/manifests/manila-csi-plugin/csi-provisioner-rbac.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: manila-csi-provisioner
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manila-external-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manila-csi-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: manila-csi-provisioner
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: manila-external-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # replace with non-default namespace name
+  namespace: default
+  name: manila-external-provisioner-cfg
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "create", "delete"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manila-csi-provisioner-role-cfg
+  # replace with non-default namespace name
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: manila-csi-provisioner
+    # replace with non-default namespace name
+    namespace: default
+roleRef:
+  kind: Role
+  name: manila-external-provisioner-cfg
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/csi/manila/controllerserver.go
+++ b/pkg/csi/manila/controllerserver.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manila
+
+import (
+	"context"
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
+
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/options"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/responsebroker"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/shareadapters"
+)
+
+type controllerServer struct {
+	d *Driver
+}
+
+var (
+	rbVolumeID = responsebroker.New()
+)
+
+func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
+	if err := validateCreateVolumeRequest(req); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// Configuration
+
+	params := req.GetParameters()
+	if params == nil {
+		params = make(map[string]string)
+	}
+
+	params["protocol"] = cs.d.shareProto
+
+	shareOpts, err := options.NewControllerVolumeContext(params)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid volume parameters: %v", err)
+	}
+
+	osOpts, err := options.NewOpenstackOptions(req.GetSecrets())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid volume secrets: %v", err)
+	}
+
+	volID := newVolumeID(req.GetName())
+
+	// Acquire a lock for this volume
+	handle, isNewRequest := rbVolumeID.Acquire(string(volID))
+	if !isNewRequest {
+		// Check if the master was successful
+
+		if respData, respErr := handle.Read(); respErr == nil {
+			// Yup
+			defer handle.Release()
+			return respData.(*csi.CreateVolumeResponse), nil
+		}
+
+		// The previous master failed, this request now becomes the master
+	}
+
+	var (
+		createErr    error
+		createResp   *csi.CreateVolumeResponse
+		manilaClient *gophercloud.ServiceClient
+		share        *shares.Share
+		accessRight  *shares.AccessRight
+	)
+
+	defer func() {
+		// Let other in-flight calls read our result
+		handle.Write(createResp, createErr)
+
+		if createErr == nil {
+			// This request was a success, wait for any other in-flight calls to read our result
+			rbVolumeID.Done(string(volID))
+		}
+	}()
+
+	manilaClient, createErr = newManilaV2Client(osOpts)
+	if createErr != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "failed to create Manila v2 client: %v", createErr)
+	}
+
+	// Create or get the share
+
+	requestedSize := req.GetCapacityRange().GetRequiredBytes()
+	if requestedSize == 0 {
+		// At least 1GiB
+		requestedSize = 1 * bytesInGiB
+	}
+
+	sizeInGiB := bytesToGiB(requestedSize)
+
+	klog.V(4).Infof("creating a share for volume %s", volID)
+
+	share, createErr = cs.getOrCreateShare(volID, sizeInGiB, shareOpts, manilaClient)
+	if createErr != nil {
+		if createErr == wait.ErrWaitTimeout {
+			return nil, status.Errorf(codes.DeadlineExceeded, "deadline exceeded while waiting for volume %s to become available", volID)
+		}
+
+		return nil, status.Errorf(codes.Internal, "failed to create volume %s: %v", volID, createErr)
+	}
+
+	if share.Size != sizeInGiB {
+		return nil, status.Errorf(codes.AlreadyExists, "volume %s already exists, but is incompatible with the request", volID)
+	}
+
+	// Grant access to the share
+
+	ad := getShareAdapter(shareOpts.Protocol)
+
+	klog.V(4).Infof("creating an access rule for volume %s (share ID %s)", volID, share.ID)
+
+	accessRight, createErr = ad.GetOrGrantAccess(&shareadapters.GrantAccessArgs{Share: share, ManilaClient: manilaClient, Options: shareOpts})
+	if createErr != nil {
+		if createErr == wait.ErrWaitTimeout {
+			return nil, status.Errorf(codes.DeadlineExceeded, "deadline exceeded while waiting for access rights for volume %s to become available", volID)
+		}
+
+		return nil, status.Errorf(codes.Internal, "failed to grant access for volume %s (share ID %s): %v", volID, share.ID, createErr)
+	}
+
+	klog.V(4).Infof("successfully created volume %s", volID)
+
+	createResp = &csi.CreateVolumeResponse{
+		Volume: &csi.Volume{
+			VolumeId:      string(volID),
+			CapacityBytes: int64(sizeInGiB) * bytesInGiB,
+			VolumeContext: map[string]string{
+				"shareID":        share.ID,
+				"shareAccessID":  accessRight.ID,
+				"cephfs-mounter": shareOpts.CephfsMounter,
+			},
+		},
+	}
+
+	return createResp, nil
+}
+
+func (cs *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
+	if err := validateDeleteVolumeRequest(req); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	volID := volumeID(req.VolumeId)
+
+	osOpts, err := options.NewOpenstackOptions(req.GetSecrets())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid volume secrets: %v", err)
+	}
+
+	manilaClient, err := newManilaV2Client(osOpts)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "failed to create Manila v2 client: %v", err)
+	}
+
+	if err := deleteShare(volID, manilaClient); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to delete volume %s: %v", volID, err)
+	}
+
+	klog.V(4).Infof("successfully deleted volume %s", volID)
+
+	return &csi.DeleteVolumeResponse{}, nil
+}
+
+func (cs *controllerServer) ControllerGetCapabilities(ctx context.Context, req *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
+	return &csi.ControllerGetCapabilitiesResponse{
+		Capabilities: cs.d.cscaps,
+	}, nil
+}
+
+func (cs *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
+func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
+func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
+func (cs *controllerServer) ListVolumes(context.Context, *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
+func (cs *controllerServer) GetCapacity(context.Context, *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
+func (cs *controllerServer) CreateSnapshot(context.Context, *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
+func (cs *controllerServer) DeleteSnapshot(context.Context, *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
+func (cs *controllerServer) ListSnapshots(context.Context, *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
+func (cs *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}

--- a/pkg/csi/manila/csiclient.go
+++ b/pkg/csi/manila/csiclient.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manila
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
+	"google.golang.org/grpc"
+	"k8s.io/klog"
+)
+
+var (
+	fwdEndpointGRPCCallCounter uint64
+)
+
+func grpcConnect(ctx context.Context, endpoint string) (*grpc.ClientConn, error) {
+	var (
+		dialOptions = []grpc.DialOption{
+			grpc.WithInsecure(),
+			grpc.WithBackoffMaxDelay(time.Second),
+			grpc.WithBlock(),
+			grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+				callID := atomic.AddUint64(&fwdEndpointGRPCCallCounter, 1)
+
+				klog.V(3).Infof("[ID:%d] FWD GRPC call: %s", callID, method)
+				klog.V(5).Infof("[ID:%d] FWD GRPC request: %s", callID, protosanitizer.StripSecrets(req))
+
+				err := invoker(ctx, method, req, reply, cc, opts...)
+				if err != nil {
+					klog.Infof("[ID:%d] FWD GRPC error: %v", callID, err)
+				} else {
+					klog.V(5).Infof("[ID:%d] FWD GRPC response: %s", callID, protosanitizer.StripSecrets(reply))
+				}
+
+				return err
+			}),
+		}
+
+		conn *grpc.ClientConn
+		err  error
+	)
+
+	if ctx != nil {
+		conn, err = grpc.DialContext(ctx, endpoint, dialOptions...)
+		if err == context.DeadlineExceeded {
+			return nil, fmt.Errorf("connecting to %s timed out: %v", endpoint, err)
+		}
+
+		return conn, err
+	} else {
+		dialFinished := make(chan bool)
+		go func() {
+			conn, err = grpc.Dial(endpoint, dialOptions...)
+			close(dialFinished)
+		}()
+
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				klog.Warningf("still connecting to %s", endpoint)
+			case <-dialFinished:
+				return conn, err
+			}
+		}
+	}
+}
+
+type csiNodeCapabilitySet map[csi.NodeServiceCapability_RPC_Type]bool
+
+func csiNodeGetCapabilities(ctx context.Context, conn *grpc.ClientConn) (csiNodeCapabilitySet, error) {
+	client := csi.NewNodeClient(conn)
+	req := csi.NodeGetCapabilitiesRequest{}
+	rsp, err := client.NodeGetCapabilities(ctx, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	caps := csiNodeCapabilitySet{}
+	for _, cap := range rsp.GetCapabilities() {
+		if cap == nil {
+			continue
+		}
+		rpc := cap.GetRpc()
+		if rpc == nil {
+			continue
+		}
+		t := rpc.GetType()
+		caps[t] = true
+	}
+	return caps, nil
+}
+
+func csiNodeGetInfo(ctx context.Context, conn *grpc.ClientConn) (*csi.NodeGetInfoResponse, error) {
+	client := csi.NewNodeClient(conn)
+	return client.NodeGetInfo(ctx, &csi.NodeGetInfoRequest{})
+}
+
+func csiNodePublishVolume(ctx context.Context, conn *grpc.ClientConn, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+	client := csi.NewNodeClient(conn)
+	return client.NodePublishVolume(ctx, req)
+}
+
+func csiNodeUnpublishVolume(ctx context.Context, conn *grpc.ClientConn, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+	client := csi.NewNodeClient(conn)
+	return client.NodeUnpublishVolume(ctx, req)
+}
+
+func csiNodeStageVolume(ctx context.Context, conn *grpc.ClientConn, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+	client := csi.NewNodeClient(conn)
+	return client.NodeStageVolume(ctx, req)
+}
+
+func csiNodeUnstageVolume(ctx context.Context, conn *grpc.ClientConn, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+	client := csi.NewNodeClient(conn)
+	return client.NodeUnstageVolume(ctx, req)
+}
+
+func csiGetPluginInfo(ctx context.Context, conn *grpc.ClientConn) (*csi.GetPluginInfoResponse, error) {
+	client := csi.NewIdentityClient(conn)
+	return client.GetPluginInfo(ctx, &csi.GetPluginInfoRequest{})
+}

--- a/pkg/csi/manila/driver.go
+++ b/pkg/csi/manila/driver.go
@@ -1,0 +1,268 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manila
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/kubernetes-csi/csi-lib-utils/connection"
+	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
+	"google.golang.org/grpc"
+	"k8s.io/klog"
+)
+
+type Driver struct {
+	nodeID     string
+	name       string
+	version    string
+	shareProto string
+
+	serverEndpoint string
+	fwdEndpoint    string
+
+	ids *identityServer
+	cs  *controllerServer
+	ns  *nodeServer
+
+	vcaps  []*csi.VolumeCapability_AccessMode
+	cscaps []*csi.ControllerServiceCapability
+	nscaps []*csi.NodeServiceCapability
+}
+
+type nonBlockingGRPCServer struct {
+	wg     sync.WaitGroup
+	server *grpc.Server
+}
+
+const (
+	driverVersion = "0.9.0"
+)
+
+var (
+	serverGRPCEndpointCallCounter uint64
+)
+
+func NewDriver(nodeID, driverName, endpoint, fwdEndpoint, shareProto string) (*Driver, error) {
+	klog.Infof("Driver: %v version: %v CSI spec version: 1.1.0", driverName, driverVersion)
+
+	d := &Driver{
+		nodeID:         nodeID,
+		name:           driverName,
+		serverEndpoint: endpoint,
+		fwdEndpoint:    fwdEndpoint,
+		shareProto:     shareProto,
+	}
+
+	serverProto, serverAddr, err := parseGRPCEndpoint(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse server endpoint address %s: %v", endpoint, err)
+	}
+
+	fwdProto, fwdAddr, err := parseGRPCEndpoint(fwdEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse proxy client address %s: %v", fwdEndpoint, err)
+	}
+
+	d.serverEndpoint = endpointAddress(serverProto, serverAddr)
+	d.fwdEndpoint = endpointAddress(fwdProto, fwdAddr)
+
+	d.addControllerServiceCapabilities([]csi.ControllerServiceCapability_RPC_Type{
+		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
+	})
+
+	d.addVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{
+		csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+		csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER,
+		csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
+		csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+		csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY,
+	})
+
+	var supportsNodeStage bool
+
+	if nodeCapsMap, err := d.initProxiedDriver(); err != nil {
+		return nil, fmt.Errorf("failed to initialize proxied CSI driver: %v", err)
+	} else {
+		var nscaps []csi.NodeServiceCapability_RPC_Type
+		for c := range nodeCapsMap {
+			nscaps = append(nscaps, c)
+
+			if c == csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME {
+				supportsNodeStage = true
+			}
+		}
+
+		d.addNodeServiceCapabilities(nscaps)
+	}
+
+	d.ids = &identityServer{d: d}
+	d.cs = &controllerServer{d: d}
+	d.ns = &nodeServer{d: d, supportsNodeStage: supportsNodeStage, nodeStageCache: make(map[volumeID]stageCacheEntry)}
+
+	return d, nil
+}
+
+func (d *Driver) Run() {
+	s := nonBlockingGRPCServer{}
+	s.start(d.serverEndpoint, d.ids, d.cs, d.ns)
+	s.wait()
+}
+
+func (d *Driver) addControllerServiceCapabilities(cs []csi.ControllerServiceCapability_RPC_Type) {
+	var caps []*csi.ControllerServiceCapability
+
+	for _, c := range cs {
+		klog.Infof("Enabling controller service capability: %v", c.String())
+		csc := &csi.ControllerServiceCapability{
+			Type: &csi.ControllerServiceCapability_Rpc{
+				Rpc: &csi.ControllerServiceCapability_RPC{
+					Type: c,
+				},
+			},
+		}
+
+		caps = append(caps, csc)
+	}
+
+	d.cscaps = caps
+}
+
+func (d *Driver) addVolumeCapabilityAccessModes(vs []csi.VolumeCapability_AccessMode_Mode) {
+	var caps []*csi.VolumeCapability_AccessMode
+
+	for _, c := range vs {
+		klog.Infof("Enabling volume access mode: %v", c.String())
+		caps = append(caps, &csi.VolumeCapability_AccessMode{Mode: c})
+	}
+
+	d.vcaps = caps
+}
+
+func (d *Driver) addNodeServiceCapabilities(ns []csi.NodeServiceCapability_RPC_Type) {
+	var caps []*csi.NodeServiceCapability
+
+	for _, c := range ns {
+		klog.Infof("Enabling node service capability: %v", c.String())
+		nsc := &csi.NodeServiceCapability{
+			Type: &csi.NodeServiceCapability_Rpc{
+				Rpc: &csi.NodeServiceCapability_RPC{
+					Type: c,
+				},
+			},
+		}
+
+		caps = append(caps, nsc)
+	}
+
+	d.nscaps = caps
+}
+
+func (d *Driver) initProxiedDriver() (csiNodeCapabilitySet, error) {
+	conn, err := grpcConnect(nil, d.fwdEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to %s endpoint failed: %v", d.fwdEndpoint, err)
+	}
+
+	if err = connection.ProbeForever(conn, time.Second*5); err != nil {
+		return nil, fmt.Errorf("probe failed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
+	defer cancel()
+
+	pluginInfo, err := csiGetPluginInfo(ctx, conn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get plugin info of the proxied driver: %v", err)
+	}
+
+	klog.Infof("proxying CSI driver %s version %s", pluginInfo.GetName(), pluginInfo.GetVendorVersion())
+
+	nodeCaps, err := csiNodeGetCapabilities(ctx, conn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node capabilities: %v", err)
+	}
+
+	return nodeCaps, nil
+}
+
+func (s *nonBlockingGRPCServer) start(endpoint string, ids *identityServer, cs *controllerServer, ns *nodeServer) {
+	s.wg.Add(1)
+	go s.serve(endpoint, ids, cs, ns)
+}
+
+func (s *nonBlockingGRPCServer) wait() {
+	s.wg.Wait()
+}
+
+func (s *nonBlockingGRPCServer) stop() {
+	s.server.GracefulStop()
+}
+
+func (s *nonBlockingGRPCServer) forceStop() {
+	s.server.Stop()
+}
+
+func (s *nonBlockingGRPCServer) serve(endpoint string, ids *identityServer, cs *controllerServer, ns *nodeServer) {
+	proto, addr, err := parseGRPCEndpoint(endpoint)
+	if err != nil {
+		klog.Fatalf("couldn't parse GRPC server endpoint address %s: %v", endpoint, err)
+	}
+
+	if proto == "unix" {
+		if err = os.Remove(addr); err != nil && !os.IsNotExist(err) {
+			klog.Fatalf("failed to remove an existing socket file %s: %v", addr, err)
+		}
+	}
+
+	listener, err := net.Listen(proto, addr)
+	if err != nil {
+		klog.Fatalf("listen failed for GRPC server: %v", err)
+	}
+
+	server := grpc.NewServer(grpc.UnaryInterceptor(func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		callID := atomic.AddUint64(&serverGRPCEndpointCallCounter, 1)
+
+		klog.V(3).Infof("[ID:%d] GRPC call: %s", callID, info.FullMethod)
+		klog.V(5).Infof("[ID:%d] GRPC request: %s", callID, protosanitizer.StripSecrets(req))
+		resp, err := handler(ctx, req)
+		if err != nil {
+			klog.Errorf("[ID:%d] GRPC error: %v", callID, err)
+		} else {
+			klog.V(5).Infof("[ID:%d] GRPC response: %s", callID, protosanitizer.StripSecrets(resp))
+		}
+		return resp, err
+	}))
+
+	s.server = server
+
+	csi.RegisterIdentityServer(server, ids)
+	csi.RegisterControllerServer(server, cs)
+	csi.RegisterNodeServer(server, ns)
+
+	klog.Infof("listening for connections on %#v", listener.Addr())
+
+	if err := server.Serve(listener); err != nil {
+		klog.Fatalf("GRPC server failure: %v", err)
+	}
+}

--- a/pkg/csi/manila/identityserver.go
+++ b/pkg/csi/manila/identityserver.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manila
+
+import (
+	"context"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type identityServer struct {
+	d *Driver
+}
+
+func (ids *identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
+	if ids.d.name == "" {
+		return nil, status.Error(codes.Unavailable, "Driver name not configured")
+	}
+
+	return &csi.GetPluginInfoResponse{
+		Name:          ids.d.name,
+		VendorVersion: driverVersion,
+	}, nil
+}
+
+func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
+	return &csi.ProbeResponse{}, nil
+}
+
+func (ids *identityServer) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
+	return &csi.GetPluginCapabilitiesResponse{
+		Capabilities: []*csi.PluginCapability{
+			{
+				Type: &csi.PluginCapability_Service_{
+					Service: &csi.PluginCapability_Service{
+						Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/pkg/csi/manila/manilaclient.go
+++ b/pkg/csi/manila/manilaclient.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manila
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/apiversions"
+	gophercloudutils "github.com/gophercloud/gophercloud/openstack/utils"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/options"
+)
+
+const (
+	minimumManilaVersion = "2.21"
+)
+
+var (
+	manilaMicroversionRegexp = regexp.MustCompile(`^(\d+)\.(\d+)$`)
+)
+
+func splitManilaMicroversion(microversion string) (major, minor int) {
+	if err := validateManilaMicroversion(microversion); err != nil {
+		return
+	}
+
+	parts := strings.Split(microversion, ".")
+	major, _ = strconv.Atoi(parts[0])
+	minor, _ = strconv.Atoi(parts[1])
+
+	return
+}
+
+func validateManilaMicroversion(microversion string) error {
+	if !manilaMicroversionRegexp.MatchString(microversion) {
+		return fmt.Errorf("invalid microversion format in %q", microversion)
+	}
+
+	return nil
+}
+
+func compareManilaVersionsLessThan(a, b string) bool {
+	aMaj, aMin := splitManilaMicroversion(a)
+	bMaj, bMin := splitManilaMicroversion(b)
+
+	return aMaj < bMaj || (aMaj == bMaj && aMin < bMin)
+}
+
+func createHTTPClient(pemCertAuthority []byte, tlsInsecure bool) (http.Client, error) {
+	if pemCertAuthority == nil || len(pemCertAuthority) == 0 {
+		return http.Client{}, nil
+	}
+
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(pemCertAuthority)
+
+	tlsConfig := &tls.Config{
+		RootCAs:            caCertPool,
+		InsecureSkipVerify: tlsInsecure,
+	}
+
+	tlsConfig.BuildNameToCertificate()
+
+	return http.Client{
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
+	}, nil
+}
+
+func authenticateOpenStackClient(o *options.OpenstackOptions) (*gophercloud.ProviderClient, error) {
+	provider, err := openstack.NewClient(o.OSAuthURL)
+	if err != nil {
+		return nil, fmt.Errorf("cannot connect to Keystone: %v", err)
+	}
+
+	var certAuth []byte
+
+	if o.OSCertAuthorityPath != "" {
+		certAuth, err = ioutil.ReadFile(o.OSCertAuthorityPath)
+		if err != nil {
+			return nil, fmt.Errorf("cannot read CA file %s: %v", o.OSCertAuthorityPath, err)
+		}
+	}
+
+	provider.HTTPClient, err = createHTTPClient(certAuth, o.OSTLSInsecure == "true")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP client: %v", err)
+	}
+
+	const (
+		v2 = "v2.0"
+		v3 = "v3"
+	)
+
+	chosenVersion, _, err := gophercloudutils.ChooseVersion(provider, []*gophercloudutils.Version{
+		{ID: v2, Priority: 20, Suffix: "/v2.0/"},
+		{ID: v3, Priority: 30, Suffix: "/v3/"},
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to choose Keystone version: %v", err)
+	}
+
+	switch chosenVersion.ID {
+	case v2:
+		if o.OSTrustID != "" {
+			return nil, fmt.Errorf("Keystone %s does not support trustee authentication", v2)
+		}
+
+		err = openstack.AuthenticateV2(provider, *o.ToAuthOptions(), gophercloud.EndpointOpts{})
+	case v3:
+		err = openstack.AuthenticateV3(provider, *o.ToAuthOptionsExt(), gophercloud.EndpointOpts{})
+	default:
+		err = fmt.Errorf("unrecognized Keystone version: %s", chosenVersion.ID)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to authenticate with Keystone %s: %v", chosenVersion.ID, err)
+	}
+
+	return provider, err
+}
+
+func validateManilaClient(c *gophercloud.ServiceClient) error {
+	serverVersion, err := apiversions.Get(c, "v2").Extract()
+	if err != nil {
+		return fmt.Errorf("failed to get Manila v2 API microversions: %v", err)
+	}
+
+	if err = validateManilaMicroversion(serverVersion.MinVersion); err != nil {
+		return fmt.Errorf("server's minimum microversion is invalid: %v", err)
+	}
+
+	if err = validateManilaMicroversion(serverVersion.Version); err != nil {
+		return fmt.Errorf("server's maximum microversion is invalid: %v", err)
+	}
+
+	if compareManilaVersionsLessThan(c.Microversion, serverVersion.MinVersion) {
+		return fmt.Errorf("client's microversion %s is lower than server's minimum microversion %s", c.Microversion, serverVersion.MinVersion)
+	}
+
+	if compareManilaVersionsLessThan(serverVersion.Version, c.Microversion) {
+		return fmt.Errorf("client's microversion %s is higher than server's highest supported microversion %s", c.Microversion, serverVersion.Version)
+	}
+
+	return nil
+}
+
+func newManilaV2Client(o *options.OpenstackOptions) (*gophercloud.ServiceClient, error) {
+	// Authenticate and create Manila v2 client
+
+	provider, err := authenticateOpenStackClient(o)
+	if err != nil {
+		return nil, fmt.Errorf("failed to authenticate: %v", err)
+	}
+
+	client, err := openstack.NewSharedFileSystemV2(provider, gophercloud.EndpointOpts{Region: o.OSRegionName})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Manila v2 client: %v", err)
+	}
+
+	// Check client's and server's versions for compatibility
+
+	client.Microversion = minimumManilaVersion
+	if err = validateManilaClient(client); err != nil {
+		return nil, fmt.Errorf("Manila v2 client validation failed: %v", err)
+	}
+
+	return client, nil
+}

--- a/pkg/csi/manila/nodeserver.go
+++ b/pkg/csi/manila/nodeserver.go
@@ -1,0 +1,362 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manila
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/options"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/shareadapters"
+	"k8s.io/klog"
+)
+
+type nodeServer struct {
+	d *Driver
+
+	supportsNodeStage bool
+	// The result of NodeStageVolume is stashed away for NodePublishVolume(s) that will follow
+	nodeStageCache    map[volumeID]stageCacheEntry
+	nodeStageCacheMtx sync.RWMutex
+}
+
+type stageCacheEntry struct {
+	volumeContext map[string]string
+	stageSecret   map[string]string
+	publishSecret map[string]string
+}
+
+func (ns *nodeServer) buildVolumeContext(volID volumeID, shareOpts *options.NodeVolumeContext, osOpts *options.OpenstackOptions) (
+	volumeContext map[string]string, accessRight *shares.AccessRight, err error,
+) {
+	manilaClient, err := newManilaV2Client(osOpts)
+	if err != nil {
+		return nil, nil, status.Errorf(codes.Unauthenticated, "failed to create Manila v2 client: %v", err)
+	}
+
+	// Retrieve the share by its ID or name
+
+	var share *shares.Share
+
+	if shareOpts.ShareID != "" {
+		share, err = getShareByID(shareOpts.ShareID, manilaClient)
+		if err != nil {
+			return nil, nil, status.Errorf(codes.InvalidArgument, "failed to retrieve volume %s (share ID %s): %v",
+				volID, shareOpts.ShareID, err)
+		}
+	} else {
+		share, err = getShareByName(shareOpts.ShareName, manilaClient)
+		if err != nil {
+			return nil, nil, status.Errorf(codes.InvalidArgument, "failed to retrieve volume %s (share name %s): %v",
+				volID, shareOpts.ShareName, err)
+		}
+	}
+
+	// Verify the plugin supports this share
+
+	if strings.ToLower(share.ShareProto) != strings.ToLower(ns.d.shareProto) {
+		return nil, nil, status.Errorf(codes.InvalidArgument,
+			"wrong share protocol %s for volume %s (share ID %s), the plugin is set to operate in %s",
+			share.ShareProto, volID, share.ID, ns.d.shareProto)
+	}
+
+	if share.Status != "available" {
+		return nil, nil, status.Errorf(codes.InvalidArgument, "invalid share status for volume %s (share ID %s): expected 'available', got '%s'",
+			volID, share.ID, share.Status)
+	}
+
+	// Get export locations and choose one
+
+	availableExportLocations, err := shares.GetExportLocations(manilaClient, share.ID).Extract()
+	if err != nil {
+		return nil, nil, status.Errorf(codes.Internal, "failed to retrieve export locations for volume %s (share ID %s): %v",
+			volID, share.ID, err)
+	}
+
+	chosenExportLocation, err := chooseExportLocation(availableExportLocations)
+	if err != nil {
+		return nil, nil, status.Errorf(codes.Internal, "failed to choose an export locations for volume %s (share ID %s): %v",
+			volID, share.ID, err)
+	}
+
+	accessRights, err := shares.ListAccessRights(manilaClient, share.ID).Extract()
+	if err != nil {
+		return nil, nil, status.Errorf(codes.Internal, "failed to list access rights for volume %s (share ID %s): %v",
+			volID, share.ID, err)
+	}
+
+	// Get the access right for this share
+
+	for i := range accessRights {
+		if accessRights[i].ID == shareOpts.ShareAccessID {
+			accessRight = &accessRights[i]
+			break
+		}
+	}
+
+	if accessRight == nil {
+		return nil, nil, status.Errorf(codes.InvalidArgument, "cannot find access right %s for volume %s (share ID %s)",
+			shareOpts.ShareAccessID, volID, share.ID)
+	}
+
+	// Build volume context for fwd plugin
+
+	sa := getShareAdapter(ns.d.shareProto)
+
+	volumeContext, err = sa.BuildVolumeContext(&shareadapters.VolumeContextArgs{Location: &chosenExportLocation, Options: shareOpts})
+	if err != nil {
+		return nil, nil, status.Errorf(codes.InvalidArgument, "failed to build volume context for volume %s: %v", volID, err)
+	}
+
+	return
+}
+
+func buildNodePublishSecret(accessRight *shares.AccessRight, sa shareadapters.ShareAdapter, volID volumeID) (map[string]string, error) {
+	secret, err := sa.BuildNodePublishSecret(&shareadapters.SecretArgs{AccessRight: accessRight})
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "failed to build publish secret for volume %s: %v", volID, err)
+	}
+
+	return secret, nil
+}
+
+func buildNodeStageSecret(accessRight *shares.AccessRight, sa shareadapters.ShareAdapter, volID volumeID) (map[string]string, error) {
+	secret, err := sa.BuildNodeStageSecret(&shareadapters.SecretArgs{AccessRight: accessRight})
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "failed to build stage secret for volume %s: %v", volID, err)
+	}
+
+	return secret, nil
+}
+
+func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+	if err := validateNodePublishVolumeRequest(req); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// Configuration
+
+	shareOpts, err := options.NewNodeVolumeContext(req.GetVolumeContext())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid volume parameters: %v", err)
+	}
+
+	osOpts, err := options.NewOpenstackOptions(req.GetSecrets())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid volume secret: %v", err)
+	}
+
+	volID := volumeID(req.GetVolumeId())
+
+	var (
+		accessRight       *shares.AccessRight
+		volumeCtx, secret map[string]string
+	)
+
+	if ns.supportsNodeStage {
+		// STAGE_UNSTAGE_VOLUME capability is enabled, NodeStageVolume should've already built the staging data
+
+		ns.nodeStageCacheMtx.RLock()
+		cacheEntry, ok := ns.nodeStageCache[volID]
+		ns.nodeStageCacheMtx.RUnlock()
+
+		if ok {
+			volumeCtx, secret = cacheEntry.volumeContext, cacheEntry.publishSecret
+		} else {
+			klog.Warningf("STAGE_UNSTAGE_VOLUME capability is enabled, but node stage cache doesn't contain an entry for %s - this is most likely a bug! Rebuilding staging data anyway...", volID)
+			volumeCtx, accessRight, err = ns.buildVolumeContext(volID, shareOpts, osOpts)
+			if err == nil {
+				secret, err = buildNodePublishSecret(accessRight, getShareAdapter(ns.d.shareProto), volID)
+			}
+		}
+	} else {
+		volumeCtx, accessRight, err = ns.buildVolumeContext(volID, shareOpts, osOpts)
+		if err == nil {
+			secret, err = buildNodePublishSecret(accessRight, getShareAdapter(ns.d.shareProto), volID)
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Forward the RPC
+
+	csiConn, err := grpcConnect(ctx, ns.d.fwdEndpoint)
+	if err != nil {
+		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
+	}
+
+	req.Secrets = secret
+	req.VolumeContext = volumeCtx
+
+	return csiNodePublishVolume(ctx, csiConn, req)
+}
+
+func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+	if err := validateNodeUnpublishVolumeRequest(req); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	csiConn, err := grpcConnect(ctx, ns.d.fwdEndpoint)
+	if err != nil {
+		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
+	}
+
+	return csiNodeUnpublishVolume(ctx, csiConn, req)
+}
+
+func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+	if err := validateNodeStageVolumeRequest(req); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// Configuration
+
+	var (
+		accessRight                *shares.AccessRight
+		volumeCtx                  map[string]string
+		stageSecret, publishSecret map[string]string
+		err                        error
+	)
+
+	shareOpts, err := options.NewNodeVolumeContext(req.GetVolumeContext())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid volume parameters: %v", err)
+	}
+
+	osOpts, err := options.NewOpenstackOptions(req.GetSecrets())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid volume secret: %v", err)
+	}
+
+	volID := volumeID(req.GetVolumeId())
+
+	ns.nodeStageCacheMtx.Lock()
+	if cacheEntry, ok := ns.nodeStageCache[volID]; ok {
+		volumeCtx, stageSecret = cacheEntry.volumeContext, cacheEntry.stageSecret
+	} else {
+		volumeCtx, accessRight, err = ns.buildVolumeContext(volID, shareOpts, osOpts)
+
+		if err == nil {
+			stageSecret, err = buildNodeStageSecret(accessRight, getShareAdapter(ns.d.shareProto), volID)
+		}
+
+		if err == nil {
+			publishSecret, err = buildNodePublishSecret(accessRight, getShareAdapter(ns.d.shareProto), volID)
+		}
+
+		ns.nodeStageCache[volID] = stageCacheEntry{volumeContext: volumeCtx, stageSecret: stageSecret, publishSecret: publishSecret}
+	}
+	ns.nodeStageCacheMtx.Unlock()
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Forward the RPC
+
+	csiConn, err := grpcConnect(ctx, ns.d.fwdEndpoint)
+	if err != nil {
+		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
+	}
+
+	req.Secrets = stageSecret
+	req.VolumeContext = volumeCtx
+
+	return csiNodeStageVolume(ctx, csiConn, req)
+}
+
+func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+	if err := validateNodeUnstageVolumeRequest(req); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	ns.nodeStageCacheMtx.Lock()
+	delete(ns.nodeStageCache, volumeID(req.VolumeId))
+	ns.nodeStageCacheMtx.Unlock()
+
+	csiConn, err := grpcConnect(ctx, ns.d.fwdEndpoint)
+	if err != nil {
+		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
+	}
+
+	return csiNodeUnstageVolume(ctx, csiConn, req)
+}
+
+func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
+	return &csi.NodeGetInfoResponse{
+		NodeId: ns.d.nodeID,
+	}, nil
+}
+
+func (ns *nodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
+	return &csi.NodeGetCapabilitiesResponse{
+		Capabilities: ns.d.nscaps,
+	}, nil
+}
+
+func (ns *nodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
+func (ns *nodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
+// Chooses one ExportLocation according to the below rules:
+// 1. Path is not empty
+// 2. IsAdminOnly == false
+// 3. Preferred == true are preferred over Preferred == false
+// 4. Locations with lower slice index are preferred over locations with higher slice index
+func chooseExportLocation(locs []shares.ExportLocation) (shares.ExportLocation, error) {
+	if len(locs) == 0 {
+		return shares.ExportLocation{}, fmt.Errorf("export locations list is empty")
+	}
+
+	var (
+		foundMatchingNotPreferred = false
+		matchingNotPreferred      shares.ExportLocation
+	)
+
+	for _, loc := range locs {
+		if loc.IsAdminOnly || strings.TrimSpace(loc.Path) == "" {
+			continue
+		}
+
+		if loc.Preferred {
+			return loc, nil
+		}
+
+		if !foundMatchingNotPreferred {
+			matchingNotPreferred = loc
+			foundMatchingNotPreferred = true
+		}
+	}
+
+	if foundMatchingNotPreferred {
+		return matchingNotPreferred, nil
+	}
+
+	return shares.ExportLocation{}, fmt.Errorf("cannot find any non-admin export location")
+}

--- a/pkg/csi/manila/options/openstackoptions.go
+++ b/pkg/csi/manila/options/openstackoptions.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/trusts"
+	"k8s.io/cloud-provider-openstack/pkg/share/manila/shareoptions/validator"
+)
+
+type OpenstackOptions struct {
+	// Common options
+
+	OSAuthURL    string `name:"os-authURL" dependsOn:"os-password|os-trustID"`
+	OSRegionName string `name:"os-region"`
+
+	OSCertAuthorityPath string `name:"os-certAuthorityPath" value:"optional"`
+	OSTLSInsecure       string `name:"os-TLSInsecure" value:"optional" dependsOn:"os-certAuthorityPath" matches:"^true|false$"`
+
+	// User authentication
+
+	OSPassword string `name:"os-password" value:"optional" dependsOn:"os-domainID|os-domainName,os-projectID|os-projectName,os-userID|os-userName"`
+	OSUserID   string `name:"os-userID" value:"optional" dependsOn:"os-password"`
+	OSUsername string `name:"os-userName" value:"optional" dependsOn:"os-password"`
+
+	OSDomainID   string `name:"os-domainID" value:"optional" dependsOn:"os-password"`
+	OSDomainName string `name:"os-domainName" value:"optional" dependsOn:"os-password"`
+
+	OSProjectID   string `name:"os-projectID" value:"optional" dependsOn:"os-password"`
+	OSProjectName string `name:"os-projectName" value:"optional" dependsOn:"os-password"`
+
+	// Trustee authentication
+
+	OSTrustID         string `name:"os-trustID" value:"optional" dependsOn:"os-trusteeID,os-trusteePassword"`
+	OSTrusteeID       string `name:"os-trusteeID" value:"optional" dependsOn:"os-trustID"`
+	OSTrusteePassword string `name:"os-trusteePassword" value:"optional" dependsOn:"os-trustID"`
+}
+
+var (
+	osOptionsValidator = validator.New(&OpenstackOptions{})
+)
+
+func NewOpenstackOptions(data map[string]string) (*OpenstackOptions, error) {
+	opts := &OpenstackOptions{}
+	if err := osOptionsValidator.Populate(data, opts); err != nil {
+		return nil, err
+	}
+
+	return opts, nil
+}
+
+func (o *OpenstackOptions) ToAuthOptions() *gophercloud.AuthOptions {
+	authOpts := &gophercloud.AuthOptions{
+		IdentityEndpoint: o.OSAuthURL,
+		UserID:           o.OSUserID,
+		Username:         o.OSUsername,
+		Password:         o.OSPassword,
+		TenantID:         o.OSProjectID,
+		TenantName:       o.OSProjectName,
+		DomainID:         o.OSDomainID,
+		DomainName:       o.OSDomainName,
+	}
+
+	if o.OSTrustID != "" {
+		authOpts.UserID = o.OSTrusteeID
+		authOpts.Password = o.OSTrusteePassword
+	}
+
+	return authOpts
+}
+
+func (o *OpenstackOptions) ToAuthOptionsExt() *trusts.AuthOptsExt {
+	return &trusts.AuthOptsExt{
+		AuthOptionsBuilder: o.ToAuthOptions(),
+		TrustID:            o.OSTrustID,
+	}
+}

--- a/pkg/csi/manila/options/shareoptions.go
+++ b/pkg/csi/manila/options/shareoptions.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"k8s.io/cloud-provider-openstack/pkg/share/manila/shareoptions/validator"
+)
+
+type ControllerVolumeContext struct {
+	Protocol       string `name:"protocol" matches:"^(?i)CEPHFS|NFS$"`
+	Type           string `name:"type" value:"default:default"`
+	ShareNetworkID string `name:"shareNetworkID" value:"optional"`
+
+	// Adapter options
+
+	CephfsMounter  string `name:"cephfs-mounter" value:"default:fuse" matches:"^kernel|fuse$"`
+	NFSShareClient string `name:"nfs-shareClient" value:"default:0.0.0.0/0"`
+}
+
+type NodeVolumeContext struct {
+	ShareID       string `name:"shareID" value:"optionalIf:shareName=." precludes:"shareName"`
+	ShareName     string `name:"shareName" value:"optionalIf:shareID=." precludes:"shareID"`
+	ShareAccessID string `name:"shareAccessID"`
+
+	// Adapter options
+
+	CephfsMounter string `name:"cephfs-mounter" value:"default:fuse" matches:"^kernel|fuse$"`
+}
+
+var (
+	controllerVolumeCtxValidator = validator.New(&ControllerVolumeContext{})
+	nodeVolumeCtxValidator       = validator.New(&NodeVolumeContext{})
+)
+
+func NewControllerVolumeContext(data map[string]string) (*ControllerVolumeContext, error) {
+	opts := &ControllerVolumeContext{}
+	if err := controllerVolumeCtxValidator.Populate(data, opts); err != nil {
+		return nil, err
+	}
+
+	return opts, nil
+}
+
+func NewNodeVolumeContext(data map[string]string) (*NodeVolumeContext, error) {
+	opts := &NodeVolumeContext{}
+	if err := nodeVolumeCtxValidator.Populate(data, opts); err != nil {
+		return nil, err
+	}
+
+	return opts, nil
+}

--- a/pkg/csi/manila/responsebroker/responsebroker.go
+++ b/pkg/csi/manila/responsebroker/responsebroker.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package responsebroker
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+)
+
+type (
+	response struct {
+		dataPtr interface{}
+		err     error
+
+		m               sync.Mutex
+		wg              sync.WaitGroup
+		ownerProtection int32
+	}
+
+	// ResponseBroker propagates a response to an arbitrary number of requests
+	ResponseBroker struct {
+		m  sync.Mutex
+		rs map[string]*response
+	}
+
+	// ResponseHandle for a request
+	ResponseHandle struct {
+		resp *response
+	}
+)
+
+func New() *ResponseBroker {
+	return &ResponseBroker{
+		rs: make(map[string]*response),
+	}
+}
+
+func (rb *ResponseBroker) Acquire(identifier string) (handle ResponseHandle, isOwner bool) {
+	rb.m.Lock()
+
+	if resp, ok := rb.rs[identifier]; ok {
+		handle.resp = resp
+		handle.resp.wg.Add(1)
+	} else {
+		isOwner = true
+
+		handle.resp = &response{ownerProtection: 1}
+		rb.rs[identifier] = handle.resp
+	}
+
+	rb.m.Unlock()
+
+	if !isOwner {
+		// Spin-lock to guard against a race condition when ResponseBroker's map mutex
+		// is already unlocked but ResponseHandle is still not locked, which could lead to a situation
+		// where a non-owner acquires handle.resp.m.Lock() before the owner - the owner must be the
+		// first one to lock.
+		// Although such situation is unlikely, it could happen if e.g. CO makes multiple CreateVolume requests
+		// for the same volume in a quick succession.
+		for atomic.LoadInt32(&handle.resp.ownerProtection) != 0 {
+			runtime.Gosched()
+		}
+	}
+
+	handle.resp.m.Lock()
+
+	if isOwner {
+		atomic.StoreInt32(&handle.resp.ownerProtection, 0)
+	}
+
+	return
+}
+
+// Done marks this request identified by `identifier` as finished
+// and waits till anyone who's interested in its response has read it.
+// Should be called after a successful request.
+// Invalidates all ResponseHandles.
+func (rb *ResponseBroker) Done(identifier string) {
+	rb.m.Lock()
+	rb.rs[identifier].wg.Wait()
+	delete(rb.rs, identifier)
+	rb.m.Unlock()
+}
+
+// Write writes a response, letting others read it
+func (h *ResponseHandle) Write(data interface{}, err error) {
+	h.resp.dataPtr = data
+	h.resp.err = err
+	h.resp.m.Unlock()
+}
+
+// Release releases the handle.
+func (h *ResponseHandle) Release() {
+	h.resp.m.Unlock()
+}
+
+// Read reads the response
+func (h *ResponseHandle) Read() (interface{}, error) {
+	defer h.resp.wg.Done()
+	return h.resp.dataPtr, h.resp.err
+}

--- a/pkg/csi/manila/responsebroker/responsebroker_test_.go
+++ b/pkg/csi/manila/responsebroker/responsebroker_test_.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package responsebroker
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestResponseBroker(t *testing.T) {
+	const N = 1000
+
+	var (
+		wg sync.WaitGroup
+		rb = New()
+	)
+
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			log.Printf("queuing %d", i)
+			testRetryTillFinished(i, &wg, rb)
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func testRetryTillFinished(id int, wg *sync.WaitGroup, rb *ResponseBroker) {
+	identifier := fmt.Sprintf("%d", id)
+
+	for {
+		finishedCh := make(chan bool)
+		log.Printf("launching %d", id)
+		go func() {
+			handle, isOwner := rb.Acquire(identifier)
+			if !isOwner {
+				if _, respErr := handle.Read(); respErr == nil {
+					handle.Release()
+					finishedCh <- true
+					return
+				}
+			}
+
+			log.Printf("running %d", id)
+
+			time.Sleep(5 * time.Second)
+			handle.Write(nil, nil)
+
+			rb.Done(identifier)
+		}()
+
+		select {
+		case <-finishedCh:
+			log.Printf("%d finished", id)
+			wg.Done()
+			return
+		case <-time.After(1100 * time.Millisecond):
+		}
+	}
+}

--- a/pkg/csi/manila/share.go
+++ b/pkg/csi/manila/share.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manila
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/options"
+	"k8s.io/klog"
+)
+
+const (
+	annProvisionedBy = "manila.csi.openstack.org/provisioned-by"
+
+	waitForAvailableShareTimeout = 3
+	waitForAvailableShareRetries = 10
+)
+
+func (cs *controllerServer) getOrCreateShare(volID volumeID, sizeInGiB int, controllerCtx *options.ControllerVolumeContext, manilaClient *gophercloud.ServiceClient) (*shares.Share, error) {
+	var (
+		share *shares.Share
+		err   error
+	)
+
+	// First, check if the share already exists or needs to be created
+
+	if share, err = getShareByName(string(volID), manilaClient); err != nil {
+		if _, ok := err.(gophercloud.ErrResourceNotFound); ok {
+			// It doesn't exist, create it
+
+			req := shares.CreateOpts{
+				ShareProto:     controllerCtx.Protocol,
+				ShareType:      controllerCtx.Type,
+				ShareNetworkID: controllerCtx.ShareNetworkID,
+				Name:           string(volID),
+				Size:           sizeInGiB,
+				Metadata: map[string]string{
+					annProvisionedBy: cs.d.name,
+				},
+			}
+
+			var createErr error
+			if share, createErr = shares.Create(manilaClient, req).Extract(); createErr != nil {
+				return nil, createErr
+			}
+		} else {
+			// Something else is wrong
+			return nil, fmt.Errorf("failed to probe for share: %v", err)
+		}
+	} else {
+		klog.V(4).Infof("volume %s (share ID %s) already exists", volID, share.ID)
+	}
+
+	// It exists, wait till it's Available
+
+	const available = "available"
+
+	if share.Status == available {
+		return share, nil
+	}
+
+	return waitForShareStatus(share.ID, available, manilaClient)
+}
+
+func deleteShare(volID volumeID, manilaClient *gophercloud.ServiceClient) error {
+	share, err := getShareByName(string(volID), manilaClient)
+	if err != nil {
+		if _, ok := err.(gophercloud.ErrResourceNotFound); ok {
+			klog.V(4).Infof("volume %s not found, assuming it to be already deleted", volID)
+			return nil
+		} else {
+			// Something else is wrong
+			return fmt.Errorf("failed to get ID for share %s: %v", volID, err)
+		}
+	}
+
+	return shares.Delete(manilaClient, share.ID).Err
+}
+
+func getShareByID(shareID string, manilaClient *gophercloud.ServiceClient) (*shares.Share, error) {
+	return shares.Get(manilaClient, shareID).Extract()
+}
+
+func getShareByName(shareName string, manilaClient *gophercloud.ServiceClient) (*shares.Share, error) {
+	shareID, err := shares.IDFromName(manilaClient, shareName)
+	if err != nil {
+		return nil, err
+	}
+
+	return getShareByID(shareID, manilaClient)
+}
+
+func waitForShareStatus(shareID string, desired string, manilaClient *gophercloud.ServiceClient) (*shares.Share, error) {
+	var (
+		backoff = wait.Backoff{
+			Duration: time.Second * waitForAvailableShareTimeout,
+			Factor:   1.2,
+			Steps:    waitForAvailableShareRetries,
+		}
+
+		share *shares.Share
+		err   error
+	)
+
+	return share, wait.ExponentialBackoff(backoff, func() (bool, error) {
+		share, err = getShareByID(shareID, manilaClient)
+
+		if err != nil {
+			return false, err
+		}
+
+		return share.Status == desired, nil
+	})
+}

--- a/pkg/csi/manila/shareadapters/cephfs.go
+++ b/pkg/csi/manila/shareadapters/cephfs.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shareadapters
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
+)
+
+type Cephfs struct{}
+
+var _ ShareAdapter = &Cephfs{}
+
+func (Cephfs) GetOrGrantAccess(args *GrantAccessArgs) (accessRight *shares.AccessRight, err error) {
+	// First, check if the access right exists or needs to be created
+
+	var rights []shares.AccessRight
+
+	rights, err = shares.ListAccessRights(args.ManilaClient, args.Share.ID).Extract()
+	if err != nil {
+		if _, ok := err.(gophercloud.ErrResourceNotFound); !ok {
+			return nil, fmt.Errorf("failed to list access rights: %v", err)
+		}
+	} else {
+		// Try to find the access right
+
+		for _, r := range rights {
+			if r.AccessTo == args.Share.Name && r.AccessType == "cephx" && r.AccessLevel == "rw" {
+				klog.V(4).Infof("cephx access right for share %s already exists", args.Share.Name)
+
+				accessRight = &r
+				break
+			}
+		}
+	}
+
+	if accessRight == nil {
+		// Not found, create it
+
+		accessRight, err = shares.GrantAccess(args.ManilaClient, args.Share.ID, shares.GrantAccessOpts{
+			AccessType:  "cephx",
+			AccessLevel: "rw",
+			AccessTo:    args.Share.Name,
+		}).Extract()
+
+		if err != nil {
+			return
+		}
+	}
+
+	if accessRight.AccessKey != "" {
+		// The access right is ready
+		return
+	}
+
+	// Wait till a ceph key is assigned to the access right
+
+	backoff := wait.Backoff{
+		Duration: time.Second * 5,
+		Factor:   1.2,
+		Steps:    10,
+	}
+
+	return accessRight, wait.ExponentialBackoff(backoff, func() (bool, error) {
+		rights, err := shares.ListAccessRights(args.ManilaClient, args.Share.ID).Extract()
+		if err != nil {
+			return false, err
+		}
+
+		var accessRight *shares.AccessRight
+
+		for i := range rights {
+			if rights[i].AccessTo == args.Share.Name {
+				accessRight = &rights[i]
+				break
+			}
+		}
+
+		if accessRight == nil {
+			return false, fmt.Errorf("cannot find the access right we've just created")
+		}
+
+		return accessRight.AccessKey != "", nil
+	})
+}
+
+func (Cephfs) BuildVolumeContext(args *VolumeContextArgs) (volumeContext map[string]string, err error) {
+	monitors, rootPath, err := splitExportLocation(args.Location)
+
+	return map[string]string{
+		"monitors":        monitors,
+		"rootPath":        rootPath,
+		"mounter":         args.Options.CephfsMounter,
+		"provisionVolume": "false",
+	}, err
+}
+
+func (Cephfs) BuildNodeStageSecret(args *SecretArgs) (secret map[string]string, err error) {
+	return map[string]string{
+		"userID":  args.AccessRight.AccessTo,
+		"userKey": args.AccessRight.AccessKey,
+	}, nil
+}
+
+func (Cephfs) BuildNodePublishSecret(args *SecretArgs) (secret map[string]string, err error) {
+	return nil, nil
+}

--- a/pkg/csi/manila/shareadapters/nfs.go
+++ b/pkg/csi/manila/shareadapters/nfs.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shareadapters
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
+	"k8s.io/klog"
+)
+
+type NFS struct{}
+
+var _ ShareAdapter = &NFS{}
+
+func (NFS) GetOrGrantAccess(args *GrantAccessArgs) (*shares.AccessRight, error) {
+	// First, check if the access right exists or needs to be created
+
+	rights, err := shares.ListAccessRights(args.ManilaClient, args.Share.ID).Extract()
+	if err != nil {
+		if _, ok := err.(gophercloud.ErrResourceNotFound); !ok {
+			return nil, fmt.Errorf("failed to list access rights: %v", err)
+		}
+	}
+
+	// Try to find the access right
+
+	for _, r := range rights {
+		if r.AccessTo == args.Options.NFSShareClient && r.AccessType == "ip" && r.AccessLevel == "rw" {
+			klog.V(4).Infof("IP access right for share %s already exists", args.Share.Name)
+			return &r, nil
+		}
+	}
+
+	// Not found, create it
+
+	return shares.GrantAccess(args.ManilaClient, args.Share.ID, shares.GrantAccessOpts{
+		AccessType:  "ip",
+		AccessLevel: "rw",
+		AccessTo:    args.Options.NFSShareClient,
+	}).Extract()
+}
+
+func (NFS) BuildVolumeContext(args *VolumeContextArgs) (volumeContext map[string]string, err error) {
+	server, path, err := splitExportLocation(args.Location)
+
+	return map[string]string{
+		"server": server,
+		"path":   path,
+	}, nil
+}
+
+func (NFS) BuildNodeStageSecret(args *SecretArgs) (secret map[string]string, err error) {
+	return nil, nil
+}
+
+func (NFS) BuildNodePublishSecret(args *SecretArgs) (secret map[string]string, err error) {
+	return nil, nil
+}

--- a/pkg/csi/manila/shareadapters/shareadapter.go
+++ b/pkg/csi/manila/shareadapters/shareadapter.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shareadapters
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/options"
+)
+
+type GrantAccessArgs struct {
+	ManilaClient *gophercloud.ServiceClient
+	Share        *shares.Share
+	Options      *options.ControllerVolumeContext
+}
+
+type VolumeContextArgs struct {
+	Location *shares.ExportLocation
+	Options  *options.NodeVolumeContext
+}
+
+type SecretArgs struct {
+	AccessRight *shares.AccessRight
+}
+
+type ShareAdapter interface {
+	// GetOrGrantAccess first tries to retrieve an access right for args.Share.
+	// An access right is created for the share in case it doesn't exist yet.
+	// Returns an existing or new access right for args.Share.
+	GetOrGrantAccess(args *GrantAccessArgs) (accessRight *shares.AccessRight, err error)
+
+	// BuildVolumeContext builds a volume context map that's passed to NodeStageVolumeRequest and NodePublishVolumeRequest
+	BuildVolumeContext(args *VolumeContextArgs) (volumeContext map[string]string, err error)
+
+	// Builds secret map for NodeStageVolumeRequest
+	BuildNodeStageSecret(args *SecretArgs) (secret map[string]string, err error)
+
+	// Builds secret map for NodePublishVolumeRequest
+	BuildNodePublishSecret(args *SecretArgs) (secret map[string]string, err error)
+}

--- a/pkg/csi/manila/shareadapters/util.go
+++ b/pkg/csi/manila/shareadapters/util.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shareadapters
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
+)
+
+func splitExportLocation(loc *shares.ExportLocation) (address, location string, err error) {
+	delimPos := strings.LastIndexByte(loc.Path, ':')
+	if delimPos <= 0 {
+		err = fmt.Errorf("failed to parse address and location from export location '%s'", loc.Path)
+		return
+	}
+
+	address = loc.Path[:delimPos]
+	location = loc.Path[delimPos+1:]
+
+	return
+}

--- a/pkg/csi/manila/util.go
+++ b/pkg/csi/manila/util.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manila
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/shareadapters"
+	"k8s.io/klog"
+)
+
+type (
+	volumeID string
+)
+
+const (
+	bytesInGiB = 1024 * 1024 * 1024
+)
+
+func parseGRPCEndpoint(endpoint string) (proto, addr string, err error) {
+	const (
+		unixScheme = "unix://"
+		tcpScheme  = "tcp://"
+	)
+
+	if strings.HasPrefix(endpoint, "/") {
+		return "unix", endpoint, nil
+	}
+
+	if strings.HasPrefix(endpoint, unixScheme) {
+		pos := len(unixScheme)
+		if endpoint[pos] != '/' {
+			// endpoint seems to be "unix://absolute/path/to/somewhere"
+			// we're missing one '/'...compensate by decrementing pos
+			pos--
+		}
+
+		return "unix", endpoint[pos:], nil
+	}
+
+	if strings.HasPrefix(endpoint, tcpScheme) {
+		return "tcp", endpoint[len(tcpScheme):], nil
+	}
+
+	return "", "", errors.New("endpoint uses unsupported scheme")
+}
+
+func endpointAddress(proto, addr string) string {
+	return fmt.Sprintf("%s://%s", proto, addr)
+}
+
+func fmtGrpcConnError(fwdEndpoint string, err error) string {
+	return fmt.Sprintf("connecting to fwd plugin at %s failed: %v", fwdEndpoint, err)
+}
+
+func newVolumeID(volumeName string) volumeID {
+	return volumeID(fmt.Sprintf("csi-manila-%s", volumeName))
+}
+
+func bytesToGiB(sizeInBytes int64) int {
+	sizeInGiB := int(sizeInBytes / bytesInGiB)
+
+	if int64(sizeInGiB)*bytesInGiB < sizeInBytes {
+		// Round up
+		return sizeInGiB + 1
+	}
+
+	return sizeInGiB
+}
+
+func getShareAdapter(proto string) shareadapters.ShareAdapter {
+	switch strings.ToLower(proto) {
+	case "cephfs":
+		return &shareadapters.Cephfs{}
+	case "nfs":
+		return &shareadapters.NFS{}
+	default:
+		klog.Fatalf("unknown share adapter %s", proto)
+	}
+
+	return nil
+}
+
+func getAccessRightByID(id, shareID string, manilaClient *gophercloud.ServiceClient) (*shares.AccessRight, error) {
+	accessRights, err := shares.ListAccessRights(manilaClient, shareID).Extract()
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range accessRights {
+		if accessRights[i].ID == id {
+			return &accessRights[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("access right %s for share ID %s not found", id, shareID)
+}
+
+//
+// Controller service request validation
+//
+
+func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
+	if req.GetName() == "" {
+		return errors.New("volume name cannot be empty")
+	}
+
+	reqCaps := req.GetVolumeCapabilities()
+	if reqCaps == nil {
+		return errors.New("volume capabilities cannot be empty")
+	}
+
+	for _, cap := range reqCaps {
+		if cap.GetBlock() != nil {
+			return errors.New("block volume not supported")
+		}
+	}
+
+	if req.GetSecrets() == nil || len(req.GetSecrets()) == 0 {
+		return errors.New("secrets cannot be empty")
+	}
+
+	return nil
+}
+
+func validateDeleteVolumeRequest(req *csi.DeleteVolumeRequest) error {
+	if req.GetVolumeId() == "" {
+		return errors.New("volume ID cannot be empty")
+	}
+
+	if req.GetSecrets() == nil || len(req.GetSecrets()) == 0 {
+		return errors.New("secrets cannot be empty")
+	}
+
+	return nil
+}
+
+//
+// Node service request validation
+//
+
+func validateNodeStageVolumeRequest(req *csi.NodeStageVolumeRequest) error {
+	if req.GetVolumeCapability() == nil {
+		return errors.New("volume capability missing in request")
+	}
+
+	if req.GetVolumeId() == "" {
+		return errors.New("volume ID missing in request")
+	}
+
+	if req.GetVolumeContext() == nil || len(req.GetVolumeContext()) == 0 {
+		return errors.New("volume context cannot be nil or empty")
+	}
+
+	if req.GetSecrets() == nil || len(req.GetSecrets()) == 0 {
+		return errors.New("stage secrets cannot be nil or empty")
+	}
+
+	return nil
+}
+
+func validateNodeUnstageVolumeRequest(req *csi.NodeUnstageVolumeRequest) error {
+	if req.GetVolumeId() == "" {
+		return errors.New("volume ID missing in request")
+	}
+
+	return nil
+}
+
+func validateNodePublishVolumeRequest(req *csi.NodePublishVolumeRequest) error {
+	if req.GetVolumeCapability() == nil {
+		return errors.New("volume capability missing in request")
+	}
+
+	if req.GetVolumeId() == "" {
+		return errors.New("volume ID missing in request")
+	}
+
+	if req.GetVolumeContext() == nil || len(req.GetSecrets()) == 0 {
+		return errors.New("volume context cannot be nil or empty")
+	}
+
+	if req.GetSecrets() == nil || len(req.GetSecrets()) == 0 {
+		return errors.New("node publish secrets cannot be nil or empty")
+	}
+
+	return nil
+}
+
+func validateNodeUnpublishVolumeRequest(req *csi.NodeUnpublishVolumeRequest) error {
+	if req.GetVolumeId() == "" {
+		return errors.New("volume ID missing in request")
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds CSI Manila driver, currently supports only CephFS and NFS. ~~I've only tested with CephFS so far.~~ Tested with CephFS and NFS.

**Which issue this PR fixes**: fixes #394 

### Design considerations / a brief description of what does what

#### "proxy" architecture

This CSI driver acts as a provisioner of Manila shares, all node-related operations (attachments, mounts) are carried out by another CSI driver, dedicated for that particular filesystem. This is achieved by forwarding CSI RPCs to the other CSI driver.

For example, creating and mounting a CephFS Manila share would go like this:

CO requests a volume provisioning with `CreateVolume`:
```
                        +--------------------+
                        |       MASTER       |
+------+  CreateVolume  |  +--------------+  |
|  CO  +------------------>+  csi-manila  |  |
+------+                |  +--------------+  |
                        +--------------------+

1. Authenticate with Manila v2 client
2. Create a CephFS share
3. Create a cephx access rule
```

And when CO publishes the volume onto a node with `NodePublishVolume`:
```
                             +--------------------------------------+
                             |                 NODE                 |
+------+  NodePublishVolume  |  +--------------+                    |
|  CO  +----------------------->+  csi-manila  |                    |
+------+                     |  +------+-------+                    |
                             |         |                            |
                             |         | FORWARD NodePublishVolume  |
                             |         V                            |
                             |  +------+-------+                    |
                             |  |  csi-cephfs  |                    |
                             |  +--------------+                    |
                             +--------------------------------------+

1. Authenticate with Manila v2 client
2. Retrieve the CephFS share
3. Retrieve the cephx access rule
4. Connect to csi-cephfs socket
5. Call csi-cephfs's NodePublishVolume, return its response
```

So the intention here is to deal with only Manila side of things, and leave all filesystem specifics to another CSI driver that's specialized for that particular fs.

If connection with the proxy'd CSI driver cannot be established, csi-manila will return an error and will let the CO retry.

Downsides:

From the documentation
> A single instance of the driver may serve only a single Manila share protocol. To support multiple share protocols, multiple deployments of the driver need to be made. In order to avoid deployment collisions, each instance of the driver should be named differently, e.g. `csi-manila-cephfs`, `csi-manila-nfs`.

The initial idea was to encompass all Manila share protocols within a single instance of csi-manila. Due to limitations of CSI, this cannot be achieved and there will have to be multiple instances of csi-manila running in order to support multiple share protocols, one for each. There are couple of RPCs in Node Service that don't bring enough context to decide which proxy'd driver that particular RPC should be forwarded to (e.g. `NodeGetCapabilities` would be ambiguous and we can't know which proxy'd driver should answer) => therefore with current design, there's only a single proxy'd driver per csi-manila instance. Such "multiplexer" design is out-of-scope for CSI anyway IMHO.

#### Concurrency

`CreateVolume` is so far the most time-expensive operation in the driver because it waits till the share is in _Available_ state, and for CephFS shares this waiting is even more pronounced because it waits till the Ceph key for the share is available. This means that the CO may retry the `CreateVolume` RPC for the same volume many times before it's actually done creating.

In Kubernetes, this means there will be multiple `CreateVolume` RPCs for the same volume in parallel - which, in our case, doesn't help the situation at all and would only create more unnecessary load on Manila itself. To guard against situations where there's a long running operation, some form of locking needs to be employed.

Using a simple mutex per volume ID would result in this:
```
  R req1             req2             req3
T -----------------+----------------+----------------+
01| LOCK           |                |                |
02| op1            |                |                |
03| op2            | LOCK...wait    |                |
04| op3            | wait...        |                |
05| UNLOCK         | wait...        | LOCK...wait    |
06| RETURN success + LOCK           | wait...        |
07|                  op1            | wait...        |
08|                  op2            | wait...        |
09|                  op3            | wait...        |
21|                  UNLOCK         | wait...        |
22|                  RETURN success + LOCK           |
23|                                   op1            |
24|                                   op2            |
25|                                   op3            |
26|                                   UNLOCK         |
27|                                   RETURN SUCCESS +
```
_(I really hope these diagrams make at least a bit of sense)_ On the Y axis, there's `T` for time, and on the X axis there's `R` for a request. The first request `req1` locks the mutex and launches a long running operation `op` (taking up 3 time units). The call times out, so the CO decides to retry with `req2` but needs to wait till `req1` finishes so that `req2` may acquire the lock. This pattern may repeat until the call doesn't time-out. There are two problems here: (a) it may take a long time till CO is satisfied with the answer, (b) the long running operation `op` is being run in all of those retries.

`pkg/csi/manila/responsebroker` from this PR tries to tackle the problem (b), and hopes to mitigate (a):
```
  R req1                                             req2                          req3
T -------------------------------------------------+-----------------------------+-----------------------------+
01| LOCK(acq-or-create)                            |                             |                             |
02| op1                                            |                             |                             |
03| op2                                            | LOCK(ack-or-create)...wait  |                             |
04| op3                                            | wait...                     |                             |
05| UNLOCK, write success, wait till all Rs finish | wait...                     | LOCK(ack-or-create)...wait  |
06| wait...                                        | LOCK, read response:success | wait...                     |
07| wait...                                        | UNLOCK                      | wait...                     |
08| wait...                                        | RETURN SUCCESS              + LOCK, read response:success |
09| RETURN SUCCESS                                 +                               UNLOCK                      |
10|                                                                                RETURN SUCCESS              +
```
The same scenario as above: `req1` locks the mutex and runs the long running operation `op` and times-out. `req2` will wait till it can acquire the lock, but instead of running `op` again, it reads the response from `req1` and if it's successful, it immediately exits with success. The `responsebroker` basically caches the result of an operation and propagates it to multiple readers. 

This mechanism could be also used to implement a form of journaling: if an error occurs in one call, the future retries would pick up the operation in the exact spot where the previous call had failed - again, saving some load from the backend. Maybe in another PR.

### To be done in this PR

* If an operator wishes to use a custom certificate for authentication, they may use the `os-certAuthority` parameter in Secrets to inject the contents of a PEM cert file. This is the way manila-provisioner does it. The problem here is the size limit: the [CSI spec allows up to 128 bytes](https://github.com/container-storage-interface/spec/blob/master/spec.md#size-limits) in `string` fields and a certificate can be obviously larger than that,
* `List*` and `GetCapacity` CSI RPCs need OpenStack credentials, but these RPCs don't carry any Secrets fields. CSI Cinder driver solves this by supplying the driver with a file containing the credentials. It doesn't rely on Secrets supplied by the CO.

**Release note**:
```release-note
added CSI Manila driver
```

/cc @tsmetana @dims @adisky 