### PR TITLE
Add magnum-auto-healer for the Kubernetes cluster

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -232,7 +232,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c6ae6215aaacaa06d48c8cd231a6c28396b8f3a1efea1ebb0b3563062e4ef26a"
+  digest = "1:8a5e9ae8b975657a3aa1bc913bbe43a317667e4eff3126ce316053e41a13dc9a"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -246,10 +246,12 @@
     "openstack/common/extensions",
     "openstack/compute/v2/extensions/attachinterfaces",
     "openstack/compute/v2/extensions/availabilityzones",
+    "openstack/compute/v2/extensions/startstop",
     "openstack/compute/v2/extensions/volumeattach",
     "openstack/compute/v2/flavors",
     "openstack/compute/v2/images",
     "openstack/compute/v2/servers",
+    "openstack/containerinfra/v1/clusters",
     "openstack/identity/v2/tenants",
     "openstack/identity/v2/tokens",
     "openstack/identity/v3/extensions/trusts",
@@ -270,6 +272,8 @@
     "openstack/networking/v2/networks",
     "openstack/networking/v2/ports",
     "openstack/networking/v2/subnets",
+    "openstack/orchestration/v1/stackresources",
+    "openstack/orchestration/v1/stacks",
     "openstack/sharedfilesystems/apiversions",
     "openstack/sharedfilesystems/v2/shares",
     "openstack/utils",
@@ -278,7 +282,7 @@
     "testhelper/client",
   ]
   pruneopts = "UT"
-  revision = "2c55d17f707cc8333ca4f49690cb2970d12a25f6"
+  revision = "e87e5f90e7e67a309e0fe96dac144b824447607f"
 
 [[projects]]
   branch = "master"
@@ -1559,8 +1563,10 @@
     "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes",
     "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces",
     "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones",
+    "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/startstop",
     "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach",
     "github.com/gophercloud/gophercloud/openstack/compute/v2/servers",
+    "github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters",
     "github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/trusts",
     "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens",
     "github.com/gophercloud/gophercloud/openstack/keymanager/v1/secrets",
@@ -1579,6 +1585,8 @@
     "github.com/gophercloud/gophercloud/openstack/networking/v2/networks",
     "github.com/gophercloud/gophercloud/openstack/networking/v2/ports",
     "github.com/gophercloud/gophercloud/openstack/networking/v2/subnets",
+    "github.com/gophercloud/gophercloud/openstack/orchestration/v1/stackresources",
+    "github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks",
     "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/apiversions",
     "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares",
     "github.com/gophercloud/gophercloud/openstack/utils",
@@ -1639,6 +1647,8 @@
     "k8s.io/client-go/rest",
     "k8s.io/client-go/tools/cache",
     "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/tools/leaderelection",
+    "k8s.io/client-go/tools/leaderelection/resourcelock",
     "k8s.io/client-go/tools/record",
     "k8s.io/client-go/util/cert",
     "k8s.io/client-go/util/retry",

--- a/cluster/images/magnum-auto-healer/Dockerfile
+++ b/cluster/images/magnum-auto-healer/Dockerfile
@@ -1,0 +1,17 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM alpine:3.7
+
+RUN apk add --no-cache ca-certificates
+ADD magnum-auto-healer /bin/
+
+CMD ["/bin/magnum-auto-healer"]

