### PR TITLE
Adding support for CA specfication

### DIFF
--- a/cmd/client-keystone-auth/main.go
+++ b/cmd/client-keystone-auth/main.go
@@ -173,10 +173,10 @@ func main() {
 	pflag.StringVar(&password, "password", os.Getenv("OS_PASSWORD"), "Password")
 	pflag.StringVar(&clientCertPath, "cert", os.Getenv("OS_CERT"), "Client certificate bundle file")
 	pflag.StringVar(&clientKeyPath, "key", os.Getenv("OS_KEY"), "Client certificate key file")
+	pflag.StringVar(&clientCAPath, "cacert", os.Getenv("OS_CACERT"), "Certificate authority file")
 	pflag.StringVar(&applicationCredentialID, "application-credential-id", os.Getenv("OS_APPLICATION_CREDENTIAL_ID"), "Application Credential ID")
 	pflag.StringVar(&applicationCredentialName, "application-credential-name", os.Getenv("OS_APPLICATION_CREDENTIAL_NAME"), "Application Credential Name")
 	pflag.StringVar(&applicationCredentialSecret, "application-credential-secret", os.Getenv("OS_APPLICATION_CREDENTIAL_SECRET"), "Application Credential Secret")
-	pflag.StringVar(&clientCAPath, "cacert", os.Getenv("OS_CACERT"), "Certificate authority file")
 	kflag.InitFlags()
 
 	// Generate Gophercloud Auth Options based on input data from stdin

--- a/cmd/client-keystone-auth/main.go
+++ b/cmd/client-keystone-auth/main.go
@@ -159,6 +159,7 @@ func main() {
 	var password string
 	var clientCertPath string
 	var clientKeyPath string
+	var clientCAPath string
 	var options keystone.Options
 	var err error
 	var applicationCredentialID string
@@ -175,6 +176,7 @@ func main() {
 	pflag.StringVar(&applicationCredentialID, "application-credential-id", os.Getenv("OS_APPLICATION_CREDENTIAL_ID"), "Application Credential ID")
 	pflag.StringVar(&applicationCredentialName, "application-credential-name", os.Getenv("OS_APPLICATION_CREDENTIAL_NAME"), "Application Credential Name")
 	pflag.StringVar(&applicationCredentialSecret, "application-credential-secret", os.Getenv("OS_APPLICATION_CREDENTIAL_SECRET"), "Application Credential Secret")
+	pflag.StringVar(&clientCAPath, "cacert", os.Getenv("OS_CACERT"), "Certificate authority file")
 	kflag.InitFlags()
 
 	// Generate Gophercloud Auth Options based on input data from stdin
@@ -210,6 +212,7 @@ func main() {
 
 	options.ClientCertPath = clientCertPath
 	options.ClientKeyPath = clientKeyPath
+	options.ClientCAPath = clientCAPath
 
 	token, err := keystone.GetToken(options)
 	if err != nil {

--- a/pkg/identity/keystone/token_getter.go
+++ b/pkg/identity/keystone/token_getter.go
@@ -23,8 +23,8 @@ import (
 	"github.com/gophercloud/gophercloud/openstack"
 	tokens3 "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 	"io/ioutil"
-	"net/http"
 	certutil "k8s.io/client-go/util/cert"
+	"net/http"
 )
 
 type Options struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the ability to specify a CA that isn't installed on the system to use for the client-kubernetes-auth plugin. Handled the same way that client cert and key are handled and keys off the OS_CACERT environment variable.

**Special notes for your reviewer**:

**Release note**:
```release-note
Added support for specifying a certificate authority that isn't installed on the client machine via OS_CACERT environment variable.
```
