### PR TITLE
Improve magnum-auto-healer log

### DIFF
--- a/pkg/autohealing/controller/controller.go
+++ b/pkg/autohealing/controller/controller.go
@@ -229,7 +229,7 @@ func (c *Controller) getUnhealthyMasterNodes() ([]healthcheck.NodeInfo, error) {
 
 	// If no checkers defined, skip
 	if len(c.masterCheckers) == 0 {
-		log.Info("No health check defined for master node, skip.")
+		log.V(3).Info("No health check defined for master node, skip.")
 		return nodes, nil
 	}
 
@@ -261,7 +261,7 @@ func (c *Controller) getUnhealthyWorkerNodes() ([]healthcheck.NodeInfo, error) {
 
 	// If no checkers defined, skip.
 	if len(c.workerCheckers) == 0 {
-		log.Info("No health check defined for worker node, skip.")
+		log.V(3).Info("No health check defined for worker node, skip.")
 		return nodes, nil
 	}
 
@@ -332,7 +332,7 @@ func (c *Controller) repairNodes(unhealthyNodes []healthcheck.NodeInfo) {
 // startMasterMonitor checks if there are failed master nodes and triggers the repair action. This function is supposed
 // to be running in a goroutine.
 func (c *Controller) startMasterMonitor(wg *sync.WaitGroup) {
-	log.V(4).Info("Starting to check master nodes.")
+	log.V(3).Info("Starting to check master nodes.")
 	defer wg.Done()
 
 	// Get all the unhealthy master nodes.
@@ -345,15 +345,16 @@ func (c *Controller) startMasterMonitor(wg *sync.WaitGroup) {
 	c.repairNodes(unhealthyNodes)
 
 	if len(unhealthyNodes) == 0 {
-		log.Info("Master nodes are healthy")
+		log.V(3).Info("Master nodes are healthy")
 	}
-	log.V(4).Info("Finished checking master nodes.")
+
+	log.V(3).Info("Finished checking master nodes.")
 }
 
 // startWorkerMonitor checks if there are failed worker nodes and triggers the repair action. This function is supposed
 // to be running in a goroutine.
 func (c *Controller) startWorkerMonitor(wg *sync.WaitGroup) {
-	log.V(4).Info("Starting to check worker nodes.")
+	log.V(3).Info("Starting to check worker nodes.")
 	defer wg.Done()
 
 	// Get all the unhealthy worker nodes.
@@ -366,10 +367,10 @@ func (c *Controller) startWorkerMonitor(wg *sync.WaitGroup) {
 	c.repairNodes(unhealthyNodes)
 
 	if len(unhealthyNodes) == 0 {
-		log.Info("Worker nodes are healthy")
+		log.V(3).Info("Worker nodes are healthy")
 	}
 
-	log.V(4).Info("Finished checking worker nodes.")
+	log.V(3).Info("Finished checking worker nodes.")
 }
 
 // Start starts the autohealing controller.


### PR DESCRIPTION
**What this PR does / why we need it**:
Decrease the default log print when there is no issues, like the following:
```
I0714 11:35:23.622809       1 controller.go:232] No health check defined for master node, skip.
I0714 11:34:53.622667       1 controller.go:352] Master nodes are healthy
I0714 11:34:53.743112       1 controller.go:373] Worker nodes are healthy
```

**Which issue this PR fixes**: fixes #

**Special notes for your reviewer**:
It's impossible to improve all the log levels for the service in one patch, we will keep doing that. We use [this guide](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md) for the logging.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
