### PR TITLE
keystone-webhook-documentation: Use consistent names for ConfigMap

### DIFF
--- a/docs/using-keystone-webhook-authenticator-and-authorizer.md
+++ b/docs/using-keystone-webhook-authenticator-and-authorizer.md
@@ -67,7 +67,7 @@ data:
         "match": [
           {
             "type": "role",
-            "values": ["memberr"]
+            "values": ["member"]
           },
           {
             "type": "project",
@@ -86,7 +86,7 @@ $ cat <<EOF > /etc/kubernetes/keystone-auth/policy-config.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: keystone-auth-policy
+  name: k8s-auth-policy
   namespace: kube-system
 data:
   policies: |
@@ -317,7 +317,7 @@ spec:
             - --tls-private-key-file
             - /etc/kubernetes/pki/key-file
             - --policy-configmap-name
-            - keystone-auth-policy
+            - k8s-auth-policy
             - --keystone-url
             - ${keystone_auth_url}
             - --v
@@ -757,8 +757,8 @@ contexts:
 - context:
     cluster: mycluster
     user: openstackuser
-  name: openstackuser@kubernetes
-current-context: default
+  name: openstackuser@mycluster
+current-context: openstackuser@mycluster
 kind: Config
 preferences: {}
 users:


### PR DESCRIPTION
* Fix some typos

**What this PR does / why we need it**:
Documentation update: I ran into some issues following the documentation, because the name of the ConfigMap used was inconsistent.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes the name of the ConfigMap so it's consistent across the whole document, and some small typos.
