### PR TITLE
Improve load balancer name

### DIFF
--- a/docs/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/expose-applications-using-loadbalancer-type-service.md
@@ -1,0 +1,78 @@
+# Exposing applications using services of LoadBalancer type
+
+This page shows how to create Services of LoadBalancer type in Kubernetes cluster which is running inside OpenStack. For an explanation of the Service concept and a discussion of the various types of Services, see [Services](https://kubernetes.io/docs/concepts/services-networking/service/).
+
+A LoadBalancer type Service is the typical way to expose an application to the internet. It relies on the cloud provider to create an external load balancer with an IP address in the relevant network space. Any traffic that is then directed to this IP address is forwarded on to the application’s service.
+
+> Note: Different cloud providers may support different Service annotations and features.
+
+## Creating a Service of LoadBalancer type
+
+Create an application of Deployment as the Service backend:
+```shell
+kubectl run echoserver --image=gcr.io/google-containers/echoserver:1.10 --port=8080
+```
+
+To provide the echoserver application with an internet facing loadbalancer we can simply run the following:
+```shell
+cat <<EOF > loadbalancer.yaml
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: loadbalanced-service
+spec:
+  selector:
+    run: echoserver
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+EOF
+kubectl apply -f loadbalancer.yaml
+```
+
+Check the state the status of the loadbalanced-service until the EXTERNAL-IP status is no longer <pending>.
+
+```shell
+$ kubectl get service loadbalanced-service
+NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)        AGE
+loadbalanced-service   LoadBalancer   10.254.28.183   202.49.242.3   80:31177/TCP   2m18s
+```
+
+Once we can see that our service is active and has been assigned an external IP address we should be able to test our application via curl from any internet accessible machine.
+
+```shell
+$ curl 202.49.242.3
+Hostname: echoserver-74dcfdbd78-fthv9
+Pod Information:
+        -no pod information available-
+Server values:
+        server_version=nginx: 1.13.3 - lua: 10008
+Request Information:
+        client_address=10.0.0.7
+        method=GET
+        real path=/
+        query=
+        request_version=1.1
+        request_scheme=http
+        request_uri=http://202.49.242.3:8080/
+Request Headers:
+        accept=*/*
+        host=202.49.242.3
+        user-agent=curl/7.47.0
+Request Body:
+        -no body in request-
+```
+
+## Supported Features
+
+### Service annotations
+TBD
+
+### Creating Service by specifying a floating IP
+TBD
+
+## Issues
+TBD


### PR DESCRIPTION
**What this PR does / why we need it**:
- Using a more meaningful name for load balancer created by Service.
- Support backward compatibility.
- Adding doc for LoadBalancer type Service guide.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
The load balancer name created by Service has been changed, now the name includes cluster name, Service namespace and Service name. The services created before this change are not affected.
```
