### PR TITLE
Add more information to gophercloud user-agent string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
                  git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
 GOFLAGS   :=
 TAGS      :=
-LDFLAGS   := "-w -s -X 'main.version=${VERSION}'"
+LDFLAGS   := "-w -s -X 'k8s.io/cloud-provider-openstack/pkg/version.Version=${VERSION}'"
 REGISTRY ?= k8scloudprovider
 
 ifneq ("$(DEST)", "$(PWD)")

--- a/cmd/cinder-csi-plugin/main.go
+++ b/cmd/cinder-csi-plugin/main.go
@@ -84,6 +84,8 @@ func main() {
 
 	cmd.PersistentFlags().StringVar(&cluster, "cluster", "", "The identifier of the cluster that the plugin is running in.")
 
+	openstack.AddExtraFlags(pflag.CommandLine)
+
 	logs.InitLogs()
 	defer logs.FlushLogs()
 

--- a/cmd/cinder-provisioner/main.go
+++ b/cmd/cinder-provisioner/main.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/cloud-provider-openstack/pkg/version"
 	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/provisioner"
+	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/volumeservice"
 	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -45,6 +46,8 @@ func main() {
 	pflag.StringVar(&kubeconfig, "kubeconfig", "", "Absolute path to the kubeconfig")
 	pflag.StringVar(&id, "id", "", "Unique provisioner identity")
 	pflag.StringVar(&cloudconfig, "cloud-config", "", "Path to OpenStack config file")
+
+	volumeservice.AddExtraFlags(pflag.CommandLine)
 
 	// Glog requires this otherwise it complains.
 	flag.CommandLine.Parse(nil)

--- a/cmd/cinder-provisioner/main.go
+++ b/cmd/cinder-provisioner/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/klog"
 
+	"k8s.io/cloud-provider-openstack/pkg/version"
 	"k8s.io/cloud-provider-openstack/pkg/volume/cinder/provisioner"
 	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 
@@ -37,7 +38,6 @@ var (
 	kubeconfig  string
 	id          string
 	cloudconfig string
-	version     string
 )
 
 func main() {
@@ -66,7 +66,7 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	klog.V(1).Infof("cinder-provisioner version: %s", version)
+	klog.V(1).Infof("cinder-provisioner version: %s", version.Version)
 
 	var config *rest.Config
 	var err error

--- a/cmd/k8s-keystone-auth/main.go
+++ b/cmd/k8s-keystone-auth/main.go
@@ -34,6 +34,8 @@ func main() {
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(klogFlags)
 
+	keystone.AddExtraFlags(pflag.CommandLine)
+
 	// Sync the glog and klog flags.
 	flag.CommandLine.VisitAll(func(f1 *flag.Flag) {
 		f2 := klogFlags.Lookup(f1.Name)

--- a/cmd/manila-csi-plugin/main.go
+++ b/cmd/manila-csi-plugin/main.go
@@ -17,7 +17,9 @@ limitations under the License.
 package main
 
 import (
-	"flag"
+	goflag "flag"
+
+	flag "github.com/spf13/pflag"
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila"
 	"k8s.io/klog"
 )
@@ -32,9 +34,10 @@ var (
 
 func main() {
 	klog.InitFlags(nil)
-	if err := flag.Set("logtostderr", "true"); err != nil {
+	if err := goflag.Set("logtostderr", "true"); err != nil {
 		klog.Exitf("failed to set logtostderr flag: %v", err)
 	}
+	manila.AddExtraFlags(flag.CommandLine)
 	flag.Parse()
 
 	d, err := manila.NewDriver(*nodeID, *driverName, *endpoint, *fwdEndpoint, *protoSelector)

--- a/cmd/manila-provisioner/main.go
+++ b/cmd/manila-provisioner/main.go
@@ -17,8 +17,9 @@ limitations under the License.
 package main
 
 import (
-	"flag"
+	goflag "flag"
 
+	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -36,11 +37,13 @@ var (
 func main() {
 	flag.Set("logtostderr", "true")
 
+	manila.AddExtraFlags(flag.CommandLine)
+
 	// Glog requires this otherwise it complains.
 	flag.Parse()
 	// This is a temporary hack to enable proper logging until upstream dependencies
 	// are migrated to fully utilize klog instead of glog.
-	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klogFlags := goflag.NewFlagSet("klog", goflag.ExitOnError)
 	klog.InitFlags(klogFlags)
 
 	// Sync the glog and klog flags.

--- a/cmd/openstack-cloud-controller-manager/main.go
+++ b/cmd/openstack-cloud-controller-manager/main.go
@@ -113,6 +113,8 @@ the cloud specific control loops shipped with Kubernetes.`,
 		fs.AddFlagSet(f)
 	}
 
+	openstack.AddExtraFlags(pflag.CommandLine)
+
 	// TODO: once we switch everything over to Cobra commands, we can go back to calling
 	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
 	// normalize func and add the go flag set by hand.

--- a/cmd/openstack-cloud-controller-manager/main.go
+++ b/cmd/openstack-cloud-controller-manager/main.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/cloud-provider"
 	"k8s.io/cloud-provider-openstack/pkg/cloudprovider/providers/openstack"
+	"k8s.io/cloud-provider-openstack/pkg/version"
 	"k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 	"k8s.io/klog"
@@ -52,8 +53,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
-
-var version string
 
 func init() {
 	mux := http.NewServeMux()
@@ -123,7 +122,7 @@ the cloud specific control loops shipped with Kubernetes.`,
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	klog.V(1).Infof("openstack-cloud-controller-manager version: %s", version)
+	klog.V(1).Infof("openstack-cloud-controller-manager version: %s", version.Version)
 
 	s.KubeCloudShared.CloudProvider.Name = openstack.ProviderName
 	if err := command.Execute(); err != nil {

--- a/pkg/autohealing/cloudprovider/register/register.go
+++ b/pkg/autohealing/cloudprovider/register/register.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/cloud-provider-openstack/pkg/autohealing/cloudprovider"
 	"k8s.io/cloud-provider-openstack/pkg/autohealing/cloudprovider/openstack"
 	"k8s.io/cloud-provider-openstack/pkg/autohealing/config"
+	"k8s.io/cloud-provider-openstack/pkg/version"
 )
 
 func registerOpenStack(cfg config.Config) (cloudprovider.CloudProvider, error) {
@@ -38,6 +39,10 @@ func registerOpenStack(cfg config.Config) (cloudprovider.CloudProvider, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	userAgent := gophercloud.UserAgent{}
+	userAgent.Prepend(fmt.Sprintf("magnum-auto-healer/%s", version.Version))
+	client.UserAgent = userAgent
 
 	if cfg.OpenStack.CAFile != "" {
 		roots, err := certutil.NewPool(cfg.OpenStack.CAFile)

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/pflag"
 	gcfg "gopkg.in/gcfg.v1"
 
 	v1 "k8s.io/api/core/v1"
@@ -50,6 +51,7 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	v1helper "k8s.io/cloud-provider-openstack/pkg/apis/core/v1/helper"
 	"k8s.io/cloud-provider-openstack/pkg/util/metadata"
+	"k8s.io/cloud-provider-openstack/pkg/version"
 	"k8s.io/klog"
 )
 
@@ -75,6 +77,14 @@ var ErrNoAddressFound = errors.New("no address found for host")
 // ErrIPv6SupportDisabled is used when one tries to use IPv6 Addresses when
 // IPv6 support is disabled by config
 var ErrIPv6SupportDisabled = errors.New("IPv6 support is disabled")
+
+// userAgentData is used to add extra information to the gophercloud user-agent
+var userAgentData []string
+
+// AddExtraFlags is called by the main package to add component specific command line flags
+func AddExtraFlags(fs *pflag.FlagSet) {
+	fs.StringArrayVar(&userAgentData, "user-agent", nil, "Extra data to add to gophercloud user-agent. Use multiple times to add more than one component.")
+}
 
 // MyDuration is the encoding.TextUnmarshaler interface for time.Duration
 type MyDuration struct {
@@ -453,6 +463,15 @@ func NewOpenStack(cfg Config) (*OpenStack, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	userAgent := gophercloud.UserAgent{}
+	userAgent.Prepend(fmt.Sprintf("openstack-cloud-controller-manager/%s", version.Version))
+	for _, data := range userAgentData {
+		userAgent.Prepend(data)
+	}
+	provider.UserAgent = userAgent
+	klog.V(4).Infof("Using user-agent %s", userAgent.Join())
+
 	if cfg.Global.CAFile != "" {
 		roots, err := certutil.NewPool(cfg.Global.CAFile)
 		if err != nil {

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -18,6 +18,7 @@ package openstack
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"os"
 
@@ -27,11 +28,21 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/trusts"
 	tokens3 "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
+	"github.com/spf13/pflag"
 	gcfg "gopkg.in/gcfg.v1"
 	netutil "k8s.io/apimachinery/pkg/util/net"
 	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/cloud-provider-openstack/pkg/version"
 	"k8s.io/klog"
 )
+
+// userAgentData is used to add extra information to the gophercloud user-agent
+var userAgentData []string
+
+// AddExtraFlags is called by the main package to add component specific command line flags
+func AddExtraFlags(fs *pflag.FlagSet) {
+	fs.StringArrayVar(&userAgentData, "user-agent", nil, "Extra data to add to gophercloud user-agent. Use multiple times to add more than one component.")
+}
 
 type IOpenStack interface {
 	CreateVolume(name string, size int, vtype, availability string, snapshotID string, tags *map[string]string) (*volumes.Volume, error)
@@ -196,6 +207,14 @@ func CreateOpenStackProvider() (IOpenStack, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	userAgent := gophercloud.UserAgent{}
+	userAgent.Prepend(fmt.Sprintf("cinder-csi-plugin/%s", version.Version))
+	for _, data := range userAgentData {
+		userAgent.Prepend(data)
+	}
+	provider.UserAgent = userAgent
+
 	if caFile != "" {
 		roots, err := certutil.NewPool(caFile)
 		if err != nil {

--- a/pkg/csi/cinder/openstack/openstack_test.go
+++ b/pkg/csi/cinder/openstack/openstack_test.go
@@ -18,10 +18,12 @@ package openstack
 
 import (
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -122,6 +124,43 @@ func TestGetConfigFromEnv(t *testing.T) {
 	// Assert
 	assert.Equal(expectedAuthOpts, actualAuthOpts)
 	assert.Equal(expectedEpOpts, actualEpOpts)
+}
+
+func TestUserAgentFlag(t *testing.T) {
+	tests := []struct {
+		name        string
+		shouldParse bool
+		flags       []string
+		expected    []string
+	}{
+		{"no_flag", true, []string{}, nil},
+		{"one_flag", true, []string{"--user-agent=cluster/abc-123"}, []string{"cluster/abc-123"}},
+		{"multiple_flags", true, []string{"--user-agent=a/b", "--user-agent=c/d"}, []string{"a/b", "c/d"}},
+		{"flag_with_space", true, []string{"--user-agent=a b"}, []string{"a b"}},
+		{"flag_split_with_space", true, []string{"--user-agent=a", "b"}, []string{"a"}},
+		{"empty_flag", false, []string{"--user-agent"}, nil},
+	}
+
+	for _, testCase := range tests {
+		userAgentData = []string{}
+
+		t.Run(testCase.name, func(t *testing.T) {
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			AddExtraFlags(fs)
+
+			err := fs.Parse(testCase.flags)
+
+			if testCase.shouldParse && err != nil {
+				t.Errorf("Flags failed to parse")
+			} else if !testCase.shouldParse && err == nil {
+				t.Errorf("Flags should not have parsed")
+			} else if testCase.shouldParse {
+				if !reflect.DeepEqual(userAgentData, testCase.expected) {
+					t.Errorf("userAgentData %#v did not match expected value %#v", userAgentData, testCase.expected)
+				}
+			}
+		})
+	}
 }
 
 func clearEnviron(t *testing.T) []string {

--- a/pkg/csi/manila/manilaclient_test.go
+++ b/pkg/csi/manila/manilaclient_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manila
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestUserAgentFlag(t *testing.T) {
+	tests := []struct {
+		name        string
+		shouldParse bool
+		flags       []string
+		expected    []string
+	}{
+		{"no_flag", true, []string{}, nil},
+		{"one_flag", true, []string{"--user-agent=cluster/abc-123"}, []string{"cluster/abc-123"}},
+		{"multiple_flags", true, []string{"--user-agent=a/b", "--user-agent=c/d"}, []string{"a/b", "c/d"}},
+		{"flag_with_space", true, []string{"--user-agent=a b"}, []string{"a b"}},
+		{"flag_split_with_space", true, []string{"--user-agent=a", "b"}, []string{"a"}},
+		{"empty_flag", false, []string{"--user-agent"}, nil},
+	}
+
+	for _, testCase := range tests {
+		userAgentData = []string{}
+
+		t.Run(testCase.name, func(t *testing.T) {
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			AddExtraFlags(fs)
+
+			err := fs.Parse(testCase.flags)
+
+			if testCase.shouldParse && err != nil {
+				t.Errorf("Flags failed to parse")
+			} else if !testCase.shouldParse && err == nil {
+				t.Errorf("Flags should not have parsed")
+			} else if testCase.shouldParse {
+				if !reflect.DeepEqual(userAgentData, testCase.expected) {
+					t.Errorf("userAgentData %#v did not match expected value %#v", userAgentData, testCase.expected)
+				}
+			}
+		})
+	}
+}

--- a/pkg/flexvolume/cinder_client.go
+++ b/pkg/flexvolume/cinder_client.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
 	gcfg "gopkg.in/gcfg.v1"
 	openstack_provider "k8s.io/cloud-provider-openstack/pkg/cloudprovider/providers/openstack"
+	"k8s.io/cloud-provider-openstack/pkg/version"
 	"k8s.io/klog"
 )
 
@@ -85,6 +86,10 @@ func newCinderClient(configFile string) (*cinderClient, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	userAgent := gophercloud.UserAgent{}
+	userAgent.Prepend(fmt.Sprintf("cinder-flex-volume-driver/%s", version.Version))
+	provider.UserAgent = userAgent
 
 	client, err := openstack.NewBlockStorageV2(provider, gophercloud.EndpointOpts{
 		Region: cfg.Global.Region,

--- a/pkg/identity/keystone/keystone_test.go
+++ b/pkg/identity/keystone/keystone_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keystone
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestUserAgentFlag(t *testing.T) {
+	tests := []struct {
+		name        string
+		shouldParse bool
+		flags       []string
+		expected    []string
+	}{
+		{"no_flag", true, []string{}, nil},
+		{"one_flag", true, []string{"--user-agent=cluster/abc-123"}, []string{"cluster/abc-123"}},
+		{"multiple_flags", true, []string{"--user-agent=a/b", "--user-agent=c/d"}, []string{"a/b", "c/d"}},
+		{"flag_with_space", true, []string{"--user-agent=a b"}, []string{"a b"}},
+		{"flag_split_with_space", true, []string{"--user-agent=a", "b"}, []string{"a"}},
+		{"empty_flag", false, []string{"--user-agent"}, nil},
+	}
+
+	for _, testCase := range tests {
+		userAgentData = []string{}
+
+		t.Run(testCase.name, func(t *testing.T) {
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			AddExtraFlags(fs)
+
+			err := fs.Parse(testCase.flags)
+
+			if testCase.shouldParse && err != nil {
+				t.Errorf("Flags failed to parse")
+			} else if !testCase.shouldParse && err == nil {
+				t.Errorf("Flags should not have parsed")
+			} else if testCase.shouldParse {
+				if !reflect.DeepEqual(userAgentData, testCase.expected) {
+					t.Errorf("userAgentData %#v did not match expected value %#v", userAgentData, testCase.expected)
+				}
+			}
+		})
+	}
+}

--- a/pkg/identity/keystone/token_getter.go
+++ b/pkg/identity/keystone/token_getter.go
@@ -24,6 +24,7 @@ import (
 	tokens3 "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 	"io/ioutil"
 	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/cloud-provider-openstack/pkg/version"
 	"net/http"
 )
 
@@ -47,6 +48,10 @@ func GetToken(options Options) (*tokens3.Token, error) {
 	}
 	tlsConfig := &tls.Config{}
 	setTransport = false
+
+	userAgent := gophercloud.UserAgent{}
+	userAgent.Prepend(fmt.Sprintf("client-keystone-auth/%s", version.Version))
+	client.UserAgent = userAgent
 
 	if options.ClientCertPath != "" && options.ClientKeyPath != "" {
 		clientCert, err := ioutil.ReadFile(options.ClientCertPath)

--- a/pkg/ingress/controller/openstack/client.go
+++ b/pkg/ingress/controller/openstack/client.go
@@ -29,6 +29,7 @@ import (
 	netutil "k8s.io/apimachinery/pkg/util/net"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/cloud-provider-openstack/pkg/ingress/config"
+	"k8s.io/cloud-provider-openstack/pkg/version"
 )
 
 // OpenStack is an implementation of cloud provider Interface for OpenStack.
@@ -45,6 +46,10 @@ func NewOpenStack(cfg config.Config) (*OpenStack, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	userAgent := gophercloud.UserAgent{}
+	userAgent.Prepend(fmt.Sprintf("octavia-ingress-controller/%s", version.Version))
+	provider.UserAgent = userAgent
 
 	if cfg.OpenStack.CAFile != "" {
 		roots, err := certutil.NewPool(cfg.OpenStack.CAFile)

--- a/pkg/kms/barbican/barbican.go
+++ b/pkg/kms/barbican/barbican.go
@@ -1,9 +1,12 @@
 package barbican
 
 import (
+	"fmt"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/keymanager/v1/secrets"
+	"k8s.io/cloud-provider-openstack/pkg/version"
 	"k8s.io/klog"
 )
 
@@ -59,6 +62,10 @@ func newBarbicanClient(cfg Config) (client *gophercloud.ServiceClient, err error
 	if err != nil {
 		return nil, err
 	}
+
+	userAgent := gophercloud.UserAgent{}
+	userAgent.Prepend(fmt.Sprintf("barbican-kms-plugin/%s", version.Version))
+	provider.UserAgent = userAgent
 
 	client, err = openstack.NewKeyManagerV1(provider, gophercloud.EndpointOpts{
 		Region: cfg.Global.Region,

--- a/pkg/share/manila/client_test.go
+++ b/pkg/share/manila/client_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manila
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestUserAgentFlag(t *testing.T) {
+	tests := []struct {
+		name        string
+		shouldParse bool
+		flags       []string
+		expected    []string
+	}{
+		{"no_flag", true, []string{}, nil},
+		{"one_flag", true, []string{"--user-agent=cluster/abc-123"}, []string{"cluster/abc-123"}},
+		{"multiple_flags", true, []string{"--user-agent=a/b", "--user-agent=c/d"}, []string{"a/b", "c/d"}},
+		{"flag_with_space", true, []string{"--user-agent=a b"}, []string{"a b"}},
+		{"flag_split_with_space", true, []string{"--user-agent=a", "b"}, []string{"a"}},
+		{"empty_flag", false, []string{"--user-agent"}, nil},
+	}
+
+	for _, testCase := range tests {
+		userAgentData = []string{}
+
+		t.Run(testCase.name, func(t *testing.T) {
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			AddExtraFlags(fs)
+
+			err := fs.Parse(testCase.flags)
+
+			if testCase.shouldParse && err != nil {
+				t.Errorf("Flags failed to parse")
+			} else if !testCase.shouldParse && err == nil {
+				t.Errorf("Flags should not have parsed")
+			} else if testCase.shouldParse {
+				if !reflect.DeepEqual(userAgentData, testCase.expected) {
+					t.Errorf("userAgentData %#v did not match expected value %#v", userAgentData, testCase.expected)
+				}
+			}
+		})
+	}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+// Version is set by the linker flags in the Makefile.
+var Version string

--- a/pkg/volume/cinder/volumeservice/connection_test.go
+++ b/pkg/volume/cinder/volumeservice/connection_test.go
@@ -19,8 +19,11 @@ package volumeservice
 import (
 	"github.com/stretchr/testify/assert"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/spf13/pflag"
 )
 
 var fakeUserName = "user"
@@ -57,6 +60,43 @@ func TestGetConfigFromEnv(t *testing.T) {
 	assert.Equal(cfg.Global.TenantID, fakeTenantID)
 	assert.Equal(cfg.Global.DomainID, fakeDomainID)
 	assert.Equal(cfg.Global.Region, fakeRegion)
+}
+
+func TestUserAgentFlag(t *testing.T) {
+	tests := []struct {
+		name        string
+		shouldParse bool
+		flags       []string
+		expected    []string
+	}{
+		{"no_flag", true, []string{}, nil},
+		{"one_flag", true, []string{"--user-agent=cluster/abc-123"}, []string{"cluster/abc-123"}},
+		{"multiple_flags", true, []string{"--user-agent=a/b", "--user-agent=c/d"}, []string{"a/b", "c/d"}},
+		{"flag_with_space", true, []string{"--user-agent=a b"}, []string{"a b"}},
+		{"flag_split_with_space", true, []string{"--user-agent=a", "b"}, []string{"a"}},
+		{"empty_flag", false, []string{"--user-agent"}, nil},
+	}
+
+	for _, testCase := range tests {
+		userAgentData = []string{}
+
+		t.Run(testCase.name, func(t *testing.T) {
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			AddExtraFlags(fs)
+
+			err := fs.Parse(testCase.flags)
+
+			if testCase.shouldParse && err != nil {
+				t.Errorf("Flags failed to parse")
+			} else if !testCase.shouldParse && err == nil {
+				t.Errorf("Flags should not have parsed")
+			} else if testCase.shouldParse {
+				if !reflect.DeepEqual(userAgentData, testCase.expected) {
+					t.Errorf("userAgentData %#v did not match expected value %#v", userAgentData, testCase.expected)
+				}
+			}
+		})
+	}
 }
 
 func clearEnviron(t *testing.T) []string {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the cloud provider version string to gophercloud user-agent string, and adds a `user-agent` flag which can be used to add any other information.

I.e in Magnum, for the cloud controller manager configuration `--user-agent="cluster/${CLUSTER_UUID}"`, to be able to see which clusters are responsible for which requests.

If there are no objections to the code for the cloud controller manager then I will make the same changes for the keystone and barbican components (and any others that are suggested)

**Which issue this PR fixes** : fixes #606 

**Special notes for your reviewer**:

Since there is only a single flag, to add more than one thing to the user-agent would be like
`--user-agent="abc/123 cluster/${CLUSTER_UUID}"`

but in yaml it would look like
```yaml
command:
  - ......
  - --user-agent=abc/123 cluster/${CLUSTER_UUID}
```
as the quotes are not necessary since the whole line is already a string, but this might not be intuitive. If the quotes are left in then they are included in the user agent.

Instead it would be possible to make `user-agent` a flag that can be used multiple times with different arguments. Is that preferable?

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Set gophercloud user-agent in all components, and add flags for custom user-agent data in openstack-cloud-controller-manager, k8s-keystone-auth, manila-csi-plugin, manila-provisioner, cinder-csi-plugin, cinder-provisioner
```