### PR TITLE
octavia-ingress-controller: Add provider configuration

### DIFF
--- a/docs/using-octavia-ingress-controller.md
+++ b/docs/using-octavia-ingress-controller.md
@@ -2,6 +2,8 @@
 
 This guide explains how to deploy and config the octavia-ingress-controller in Kubernetes cluster on top of OpenStack cloud.
 
+> NOTE: octavia-ingress-controller is still in Beta, support for the overall feature will not be dropped, though details may change.
+
 ## What is an Ingress Controller?
 In Kubernetes, Ingress allows external users and client applications access to HTTP services. Ingress consists of two components.
 

--- a/pkg/ingress/config/config.go
+++ b/pkg/ingress/config/config.go
@@ -54,14 +54,18 @@ type osConfig struct {
 
 // Octavia service related configuration
 type octaviaConfig struct {
-	// (Required)Subnet ID to create the load balancer.
+	// (Optional) Provider name for the load balancer. Default: octavia
+	// For more information: https://docs.openstack.org/octavia/latest/admin/providers.html
+	Provider string `mapstructure:"provider"`
+
+	// (Required) Subnet ID to create the load balancer.
 	SubnetID string `mapstructure:"subnet-id"`
 
-	// (Optional)Public network ID to create floating IP.
+	// (Optional) Public network ID to create floating IP.
 	// If empty, no floating IP will be allocated to the load balancer vip.
 	FloatingIPNetwork string `mapstructure:"floating-network-id"`
 
-	// (Optional)If the ingress controller should manage the security groups attached to the cluster nodes.
+	// (Optional) If the ingress controller should manage the security groups attached to the cluster nodes.
 	// Default is false.
 	ManageSecurityGroups bool `mapstructure:"manage-security-groups"`
 }

--- a/pkg/ingress/controller/openstack/octavia.go
+++ b/pkg/ingress/controller/openstack/octavia.go
@@ -312,11 +312,18 @@ func (os *OpenStack) EnsureLoadBalancer(name string, subnetID string, ingNamespa
 
 		log.WithFields(log.Fields{"name": name}).Debug("creating loadbalancer")
 
+		var provider string
+		if os.config.Octavia.Provider == "" {
+			provider = "octavia"
+		} else {
+			provider = os.config.Octavia.Provider
+		}
+
 		createOpts := loadbalancers.CreateOpts{
 			Name:        name,
 			Description: fmt.Sprintf("Kubernetes ingress %s in namespace %s from cluster %s", ingName, ingNamespace, clusterName),
 			VipSubnetID: subnetID,
-			Provider:    "octavia",
+			Provider:    provider,
 		}
 		loadbalancer, err = loadbalancers.Create(os.octavia, createOpts).Extract()
 		if err != nil {

--- a/pkg/ingress/utils/utils.go
+++ b/pkg/ingress/utils/utils.go
@@ -33,7 +33,8 @@ func Hash(data string) string {
 
 // GetResourceName get Ingress related resource name.
 func GetResourceName(namespace, name, clusterName string) string {
-	return fmt.Sprintf("k8s_ing_%s_%s_%s", clusterName, namespace, name)
+	// Keep consistent with the name of load balancer created for Service.
+	return fmt.Sprintf("kube_ingress_%s_%s_%s", clusterName, namespace, name)
 }
 
 // NodeNames get all the node names.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add provider support in octavia-ingress-controller configuration.

For more details about provider in Octavia: <https://docs.openstack.org/octavia/latest/admin/providers.html>

An example config file:
```
cluster-name: devstack-k8s
kubernetes:
    api-host:
    kubeconfig: /home/ubuntu/.kube/config
openstack:
    user-id: ${user_id}
    password: password
    project-id: ${project_id}
    auth-url: ${auth_url}/v3
    region: RegionOne
octavia:
    subnet-id: ${subnet_id}
    floating-network-id: ${public_net_id}
    manage-security-groups: false
    provider: amphora
```

**Which issue this PR fixes**: fixes #610

**Special notes for your reviewer**:

**Release note**:
