### PR TITLE
Fix getStorageSizeInGiga

### DIFF
--- a/pkg/share/manila/util.go
+++ b/pkg/share/manila/util.go
@@ -18,7 +18,6 @@ package manila
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
@@ -59,11 +58,7 @@ func getStorageSizeInGiga(pvc *v1.PersistentVolumeClaim) (int, error) {
 		return 0, fmt.Errorf("requested storage size must be greater than zero")
 	}
 
-	var buf []byte
-	canonicalValue, _ := storageSize.AsScale(resource.Giga)
-	storageSizeAsByteSlice, _ := canonicalValue.AsCanonicalBytes(buf)
-
-	return strconv.Atoi(string(storageSizeAsByteSlice))
+	return int(storageSize.ScaledValue(resource.Giga)), nil
 }
 
 // Chooses one ExportLocation according to the below rules:


### PR DESCRIPTION
Corner cases like 1000G and 2000G were being translated
to 1G and 2G when sending to manila. Use ScaledValue to
round to Gigabytes.

Signed-off-by: Spyros Trigazis <spyridon.trigazis@cern.ch>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Corner cases like 1000G and 2000G were being translated
to 1G and 2G when sending to manila. 

**Special notes for your reviewer**:

reproducer:
```
package main

import (
	"fmt"
	"strconv"

	v1 "k8s.io/api/core/v1"
	"k8s.io/apimachinery/pkg/api/resource"
	"k8s.io/client-go/kubernetes/scheme"
)

var filecontent = `
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: deleteme
spec:
  accessModes:
    - ReadWriteMany
  resources:
    requests:
      storage: "1000G"
  storageClassName: meyrin-cephfs-hyperconverged
`

func main() {
	decode := scheme.Codecs.UniversalDeserializer().Decode
	obj, _, _ := decode([]byte(filecontent), nil, nil)


	pvc := obj.(*v1.PersistentVolumeClaim)
	storageSize, _ := pvc.Spec.Resources.Requests[v1.ResourceStorage]
	fmt.Println(storageSize)
	var buf []byte
	canonicalValue, _ := storageSize.AsScale(resource.Giga)
	fmt.Println("canonicalValue", canonicalValue)
	storageSizeAsByteSlice, _ := canonicalValue.AsCanonicalBytes(buf)
	fmt.Println("canonicalValue.AsCanonicalBytes(buf)", storageSizeAsByteSlice)
	res, _ := strconv.Atoi(string(storageSizeAsByteSlice))
	fmt.Println(res)
}
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix getStorageSizeInGiga for manila provisioner
```
