### PR TITLE
Allow to specify a Tenant Domain Name/ID

### DIFF
--- a/docs/provider-configuration.md
+++ b/docs/provider-configuration.md
@@ -103,11 +103,10 @@ file.
   OpenStack control panels, this can be found at Access and Security > API
   Access > Credentials.
 * `password`: Refers to the password of a valid user set in keystone.
-* `tenant-id`: Used to specify the ID of the project where you want
-  to create your resources. When using Keystone V3 - which changed the 
-  identifier `tenant` to `project` - the `tenant-id` value is automatically
-  mapped to the project construct in the API.
 * `username`: Refers to the username of a valid user set in keystone.
+
+It is also required to provide either `tenant-id` only or `tenant-name` together
+with information about domain: `domain-id` or `domain-name`.
 
 ##### Global Optional Parameters
 * `ca-file`: Used to specify the path to your custom CA file. 
@@ -121,8 +120,16 @@ file.
   connotation, a deployment can use a geographical name for a region identifier
   such as `us-east`. Available regions are found under the `/v3/regions`
   endpoint of the Keystone API.
+* `tenant-id`: Used to specify the ID of the project where you want
+  to create your resources. When using Keystone V3 - which changed the
+  identifier `tenant` to `project` - the `tenant-id` value is automatically
+  mapped to the project construct in the API.
 * `tenant-name`: Used to specify the name of the project where you
   want to create your resources.