--- a/cmd/magnum-auto-healer/main.go
+++ b/cmd/magnum-auto-healer/main.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"k8s.io/cloud-provider-openstack/pkg/autohealing/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/docs/using-magnum-auto-healer.md
+++ b/docs/using-magnum-auto-healer.md
@@ -1,0 +1,227 @@
+# Using magnum-auto-healer
+
+## What is magnum-auto-healer
+
+Kubernetes is self-healing container orchestration platform that will detect failures from your pods and redeploy that workload, however, magnum-auto-healer is a self-healing cluster management service that will automatically recover a failed master or worker node within your Magnum cluster. Basically, magnum-auto-healer ensures the running Kubernetes nodes are healthy by monitoring the nodes' status periodically, searching for unhealthy instances and triggering replacements when needed, maximizing your cluster's high availability and reliability, and protecting your application from downtime when the node it's running on fails.
+
+The other side of concerns for Kubernetes cluster is scalability. Kubernetes [cluster-autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) can scale the worker pools in your cluster automatically to increase or decrease the number of worker nodes based on the sizing needs of the scheduled workloads. cluster-autoscaler periodically scans the cluster to adjust the number of worker nodes in response to your workload resource requests and any custom settings that you configure, such as scanning intervals. The main purpose of cluster-autoscaler is autoscaling, not autohealing. cluster-autoscaler can be deployed together with magnum-auto-healer.
+
+Like cluster-autoscaler, magnum-auto-healer is implemented to use together with cloud providers as well, [OpenStack Magnum](https://docs.openstack.org/magnum/latest/user/) is supported by default.
+
+## magnum-auto-healer Design
+
+There are some considerations when we were designing the magnum-auto-healer service:
+
+- We want to have a single component for the cluster autohealing purpose. There are already some other components out there in the community to deal with some specific tasks separately, combining them together with some customization may work, but will lead to much complexity and maintenance overhead.
+- Support both master nodes and worker nodes.
+- Cluster administrator is able to disable the autohealing feature on the fly, which is very important for the cluster operations like upgrade or scheduled maintenance.
+- The Kubernetes cluster is not necessary to be exposed to either the public or the OpenStack control plane. For example, In Magnum, the end user may create a private cluster which is not accessible even from Magnum control services.
+- The health check should be pluggable. Deployers should be able to write their own health check plugin with customized health check parameters.
+- Support different cloud providers.
+
+## Deploying and testing magnum-auto-healer
+
+### Prerequisites
+
+1. A multi-node cluster(3 masters and 3 workers) is created in Magnum.
+
+    ```
+    $ openstack coe cluster list
+    +--------------------------------------+-----------------------------+-----------------+------------+--------------+-----------------+
+    | uuid                                 | name                        | keypair         | node_count | master_count | status          |
+    +--------------------------------------+-----------------------------+-----------------+------------+--------------+-----------------+
+    | c418c335-0e52-42fc-bd68-baa8d264e072 | lingxian_por_test_1.12.7_ha | lingxian_laptop |          3 |            3 | CREATE_COMPLETE |
+    +--------------------------------------+-----------------------------+-----------------+------------+--------------+-----------------+
+    $ openstack server list --name lingxian-por-test-1-12-7-ha
+    +--------------------------------------+---------------------------------------------------+--------+-----------------------------------------+-------------------------+---------+
+    | ID                                   | Name                                              | Status | Networks                                | Image                   | Flavor  |
+    +--------------------------------------+---------------------------------------------------+--------+-----------------------------------------+-------------------------+---------+
+    | 908957c2-ac88-4b54-a1fc-91f9cc8f98f1 | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-minion-2 | ACTIVE | lingxian_net=10.0.10.33, 150.242.42.234 | fedora-atomic-27-x86_64 | c1.c4r8 |
+    | 8f0c3ad9-caf5-45b6-bf3a-97b3bb6de623 | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-minion-0 | ACTIVE | lingxian_net=10.0.10.32, 150.242.42.233 | fedora-atomic-27-x86_64 | c1.c4r8 |
+    | a6ae4cee-7cf2-4b25-89bc-a5c6cb2c364d | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-minion-1 | ACTIVE | lingxian_net=10.0.10.34, 150.242.42.245 | fedora-atomic-27-x86_64 | c1.c4r8 |
+    | 2af96203-cc6f-4b55-8fb2-062340207ebb | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-master-2 | ACTIVE | lingxian_net=10.0.10.31, 150.242.42.226 | fedora-atomic-27-x86_64 | c1.c2r4 |
+    | 10bef366-b5a8-4400-b2c3-82188ec06b13 | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-master-1 | ACTIVE | lingxian_net=10.0.10.30, 150.242.42.22  | fedora-atomic-27-x86_64 | c1.c2r4 |
+    | 9c17f034-6825-4e49-b3cb-0ecddd1a8dd8 | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-master-0 | ACTIVE | lingxian_net=10.0.10.29, 150.242.42.213 | fedora-atomic-27-x86_64 | c1.c2r4 |
+    +--------------------------------------+---------------------------------------------------+--------+-----------------------------------------+-------------------------+---------+
+    ```
+
+2. The kubeconfig file of the cluster is in place.
+
+### Deploy magnum-auto-healer
+
+It's recommended to run magnum-auto-healer service as a DaemonSet on the master nodes, the service is running in active-passive mode using leader election mechanism. There is a sample manifest file in `manifests/magnum-auto-healer/magnum-auto-healer.yaml`, you need to change some variables as needed before actually running `kubectl apply` command. The following commands are just examples:
+
+```shell
+magnum_cluster_uuid=c418c335-0e52-42fc-bd68-baa8d264e072
+keystone_auth_url=https://api.nz-por-1.catalystcloud.io:5000/v3
+user_id=ceb61464a3d341ebabdf97d1d4b97099
+user_project_id=b23a5e41d1af4c20974bf58b4dff8e5a
+password=password
+region=RegionOne
+image=lingxiankong/magnum-auto-healer:0.1.0
+
+cat <<EOF | kubectl apply -f -
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: magnum-auto-healer
+  namespace: kube-system
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: magnum-auto-healer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: magnum-auto-healer
+    namespace: kube-system
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: magnum-auto-healer-config
+  namespace: kube-system
+data:
+  config.yaml: |
+    cluster-name: ${magnum_cluster_uuid}
+    dry-run: false
+    monitor-interval: 15s
+    check-delay-after-add: 20m
+    leader-elect: true
+    healthcheck:
+      master:
+        - type: Endpoint
+          params:
+            unhealthyDuration: 30s
+            protocol: HTTPS
+            port: 6443
+            endpoints: ["/healthz"]
+            okCodes: [200]
+        - type: NodeCondition
+          params:
+            unhealthyDuration: 1m
+            types: ["Ready"]
+            okValues: ["True"]
+      worker:
+        - type: NodeCondition
+          params:
+            unhealthyDuration: 1m
+            types: ["Ready"]
+            okValues: ["True"]
+    openstack:
+      auth-url: ${keystone_auth_url}
+      user-id: ${user_id}
+      project-id: ${user_project_id}
+      password: ${password}
+      region: ${region}
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: magnum-auto-healer
+  namespace: kube-system
+  labels:
+    k8s-app: magnum-auto-healer
+spec:
+  selector:
+    matchLabels:
+      k8s-app: magnum-auto-healer
+  template:
+    metadata:
+      labels:
+        k8s-app: magnum-auto-healer
+    spec:
+      serviceAccountName: magnum-auto-healer
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      containers:
+        - name: magnum-auto-healer
+          image: ${image}
+          imagePullPolicy: Always
+          args:
+            - /bin/magnum-auto-healer
+            - --config=/etc/magnum-auto-healer/config.yaml
+            - --v
+            - "2"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/magnum-auto-healer
+      volumes:
+        - name: config
+          configMap:
+            name: magnum-auto-healer-config
+EOF
+```
+
+### Testing magnum-auto-healer
+
+We could ssh into a worker node(`lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-minion-1` in this example) and stop the kubelet service to simulate the worker node failure. The node status check is covered in NodeCondition type of health check plugin(see configuration above).
+
+```shell
+$ ssh fedora@150.242.42.245
+[fedora@lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-minion-1 ~]$ sudo systemctl stop kubelet
+```
+
+Now waiting for the magnum-auto-healer to detect the node failure and trigger the repair process. First, you would see the unhealthy node is shutdown:
+
+```shell
++--------------------------------------+---------------------------------------------------+---------+-----------------------------------------+-------------------------+---------+
+| ID                                   | Name                                              | Status  | Networks                                | Image                   | Flavor  |
++--------------------------------------+---------------------------------------------------+---------+-----------------------------------------+-------------------------+---------+
+| 908957c2-ac88-4b54-a1fc-91f9cc8f98f1 | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-minion-2 | ACTIVE  | lingxian_net=10.0.10.33, 150.242.42.234 | fedora-atomic-27-x86_64 | c1.c4r8 |
+| a6ae4cee-7cf2-4b25-89bc-a5c6cb2c364d | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-minion-1 | SHUTOFF | lingxian_net=10.0.10.34, 150.242.42.245 | fedora-atomic-27-x86_64 | c1.c4r8 |
+| 8f0c3ad9-caf5-45b6-bf3a-97b3bb6de623 | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-minion-0 | ACTIVE  | lingxian_net=10.0.10.32, 150.242.42.233 | fedora-atomic-27-x86_64 | c1.c4r8 |
+| 2af96203-cc6f-4b55-8fb2-062340207ebb | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-master-2 | ACTIVE  | lingxian_net=10.0.10.31, 150.242.42.226 | fedora-atomic-27-x86_64 | c1.c2r4 |
+| 10bef366-b5a8-4400-b2c3-82188ec06b13 | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-master-1 | ACTIVE  | lingxian_net=10.0.10.30, 150.242.42.22  | fedora-atomic-27-x86_64 | c1.c2r4 |
+| 9c17f034-6825-4e49-b3cb-0ecddd1a8dd8 | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-master-0 | ACTIVE  | lingxian_net=10.0.10.29, 150.242.42.213 | fedora-atomic-27-x86_64 | c1.c2r4 |
++--------------------------------------+---------------------------------------------------+---------+-----------------------------------------+-------------------------+---------+
+```
+
+Then a new one comes up:
+
+```shell
++--------------------------------------+---------------------------------------------------+---------+-----------------------------------------+-------------------------+---------+
+| ID                                   | Name                                              | Status  | Networks                                | Image                   | Flavor  |
++--------------------------------------+---------------------------------------------------+---------+-----------------------------------------+-------------------------+---------+
+| 31d5e246-6f40-4e14-88a9-8cd86a19c75a | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-minion-1 | BUILD   |                                         | fedora-atomic-27-x86_64 | c1.c4r8 |
+| 908957c2-ac88-4b54-a1fc-91f9cc8f98f1 | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-minion-2 | ACTIVE  | lingxian_net=10.0.10.33, 150.242.42.234 | fedora-atomic-27-x86_64 | c1.c4r8 |
+| a6ae4cee-7cf2-4b25-89bc-a5c6cb2c364d | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-minion-1 | SHUTOFF |                                         | fedora-atomic-27-x86_64 | c1.c4r8 |
+| 8f0c3ad9-caf5-45b6-bf3a-97b3bb6de623 | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-minion-0 | ACTIVE  | lingxian_net=10.0.10.32, 150.242.42.233 | fedora-atomic-27-x86_64 | c1.c4r8 |
+| 2af96203-cc6f-4b55-8fb2-062340207ebb | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-master-2 | ACTIVE  | lingxian_net=10.0.10.31, 150.242.42.226 | fedora-atomic-27-x86_64 | c1.c2r4 |
+| 10bef366-b5a8-4400-b2c3-82188ec06b13 | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-master-1 | ACTIVE  | lingxian_net=10.0.10.30, 150.242.42.22  | fedora-atomic-27-x86_64 | c1.c2r4 |
+| 9c17f034-6825-4e49-b3cb-0ecddd1a8dd8 | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-master-0 | ACTIVE  | lingxian_net=10.0.10.29, 150.242.42.213 | fedora-atomic-27-x86_64 | c1.c2r4 |
++--------------------------------------+---------------------------------------------------+---------+-----------------------------------------+-------------------------+---------+
+```
+
+Finally, all the nodes are healthy again. In Magnum, the new node has the same IP address and hostname with the old one:
+
+```shell
++--------------------------------------+---------------------------------------------------+--------+-----------------------------------------+-------------------------+---------+
+| ID                                   | Name                                              | Status | Networks                                | Image                   | Flavor  |
++--------------------------------------+---------------------------------------------------+--------+-----------------------------------------+-------------------------+---------+
+| 31d5e246-6f40-4e14-88a9-8cd86a19c75a | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-minion-1 | ACTIVE | lingxian_net=10.0.10.34, 150.242.42.245 | fedora-atomic-27-x86_64 | c1.c4r8 |
+| 908957c2-ac88-4b54-a1fc-91f9cc8f98f1 | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-minion-2 | ACTIVE | lingxian_net=10.0.10.33, 150.242.42.234 | fedora-atomic-27-x86_64 | c1.c4r8 |
+| 8f0c3ad9-caf5-45b6-bf3a-97b3bb6de623 | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-minion-0 | ACTIVE | lingxian_net=10.0.10.32, 150.242.42.233 | fedora-atomic-27-x86_64 | c1.c4r8 |
+| 2af96203-cc6f-4b55-8fb2-062340207ebb | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-master-2 | ACTIVE | lingxian_net=10.0.10.31, 150.242.42.226 | fedora-atomic-27-x86_64 | c1.c2r4 |
+| 10bef366-b5a8-4400-b2c3-82188ec06b13 | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-master-1 | ACTIVE | lingxian_net=10.0.10.30, 150.242.42.22  | fedora-atomic-27-x86_64 | c1.c2r4 |
+| 9c17f034-6825-4e49-b3cb-0ecddd1a8dd8 | lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-master-0 | ACTIVE | lingxian_net=10.0.10.29, 150.242.42.213 | fedora-atomic-27-x86_64 | c1.c2r4 |
++--------------------------------------+---------------------------------------------------+--------+-----------------------------------------+-------------------------+---------+
+```
+
+### magnum-auto-healer video demo
+You can find a video demo [here](https://youtu.be/QCf-26P0lPg).

--- a/manifests/magnum-auto-healer/magnum-auto-healer.yaml
+++ b/manifests/magnum-auto-healer/magnum-auto-healer.yaml
@@ -1,0 +1,104 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: magnum-auto-healer
+  namespace: kube-system
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: magnum-auto-healer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: magnum-auto-healer
+    namespace: kube-system
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: magnum-auto-healer-config
+  namespace: kube-system
+data:
+  config.yaml: |
+    cluster-name: ${magnum_cluster_uuid}
+    dry-run: false
+    monitor-interval: 15s
+    check-delay-after-add: 20m
+    leader-elect: true
+    healthcheck:
+      master:
+        - type: Endpoint
+          params:
+            unhealthyDuration: 30s
+            protocol: HTTPS
+            port: 6443
+            endpoints: ["/healthz"]
+            okCodes: [200]
+        - type: NodeCondition
+          params:
+            unhealthyDuration: 1m
+            types: ["Ready"]
+            okValues: ["True"]
+      worker:
+        - type: NodeCondition
+          params:
+            unhealthyDuration: 1m
+            types: ["Ready"]
+            okValues: ["True"]
+    openstack:
+      auth-url: ${keystone_auth_url}
+      user-id: ${user_id}
+      project-id: ${user_project_id}
+      password: ${password}
+      region: ${region}
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: magnum-auto-healer
+  namespace: kube-system
+  labels:
+    k8s-app: magnum-auto-healer
+spec:
+  selector:
+    matchLabels:
+      k8s-app: magnum-auto-healer
+  template:
+    metadata:
+      labels:
+        k8s-app: magnum-auto-healer
+    spec:
+      serviceAccountName: magnum-auto-healer
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      containers:
+        - name: magnum-auto-healer
+          image: ${image}
+          imagePullPolicy: Always
+          args:
+            - /bin/magnum-auto-healer
+            - --config=/etc/magnum-auto-healer/config.yaml
+            - --v
+            - "2"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/magnum-auto-healer
+      volumes:
+        - name: config
+          configMap:
+            name: magnum-auto-healer-config

--- a/pkg/autohealing/OWNERS
+++ b/pkg/autohealing/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- lingxiankong
+- openstacker
+reviewers:
+- lingxiankong
+- openstacker

--- a/pkg/autohealing/cloudprovider/cloudprovider.go
+++ b/pkg/autohealing/cloudprovider/cloudprovider.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudprovider
+
+import (
+	log "k8s.io/klog"
+
+	"k8s.io/cloud-provider-openstack/pkg/autohealing/config"
+	"k8s.io/cloud-provider-openstack/pkg/autohealing/healthcheck"
+)
+
+var (
+	providers = make(map[string]RegisterFunc)
+)
+
+// CloudProvider is an abstract, pluggable interface for cloud providers.
+type CloudProvider interface {
+	// GetName returns the cloud provider name.
+	GetName() string
+
+	// Repair triggers the node repair process in the cloud.
+	Repair([]healthcheck.NodeInfo) error
+
+	// Enabled decides if the repair should be triggered.
+	// It's recommended that the `Enabled()` function of the cloud provider doesn't allow to re-trigger when the repair
+	// is in place, e.g. before the repair process is finished, `Enabled()` should return false so that we won't
+	// re-trigger the repair process in the subsequent checks.
+	// This function also provides the cluster admin the capability to disable the cluster auto healing on the fly.
+	Enabled() bool
+}
+
+type RegisterFunc func(config config.Config) (CloudProvider, error)
+
+// RegisterCloudProvider registers a cloudprovider.Factory by name. This
+// is expected to happen during app startup.
+func RegisterCloudProvider(name string, register RegisterFunc) {
+	if _, found := providers[name]; found {
+		log.Fatalf("Cloud provider %s is already registered.", name)
+	}
+
+	log.Infof("Registered cloud provider %s.", name)
+	providers[name] = register
+}
+
+// GetCloudProvider creates an instance of the named cloud provider
+func GetCloudProvider(name string, config config.Config) (CloudProvider, error) {
+	f, found := providers[name]
+	if !found {
+		return nil, nil
+	}
+	return f(config)
+}

--- a/pkg/autohealing/cloudprovider/openstack/provider.go
+++ b/pkg/autohealing/cloudprovider/openstack/provider.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/startstop"
+	"github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters"
+	"github.com/gophercloud/gophercloud/openstack/orchestration/v1/stackresources"
+	"github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks"
+	uuid "github.com/pborman/uuid"
+	"k8s.io/apimachinery/pkg/util/sets"
+	log "k8s.io/klog"
+
+	"k8s.io/cloud-provider-openstack/pkg/autohealing/config"
+	"k8s.io/cloud-provider-openstack/pkg/autohealing/healthcheck"
+)
+
+const (
+	ProviderName                  = "openstack"
+	ClusterAutoHealingLabel       = "auto_healing_enabled"
+	clusterStatusUpdateInProgress = "UPDATE_IN_PROGRESS"
+	clusterStatusUpdateComplete   = "UPDATE_COMPLETE"
+	clusterStatusUpdateFailed     = "UPDATE_FAILED"
+	stackStatusUpdateFailed       = "UPDATE_FAILED"
+	stackStatusUpdateInProgress   = "UPDATE_IN_PROGRESS"
+	stackStatusUpdateComplete     = "UPDATE_COMPLETE"
+)
+
+var statusesPreventingRepair = sets.NewString(
+	stackStatusUpdateInProgress,
+	stackStatusUpdateFailed,
+)
+
+// OpenStack is an implementation of cloud provider Interface for OpenStack.
+type OpenStackCloudProvider struct {
+	Nova                 *gophercloud.ServiceClient
+	Heat                 *gophercloud.ServiceClient
+	Magnum               *gophercloud.ServiceClient
+	Config               config.Config
+	ResourceStackMapping map[string]ResourceStackRelationship
+}
+
+type ResourceStackRelationship struct {
+	ResourceID   string
+	ResourceName string
+	StackID      string
+	StackName    string
+}
+
+func (provider OpenStackCloudProvider) GetName() string {
+	return ProviderName
+}
+
+// getStackName finds the name of a stack matching a given ID.
+func (provider *OpenStackCloudProvider) getStackName(stackID string) (string, error) {
+	stack, err := stacks.Find(provider.Heat, stackID).Extract()
+	if err != nil {
+		return "", err
+	}
+
+	return stack.Name, nil
+}
+
+// getAllStackResourceMapping returns all mapping relationships including
+// masters and minions(workers). The key in the map is the server/instance ID
+// in Nova and the value is the resource ID and name of the server, and the
+// parent stack ID and name.
+func (provider *OpenStackCloudProvider) getAllStackResourceMapping(stackName, stackID string) (m map[string]ResourceStackRelationship, err error) {
+	if provider.ResourceStackMapping != nil {
+		return provider.ResourceStackMapping, nil
+	}
+
+	mapping := make(map[string]ResourceStackRelationship)
+
+	serverPages, err := stackresources.List(provider.Heat, stackName, stackID, stackresources.ListOpts{Depth: 2}).AllPages()
+	if err != nil {
+		return m, err
+	}
+	serverResources, err := stackresources.ExtractResources(serverPages)
+	if err != nil {
+		return m, err
+	}
+
+	for _, sr := range serverResources {
+		if sr.Type != "OS::Nova::Server" {
+			continue
+		}
+
+		for _, link := range sr.Links {
+			if link.Rel == "self" {
+				continue
+			}
+
+			paths := strings.Split(link.Href, "/")
+			if len(paths) > 2 {
+				m := ResourceStackRelationship{
+					ResourceID:   sr.PhysicalID,
+					ResourceName: sr.Name,
+					StackID:      paths[len(paths)-1],
+					StackName:    paths[len(paths)-2],
+				}
+
+				log.V(4).Infof("resource ID: %s, resource name: %s, parent stack ID: %s, parent stack name: %s", sr.PhysicalID, sr.Name, paths[len(paths)-1], paths[len(paths)-2])
+
+				mapping[sr.PhysicalID] = m
+			}
+		}
+	}
+	provider.ResourceStackMapping = mapping
+
+	return provider.ResourceStackMapping, nil
+}
+
+// Repair soft deletes the VMs, marks the heat resource "unhealthy" then trigger Heat stack update in order to rebuild
+// the VMs. The information this function needs:
+// - Nova VM IDs
+// - Heat stack ID and resource ID.
+func (provider OpenStackCloudProvider) Repair(nodes []healthcheck.NodeInfo) error {
+	clusterName := provider.Config.ClusterName
+	cluster, err := clusters.Get(provider.Magnum, clusterName).Extract()
+	if err != nil {
+		return fmt.Errorf("failed to get the cluster %s, error: %v", clusterName, err)
+	}
+
+	clusterStackName, err := provider.getStackName(cluster.StackID)
+	if err != nil {
+		return fmt.Errorf("failed to get the Heat stack for cluster %s, error: %v", clusterName, err)
+	}
+
+	// In order to rebuild the nodes by Heat stack update, we need to know the parent stack ID of the resources and
+	// mark them unhealthy first.
+	allMapping, err := provider.getAllStackResourceMapping(clusterStackName, cluster.StackID)
+	if err != nil {
+		return fmt.Errorf("failed to get the resource stack mapping for cluster %s, error: %v", clusterName, err)
+	}
+
+	for _, n := range nodes {
+		id := uuid.Parse(n.KubeNode.Status.NodeInfo.MachineID)
+		if id == nil {
+			log.Warningf("Failed to get the correct server ID for server %s", n.KubeNode.Name)
+			continue
+		}
+
+		serverID := id.String()
+		err = startstop.Stop(provider.Nova, serverID).ExtractErr()
+		if err != nil {
+			log.Warningf("Failed to shutdown server server %s, error: %v, continue handling...", serverID, err)
+		}
+
+		log.Infof("Marking Nova VM %s(Heat resource %s) unhealthy for Heat stack %s", serverID, allMapping[serverID].ResourceID, cluster.StackID)
+
+		opts := stackresources.MarkUnhealthyOpts{
+			MarkUnhealthy:        true,
+			ResourceStatusReason: "Mark resource unhealthy by autohealing service",
+		}
+		err = stackresources.MarkUnhealthy(provider.Heat, allMapping[serverID].StackName, allMapping[serverID].StackID, allMapping[serverID].ResourceID, opts).ExtractErr()
+		if err != nil {
+			log.Errorf("failed to mark resource %s unhealthy, error: %v", serverID, err)
+		}
+	}
+
+	err = stacks.UpdatePatch(provider.Heat, clusterStackName, cluster.StackID, stacks.UpdateOpts{}).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("failed to update Heat stack to rebuild resources, error: %v", err)
+	}
+	log.Infof("Started Heat stack update to rebuild resources, cluster: %s, stack: %s", clusterName, cluster.StackID)
+
+	return nil
+}
+
+// Enabled decides if the repair should be triggered.
+// There are  two conditions that we disable the repair:
+// - The cluster admin disables the auto healing via OpenStack API.
+// - The Magnum cluster is not in stable status.
+func (provider OpenStackCloudProvider) Enabled() bool {
+	clusterName := provider.Config.ClusterName
+
+	cluster, err := clusters.Get(provider.Magnum, clusterName).Extract()
+	if err != nil {
+		log.Warningf("Failed to get the cluster %s, error: %v", clusterName, err)
+		return false
+	}
+
+	if _, isPresent := cluster.Labels[ClusterAutoHealingLabel]; !isPresent {
+		log.Infof("Autohealing is disalbed for cluster %s", clusterName)
+		return false
+	}
+	autoHealingEnabled, err := strconv.ParseBool(cluster.Labels[ClusterAutoHealingLabel])
+	if err != nil {
+		log.Warningf("Unexpected value for %s label in cluster %s", ClusterAutoHealingLabel, clusterName)
+		return false
+	}
+	if !autoHealingEnabled {
+		log.Infof("Autohealing is disalbed for cluster %s", clusterName)
+		return false
+	}
+
+	clusterStackName, err := provider.getStackName(cluster.StackID)
+	if err != nil {
+		log.Warningf("Failed to get the Heat stack ID for cluster %s, error: %v", clusterName, err)
+		return false
+	}
+	stack, err := stacks.Get(provider.Heat, clusterStackName, cluster.StackID).Extract()
+	if err != nil {
+		log.Warningf("Failed to get Heat stack %s for cluster %s, error: %v", cluster.StackID, clusterName, err)
+		return false
+	}
+
+	if statusesPreventingRepair.Has(stack.Status) {
+		log.Infof("Current cluster stack is in status %s, skip the repair", stack.Status)
+		return false
+	}
+
+	return true
+}

--- a/pkg/autohealing/cloudprovider/register/register.go
+++ b/pkg/autohealing/cloudprovider/register/register.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// register package is introduced in order to avoid circle imports between openstack and cloudprovider packages.
+package register
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+
+	"github.com/gophercloud/gophercloud"
+	gopenstack "github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/trusts"
+	netutil "k8s.io/apimachinery/pkg/util/net"
+	certutil "k8s.io/client-go/util/cert"
+
+	"k8s.io/cloud-provider-openstack/pkg/autohealing/cloudprovider"
+	"k8s.io/cloud-provider-openstack/pkg/autohealing/cloudprovider/openstack"
+	"k8s.io/cloud-provider-openstack/pkg/autohealing/config"
+)
+
+func registerOpenStack(cfg config.Config) (cloudprovider.CloudProvider, error) {
+	client, err := gopenstack.NewClient(cfg.OpenStack.AuthURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.OpenStack.CAFile != "" {
+		roots, err := certutil.NewPool(cfg.OpenStack.CAFile)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig := &tls.Config{}
+		tlsConfig.RootCAs = roots
+		client.HTTPClient.Transport = netutil.SetOldTransportDefaults(&http.Transport{TLSClientConfig: tlsConfig})
+	}
+
+	if cfg.OpenStack.TrustID != "" {
+		opts := cfg.ToV3AuthOptions()
+		authOptsExt := trusts.AuthOptsExt{
+			TrustID:            cfg.OpenStack.TrustID,
+			AuthOptionsBuilder: &opts,
+		}
+		err = gopenstack.AuthenticateV3(client, authOptsExt, gophercloud.EndpointOpts{})
+	} else {
+		err = gopenstack.Authenticate(client, cfg.ToAuthOptions())
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// get nova service client
+	var novaClient *gophercloud.ServiceClient
+	novaClient, err = gopenstack.NewComputeV2(client, gophercloud.EndpointOpts{
+		Region: cfg.OpenStack.Region,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to find Nova service endpoint in the region %s: %v", cfg.OpenStack.Region, err)
+	}
+
+	// get heat service client
+	var heatClient *gophercloud.ServiceClient
+	heatClient, err = gopenstack.NewOrchestrationV1(client, gophercloud.EndpointOpts{
+		Region: cfg.OpenStack.Region,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to find Heat service endpoint in the region %s: %v", cfg.OpenStack.Region, err)
+	}
+
+	// get magnum service client
+	var magnumClient *gophercloud.ServiceClient
+	magnumClient, err = gopenstack.NewContainerInfraV1(client, gophercloud.EndpointOpts{
+		Region: cfg.OpenStack.Region,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to find Magnum service endpoint in the region %s: %v", cfg.OpenStack.Region, err)
+	}
+
+	var p cloudprovider.CloudProvider
+	p = openstack.OpenStackCloudProvider{
+		Nova:   novaClient,
+		Heat:   heatClient,
+		Magnum: magnumClient,
+		Config: cfg,
+	}
+
+	return p, nil
+}
+
+func init() {
+	cloudprovider.RegisterCloudProvider(openstack.ProviderName, registerOpenStack)
+}

--- a/pkg/autohealing/cmd/root.go
+++ b/pkg/autohealing/cmd/root.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	goflag "flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"k8s.io/client-go/tools/leaderelection"
+	log "k8s.io/klog"
+
+	"k8s.io/cloud-provider-openstack/pkg/autohealing/config"
+	"k8s.io/cloud-provider-openstack/pkg/autohealing/controller"
+)
+
+var (
+	cfgFile string
+	conf    config.Config
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "magnum-auto-healer",
+	Short: "Auto healer for Kubernetes cluster.",
+	Long: "Auto healer is responsible for monitoring the nodes’ status periodically in the cloud environment, searching " +
+		"for unhealthy instances and triggering replacements when needed, maximizing the cluster’s efficiency and performance. " +
+		"OpenStack is supported by default.",
+
+	Run: func(cmd *cobra.Command, args []string) {
+		autohealer := controller.NewController(conf)
+
+		if !conf.LeaderElect {
+			autohealer.Start(context.TODO())
+			panic("unreachable")
+		}
+
+		lock, err := autohealer.GetLeaderElectionLock()
+		if err != nil {
+			log.Fatalf("failed to get resource lock for leader election, error: %v", err)
+		}
+
+		// Try and become the leader and start autohealing loops
+		leaderelection.RunOrDie(context.TODO(), leaderelection.LeaderElectionConfig{
+			Lock:          lock,
+			LeaseDuration: 20 * time.Second,
+			RenewDeadline: 15 * time.Second,
+			RetryPeriod:   5 * time.Second,
+			Callbacks: leaderelection.LeaderCallbacks{
+				OnStartedLeading: autohealer.Start,
+				OnStoppedLeading: func() {
+					log.Fatal("leaderelection lost")
+				},
+			},
+			Name: "k8s-auto-healer",
+		})
+
+		sigCh := make(chan os.Signal)
+		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+		<-sigCh
+	},
+}
+
+// Execute adds all child commands to the root command sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.kube_autohealer_config.yaml)")
+
+	log.InitFlags(nil)
+	goflag.CommandLine.Parse(nil)
+	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+}
+
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if cfgFile != "" {
+		// Use config file from the flag.
+		viper.SetConfigFile(cfgFile)
+	} else {
+		// Find home directory.
+		home, err := homedir.Dir()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		// Search config in home directory with name ".kube_autohealer_config" (without extension).
+		viper.AddConfigPath(home)
+		viper.SetConfigName(".kube_autohealer_config")
+	}
+
+	viper.AutomaticEnv() // read in environment variables that match
+
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err != nil {
+		log.Fatalf("Failed to read config file, error: %s", err)
+	}
+
+	log.Infof("Using config file %s", viper.ConfigFileUsed())
+
+	conf = config.NewConfig()
+	if err := viper.Unmarshal(&conf); err != nil {
+		log.Fatalf("Unable to decode the configuration, error: %v", err)
+	}
+	if conf.ClusterName == "" {
+		log.Fatal("cluster-name is required in the configuration.")
+	}
+}

--- a/pkg/autohealing/config/config.go
+++ b/pkg/autohealing/config/config.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
+)
+
+// Config struct contains ingress controller configuration
+type Config struct {
+	// (Optional) Emit an event without repairing nodes. Default: false
+	DryRun bool `mapstructure:"dry-run"`
+
+	// (Required) Cluster identifier
+	ClusterName string `mapstructure:"cluster-name"`
+
+	// (Optional) Cloud provider name. Default: openstack
+	CloudProvider string `mapstructure:"cloud-provider"`
+
+	// (Optional) Interval of the nodes monitoring check. Default: 30s
+	MonitorInterval time.Duration `mapstructure:"monitor-interval"`
+
+	// (Optional) If master nodes monitoring is enabled. Default: true
+	MasterMonitorEnabled bool `mapstructure:"master-monitor-enabled"`
+
+	// (Optional) If worker nodes monitoring is enabled. Default: true
+	WorkerMonitorEnabled bool `mapstructure:"worker-monitor-enabled"`
+
+	// (Optional) Kubernetes related configuration.
+	Kubernetes kubeConfig `mapstructure:"kubernetes"`
+
+	// (Required) OpenStack related configuration.
+	OpenStack osConfig `mapstructure:"openstack"`
+
+	// (Optional) Healthcheck configuration for master and worker.
+	HealthCheck healthCheck `mapstructure:"healthcheck"`
+
+	// (Optional) Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability. Default: true
+	LeaderElect bool `mapstructure:"leader-elect"`
+
+	// (Optional) How long after new node added that the node will be checked for health status. Default: 10m
+	CheckDelayAfterAdd time.Duration `mapstructure:"check-delay-after-add"`
+}
+
+type healthCheck struct {
+	Master []Check `mapstructure:"master"`
+	Worker []Check `mapstructure:"worker"`
+}
+
+type Check struct {
+	// (Required) Health check plugin type.
+	Type string `mapstructure:"type"`
+
+	// (Required) Customized health check parameters defined by individual health check plugin.
+	Params map[string]interface{} `mapstructure:"params"`
+}
+
+// Configuration for connecting to Kubernetes API server, either api_host or kubeconfig should be configured.
+type kubeConfig struct {
+	// (Optional) Kubernetes API server host address.
+	ApiserverHost string `mapstructure:"api-host"`
+
+	// (Optional) Kubeconfig file used to connect to Kubernetes cluster.
+	KubeConfig string `mapstructure:"kubeconfig"`
+}
+
+// OpenStack credentials configuration, the section is required.
+type osConfig struct {
+	Username   string
+	UserID     string `mapstructure:"user-id"`
+	TrustID    string `mapstructure:"trust-id"`
+	Password   string
+	ProjectID  string `mapstructure:"project-id"`
+	AuthURL    string `mapstructure:"auth-url"`
+	Region     string
+	DomainID   string `mapstructure:"domain-id"`
+	DomainName string `mapstructure:"domain-name"`
+	CAFile     string `mapstructure:"ca-file"`
+}
+
+// ToAuthOptions gets openstack auth options
+func (cfg Config) ToAuthOptions() gophercloud.AuthOptions {
+	return gophercloud.AuthOptions{
+		IdentityEndpoint: cfg.OpenStack.AuthURL,
+		Username:         cfg.OpenStack.Username,
+		UserID:           cfg.OpenStack.UserID,
+		Password:         cfg.OpenStack.Password,
+		TenantID:         cfg.OpenStack.ProjectID,
+		DomainID:         cfg.OpenStack.DomainID,
+		DomainName:       cfg.OpenStack.DomainName,
+		AllowReauth:      true,
+	}
+}
+
+func (cfg Config) ToV3AuthOptions() tokens.AuthOptions {
+	return tokens.AuthOptions{
+		IdentityEndpoint: cfg.OpenStack.AuthURL,
+		Username:         cfg.OpenStack.Username,
+		UserID:           cfg.OpenStack.UserID,
+		Password:         cfg.OpenStack.Password,
+		DomainID:         cfg.OpenStack.DomainID,
+		DomainName:       cfg.OpenStack.DomainName,
+		AllowReauth:      true,
+	}
+}
+
+// NewConfig defines the default values for Config
+func NewConfig() Config {
+	return Config{
+		DryRun:               false,
+		CloudProvider:        "openstack",
+		MonitorInterval:      30 * time.Second,
+		MasterMonitorEnabled: true,
+		WorkerMonitorEnabled: true,
+		LeaderElect:          true,
+		CheckDelayAfterAdd:   10 * time.Minute,
+	}
+}

--- a/pkg/autohealing/controller/controller.go
+++ b/pkg/autohealing/controller/controller.go
@@ -1,0 +1,398 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/tools/record"
+	log "k8s.io/klog"
+
+	"k8s.io/cloud-provider-openstack/pkg/autohealing/cloudprovider"
+	_ "k8s.io/cloud-provider-openstack/pkg/autohealing/cloudprovider/register"
+	"k8s.io/cloud-provider-openstack/pkg/autohealing/config"
+	"k8s.io/cloud-provider-openstack/pkg/autohealing/healthcheck"
+)
+
+// EventType type of event associated with an informer
+type EventType string
+
+const (
+	// High enough QPS to fit all expected use cases. QPS=0 is not set here, because
+	// client code is overriding it.
+	defaultQPS = 1e6
+	// High enough Burst to fit all expected use cases. Burst=0 is not set here, because
+	// client code is overriding it.
+	defaultBurst = 1e6
+
+	// CreateEvent event associated with new objects in an informer
+	CreateEvent EventType = "CREATE"
+	// UpdateEvent event associated with an object update in an informer
+	UpdateEvent EventType = "UPDATE"
+	// DeleteEvent event associated when an object is removed from an informer
+	DeleteEvent EventType = "DELETE"
+
+	// LabelNodeRoleMaster specifies that a node is a master
+	// Related discussion: https://github.com/kubernetes/kubernetes/pull/39112
+	LabelNodeRoleMaster = "node-role.kubernetes.io/master"
+)
+
+// Event holds the context of an event
+type Event struct {
+	Type EventType
+	Obj  interface{}
+}
+
+func createKubeClients(apiserverHost string, kubeConfig string) (*kubernetes.Clientset, *kubernetes.Clientset, error) {
+	cfg, err := clientcmd.BuildConfigFromFlags(apiserverHost, kubeConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cfg.QPS = defaultQPS
+	cfg.Burst = defaultBurst
+	cfg.ContentType = "application/vnd.kubernetes.protobuf"
+	cfg.Timeout = 5 * time.Second
+
+	log.V(4).Info("Creating kubernetes API clients")
+
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	leaderElectionClient, err := kubernetes.NewForConfig(restclient.AddUserAgent(cfg, "leader-election"))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	v, err := client.Discovery().ServerVersion()
+	if err != nil {
+		return nil, nil, err
+	}
+	log.V(4).Infof("Kubernetes API client created, server version: %s", fmt.Sprintf("v%v.%v", v.Major, v.Minor))
+
+	return client, leaderElectionClient, nil
+}
+
+// NewController creates a new autohealer controller.
+func NewController(conf config.Config) *Controller {
+	// initialize cloud provider
+	provider, err := cloudprovider.GetCloudProvider(conf.CloudProvider, conf)
+	if err != nil {
+		log.Fatalf("Failed to get the cloud provider %s: %v", conf.CloudProvider, err)
+	}
+
+	log.Infof("Using cloud provider: %s", provider.GetName())
+
+	// initialize k8s clients
+	kubeClient, leaderElectionClient, err := createKubeClients(conf.Kubernetes.ApiserverHost, conf.Kubernetes.KubeConfig)
+	if err != nil {
+		log.Fatalf("failed to initialize kubernetes client, error: %v", err)
+	}
+
+	// event
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(log.V(4).Infof)
+	eventBroadcaster.StartRecordingToSink(&typev1.EventSinkImpl{
+		Interface: kubeClient.CoreV1().Events(""),
+	})
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, apiv1.EventSource{Component: "openstack-ingress-controller"})
+
+	// Initialize the configured health checkers
+	var workerCheckers []healthcheck.HealthCheck
+	var masterCheckers []healthcheck.HealthCheck
+	for _, item := range conf.HealthCheck.Worker {
+		checker, err := healthcheck.GetHealthChecker(item.Type, item.Params)
+		if err != nil {
+			log.Fatalf("failed to get %s type health check for worker node, error: %v", item.Type, err)
+		}
+		if !checker.IsWorkerSupported() {
+			log.Warningf("Plugin type %s does not support worker node health check, will skip", item.Type)
+			continue
+		}
+		workerCheckers = append(workerCheckers, checker)
+	}
+	for _, item := range conf.HealthCheck.Master {
+		checker, err := healthcheck.GetHealthChecker(item.Type, item.Params)
+		if err != nil {
+			log.Fatalf("failed to get %s type health check for master node, error: %v", item.Type, err)
+		}
+		if !checker.IsMasterSupported() {
+			log.Warningf("Plugin type %s does not support master node health check, will skip", item.Type)
+			continue
+		}
+		masterCheckers = append(masterCheckers, checker)
+	}
+
+	controller := &Controller{
+		config:               conf,
+		recorder:             recorder,
+		provider:             provider,
+		kubeClient:           kubeClient,
+		leaderElectionClient: leaderElectionClient,
+		masterCheckers:       masterCheckers,
+		workerCheckers:       workerCheckers,
+	}
+
+	return controller
+}
+
+// Controller ...
+type Controller struct {
+	provider             cloudprovider.CloudProvider
+	recorder             record.EventRecorder
+	kubeClient           kubernetes.Interface
+	leaderElectionClient kubernetes.Interface
+	config               config.Config
+	workerCheckers       []healthcheck.HealthCheck
+	masterCheckers       []healthcheck.HealthCheck
+}
+
+// UpdateNodeAnnotation updates the specified node annotation, if value equals empty string, the annotation will be
+// removed. This implements the interface healthcheck.NodeController
+func (c *Controller) UpdateNodeAnnotation(node healthcheck.NodeInfo, annotation string, value string) error {
+	n, err := c.kubeClient.CoreV1().Nodes().Get(node.KubeNode.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if value == "" {
+		delete(n.Annotations, annotation)
+	} else {
+		n.Annotations[annotation] = value
+	}
+
+	if _, err := c.kubeClient.CoreV1().Nodes().Update(n); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Controller) GetLeaderElectionLock() (resourcelock.Interface, error) {
+	// Identity used to distinguish between multiple cloud controller manager instances
+	id, err := os.Hostname()
+	if err != nil {
+		return nil, err
+	}
+	// add a uniquifier so that two processes on the same host don't accidentally both become active
+	id = id + "_" + string(uuid.NewUUID())
+
+	rl, err := resourcelock.New(
+		"configmaps",
+		"kube-system",
+		"magnum-auto-healer",
+		c.leaderElectionClient.CoreV1(),
+		c.leaderElectionClient.CoordinationV1(),
+		resourcelock.ResourceLockConfig{
+			Identity:      id,
+			EventRecorder: c.recorder,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	return rl, nil
+}
+
+// getUnhealthyMasterNodes returns the master nodes that need to be repaired.
+func (c *Controller) getUnhealthyMasterNodes() ([]healthcheck.NodeInfo, error) {
+	var nodes []healthcheck.NodeInfo
+
+	// If no checkers defined, skip
+	if len(c.masterCheckers) == 0 {
+		log.Info("No health check defined for master node, skip.")
+		return nodes, nil
+	}
+
+	// Get all the master nodes need to check
+	nodeList, err := c.kubeClient.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for _, node := range nodeList.Items {
+		if _, hasMasterRoleLabel := node.Labels[LabelNodeRoleMaster]; hasMasterRoleLabel {
+			if time.Now().Before(node.ObjectMeta.GetCreationTimestamp().Add(c.config.CheckDelayAfterAdd)) {
+				log.V(4).Infof("The node %s is created less than the configured check delay, skip", node.Name)
+				continue
+			}
+
+			nodes = append(nodes, healthcheck.NodeInfo{KubeNode: node})
+		}
+	}
+
+	// Do health check
+	unhealthyNodes := healthcheck.CheckNodes(c.masterCheckers, nodes, c)
+
+	return unhealthyNodes, nil
+}
+
+// getUnhealthyWorkerNodes returns the nodes that need to be repaired.
+func (c *Controller) getUnhealthyWorkerNodes() ([]healthcheck.NodeInfo, error) {
+	var nodes []healthcheck.NodeInfo
+
+	// If no checkers defined, skip.
+	if len(c.workerCheckers) == 0 {
+		log.Info("No health check defined for worker node, skip.")
+		return nodes, nil
+	}
+
+	// Get all the worker nodes.
+	nodeList, err := c.kubeClient.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for _, node := range nodeList.Items {
+		if _, hasMasterRoleLabel := node.Labels[LabelNodeRoleMaster]; hasMasterRoleLabel {
+			continue
+		}
+		if len(node.Status.Conditions) == 0 {
+			continue
+		}
+		if time.Now().Before(node.ObjectMeta.GetCreationTimestamp().Add(c.config.CheckDelayAfterAdd)) {
+			log.V(4).Infof("The node %s is created less than the configured check delay, skip", node.Name)
+			continue
+		}
+		nodes = append(nodes, healthcheck.NodeInfo{KubeNode: node})
+	}
+
+	// Do health check
+	unhealthyNodes := healthcheck.CheckNodes(c.workerCheckers, nodes, c)
+
+	return unhealthyNodes, nil
+}
+
+func (c *Controller) repairNodes(unhealthyNodes []healthcheck.NodeInfo) {
+	unhealthyNodeNames := sets.NewString()
+	for _, n := range unhealthyNodes {
+		unhealthyNodeNames.Insert(n.KubeNode.Name)
+	}
+
+	// Trigger unhealthy nodes repair.
+	if len(unhealthyNodes) > 0 {
+		if !c.provider.Enabled() {
+			// The cloud provider doesn't allow to trigger node repair.
+			log.Infof("Auto healing is ignored for nodes %s", unhealthyNodeNames.List())
+		} else {
+			log.Infof("Starting to repair nodes %s, dryrun: %t", unhealthyNodeNames.List(), c.config.DryRun)
+
+			if !c.config.DryRun {
+				// Cordon the nodes before repair.
+				for _, node := range unhealthyNodes {
+					nodeName := node.KubeNode.Name
+					newNode := node.KubeNode.DeepCopy()
+					newNode.Spec.Unschedulable = true
+
+					if _, err := c.kubeClient.CoreV1().Nodes().Update(newNode); err != nil {
+						log.Errorf("Failed to cordon node %s, error: %v", nodeName, err)
+					} else {
+						log.Infof("Node %s is cordoned", nodeName)
+					}
+
+					// TODO: Deal with the situation that the autohealer is running on a failed node
+				}
+
+				// Start to repair all the unhealthy nodes.
+				if err := c.provider.Repair(unhealthyNodes); err != nil {
+					log.Errorf("Failed to repair the nodes %s, error: %v", unhealthyNodeNames.List(), err)
+				}
+			}
+		}
+	}
+}
+
+// startMasterMonitor checks if there are failed master nodes and triggers the repair action. This function is supposed
+// to be running in a goroutine.
+func (c *Controller) startMasterMonitor(wg *sync.WaitGroup) {
+	log.V(4).Info("Starting to check master nodes.")
+	defer wg.Done()
+
+	// Get all the unhealthy master nodes.
+	unhealthyNodes, err := c.getUnhealthyMasterNodes()
+	if err != nil {
+		log.Errorf("Failed to get unhealthy master nodes, error: %v", err)
+		return
+	}
+
+	c.repairNodes(unhealthyNodes)
+
+	if len(unhealthyNodes) == 0 {
+		log.Info("Master nodes are healthy")
+	}
+	log.V(4).Info("Finished checking master nodes.")
+}
+
+// startWorkerMonitor checks if there are failed worker nodes and triggers the repair action. This function is supposed
+// to be running in a goroutine.
+func (c *Controller) startWorkerMonitor(wg *sync.WaitGroup) {
+	log.V(4).Info("Starting to check worker nodes.")
+	defer wg.Done()
+
+	// Get all the unhealthy worker nodes.
+	unhealthyNodes, err := c.getUnhealthyWorkerNodes()
+	if err != nil {
+		log.Errorf("Failed to get unhealthy worker nodes, error: %v", err)
+		return
+	}
+
+	c.repairNodes(unhealthyNodes)
+
+	if len(unhealthyNodes) == 0 {
+		log.Info("Worker nodes are healthy")
+	}
+
+	log.V(4).Info("Finished checking worker nodes.")
+}
+
+// Start starts the autohealing controller.
+func (c *Controller) Start(ctx context.Context) {
+	log.Info("Starting autohealing controller")
+
+	ticker := time.NewTicker(c.config.MonitorInterval)
+	defer ticker.Stop()
+
+	var wg sync.WaitGroup
+	for {
+		select {
+		case <-ticker.C:
+			if c.config.MasterMonitorEnabled {
+				wg.Add(1)
+				go c.startMasterMonitor(&wg)
+			}
+			if c.config.WorkerMonitorEnabled {
+				wg.Add(1)
+				go c.startWorkerMonitor(&wg)
+			}
+
+			wg.Wait()
+		}
+	}
+}

--- a/pkg/autohealing/healthcheck/healthcheck.go
+++ b/pkg/autohealing/healthcheck/healthcheck.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthcheck
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	log "k8s.io/klog"
+)
+
+var (
+	checkPlugins = make(map[string]registerPlugin)
+)
+
+type registerPlugin func(config interface{}) (HealthCheck, error)
+
+// NodeInfo is a wrapper of Node, may contains more information in future.
+type NodeInfo struct {
+	KubeNode apiv1.Node
+}
+
+type HealthCheck interface {
+	// Check checks the node health, returns false if the node is unhealthy. The plugin should deal with any error happened.
+	Check(node NodeInfo, controller NodeController) bool
+
+	// IsMasterSupported checks if the health check plugin supports master node.
+	IsMasterSupported() bool
+
+	// IsWorkerSupported checks if the health check plugin supports worker node.
+	IsWorkerSupported() bool
+}
+
+// The purpose of NodeController is to avoid circle reference.
+type NodeController interface {
+	// UpdateNodeAnnotation updates the specified node annotation, if value equals empty string, the annotation will be
+	// removed.
+	UpdateNodeAnnotation(node NodeInfo, annotation string, value string) error
+}
+
+func registerHealthCheck(name string, register registerPlugin) {
+	if _, found := checkPlugins[name]; found {
+		log.Fatalf("Health check plugin %s is already registered.", name)
+	}
+
+	log.Infof("Registered health check plugin %s", name)
+	checkPlugins[name] = register
+}
+
+func GetHealthChecker(name string, config interface{}) (HealthCheck, error) {
+	c, found := checkPlugins[name]
+	if !found {
+		return nil, nil
+	}
+	return c(config)
+}
+
+// CheckNodes goes through the health checkers, returns the unhealthy nodes.
+func CheckNodes(checkers []HealthCheck, nodes []NodeInfo, controller NodeController) []NodeInfo {
+	var unhealthyNodes []NodeInfo
+
+	// Check the health for each node.
+	for _, node := range nodes {
+		for _, checker := range checkers {
+			if !checker.Check(node, controller) {
+				unhealthyNodes = append(unhealthyNodes, node)
+				break
+			}
+		}
+	}
+
+	return unhealthyNodes
+}

--- a/pkg/autohealing/healthcheck/plugin_endpoint.go
+++ b/pkg/autohealing/healthcheck/plugin_endpoint.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthcheck
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+	log "k8s.io/klog"
+
+	"k8s.io/cloud-provider-openstack/pkg/autohealing/utils"
+)
+
+const (
+	EndpointType = "Endpoint"
+	TokenPath    = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	TimeLayout   = "2006-01-02 15:04:05"
+)
+
+type EndpointCheck struct {
+	// (Optional) URL scheme, case insensitive, e.g. HTTP, HTTPS. Default: ["HTTPS"].
+	Protocol string `mapstructure:"protocol"`
+
+	// (Optional) Service port. Default: 6443
+	Port int `mapstructure:"port"`
+
+	// (Optional) The endpoints for health check. Default: ["/healthz"].
+	Endpoints []string `mapstructure:"endpoints"`
+
+	// (Optional) How long to wait before a unhealthy worker node should be repaired. Default: 300s
+	UnhealthyDuration time.Duration `mapstructure:"unhealthyDuration"`
+
+	// (Optional) The node annotation which records the node unhealthy time. Default: autohealing.openstack.org/unhealthy-timestamp
+	UnhealthyAnnotation string `mapstructure:"unhealthyAnnotation"`
+
+	// (Optional) The accepted HTTP response codes. Default: [200].
+	OKCodes []int `mapstructure:"okCodes"`
+
+	// (Optional) If token is required to access the endpoint. Default: false
+	RequireToken bool `mapstructure:"requireToken"`
+
+	// (Optional) Token to use in the request header. Default: read from TokenPath file
+	Token string `mapstructure:"token"`
+}
+
+// IsMasterSupported checks if the health check plugin supports master node.
+func (check *EndpointCheck) IsMasterSupported() bool {
+	return true
+}
+
+// IsWorkerSupported checks if the health check plugin supports worker node.
+func (check *EndpointCheck) IsWorkerSupported() bool {
+	return false
+}
+
+// checkDuration checks if the node should be marked as healthy or not.
+func (check *EndpointCheck) checkDuration(node NodeInfo, controller NodeController, checkRet bool) bool {
+	name := node.KubeNode.Name
+
+	if checkRet {
+		// Remove the annotation
+		if err := controller.UpdateNodeAnnotation(node, check.UnhealthyAnnotation, ""); err != nil {
+			log.Errorf("Failed to remove the node annotation(will skip the check) for %s, error: %v", name, err)
+		}
+		return true
+	}
+
+	now := time.Now()
+	var unhealthyStartTime *time.Time
+
+	// Get the current annotation value
+	if timeStr, isPresent := node.KubeNode.Annotations[check.UnhealthyAnnotation]; isPresent {
+		if timeStr != "" {
+			startTime, err := time.Parse(TimeLayout, timeStr)
+			if err != nil {
+				unhealthyStartTime = nil
+			} else {
+				unhealthyStartTime = &startTime
+			}
+		}
+	}
+
+	if unhealthyStartTime == nil {
+		// Set the annotation value
+		if err := controller.UpdateNodeAnnotation(node, check.UnhealthyAnnotation, now.Format(TimeLayout)); err != nil {
+			log.Errorf("Failed to set the node annotation(will skip the check) for %s, error: %v", name, err)
+		}
+		return true
+	}
+
+	if now.Sub(*unhealthyStartTime) >= check.UnhealthyDuration {
+		// Need repair
+		return false
+	} else {
+		// Keep the annotation value
+		return true
+	}
+}
+
+// Check checks the node health, returns false if the node is unhealthy. Update the node cache accordingly.
+func (check *EndpointCheck) Check(node NodeInfo, controller NodeController) bool {
+	nodeName := node.KubeNode.Name
+	ip := ""
+	for _, addr := range node.KubeNode.Status.Addresses {
+		if addr.Type == "InternalIP" {
+			ip = addr.Address
+			break
+		}
+	}
+
+	if ip == "" {
+		log.Warningf("Cannot find IP address for node %s, skip the check", nodeName)
+		return true
+	}
+
+	var client *http.Client
+	protocol := strings.ToLower(check.Protocol)
+	if protocol == "https" {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client = &http.Client{Transport: tr, Timeout: time.Second * 5}
+	} else if protocol == "http" {
+		client = &http.Client{Timeout: time.Second * 5}
+	}
+
+	for _, endpoint := range check.Endpoints {
+		url := fmt.Sprintf("%s://%s:%d/%s", strings.ToLower(check.Protocol), ip, check.Port, strings.TrimLeft(endpoint, "/"))
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			log.Errorf("Node %s, failed to get request %s, error: %v", nodeName, url, err)
+			return check.checkDuration(node, controller, false)
+		}
+
+		if check.RequireToken {
+			if check.Token == "" {
+				b, err := ioutil.ReadFile(TokenPath)
+				if err != nil {
+					log.Warningf("Node %s, failed to get token from %s, skip the check", nodeName, TokenPath)
+					return true
+				}
+				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", string(b)))
+			} else {
+				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", check.Token))
+			}
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			log.Errorf("Node %s, failed to read response for url %s, error: %v", nodeName, url, err)
+			return check.checkDuration(node, controller, false)
+		}
+		resp.Body.Close()
+
+		if !utils.ContainsInt(check.OKCodes, resp.StatusCode) {
+			log.V(4).Infof("Node %s, return code for url %s is %d, expected: %d", nodeName, url, resp.StatusCode, check.OKCodes)
+			return check.checkDuration(node, controller, false)
+		}
+	}
+
+	return check.checkDuration(node, controller, true)
+}
+
+func newEndpointCheck(config interface{}) (HealthCheck, error) {
+	check := EndpointCheck{
+		Protocol:            "https",
+		Port:                6443,
+		UnhealthyDuration:   300 * time.Second,
+		Endpoints:           []string{"/healthz"},
+		OKCodes:             []int{200},
+		RequireToken:        false,
+		UnhealthyAnnotation: "autohealing.openstack.org/unhealthy-timestamp",
+	}
+
+	decConfig := mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.StringToTimeDurationHookFunc(),
+		Result:     &check,
+	}
+	decoder, err := mapstructure.NewDecoder(&decConfig)
+	if err != nil {
+		return nil, err
+	}
+	err = decoder.Decode(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get configuration for health check plugin %s, error: %v", NodeConditionType, err)
+	}
+
+	return &check, nil
+}
+
+func init() {
+	registerHealthCheck(EndpointType, newEndpointCheck)
+}

