### PR TITLE
Update CI conformance jobs - 1.14/master

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -71,22 +71,6 @@
               - ^.*\.md$
               - ^OWNERS$
               - ^SECURITY_CONTACTS$
-    cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.12:
-      jobs:
-        - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.12:
-            irrelevant-files:
-              - ^docs/.*$
-              - ^.*\.md$
-              - ^OWNERS$
-              - ^SECURITY_CONTACTS$
-    cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.13:
-      jobs:
-        - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.13:
-            irrelevant-files:
-              - ^docs/.*$
-              - ^.*\.md$
-              - ^OWNERS$
-              - ^SECURITY_CONTACTS$
     cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.14:
       jobs:
         - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.14:
@@ -99,9 +83,5 @@
       jobs:
         - cloud-provider-openstack-acceptance-test-e2e-conformance:
             branches: master
-        - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.12:
-            branches: release-1.12
-        - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.13:
-            branches: release-1.13
         - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.14:
             branches: master # TODO update to release-1.14 when cpo cuts it - k8s already has release-1.14 branch


### PR DESCRIPTION
**What this PR does / why we need it**:

Conformance jobs should only be running relevant to the branch they appear on. The periodic jobs for 1.10 and 1.11 are being removed due to being EOL and when run pushing the wrong binaries with the tag latest to dockerhub.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
We need to merge this as soon as possible due to it pushing the wrong binaries to dockerhub using the latest tag. I recommend ignoring OpenLab CI errors and forcing it.

**Release note**:

```release-note
NONE
```