### PR TITLE
Add Max Vol Limit for Cinder CSI

### DIFF
--- a/docs/provider-configuration.md
+++ b/docs/provider-configuration.md
@@ -229,6 +229,11 @@ and should appear in the `[BlockStorage]` section of the `$CLOUD_CONFIG` file.
   the device path based on its serial number and `/dev/disk/by-id` mapping and is
   the recommended approach.
 
+##### Block Storage (CSI)
+
+* `NodeVolumeAttachLimit`: Maximum volumes that can be attached to the node. Its
+  default value is 256.
+
 ##### Block Storage Notes
 
 If deploying Kubernetes versions <= 1.8 on an OpenStack deployment that uses

--- a/pkg/csi/cinder/fake.go
+++ b/pkg/csi/cinder/fake.go
@@ -64,3 +64,5 @@ var FakeSnapshotRes = snapshots.Snapshot{
 var FakeSnapshotsRes = []snapshots.Snapshot{FakeSnapshotRes}
 var FakeVolList = []openstack.Volume{FakeVol1, FakeVol3}
 var FakeInstanceID = "321a8b81-3660-43e5-bab8-6470b65ee4e8"
+
+const FakeMaxVolume int64 = 256

--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -197,9 +197,12 @@ func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 	zone, err := getAvailabilityZoneMetadataService(ns.Metadata)
 	topology := &csi.Topology{Segments: map[string]string{topologyKey: zone}}
 
+	maxVolume := getMaxVolumeLimit()
+
 	return &csi.NodeGetInfoResponse{
 		NodeId:             nodeID,
 		AccessibleTopology: topology,
+		MaxVolumesPerNode:  maxVolume,
 	}, nil
 }
 
@@ -263,4 +266,9 @@ func getNodeID(mount mount.IMount, metadata openstack.IMetadata) (string, error)
 		return "", err
 	}
 	return nodeID, nil
+}
+
+func getMaxVolumeLimit() int64 {
+	return openstack.GetMaxVolLimit()
+
 }

--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -57,6 +57,8 @@ func TestNodeGetInfo(t *testing.T) {
 
 	metamock.On("GetAvailabilityZone").Return(FakeAvailability, nil)
 
+	osmock.On("GetMaxVolumeLimit").Return(FakeMaxVolume)
+
 	// Init assert
 	assert := assert.New(t)
 
@@ -64,6 +66,7 @@ func TestNodeGetInfo(t *testing.T) {
 	expectedRes := &csi.NodeGetInfoResponse{
 		NodeId:             FakeNodeID,
 		AccessibleTopology: &csi.Topology{Segments: map[string]string{topologyKey: FakeAvailability}},
+		MaxVolumesPerNode:  FakeMaxVolume,
 	}
 
 	// Fake request

--- a/pkg/csi/cinder/openstack/openstack_mock.go
+++ b/pkg/csi/cinder/openstack/openstack_mock.go
@@ -321,3 +321,7 @@ func (_m *OpenStackMock) WaitSnapshotReady(snapshotID string) error {
 
 	return r0
 }
+
+func (_m *OpenStackMock) GetMaxVolLimit() int64 {
+	return 0
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR adds support for returning max volume limit in _CSI NodeGetInfo_ call, It returns MaxVolumesPerNode in CSINodeGetInfo response, which defaults to 256(same as intree driver), This can be configured via _node-volume-attach-limit_ from cloud config file.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #572

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
