### PR TITLE
Fix GetMaxVolLimit to return correct value

### DIFF
--- a/docs/provider-configuration.md
+++ b/docs/provider-configuration.md
@@ -238,7 +238,7 @@ and should appear in the `[BlockStorage]` section of the `$CLOUD_CONFIG` file.
 
 ##### Block Storage (CSI)
 
-* `NodeVolumeAttachLimit`: Maximum volumes that can be attached to the node. Its
+* `node-volume-attach-limit`: Maximum volumes that can be attached to the node. Its
   default value is 256.
 
 ##### Block Storage Notes

--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -297,7 +297,7 @@ func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 	zone, err := getAvailabilityZoneMetadataService(ns.Metadata)
 	topology := &csi.Topology{Segments: map[string]string{topologyKey: zone}}
 
-	maxVolume := getMaxVolumeLimit()
+	maxVolume := ns.Cloud.GetMaxVolLimit()
 
 	return &csi.NodeGetInfoResponse{
 		NodeId:             nodeID,
@@ -400,9 +400,4 @@ func getNodeID(mount mount.IMount, metadata openstack.IMetadata) (string, error)
 		return "", err
 	}
 	return nodeID, nil
-}
-
-func getMaxVolumeLimit() int64 {
-	return openstack.GetMaxVolLimit()
-
 }

--- a/pkg/csi/cinder/openstack/openstack_mock.go
+++ b/pkg/csi/cinder/openstack/openstack_mock.go
@@ -318,7 +318,7 @@ func (_m *OpenStackMock) WaitSnapshotReady(snapshotID string) error {
 }
 
 func (_m *OpenStackMock) GetMaxVolLimit() int64 {
-	return 0
+	return 256
 }
 
 func (_m *OpenStackMock) GetInstanceByID(instanceID string) (*servers.Server, error) {

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -261,6 +261,15 @@ func (os *OpenStack) ExpandVolume(volumeID string, newSize int) error {
 	return err
 }
 
+//GetMaxVolLimit returns max vol limit
+func (os *OpenStack) GetMaxVolLimit() int64 {
+	if os.bsOpts.NodeVolumeAttachLimit > 0 && os.bsOpts.NodeVolumeAttachLimit <= 256 {
+		return os.bsOpts.NodeVolumeAttachLimit
+	}
+
+	return defaultMaxVolAttachLimit
+}
+
 // diskIsAttached queries if a volume is attached to a compute instance
 func (os *OpenStack) diskIsAttached(instanceID, volumeID string) (bool, error) {
 	volume, err := os.GetVolume(volumeID)

--- a/pkg/csi/cinder/sanity/fakecloud.go
+++ b/pkg/csi/cinder/sanity/fakecloud.go
@@ -213,3 +213,7 @@ func (cloud *cloud) GetInstanceByID(instanceID string) (*servers.Server, error) 
 func (cloud *cloud) ExpandVolume(volumeID string, size int) error {
 	return nil
 }
+
+func (cloud *cloud) GetMaxVolLimit() int64 {
+	return 256
+}


### PR DESCRIPTION
Values of BlockStorageOpts set in config file are not getting
reflected as of now. This PR is to fix the same

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #633

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
