### PR TITLE
Update CI conformance jobs 1.10

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -26,7 +26,3 @@
     cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.10:
       jobs:
         - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.10
-    #periodic:
-    #  jobs:
-    #    - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.10:
-    #        branches: release-1.10


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove periodic job. It is not required since 1.10 is EOL and it is still running after commenting section.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
OpenLab CI errors ok to ignore

**Release note**:
```release-note
NONE
```