+* `tenant-domain-id`: Used to specify the ID of the domain your project belongs
+  to.
+* `tenant-domain-name`: Used to specify the name of the domain your project
+  belongs to.
 * `trust-id`: Used to specify the identifier of the trust to use for
   authorization. A trust represents a user's (the trustor) authorization to
   delegate roles to another user (the trustee), and optionally allow the trustee

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -162,20 +162,22 @@ type OpenStack struct {
 // Config is used to read and store information from the cloud configuration file
 type Config struct {
 	Global struct {
-		AuthURL    string `gcfg:"auth-url"`
-		Username   string
-		UserID     string `gcfg:"user-id"`
-		Password   string
-		TenantID   string `gcfg:"tenant-id"`
-		TenantName string `gcfg:"tenant-name"`
-		TrustID    string `gcfg:"trust-id"`
-		DomainID   string `gcfg:"domain-id"`
-		DomainName string `gcfg:"domain-name"`
-		Region     string
-		CAFile     string `gcfg:"ca-file"`
-		UseClouds  bool   `gcfg:"use-clouds"`
-		CloudsFile string `gcfg:"clouds-file,omitempty"`
-		Cloud      string `gcfg:"cloud,omitempty"`
+		AuthURL          string `gcfg:"auth-url"`
+		Username         string
+		UserID           string `gcfg:"user-id"`
+		Password         string
+		TenantID         string `gcfg:"tenant-id"`
+		TenantName       string `gcfg:"tenant-name"`
+		TrustID          string `gcfg:"trust-id"`
+		DomainID         string `gcfg:"domain-id"`
+		DomainName       string `gcfg:"domain-name"`
+		TenantDomainID   string `gcfg:"tenant-domain-id"`
+		TenantDomainName string `gcfg:"tenant-domain-name"`
+		Region           string
+		CAFile           string `gcfg:"ca-file"`
+		UseClouds        bool   `gcfg:"use-clouds"`
+		CloudsFile       string `gcfg:"clouds-file,omitempty"`
+		Cloud            string `gcfg:"cloud,omitempty"`
 	}
 	LoadBalancer LoadBalancerOpts
 	BlockStorage BlockStorageOpts
@@ -231,6 +233,30 @@ func (cfg Config) toAuthOptions() gophercloud.AuthOptions {
 }
 
 func (cfg Config) toAuth3Options() tokens3.AuthOptions {
+	// Setting up a scope
+	scope := tokens3.Scope{}
+
+	// Gophercloud requires that either ProjectID or ProjectName is specified,
+	// but not both.
+	if cfg.Global.TenantID != "" {
+		scope.ProjectID = cfg.Global.TenantID
+	} else {
+		scope.ProjectName = cfg.Global.TenantName
+
+		// If Tenant Domain Name/ID was provided, then use it for the scope, otherwise
+		// fall back to Domain Name/ID
+		if cfg.Global.TenantDomainID != "" {
+			scope.DomainID = cfg.Global.TenantDomainID
+		} else {
+			scope.DomainID = cfg.Global.DomainID
+		}
+		if cfg.Global.TenantDomainName != "" {
+			scope.DomainName = cfg.Global.TenantDomainName
+		} else {
+			scope.DomainName = cfg.Global.DomainName
+		}
+	}
+
 	return tokens3.AuthOptions{
 		IdentityEndpoint: cfg.Global.AuthURL,
 		Username:         cfg.Global.Username,
@@ -238,6 +264,7 @@ func (cfg Config) toAuth3Options() tokens3.AuthOptions {
 		Password:         cfg.Global.Password,
 		DomainID:         cfg.Global.DomainID,
 		DomainName:       cfg.Global.DomainName,
+		Scope:            scope,
 		AllowReauth:      true,
 	}
 }
@@ -270,6 +297,9 @@ func configFromEnv() (cfg Config, ok bool) {
 	if cfg.Global.DomainName == "" {
 		cfg.Global.DomainName = os.Getenv("OS_USER_DOMAIN_NAME")
 	}
+
+	cfg.Global.TenantDomainID = os.Getenv("OS_PROJECT_DOMAIN_ID")
+	cfg.Global.TenantDomainName = os.Getenv("OS_PROJECT_DOMAIN_NAME")
 
 	ok = cfg.Global.AuthURL != "" &&
 		cfg.Global.Username != "" &&
@@ -430,6 +460,9 @@ func NewOpenStack(cfg Config) (*OpenStack, error) {
 			AuthOptionsBuilder: &opts,
 		}
 		err = openstack.AuthenticateV3(provider, authOptsExt, gophercloud.EndpointOpts{})
+	} else if cfg.Global.TenantDomainID != "" || cfg.Global.TenantDomainName != "" {
+		opts := cfg.toAuth3Options()
+		err = openstack.AuthenticateV3(provider, &opts, gophercloud.EndpointOpts{})
 	} else {
 		err = openstack.Authenticate(provider, cfg.toAuthOptions())
 	}

--- a/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -107,6 +107,7 @@ func TestReadConfig(t *testing.T) {
  auth-url = http://auth.url
  user-id = user
  tenant-name = demo
+ tenant-domain-name = Default
  region = RegionOne
  [LoadBalancer]
  create-monitor = yes
@@ -138,6 +139,10 @@ func TestReadConfig(t *testing.T) {
 	// config file wins over environment variable
 	if cfg.Global.TenantName != "demo" {
 		t.Errorf("incorrect tenant name: %s", cfg.Global.TenantName)
+	}
+
+	if cfg.Global.TenantDomainName != "Default" {
+		t.Errorf("incorrect tenant domain name: %s", cfg.Global.TenantDomainName)
 	}
 
 	if cfg.Global.Region != "RegionOne" {
@@ -922,6 +927,8 @@ func TestToAuth3Options(t *testing.T) {
 	cfg.Global.DomainName = "local"
 	cfg.Global.AuthURL = "http://auth.url"
 	cfg.Global.UserID = "user"
+	cfg.Global.TenantName = "demo"
+	cfg.Global.TenantDomainName = "Default"
 
 	ao := cfg.toAuth3Options()
 
@@ -945,6 +952,84 @@ func TestToAuth3Options(t *testing.T) {
 	}
 	if ao.DomainName != cfg.Global.DomainName {
 		t.Errorf("DomainName %s != %s", ao.DomainName, cfg.Global.DomainName)
+	}
+	if ao.Scope.ProjectName != cfg.Global.TenantName {
+		t.Errorf("TenantName %s != %s", ao.Scope.ProjectName, cfg.Global.TenantName)
+	}
+	if ao.Scope.DomainName != cfg.Global.TenantDomainName {
+		t.Errorf("TenantDomainName %s != %s", ao.Scope.DomainName, cfg.Global.TenantDomainName)
+	}
+}
+
+func TestToAuth3OptionsScope(t *testing.T) {
+	// Use Domain Name/ID if Tenant Domain Name/ID is not set
+	cfg := Config{}
+	cfg.Global.Username = "user"
+	cfg.Global.Password = "pass"
+	cfg.Global.DomainID = "2a73b8f597c04551a0fdc8e95544be8a"
+	cfg.Global.DomainName = "local"
+	cfg.Global.AuthURL = "http://auth.url"
+	cfg.Global.UserID = "user"
+	cfg.Global.TenantName = "demo"
+
+	ao := cfg.toAuth3Options()
+
+	if ao.Scope.ProjectName != cfg.Global.TenantName {
+		t.Errorf("TenantName %s != %s", ao.Scope.ProjectName, cfg.Global.TenantName)
+	}
+	if ao.Scope.DomainName != cfg.Global.DomainName {
+		t.Errorf("DomainName %s != %s", ao.Scope.DomainName, cfg.Global.DomainName)
+	}
+	if ao.Scope.DomainID != cfg.Global.DomainID {
+		t.Errorf("DomainID %s != %s", ao.Scope.DomainName, cfg.Global.DomainID)
+	}
+
+	// Use Tenant Domain Name/ID if set
+	cfg = Config{}
+	cfg.Global.Username = "user"
+	cfg.Global.Password = "pass"
+	cfg.Global.DomainID = "2a73b8f597c04551a0fdc8e95544be8a"
+	cfg.Global.DomainName = "local"
+	cfg.Global.AuthURL = "http://auth.url"
+	cfg.Global.UserID = "user"
+	cfg.Global.TenantName = "demo"
+	cfg.Global.TenantDomainName = "Default"
+	cfg.Global.TenantDomainID = "default"
+
+	ao = cfg.toAuth3Options()
+
+	if ao.Scope.ProjectName != cfg.Global.TenantName {
+		t.Errorf("TenantName %s != %s", ao.Scope.ProjectName, cfg.Global.TenantName)
+	}
+	if ao.Scope.DomainName != cfg.Global.TenantDomainName {
+		t.Errorf("TenantDomainName %s != %s", ao.Scope.DomainName, cfg.Global.TenantDomainName)
+	}
+	if ao.Scope.DomainID != cfg.Global.TenantDomainID {
+		t.Errorf("TenantDomainID %s != %s", ao.Scope.DomainName, cfg.Global.TenantDomainID)
+	}
+
+	// Do not use neither Domain Name nor ID, if Tenant ID was provided
+	cfg = Config{}
+	cfg.Global.Username = "user"
+	cfg.Global.Password = "pass"
+	cfg.Global.DomainID = "2a73b8f597c04551a0fdc8e95544be8a"
+	cfg.Global.DomainName = "local"
+	cfg.Global.AuthURL = "http://auth.url"
+	cfg.Global.UserID = "user"
+	cfg.Global.TenantID = "7808db451cfc43eaa9acda7d67da8cf1"
+	cfg.Global.TenantDomainName = "Default"
+	cfg.Global.TenantDomainID = "default"
+
+	ao = cfg.toAuth3Options()
+
+	if ao.Scope.ProjectName != "" {
+		t.Errorf("TenantName in the scope  is not empty")
+	}
+	if ao.Scope.DomainName != "" {
+		t.Errorf("DomainName in the scope is not empty")
+	}
+	if ao.Scope.DomainID != "" {
+		t.Errorf("DomainID in the scope is not empty")
 	}
 }
 


### PR DESCRIPTION
This commit adds a possibility to specify a domain name/id for a tenant other than the default one.

/kind feature

```release-note
Allow to specify a domain name/id for a tenant other than the default one for the OpenStack cloud provider.
```