### PR TITLE
Get real device path from node

### DIFF
--- a/pkg/csi/cinder/mount/mount.go
+++ b/pkg/csi/cinder/mount/mount.go
@@ -20,9 +20,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/util/mount"
 	utilexec "k8s.io/utils/exec"
 
@@ -30,13 +32,17 @@ import (
 )
 
 const (
-	probeVolumeDuration = 1 * time.Second
-	probeVolumeTimeout  = 60 * time.Second
-	instanceIDFile      = "/var/lib/cloud/data/instance-id"
+	probeVolumeDuration      = 1 * time.Second
+	probeVolumeTimeout       = 60 * time.Second
+	operationFinishInitDelay = 1 * time.Second
+	operationFinishFactor    = 1.1
+	operationFinishSteps     = 15
+	instanceIDFile           = "/var/lib/cloud/data/instance-id"
 )
 
 type IMount interface {
 	ScanForAttach(devicePath string) error
+	GetDevicePath(volumeID string) (string, error)
 	IsLikelyNotMountPointAttach(targetpath string) (bool, error)
 	FormatAndMount(source string, target string, fstype string, options []string) error
 	IsLikelyNotMountPointDetach(targetpath string) (bool, error)
@@ -79,6 +85,63 @@ func probeVolume() error {
 		return err
 	}
 	return nil
+}
+
+// GetDevicePath returns the path of an attached block storage volume, specified by its id.
+func (m *Mount) GetDevicePath(volumeID string) (string, error) {
+	backoff := wait.Backoff{
+		Duration: operationFinishInitDelay,
+		Factor:   operationFinishFactor,
+		Steps:    operationFinishSteps,
+	}
+
+	var devicePath string
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		devicePath = m.getDevicePathBySerialID(volumeID)
+		if devicePath != "" {
+			return true, nil
+		}
+		return false, nil
+	})
+
+	if err == wait.ErrWaitTimeout {
+		return "", fmt.Errorf("Failed to find device for the volumeID: %q within the alloted time", volumeID)
+	} else if devicePath == "" {
+		return "", fmt.Errorf("Device path was empty for volumeID: %q", volumeID)
+	}
+	return devicePath, nil
+}
+
+// GetDevicePathBySerialID returns the path of an attached block storage volume, specified by its id.
+func (m *Mount) getDevicePathBySerialID(volumeID string) string {
+	// Build a list of candidate device paths.
+	// Certain Nova drivers will set the disk serial ID, including the Cinder volume id.
+	candidateDeviceNodes := []string{
+		// KVM
+		fmt.Sprintf("virtio-%s", volumeID[:20]),
+		// KVM virtio-scsi
+		fmt.Sprintf("scsi-0QEMU_QEMU_HARDDISK_%s", volumeID[:20]),
+		// ESXi
+		fmt.Sprintf("wwn-0x%s", strings.Replace(volumeID, "-", "", -1)),
+	}
+
+	files, err := ioutil.ReadDir("/dev/disk/by-id/")
+	if err != nil {
+		klog.V(4).Infof("ReadDir failed with error %v", err)
+	}
+
+	for _, f := range files {
+		for _, c := range candidateDeviceNodes {
+			if c == f.Name() {
+				klog.V(4).Infof("Found disk attached as %q; full devicepath: %s\n",
+					f.Name(), path.Join("/dev/disk/by-id/", f.Name()))
+				return path.Join("/dev/disk/by-id/", f.Name())
+			}
+		}
+	}
+
+	klog.V(4).Infof("Failed to find device for the volumeID: %q by serial ID", volumeID)
+	return ""
 }
 
 // ScanForAttach

--- a/pkg/csi/cinder/mount/mount_mock.go
+++ b/pkg/csi/cinder/mount/mount_mock.go
@@ -129,6 +129,27 @@ func (_m *MountMock) ScanForAttach(devicePath string) error {
 	return r0
 }
 
+// GetDevicePath provides a mock function with given fields: volumeID
+func (_m *MountMock) GetDevicePath(volumeID string) (string, error) {
+	ret := _m.Called(volumeID)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(volumeID)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(volumeID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // UnmountPath provides a mock function with given fields: mountPath
 func (_m *MountMock) UnmountPath(mountPath string) error {
 	ret := _m.Called(mountPath)

--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -125,8 +125,8 @@ func TestNodePublishVolume(t *testing.T) {
 // Test NodeStageVolume
 func TestNodeStageVolume(t *testing.T) {
 
-	// ScanForAttach(devicePath string) error
-	mmock.On("ScanForAttach", FakeDevicePath).Return(nil)
+	// GetDevicePath(volumeID string) error
+	mmock.On("GetDevicePath", FakeVolID).Return(FakeDevicePath, nil)
 	// IsLikelyNotMountPointAttach(targetpath string) (bool, error)
 	mmock.On("IsLikelyNotMountPointAttach", FakeStagingTargetPath).Return(true, nil)
 	// FormatAndMount(source string, target string, fstype string, options []string) error

--- a/pkg/csi/cinder/sanity/fakemount.go
+++ b/pkg/csi/cinder/sanity/fakemount.go
@@ -35,3 +35,7 @@ func (m *fakemount) UnmountPath(mountPath string) error {
 func (m *fakemount) GetInstanceID() (string, error) {
 	return cinder.FakeInstanceID, nil
 }
+
+func (m *fakemount) GetDevicePath(volumeID string) (string, error) {
+	return "", nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR is to get the real device path from the node and not
to trust the device path returned by cinder which often leads to failed mount

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #531 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
