### PR TITLE
Support to keep original client IP for the Service

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -231,7 +231,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4856f6fbc24d863e5d3e08ae19d7839607060d18597f0f71e350d8f08e0ce020"
+  digest = "1:ba2ade5da932202872cfbe51377e7b108f4e82f981a15c1f07045678a4818464"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -277,7 +277,7 @@
     "testhelper/client",
   ]
   pruneopts = "UT"
-  revision = "737db56db180519300c1b7b326e40d431de10206"
+  revision = "a127a1b294c369554364af633d29d213ba88ef16"
 
 [[projects]]
   branch = "master"

--- a/docs/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/expose-applications-using-loadbalancer-type-service.md
@@ -69,7 +69,17 @@ Request Body:
 ## Supported Features
 
 ### Service annotations
-TBD
+- loadbalancer.openstack.org/floating-network-id
+- loadbalancer.openstack.org/floating-subnet
+- loadbalancer.openstack.org/floating-subnet-id
+- loadbalancer.openstack.org/subnet-id
+- loadbalancer.openstack.org/port-id
+- loadbalancer.openstack.org/connection-limit
+- loadbalancer.openstack.org/keep-floatingip
+- loadbalancer.openstack.org/proxy-protocol
+- loadbalancer.openstack.org/x-forwarded-for
+
+  If 'true', `X-Forwarded-For` is inserted into the HTTP headers which contains the original client IP address so that the backend HTTP service is able to get the real source IP of the request.
 
 ### Creating Service by specifying a floating IP
 TBD


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `X-Forwarded-For` support for the backend HTTP service. A new Service annotation `loadbalancer.openstack.org/x-forwarded-for` is introduced.

**Which issue this PR fixes**: fixes #

**Special notes for your reviewer**:

Test steps:

1. Create the echoserver service

    ```
    $ kubectl run echoserver --image=gcr.io/google-containers/echoserver:1.10 --port=8080
    $ cat <<EOF | kubectl apply -f -
    kind: Service
    apiVersion: v1
    metadata:
      name: echoserver
      annotations:
        loadbalancer.openstack.org/x-forwarded-for: "true"
    spec:
      type: LoadBalancer
      selector:
        run: echoserver
      ports:
        - protocol: TCP
          port: 80
          targetPort: 8080
    EOF
    ```

1. Waiting for the service to get an external IP.

    ```
    $ kubectl get svc
    NAME         TYPE           CLUSTER-IP       EXTERNAL-IP    PORT(S)        AGE
    echoserver   LoadBalancer   10.103.126.110   172.24.4.166   80:31209/TCP   32s
    ```

1. Try to send HTTP request from a host that could access the service external IP.

    ```
    $ ip route get 8.8.8.8 | head -1 | awk '{print $7}'
    192.168.206.8
    $ curl 172.24.4.166
    Hostname: echoserver-74dcfdbd78-fthv9

    Pod Information:
            -no pod information available-

    Server values:
            server_version=nginx: 1.13.3 - lua: 10008

    Request Information:
            client_address=10.0.0.7
            method=GET
            real path=/
            query=
            request_version=1.1
            request_scheme=http
            request_uri=http://172.24.4.166:8080/

    Request Headers:
            accept=*/*
            host=172.24.4.166
            user-agent=curl/7.47.0
            x-forwarded-for=192.168.206.8

    Request Body:
            -no body in request-
    ```
    You can see the host IP address appears in x-forwarded-for header.

**Release note**:
```release-note
Support a new Service annotation 'loadbalancer.openstack.org/x-forwarded-for', if set to "true", the backend HTTP service is able to get the real source IP of the request from the HTTP headers(X-Forwarded-For).
```
