### PR TITLE
Give cloud-controller-manager permission to watch secrets

### DIFF
--- a/cluster/addons/rbac/cloud-controller-manager-roles.yaml
+++ b/cluster/addons/rbac/cloud-controller-manager-roles.yaml
@@ -72,6 +72,7 @@ items:
     verbs:
     - list
     - get
+    - watch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

In [kubernetes/kubernetes/pkg/controller/client_builder.go](https://github.com/kubernetes/kubernetes/blob/bdc013ad57df721a148a5e15953c5a8b67efdeec/pkg/controller/client_builder.go#L174) it attempts to start a watch for new secrets if the secret containing a token for a service account does not exist the first time it checks. Without the watch permission for secrets this crashes the cloud-controller-manager and the pod restarts until the secret does exist.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #545 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
