### PR TITLE
k8s-keystone-auth: Resource name should be case insensitive

### DIFF
--- a/pkg/identity/keystone/authorizer.go
+++ b/pkg/identity/keystone/authorizer.go
@@ -113,7 +113,7 @@ func resourcePermissionAllowed(permissionSpec map[string][]string, attr authoriz
 
 		allowedVerbs := sets.NewString()
 		for _, val := range value {
-			allowedVerbs.Insert(val)
+			allowedVerbs.Insert(strings.ToLower(val))
 		}
 		if allowedVerbs.Has("*") {
 			allowedVerbs.Insert(verb)
@@ -125,8 +125,8 @@ func resourcePermissionAllowed(permissionSpec map[string][]string, attr authoriz
 			klog.V(4).Infof("Skip the permission definition %s", key)
 			continue
 		}
-		nsDef := strings.TrimSpace(keyList[0])
-		resDef := strings.TrimSpace(keyList[1])
+		nsDef := strings.ToLower(strings.TrimSpace(keyList[0]))
+		resDef := strings.ToLower(strings.TrimSpace(keyList[1]))
 
 		allowedNamespaces, err := getAllowed(nsDef, ns)
 		if err != nil {

--- a/pkg/identity/keystone/authorizer_test.go
+++ b/pkg/identity/keystone/authorizer_test.go
@@ -310,6 +310,7 @@ func TestAuthorizerVersion2(t *testing.T) {
 		},
 	}
 
+	// Test developer
 	attrs := authorizer.AttributesRecord{User: developer, ResourceRequest: true, Verb: "get", Namespace: "default", Resource: "pods"}
 	decision, _, _ := a.Authorize(attrs)
 	th.AssertEquals(t, authorizer.DecisionAllow, decision)
@@ -325,6 +326,11 @@ func TestAuthorizerVersion2(t *testing.T) {
 	attrs = authorizer.AttributesRecord{User: developer, ResourceRequest: true, Verb: "create", Namespace: "", Resource: "clusterrolebindings"}
 	decision, _, _ = a.Authorize(attrs)
 	th.AssertEquals(t, authorizer.DecisionDeny, decision)
+
+	// Test developer, resource name should be case insensitive.
+	attrs = authorizer.AttributesRecord{User: developer, ResourceRequest: true, Verb: "get", Namespace: "", Resource: "podsecuritypolicies"}
+	decision, _, _ = a.Authorize(attrs)
+	th.AssertEquals(t, authorizer.DecisionAllow, decision)
 
 	// Test viewer
 	attrs = authorizer.AttributesRecord{User: viewer, ResourceRequest: true, Verb: "get", Namespace: "default", Resource: "deployments"}

--- a/pkg/identity/keystone/authorizer_test_policy_version2.json
+++ b/pkg/identity/keystone/authorizer_test_policy_version2.json
@@ -5,8 +5,8 @@
       "projects": ["demo"]
     },
     "resource_permissions": {
-      "!kube-system/!['namespaces', 'clusterrolebindings', 'clusterroles', 'podsecuritypolicies', 'rolebindings', 'roles']": ["*"],
-      "!kube-system/['namespaces', 'clusterrolebindings', 'clusterroles', 'podsecuritypolicies', 'rolebindings', 'roles']": ["get", "list"]
+      "!kube-system/!['namespaces', 'clusterrolebindings', 'clusterroles', 'podsecuritypolicies', 'rolebindings', 'roles', 'podSecurityPolicies']": ["*"],
+      "!kube-system/['namespaces', 'clusterrolebindings', 'clusterroles', 'podsecuritypolicies', 'rolebindings', 'roles', 'podSecurityPolicies']": ["get", "list"]
     }
   },
   {


### PR DESCRIPTION
**What this PR does / why we need it**:
Make the namespace and resource name in the permission definition to be case insensitive.

**Which issue this PR fixes**: fixes #725

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
