### PR TITLE
trivial: Fix link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ flag to `external` when starting the kube-controller-manager.
 
 For more details, please see:
 
-- <https://github.com/kubernetes/community/blob/master/keps/sig-cloud-provider/0002-cloud-controller-manager.md>
+- <https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20180530-cloud-controller-manager.md>
 - <https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager>
 - <https://kubernetes.io/docs/tasks/administer-cluster/developing-cloud-controller-manager/>
 


### PR DESCRIPTION
The link to the KEP that describes the original cloud controller
manager work was pointing to the generic KEPs repository. This commit
fixes the link so that readers don't have to go hunting for the link
in the new location.