### PR TITLE
magnum-auto-healer: Remove Node object after Heat stack update

### DIFF
--- a/pkg/autohealing/cloudprovider/cloudprovider.go
+++ b/pkg/autohealing/cloudprovider/cloudprovider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudprovider
 
 import (
+	"k8s.io/client-go/kubernetes"
 	log "k8s.io/klog"
 
 	"k8s.io/cloud-provider-openstack/pkg/autohealing/config"
@@ -43,7 +44,7 @@ type CloudProvider interface {
 	Enabled() bool
 }
 
-type RegisterFunc func(config config.Config) (CloudProvider, error)
+type RegisterFunc func(config config.Config, client kubernetes.Interface) (CloudProvider, error)
 
 // RegisterCloudProvider registers a cloudprovider.Factory by name. This
 // is expected to happen during app startup.
@@ -57,10 +58,10 @@ func RegisterCloudProvider(name string, register RegisterFunc) {
 }
 
 // GetCloudProvider creates an instance of the named cloud provider
-func GetCloudProvider(name string, config config.Config) (CloudProvider, error) {
+func GetCloudProvider(name string, config config.Config, client kubernetes.Interface) (CloudProvider, error) {
 	f, found := providers[name]
 	if !found {
 		return nil, nil
 	}
-	return f(config)
+	return f(config, client)
 }

--- a/pkg/autohealing/cloudprovider/register/register.go
+++ b/pkg/autohealing/cloudprovider/register/register.go
@@ -26,6 +26,7 @@ import (
 	gopenstack "github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/trusts"
 	netutil "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/kubernetes"
 	certutil "k8s.io/client-go/util/cert"
 
 	"k8s.io/cloud-provider-openstack/pkg/autohealing/cloudprovider"
@@ -33,7 +34,7 @@ import (
 	"k8s.io/cloud-provider-openstack/pkg/autohealing/config"
 )
 
-func registerOpenStack(cfg config.Config) (cloudprovider.CloudProvider, error) {
+func registerOpenStack(cfg config.Config, kubeClient kubernetes.Interface) (cloudprovider.CloudProvider, error) {
 	client, err := gopenstack.NewClient(cfg.OpenStack.AuthURL)
 	if err != nil {
 		return nil, err
@@ -93,10 +94,11 @@ func registerOpenStack(cfg config.Config) (cloudprovider.CloudProvider, error) {
 
 	var p cloudprovider.CloudProvider
 	p = openstack.OpenStackCloudProvider{
-		Nova:   novaClient,
-		Heat:   heatClient,
-		Magnum: magnumClient,
-		Config: cfg,
+		KubeClient: kubeClient,
+		Nova:       novaClient,
+		Heat:       heatClient,
+		Magnum:     magnumClient,
+		Config:     cfg,
 	}
 
 	return p, nil

--- a/pkg/autohealing/controller/controller.go
+++ b/pkg/autohealing/controller/controller.go
@@ -104,19 +104,19 @@ func createKubeClients(apiserverHost string, kubeConfig string) (*kubernetes.Cli
 
 // NewController creates a new autohealer controller.
 func NewController(conf config.Config) *Controller {
-	// initialize cloud provider
-	provider, err := cloudprovider.GetCloudProvider(conf.CloudProvider, conf)
-	if err != nil {
-		log.Fatalf("Failed to get the cloud provider %s: %v", conf.CloudProvider, err)
-	}
-
-	log.Infof("Using cloud provider: %s", provider.GetName())
-
 	// initialize k8s clients
 	kubeClient, leaderElectionClient, err := createKubeClients(conf.Kubernetes.ApiserverHost, conf.Kubernetes.KubeConfig)
 	if err != nil {
 		log.Fatalf("failed to initialize kubernetes client, error: %v", err)
 	}
+
+	// initialize cloud provider
+	provider, err := cloudprovider.GetCloudProvider(conf.CloudProvider, conf, kubeClient)
+	if err != nil {
+		log.Fatalf("Failed to get the cloud provider %s: %v", conf.CloudProvider, err)
+	}
+
+	log.Infof("Using cloud provider: %s", provider.GetName())
 
 	// event
 	eventBroadcaster := record.NewBroadcaster()
@@ -316,12 +316,6 @@ func (c *Controller) repairNodes(unhealthyNodes []healthcheck.NodeInfo) {
 					} else {
 						log.Infof("Node %s is cordoned", nodeName)
 					}
-
-					// Remove the broken node from the cluster
-					if err := c.kubeClient.CoreV1().Nodes().Delete(nodeName, &metav1.DeleteOptions{}); err != nil {
-						log.Errorf("Failed to remove the node %s from cluster, error: %v", unhealthyNodeNames.List(), err)
-					}
-					// TODO: Deal with the situation that the autohealer is running on a failed node
 				}
 
 				// Start to repair all the unhealthy nodes.


### PR DESCRIPTION
**What this PR does / why we need it**:
Delete Kubernetes Node after updating the Heat stack, this is to avoid the following issues:

- If an error happens during the repairing process in the cloud provider, there is no chance to fix the failed node in the future because the Node object has been deleted from Kubernetes.
- If the magnum-auto-healer(master) is running on a failed node, there is no chance for the slaves to fix that node because the Node object has been deleted from Kubernetes.

**Which issue this PR fixes**: fixes #700

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
