### PR TITLE
csi: Support xfs filesystem for csi-node-provisioner

### DIFF
--- a/cluster/images/cinder-csi-plugin/Dockerfile
+++ b/cluster/images/cinder-csi-plugin/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainers="Kubernetes Authors"
 LABEL description="Cinder CSI Plugin"
 
 # Install e4fsprogs for format
-RUN apk add --no-cache ca-certificates e2fsprogs eudev
+RUN apk add --no-cache ca-certificates e2fsprogs eudev xfsprogs
 
 ADD cinder-csi-plugin /bin/
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

This PR adds support for the csi-node-plugin to format disks using xfs.
When building the csi-node-plugin using `make image-csi-plugin` there will currently be no `xfsprogs` installed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added support for xfs to csi-node-provisioner
```
