### PR TITLE
Migrate to the apps/v1 API group

### DIFF
--- a/cluster/images/flex-volume-driver/flexvolume-ds.yaml
+++ b/cluster/images/flex-volume-driver/flexvolume-ds.yaml
@@ -1,5 +1,5 @@
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: cinder-flexvolume
   namespace: kube-system

--- a/examples/loadbalancers/README.MD
+++ b/examples/loadbalancers/README.MD
@@ -12,12 +12,15 @@ The example below will create a nginx deployment and expose it via an OpenStack 
 
 ```yaml
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: external-http-nginx-deployment
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       labels:
@@ -83,12 +86,15 @@ The example below will create a nginx deployment and expose it via an OpenStack 
 
 ```yaml
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: internal-http-nginx-deployment
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       labels:

--- a/examples/loadbalancers/external-http-nginx.yaml
+++ b/examples/loadbalancers/external-http-nginx.yaml
@@ -1,10 +1,13 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: external-http-nginx-deployment
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       labels:

--- a/examples/loadbalancers/internal-http-nginx.yaml
+++ b/examples/loadbalancers/internal-http-nginx.yaml
@@ -1,10 +1,13 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: internal-http-nginx-deployment
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       labels:

--- a/examples/manila-provisioner/csi-cephfs/daemonsets.yaml
+++ b/examples/manila-provisioner/csi-cephfs/daemonsets.yaml
@@ -1,5 +1,5 @@
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: csi-cephfsplugin
 spec:

--- a/examples/manila-provisioner/csi-cephfs/statefulsets.yaml
+++ b/examples/manila-provisioner/csi-cephfs/statefulsets.yaml
@@ -1,5 +1,5 @@
 kind: StatefulSet
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: csi-attacher
 spec:
@@ -35,7 +35,7 @@ spec:
             type: DirectoryOrCreate
 ---
 kind: StatefulSet
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: csi-provisioner
 spec:


### PR DESCRIPTION
DaemonSet, Deployment, and ReplicaSet resources will
no longer be served from extensions/v1beta1, apps/v1beta1,
or apps/v1beta2 and removed in v1.16. Migrate to the apps/v1 API,
available since v1.9. Existing persisted data can be retrieved
via the apps/v1 API.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