--- a/pkg/autohealing/healthcheck/plugin_nodecondition.go
+++ b/pkg/autohealing/healthcheck/plugin_nodecondition.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthcheck
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+	log "k8s.io/klog"
+
+	"k8s.io/cloud-provider-openstack/pkg/autohealing/utils"
+)
+
+const (
+	NodeConditionType = "NodeCondition"
+)
+
+type NodeConditionCheck struct {
+	// (Optional) The condition types(case sensitive) specified in Node.spec.status.conditions items. Default: ["Ready"].
+	Types []string `mapstructure:"types"`
+
+	// (Optional) How long to wait before a unhealthy worker node should be repaired. Default: 300s
+	UnhealthyDuration time.Duration `mapstructure:"unhealthyDuration"`
+
+	// (Optional) The accepted healthy values(case sensitive) for the type. Default: ["True"]. OKValues could not be used together with ErrorValues.
+	OKValues []string `mapstructure:"okValues"`
+
+	// (Optional) The unhealthy values(case sensitive) for the type. Default: []. ErrorValues could not be used together with OKValues.
+	ErrorValues []string `mapstructure:"errorValues"`
+}
+
+// Check checks the node health, returns false if the node is unhealthy.
+func (check *NodeConditionCheck) Check(node NodeInfo, controller NodeController) bool {
+	nodeName := node.KubeNode.Name
+
+	for _, cond := range node.KubeNode.Status.Conditions {
+		if utils.Contains(check.Types, string(cond.Type)) {
+			unhealthyDuration := time.Now().Sub(cond.LastTransitionTime.Time)
+
+			if len(check.ErrorValues) > 0 {
+				if utils.Contains(check.ErrorValues, string(cond.Status)) {
+					if unhealthyDuration >= check.UnhealthyDuration {
+						return false
+					} else {
+						log.Warningf("Node %s is unhealthy, %s: %s", nodeName, string(cond.Type), string(cond.Status))
+					}
+				}
+			} else if len(check.OKValues) > 0 {
+				if !utils.Contains(check.OKValues, string(cond.Status)) {
+					if unhealthyDuration >= check.UnhealthyDuration {
+						return false
+					} else {
+						log.Warningf("Node %s is unhealthy, %s: %s", nodeName, string(cond.Type), string(cond.Status))
+					}
+				}
+			}
+		}
+	}
+
+	return true
+}
+
+// IsMasterSupported checks if the health check plugin supports master node.
+func (check *NodeConditionCheck) IsMasterSupported() bool {
+	return true
+}
+
+// IsWorkerSupported checks if the health check plugin supports worker node.
+func (check *NodeConditionCheck) IsWorkerSupported() bool {
+	return true
+}
+
+func newNodeConditionCheck(config interface{}) (HealthCheck, error) {
+	check := NodeConditionCheck{
+		UnhealthyDuration: 300 * time.Second,
+		Types:             []string{"Ready"},
+		OKValues:          []string{"True"},
+	}
+
+	decConfig := mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.StringToTimeDurationHookFunc(),
+		Result:     &check,
+	}
+	decoder, err := mapstructure.NewDecoder(&decConfig)
+	if err != nil {
+		return nil, err
+	}
+	err = decoder.Decode(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get configuration for health check plugin %s, error: %v", NodeConditionType, err)
+	}
+
+	return &check, nil
+}
+
+func init() {
+	registerHealthCheck(NodeConditionType, newNodeConditionCheck)
+}

--- a/pkg/autohealing/utils/utils.go
+++ b/pkg/autohealing/utils/utils.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+// Contains searches if a string list contains the given string or not.
+func Contains(list []string, strToSearch string) bool {
+	for _, item := range list {
+		if item == strToSearch {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsInt searches if a int list contains the given int or not.
+func ContainsInt(list []int, toSearch int) bool {
+	for _, item := range list {
+		if item == toSearch {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add k8s-auto-healer for the Kubernetes cluster running on top of cloud environment, OpenStack is the default cloud provider implementation.

k8s-auto-healer ensures that the running Kubernetes nodes are healthy by monitoring the nodes’ status periodically, searching for unhealthy instances and triggering replacements when needed, maximizing your cluster’s efficiency and performance.

The cluster provider and health check mechanism are both pluggable and easy to integrate with other clouds and customized health check approaches.

For the openstack cloud provider:
- Only the Magnum cluster is supported, doesn't support the Kubernetes cluster created in other ways(kops, cluster-api, kubeadm, etc.)
- Auto-healing is achieved via Heat stack update, which replaces the unhealthy resources with new ones.

**Which issue this PR fixes**: fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
```
