### PR TITLE
Support listener timeouts as service annotations

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -231,7 +231,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ba2ade5da932202872cfbe51377e7b108f4e82f981a15c1f07045678a4818464"
+  digest = "1:c6ae6215aaacaa06d48c8cd231a6c28396b8f3a1efea1ebb0b3563062e4ef26a"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -277,7 +277,7 @@
     "testhelper/client",
   ]
   pruneopts = "UT"
-  revision = "a127a1b294c369554364af633d29d213ba88ef16"
+  revision = "2c55d17f707cc8333ca4f49690cb2970d12a25f6"
 
 [[projects]]
   branch = "master"

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -40,7 +40,7 @@ import (
 	neutronports "github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	"github.com/gophercloud/gophercloud/pagination"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -73,20 +73,24 @@ const (
 	activeStatus = "ACTIVE"
 	errorStatus  = "ERROR"
 
-	ServiceAnnotationLoadBalancerFloatingNetworkID = "loadbalancer.openstack.org/floating-network-id"
-	ServiceAnnotationLoadBalancerFloatingSubnet    = "loadbalancer.openstack.org/floating-subnet"
-	ServiceAnnotationLoadBalancerFloatingSubnetID  = "loadbalancer.openstack.org/floating-subnet-id"
-	ServiceAnnotationLoadBalancerSubnetID          = "loadbalancer.openstack.org/subnet-id"
-	ServiceAnnotationLoadBalancerPortID            = "loadbalancer.openstack.org/port-id"
-	ServiceAnnotationLoadBalancerConnLimit         = "loadbalancer.openstack.org/connection-limit"
-	ServiceAnnotationLoadBalancerKeepFloatingIP    = "loadbalancer.openstack.org/keep-floatingip"
-	ServiceAnnotationLoadBalancerProxyEnabled      = "loadbalancer.openstack.org/proxy-protocol"
-	ServiceAnnotationLoadBalancerXForwardedFor     = "loadbalancer.openstack.org/x-forwarded-for"
+	ServiceAnnotationLoadBalancerConnLimit            = "loadbalancer.openstack.org/connection-limit"
+	ServiceAnnotationLoadBalancerFloatingNetworkID    = "loadbalancer.openstack.org/floating-network-id"
+	ServiceAnnotationLoadBalancerFloatingSubnet       = "loadbalancer.openstack.org/floating-subnet"
+	ServiceAnnotationLoadBalancerFloatingSubnetID     = "loadbalancer.openstack.org/floating-subnet-id"
+	ServiceAnnotationLoadBalancerInternal             = "service.beta.kubernetes.io/openstack-internal-load-balancer"
+	ServiceAnnotationLoadBalancerKeepFloatingIP       = "loadbalancer.openstack.org/keep-floatingip"
+	ServiceAnnotationLoadBalancerPortID               = "loadbalancer.openstack.org/port-id"
+	ServiceAnnotationLoadBalancerProxyEnabled         = "loadbalancer.openstack.org/proxy-protocol"
+	ServiceAnnotationLoadBalancerSubnetID             = "loadbalancer.openstack.org/subnet-id"
+	ServiceAnnotationLoadBalancerTimeoutClientData    = "loadbalancer.openstack.org/timeout-client-data"
+	ServiceAnnotationLoadBalancerTimeoutMemberConnect = "loadbalancer.openstack.org/timeout-member-connect"
+	ServiceAnnotationLoadBalancerTimeoutMemberData    = "loadbalancer.openstack.org/timeout-member-data"
+	ServiceAnnotationLoadBalancerTimeoutTCPInspect    = "loadbalancer.openstack.org/timeout-tcp-inspect"
+	ServiceAnnotationLoadBalancerXForwardedFor        = "loadbalancer.openstack.org/x-forwarded-for"
 
 	// ServiceAnnotationLoadBalancerInternal is the annotation used on the service
 	// to indicate that we want an internal loadbalancer service.
 	// If the value of ServiceAnnotationLoadBalancerInternal is false, it indicates that we want an external loadbalancer service. Default to false.
-	ServiceAnnotationLoadBalancerInternal = "service.beta.kubernetes.io/openstack-internal-load-balancer"
 )
 
 // LbaasV2 is a LoadBalancer implementation for Neutron LBaaS v2 API
