### PR TITLE
Adds openstack instance to nodeserver

### DIFF
--- a/pkg/csi/cinder/driver.go
+++ b/pkg/csi/cinder/driver.go
@@ -135,7 +135,7 @@ func (d *CinderDriver) SetupDriver(cloud openstack.IOpenStack, mount mount.IMoun
 
 	d.ids = NewIdentityServer(d)
 	d.cs = NewControllerServer(d, cloud)
-	d.ns = NewNodeServer(d, mount, metadata)
+	d.ns = NewNodeServer(d, mount, metadata, cloud)
 
 }
 

--- a/pkg/csi/cinder/utils.go
+++ b/pkg/csi/cinder/utils.go
@@ -49,11 +49,12 @@ func NewIdentityServer(d *CinderDriver) *identityServer {
 	}
 }
 
-func NewNodeServer(d *CinderDriver, mount mount.IMount, metadata openstack.IMetadata) *nodeServer {
+func NewNodeServer(d *CinderDriver, mount mount.IMount, metadata openstack.IMetadata, cloud openstack.IOpenStack) *nodeServer {
 	return &nodeServer{
 		Driver:   d,
 		Mount:    mount,
 		Metadata: metadata,
+		Cloud:    cloud,
 	}
 }
 


### PR DESCRIPTION
This commit adds cloud instance to nodeserver to be able to query openstack and adds
error codes as per csi spec.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #661 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
