### PR TITLE
Update CI conformance jobs - 1.12

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -23,26 +23,10 @@
     cloud-provider-openstack-acceptance-test-flexvolume-cinder:
       jobs:
         - cloud-provider-openstack-acceptance-test-flexvolume-cinder
-    cloud-provider-openstack-acceptance-test-e2e-conformance:
-      jobs:
-        - cloud-provider-openstack-acceptance-test-e2e-conformance
-    cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.10:
-      jobs:
-        - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.10
-    cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.11:
-      jobs:
-        - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.11
     cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.12:
       jobs:
         - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.12
     periodic:
       jobs:
-        - cloud-provider-openstack-acceptance-test-e2e-conformance:
-            branches: master
-        - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.10:
-            branches: release-1.10
-        - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.11:
-            branches: release-1.11
         - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.12:
-            #TODO: change branch to release-1.12 when we have it
-            branches: master
+            branches: release-1.12


### PR DESCRIPTION
**What this PR does / why we need it**:

Conformance jobs should only be running relevant to the branch they appear on. The periodic jobs for 1.10 and 1.11 are being removed due to being EOL and when run pushing the wrong binaries with the tag latest to dockerhub.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
We need to merge this as soon as possible due to it pushing the wrong binaries to dockerhub using the latest tag. I recommend ignoring OpenLab CI errors and forcing it.

**Release note**:

```release-note
NONE
```