### PR TITLE
k8s-keystone-auth: Support project ID in policy v2

### DIFF
--- a/docs/using-keystone-webhook-authenticator-and-authorizer.md
+++ b/docs/using-keystone-webhook-authenticator-and-authorizer.md
@@ -458,7 +458,9 @@ the operation is allowed if *ANY* rule defined in the permissions is
 satisfied.
 
 - "users" defines which projects the OpenStack users belong to and what
-  roles they have.
+  roles they have. You could define multiple projects or roles, if the project
+  of the target user is included in the projects, the permission is going to be
+  checked.
 - "resource_permissions" is a map with the key defines namespaces and
   resources, the value defines the allowed operations. `/` is used as separator
   for namespace and resource. `!` and `*` are supported both for namespaces and

--- a/pkg/identity/keystone/authorizer.go
+++ b/pkg/identity/keystone/authorizer.go
@@ -310,8 +310,15 @@ func (a *Authorizer) Authorize(attributes authorizer.Attributes) (authorized aut
 			userRoles.Insert(role)
 		}
 	}
+
+	// We support both project name and project ID.
 	userProjects := sets.NewString()
 	if val, ok := user.GetExtra()[ProjectName]; ok {
+		for _, project := range val {
+			userProjects.Insert(project)
+		}
+	}
+	if val, ok := user.GetExtra()[ProjectID]; ok {
 		for _, project := range val {
 			userProjects.Insert(project)
 		}
@@ -339,7 +346,7 @@ func (a *Authorizer) Authorize(attributes authorizer.Attributes) (authorized aut
 
 			klog.V(4).Infof("policyRoles: %s, policyProjects: %s", policyRoles.List(), policyProjects.List())
 
-			if !userRoles.IsSuperset(policyRoles) || !userProjects.IsSuperset(policyProjects) {
+			if !userRoles.IsSuperset(policyRoles) || !policyProjects.HasAny(userProjects.List()...) {
 				continue
 			}
 		}

--- a/pkg/identity/keystone/authorizer_test.go
+++ b/pkg/identity/keystone/authorizer_test.go
@@ -223,6 +223,16 @@ func TestAuthorizerVersion2(t *testing.T) {
 		Groups: []string{"group2"},
 		Extra: map[string][]string{
 			ProjectName: {"demo"},
+			ProjectID:   {"ff9db8980cf24a74bc9dd796b6ce811f"},
+			Roles:       {"viewer"},
+		},
+	}
+	anotherviewer := &user.DefaultInfo{
+		Name:   "anotherviewer",
+		Groups: []string{"group"},
+		Extra: map[string][]string{
+			ProjectName: {"alt_demo"},
+			ProjectID:   {"cd08a539b7c845ddb92c5d08752101d1"},
 			Roles:       {"viewer"},
 		},
 	}
@@ -251,6 +261,7 @@ func TestAuthorizerVersion2(t *testing.T) {
 	decision, _, _ = a.Authorize(attrs)
 	th.AssertEquals(t, authorizer.DecisionDeny, decision)
 
+	// Test viewer
 	attrs = authorizer.AttributesRecord{User: viewer, ResourceRequest: true, Verb: "get", Namespace: "default", Resource: "deployments"}
 	decision, _, _ = a.Authorize(attrs)
 	th.AssertEquals(t, authorizer.DecisionAllow, decision)
@@ -260,6 +271,19 @@ func TestAuthorizerVersion2(t *testing.T) {
 	th.AssertEquals(t, authorizer.DecisionDeny, decision)
 
 	attrs = authorizer.AttributesRecord{User: viewer, ResourceRequest: true, Verb: "create", Namespace: "default", Resource: "pods"}
+	decision, _, _ = a.Authorize(attrs)
+	th.AssertEquals(t, authorizer.DecisionDeny, decision)
+
+	// Test anotherviewer, the result should be the same with viewer
+	attrs = authorizer.AttributesRecord{User: anotherviewer, ResourceRequest: true, Verb: "get", Namespace: "default", Resource: "deployments"}
+	decision, _, _ = a.Authorize(attrs)
+	th.AssertEquals(t, authorizer.DecisionAllow, decision)
+
+	attrs = authorizer.AttributesRecord{User: anotherviewer, ResourceRequest: true, Verb: "get", Namespace: "kube-system", Resource: "services"}
+	decision, _, _ = a.Authorize(attrs)
+	th.AssertEquals(t, authorizer.DecisionDeny, decision)
+
+	attrs = authorizer.AttributesRecord{User: anotherviewer, ResourceRequest: true, Verb: "create", Namespace: "default", Resource: "pods"}
 	decision, _, _ = a.Authorize(attrs)
 	th.AssertEquals(t, authorizer.DecisionDeny, decision)
 

--- a/pkg/identity/keystone/authorizer_test_policy_version2.json
+++ b/pkg/identity/keystone/authorizer_test_policy_version2.json
@@ -12,7 +12,7 @@
   {
     "users": {
       "roles": ["viewer"],
-      "projects": ["demo"]
+      "projects": ["demo", "cd08a539b7c845ddb92c5d08752101d1"]
     },
     "resource_permissions": {
       "default/['*']": ["get", "list"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Support project ID in Keystone auth policy v2 definition.

In the current implementation, only project name is supported. With this PR,
the cluster admin could specify project ID or project name in the policy, e.g.

```
{
  "users": {
    "roles": ["viewer"],
    "projects": ["demo", "cd08a539b7c845ddb92c5d08752101d1"]
  },
  "resource_permissions": {
    "default/['*']": ["get", "list"]
  }
}
```

So user in the project demo(project name) or
cd08a539b7c845ddb92c5d08752101d1(project ID) with the `viewer` role has the
permission to query resources in the default namespace.

**Which issue this PR fixes**: fixes #

**Special notes for your reviewer**:
Please use `lingxiankong/k8s-keystone-auth:policy-version2` for testing.

**Release note**:
```release-note
```
