### PR TITLE
kubeadm documentation update

### DIFF
--- a/docs/using-controller-manager-with-kubeadm.md
+++ b/docs/using-controller-manager-with-kubeadm.md
@@ -28,7 +28,7 @@
     ```
 
     You can find an example kubeadm.conf in `manifests/controller-manager/kubeadm.conf`. Follow the usual steps to install the network plugin and then bootstrap the other nodes using `kubeadm join`.
-    _Note, your nodes may not have an External IP address. This will cause logs and CNI to have have issues until the cluster provider is complete. Reference https://github.com/kubernetes/kubernetes/pull/75229 for further information._
+     >Note, your nodes may not have an External IP address. This will cause logs and CNI to have have issues until the cluster provider is complete. Reference https://github.com/kubernetes/kubernetes/pull/75229 for further information.
 
 - Allow controller-manager to have access `/etc/kubernetes/cloud-config`.
 

--- a/docs/using-controller-manager-with-kubeadm.md
+++ b/docs/using-controller-manager-with-kubeadm.md
@@ -28,6 +28,7 @@
     ```
 
     You can find an example kubeadm.conf in `manifests/controller-manager/kubeadm.conf`. Follow the usual steps to install the network plugin and then bootstrap the other nodes using `kubeadm join`.
+    _Note, your nodes may not have an External IP address. This will cause logs and CNI to have have issues until the cluster provider is complete. Reference https://github.com/kubernetes/kubernetes/pull/75229 for further information._
 
 - Allow controller-manager to have access `/etc/kubernetes/cloud-config`.
 
@@ -59,25 +60,6 @@
     kubectl -f manifests/controller-manager/cloud-config-secret.yaml apply
     ```
 
-- Create InitializerConfiguration for the cloud-controller-manager to label persistent volumes, see more details [here](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager)
-
-    ```
-    cat <<EOF | kubectl apply -f -
-    kind: InitializerConfiguration
-    apiVersion: admissionregistration.k8s.io/v1alpha1
-    metadata:
-      name: pvlabel.kubernetes.io
-    initializers:
-      - name: pvlabel.kubernetes.io
-        rules:
-        - apiGroups:
-          - ""
-          apiVersions:
-          - "*"
-          resources:
-          - persistentvolumes
-    EOF
-    ```
 - Before we create cloud-controller-manager deamonset, you can find all the nodes have the taint `node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule` and waiting for being initialized by cloud-controller-manager.
 
 - Create RBAC resources and cloud-controller-manager deamonset.


### PR DESCRIPTION
**What this PR does / why we need it**:

This clarifies the kubeadm documentation for cloud-provider-openstack

**Special notes for your reviewer**:
This is based on troubleshooting assistance provided by a_sykim in the k8s slack channel #sig-cloud-provider 

- InitializerConfiguration was removed in v1.14 and is no longer referenced in the documentation linked. 
- A known issue related to a race condition causes external addresses to not be listed when checking on nodes. A notice was put in to prevent the user from wondering why this is occurring. https://github.com/kubernetes/kubernetes/pull/75229

