### PR TITLE
Add CSIDriver object

### DIFF
--- a/docs/using-cinder-csi-plugin.md
+++ b/docs/using-cinder-csi-plugin.md
@@ -49,6 +49,31 @@ csi-cinder-controllerplugin         4/4     Running   0          29h
 csi-cinder-nodeplugin               2/2     Running   0          46h
 ```
 
+you can get information about CSI Drivers running in a cluster, using **CSIDriver** object    
+
+```
+$ kubectl get csidrivers.storage.k8s.io
+NAME                       CREATED AT
+cinder.csi.openstack.org   2019-07-29T09:02:40Z
+
+$ kubectl describe csidrivers.storage.k8s.io
+Name:         cinder.csi.openstack.org
+Namespace:    
+Labels:       <none>
+Annotations:  <none>
+API Version:  storage.k8s.io/v1beta1
+Kind:         CSIDriver
+Metadata:
+  Creation Timestamp:  2019-07-29T09:02:40Z
+  Resource Version:    1891
+  Self Link:           /apis/storage.k8s.io/v1beta1/csidrivers/cinder.csi.openstack.org
+  UID:                 2bd1f3bf-3c41-46a8-b99b-5773cb5eacd3
+Spec:
+  Attach Required:    true
+  Pod Info On Mount:  false
+Events:               <none>
+```
+ 
 ### Example Nginx application usage
 
 After performing above steps, you can try to create StorageClass, PersistentVolumeClaim and pod to consume it.

--- a/manifests/cinder-csi-plugin/csi-cinder-driver.yaml
+++ b/manifests/cinder-csi-plugin/csi-cinder-driver.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: cinder.csi.openstack.org
+spec:
+  attachRequired: true
+  podInfoOnMount: false


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
CSIDriver objects needs to created after v1.14 as
cluster-driver-registrar is deprecated

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE.
```
