### PR TITLE
Fix getVolume to return proper error

### DIFF
--- a/pkg/csi/cinder/sanity/fakecloud.go
+++ b/pkg/csi/cinder/sanity/fakecloud.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder"
@@ -114,10 +115,14 @@ func (cloud *cloud) GetVolume(volumeID string) (*volumes.Volume, error) {
 	vol, ok := cloud.volumes[volumeID]
 
 	if !ok {
-		return nil, errors.New("Volume not found")
+		return nil, notFoundError()
 	}
 
 	return vol, nil
+}
+
+func notFoundError() error {
+	return gophercloud.ErrDefault404{}
 }
 
 func (cloud *cloud) CreateSnapshot(name, volID, description string, tags *map[string]string) (*snapshots.Snapshot, error) {


### PR DESCRIPTION
Currently, error returned by getVolume is not recognized as
NotFound error, so still sanity test still shows the error.
This commit is to fix the same.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
