### PR TITLE
Add manila-csi-plugin binary to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ zz_generated.openapi.go
 /octavia-ingress-controller
 /client-keystone-auth
 /manila-provisioner
+/manila-csi-plugin
 /barbican-kms-plugin
 /magnum-auto-healer
 


### PR DESCRIPTION
**What this PR does / why we need it**:

manila-csi-plugin is missing from the .gitignore, all the other binaries are there.