@@ -587,6 +591,18 @@ func getStringFromServiceAnnotation(service *v1.Service, annotationKey string, d
 	return defaultSetting
 }
 
+func getIntFromServiceAnnotation(service *v1.Service, annotationKey string) (int, bool) {
+	intString := getStringFromServiceAnnotation(service, annotationKey, "")
+	if len(intString) > 0 {
+		annotationValue, err := strconv.Atoi(intString)
+		if err == nil {
+			klog.V(4).Infof("Found a Service Annotation: %v = %v", annotationKey, annotationValue)
+			return annotationValue, true
+		}
+	}
+	return 0, false
+}
+
 //getBoolFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's value or a specified defaultSetting
 func getBoolFromServiceAnnotation(service *v1.Service, annotationKey string, defaultSetting bool) (bool, error) {
 	klog.V(4).Infof("getBoolFromServiceAnnotation(%v, %v, %v)", service, annotationKey, defaultSetting)
@@ -955,6 +971,20 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 				ConnLimit:      &connLimit,
 				LoadbalancerID: loadbalancer.ID,
 			}
+
+			if timeoutClientData, ok := getIntFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerTimeoutClientData); ok {
+				listenerCreateOpt.TimeoutClientData = &timeoutClientData
+			}
+			if timeoutMemberData, ok := getIntFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerTimeoutMemberData); ok {
+				listenerCreateOpt.TimeoutMemberData = &timeoutMemberData
+			}
+			if timeoutMemberConnect, ok := getIntFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerTimeoutMemberConnect); ok {
+				listenerCreateOpt.TimeoutMemberConnect = &timeoutMemberConnect
+			}
+			if timeoutTCPInspect, ok := getIntFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerTimeoutTCPInspect); ok {
+				listenerCreateOpt.TimeoutTCPInspect = &timeoutTCPInspect
+			}
+
 			if keepClientIP {
 				listenerCreateOpt.InsertHeaders = map[string]string{"X-Forwarded-For": "true"}
 			}
@@ -1205,9 +1235,8 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 					floatIP, err = floatingips.Update(lbaas.network, floatingip.ID, floatUpdateOpts).Extract()
 					if err != nil {
 						return nil, fmt.Errorf("error updating LB floatingip %+v: %v", floatUpdateOpts, err)
-					} else {
-						needCreate = false
 					}
+					needCreate = false
 				} else {
 					return nil, fmt.Errorf("floatingip is attached already to another port")
 				}


### PR DESCRIPTION
**What this PR does / why we need it**: Extends support for listener [timeout values](https://developer.openstack.org/api-ref/load-balancer/v2/index.html?expanded=create-listener-detail#id34) to Kubernetes services via annotation

**Which issue this PR fixes**: fixes #588 by allowing the default listener timeout values of the loadbalancer Octavia creates for each Kubernetes LoadBalancer service to be individually overridden. For longer-living connections, unexpected disconnects/RST can be observed when a successfully negotiated connection reaches the [default timeout](https://github.com/kubernetes/cloud-provider-openstack/issues/588#issuecomment-482819223) values without activity. For example, if the `kube-apiserver` is placed behind an Octavia loadbalancer with the default listener timeouts and `kubectl logs -f <pod>` is used, after 50 seconds the client receives a connection reset and logs `error: unexpected EOF`. Tuning these values allows for LoadBalancer services to be configured to accommodate longer-lived connections.

**Special notes for your reviewer**: the additional createOpts for the listener are supported in gophercloud by virtue of this change https://github.com/gophercloud/gophercloud/pull/1544

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```Adds support for setting timeout_client_data, timeout_member_connect, timeout_member_data, and timeout_tcp_inspect values on load balancers```
