### PR TITLE
Remove cinderv1 support from cloudprovider

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -246,14 +246,13 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:25782881f00fe40c1279ca04820fc7a763669950b116ad670cfe86a34d046faf"
+  digest = "1:b890ef67a34c497fdd0a4720797c8b5b80b649861dc0300eca35d8a95604dbff"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
     "openstack",
     "openstack/blockstorage/extensions/volumeactions",
     "openstack/blockstorage/noauth",
-    "openstack/blockstorage/v1/volumes",
     "openstack/blockstorage/v2/volumes",
     "openstack/blockstorage/v3/snapshots",
     "openstack/blockstorage/v3/volumes",
@@ -1623,7 +1622,6 @@
     "github.com/gophercloud/gophercloud/openstack",
     "github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions",
     "github.com/gophercloud/gophercloud/openstack/blockstorage/noauth",
-    "github.com/gophercloud/gophercloud/openstack/blockstorage/v1/volumes",
     "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes",
     "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots",
     "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes",

--- a/docs/provider-configuration.md
+++ b/docs/provider-configuration.md
@@ -34,7 +34,7 @@ The provider supports several OpenStack services:
 |--------------------------|----------------|----------|
 | Identity (Keystone)      | v2, v3 †       | Yes      |
 | Compute (Nova)           | v2             | No       |
-| Block Storage (Cinder)   | v1, v2, v3‡    | No       |
+| Block Storage (Cinder)   | v2, v3‡        | No       |
 | Load Balancing (Neutron) | v1§, v2        | No       |
 | Load Balancing (Octavia) | v2             | No       |
 
@@ -43,8 +43,7 @@ The provider supports several OpenStack services:
 a future release. As of the "Queens" release, OpenStack no longer exposes the
 Identity v2 API.
 
-‡ Block Storage v1 API support is deprecated, Block Storage v3 API support was
-added in Kubernetes 1.9.
+‡ Block Storage v3 API support was added in Kubernetes 1.9.
 
 § Load Balancing v1 API support was removed in Kubernetes 1.9.
 
@@ -220,7 +219,7 @@ and should appear in the `[BlockStorage]` section of the `$CLOUD_CONFIG` file.
 ##### Block Storage Optional Parameters
 
 * `bs-version`: Used to override automatic version detection. Valid
-  values are `v1`, `v2`, `v3` and `auto`. When `auto` is specified automatic
+  values are `v2`, `v3` and `auto`. When `auto` is specified automatic
   detection will select the highest supported version exposed by the underlying
   OpenStack cloud. The default value if none is provided is `auto`.
 * `ignore-volume-az`: Used to influence availability zone use when

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -924,13 +924,6 @@ func (os *OpenStack) volumeService(forceVersion string) (volumeService, error) {
 	}
 
 	switch bsVersion {
-	case "v1":
-		sClient, err := os.NewBlockStorageV1()
-		if err != nil {
-			return nil, err
-		}
-		klog.V(3).Info("Using Blockstorage API V1")
-		return &VolumesV1{sClient, os.bsOpts}, nil
 	case "v2":
 		sClient, err := os.NewBlockStorageV2()
 		if err != nil {
@@ -958,11 +951,6 @@ func (os *OpenStack) volumeService(forceVersion string) (volumeService, error) {
 		if sClient, err := os.NewBlockStorageV2(); err == nil {
 			klog.V(3).Info("Using Blockstorage API V2")
 			return &VolumesV2{sClient, os.bsOpts}, nil
-		}
-
-		if sClient, err := os.NewBlockStorageV1(); err == nil {
-			klog.V(3).Info("Using Blockstorage API V1")
-			return &VolumesV1{sClient, os.bsOpts}, nil
 		}
 
 		errTxt := "BlockStorage API version autodetection failed. " +


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Cinder v1 is deprecated in Juno release of Openstack and removed completely in Queens (https://docs.openstack.org/releasenotes/cinder/queens.html) . This PR removes the support for the same in cloudprovider.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #695 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cinderv1 support is removed from cloudprovider.
```
