### PR TITLE
[csi-manila] CSI client moved into a separate package

### DIFF
--- a/cmd/manila-csi-plugin/main.go
+++ b/cmd/manila-csi-plugin/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/csiclient"
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila/manilaclient"
 	"k8s.io/component-base/logs"
 	"k8s.io/klog"
@@ -81,7 +82,7 @@ func main() {
 				klog.Fatalf(err.Error())
 			}
 
-			d, err := manila.NewDriver(nodeID, driverName, endpoint, fwdEndpoint, protoSelector, &manilaclient.ClientBuilder{UserAgentData: userAgentData})
+			d, err := manila.NewDriver(nodeID, driverName, endpoint, fwdEndpoint, protoSelector, &manilaclient.ClientBuilder{UserAgentData: userAgentData}, &csiclient.ClientBuilder{})
 			if err != nil {
 				klog.Fatalf("driver initialization failed: %v", err)
 			}

--- a/pkg/csi/manila/csiclient.go
+++ b/pkg/csi/manila/csiclient.go
@@ -18,81 +18,15 @@ package manila
 
 import (
 	"context"
-	"fmt"
-	"sync/atomic"
-	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
-	"google.golang.org/grpc"
-	"k8s.io/klog"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/csiclient"
 )
-
-var (
-	fwdEndpointGRPCCallCounter uint64
-)
-
-func grpcConnect(ctx context.Context, endpoint string) (*grpc.ClientConn, error) {
-	var (
-		dialOptions = []grpc.DialOption{
-			grpc.WithInsecure(),
-			grpc.WithBackoffMaxDelay(time.Second),
-			grpc.WithBlock(),
-			grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-				callID := atomic.AddUint64(&fwdEndpointGRPCCallCounter, 1)
-
-				klog.V(3).Infof("[ID:%d] FWD GRPC call: %s", callID, method)
-				klog.V(5).Infof("[ID:%d] FWD GRPC request: %s", callID, protosanitizer.StripSecrets(req))
-
-				err := invoker(ctx, method, req, reply, cc, opts...)
-				if err != nil {
-					klog.Infof("[ID:%d] FWD GRPC error: %v", callID, err)
-				} else {
-					klog.V(5).Infof("[ID:%d] FWD GRPC response: %s", callID, protosanitizer.StripSecrets(reply))
-				}
-
-				return err
-			}),
-		}
-
-		conn *grpc.ClientConn
-		err  error
-	)
-
-	if ctx != nil {
-		conn, err = grpc.DialContext(ctx, endpoint, dialOptions...)
-		if err == context.DeadlineExceeded {
-			return nil, fmt.Errorf("connecting to %s timed out: %v", endpoint, err)
-		}
-
-		return conn, err
-	} else {
-		dialFinished := make(chan bool)
-		go func() {
-			conn, err = grpc.Dial(endpoint, dialOptions...)
-			close(dialFinished)
-		}()
-
-		ticker := time.NewTicker(time.Second)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ticker.C:
-				klog.Warningf("still connecting to %s", endpoint)
-			case <-dialFinished:
-				return conn, err
-			}
-		}
-	}
-}
 
 type csiNodeCapabilitySet map[csi.NodeServiceCapability_RPC_Type]bool
 
-func csiNodeGetCapabilities(ctx context.Context, conn *grpc.ClientConn) (csiNodeCapabilitySet, error) {
-	client := csi.NewNodeClient(conn)
-	req := csi.NodeGetCapabilitiesRequest{}
-	rsp, err := client.NodeGetCapabilities(ctx, &req)
+func csiNodeGetCapabilities(ctx context.Context, nodeClient csiclient.Node) (csiNodeCapabilitySet, error) {
+	rsp, err := nodeClient.GetCapabilities(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -109,35 +43,6 @@ func csiNodeGetCapabilities(ctx context.Context, conn *grpc.ClientConn) (csiNode
 		t := rpc.GetType()
 		caps[t] = true
 	}
+
 	return caps, nil
-}
-
-func csiNodeGetInfo(ctx context.Context, conn *grpc.ClientConn) (*csi.NodeGetInfoResponse, error) {
-	client := csi.NewNodeClient(conn)
-	return client.NodeGetInfo(ctx, &csi.NodeGetInfoRequest{})
-}
-
-func csiNodePublishVolume(ctx context.Context, conn *grpc.ClientConn, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
-	client := csi.NewNodeClient(conn)
-	return client.NodePublishVolume(ctx, req)
-}
-
-func csiNodeUnpublishVolume(ctx context.Context, conn *grpc.ClientConn, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
-	client := csi.NewNodeClient(conn)
-	return client.NodeUnpublishVolume(ctx, req)
-}
-
-func csiNodeStageVolume(ctx context.Context, conn *grpc.ClientConn, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
-	client := csi.NewNodeClient(conn)
-	return client.NodeStageVolume(ctx, req)
-}
-
-func csiNodeUnstageVolume(ctx context.Context, conn *grpc.ClientConn, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
-	client := csi.NewNodeClient(conn)
-	return client.NodeUnstageVolume(ctx, req)
-}
-
-func csiGetPluginInfo(ctx context.Context, conn *grpc.ClientConn) (*csi.GetPluginInfoResponse, error) {
-	client := csi.NewIdentityClient(conn)
-	return client.GetPluginInfo(ctx, &csi.GetPluginInfoRequest{})
 }

--- a/pkg/csi/manila/csiclient/builder.go
+++ b/pkg/csi/manila/csiclient/builder.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csiclient
+
+import (
+	"context"
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
+	"google.golang.org/grpc"
+	"k8s.io/klog"
+	"sync/atomic"
+	"time"
+)
+
+var (
+	grpcCallCounter uint64
+
+	dialOptions = []grpc.DialOption{
+		grpc.WithInsecure(),
+		grpc.WithBackoffMaxDelay(time.Second),
+		grpc.WithBlock(),
+		grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+			callID := atomic.AddUint64(&grpcCallCounter, 1)
+
+			klog.V(3).Infof("[ID:%d] FWD GRPC call: %s", callID, method)
+			klog.V(5).Infof("[ID:%d] FWD GRPC request: %s", callID, protosanitizer.StripSecrets(req))
+
+			err := invoker(ctx, method, req, reply, cc, opts...)
+			if err != nil {
+				klog.Infof("[ID:%d] FWD GRPC error: %v", callID, err)
+			} else {
+				klog.V(5).Infof("[ID:%d] FWD GRPC response: %s", callID, protosanitizer.StripSecrets(reply))
+			}
+
+			return err
+		}),
+	}
+)
+
+func NewNodeSvcClient(conn *grpc.ClientConn) *NodeSvcClient {
+	return &NodeSvcClient{cl: csi.NewNodeClient(conn)}
+}
+
+func NewIdentitySvcClient(conn *grpc.ClientConn) *IdentitySvcClient {
+	return &IdentitySvcClient{cl: csi.NewIdentityClient(conn)}
+}
+
+func NewConnection(endpoint string) (*grpc.ClientConn, error) {
+	var (
+		conn *grpc.ClientConn
+		err  error
+	)
+
+	dialFinished := make(chan bool)
+	go func() {
+		conn, err = grpc.Dial(endpoint, dialOptions...)
+		close(dialFinished)
+	}()
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			klog.Warningf("still connecting to %s", endpoint)
+		case <-dialFinished:
+			return conn, err
+		}
+	}
+}
+
+func NewConnectionWithContext(ctx context.Context, endpoint string) (*grpc.ClientConn, error) {
+	return grpc.DialContext(ctx, endpoint, dialOptions...)
+}
+
+type ClientBuilder struct{}
+
+func (b ClientBuilder) NewConnection(endpoint string) (*grpc.ClientConn, error) {
+	return NewConnection(endpoint)
+}
+
+func (b ClientBuilder) NewConnectionWithContext(ctx context.Context, endpoint string) (*grpc.ClientConn, error) {
+	return NewConnectionWithContext(ctx, endpoint)
+}
+
+func (b ClientBuilder) NewNodeServiceClient(conn *grpc.ClientConn) Node {
+	return NewNodeSvcClient(conn)
+}
+
+func (b ClientBuilder) NewIdentityServiceClient(conn *grpc.ClientConn) Identity {
+	return NewIdentitySvcClient(conn)
+}

--- a/pkg/csi/manila/csiclient/client.go
+++ b/pkg/csi/manila/csiclient/client.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csiclient
+
+import (
+	"context"
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/kubernetes-csi/csi-lib-utils/connection"
+	"google.golang.org/grpc"
+	"time"
+)
+
+type NodeSvcClient struct {
+	cl csi.NodeClient
+}
+
+func (c *NodeSvcClient) GetCapabilities(ctx context.Context) (*csi.NodeGetCapabilitiesResponse, error) {
+	return c.cl.NodeGetCapabilities(ctx, &csi.NodeGetCapabilitiesRequest{})
+}
+
+func (c *NodeSvcClient) StageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+	return c.cl.NodeStageVolume(ctx, req)
+}
+
+func (c *NodeSvcClient) UnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+	return c.cl.NodeUnstageVolume(ctx, req)
+}
+
+func (c *NodeSvcClient) PublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+	return c.cl.NodePublishVolume(ctx, req)
+}
+
+func (c *NodeSvcClient) UnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+	return c.cl.NodeUnpublishVolume(ctx, req)
+}
+
+type IdentitySvcClient struct {
+	cl csi.IdentityClient
+}
+
+func (c IdentitySvcClient) ProbeForever(conn *grpc.ClientConn, singleProbeTimeout time.Duration) error {
+	return connection.ProbeForever(conn, singleProbeTimeout)
+}
+
+func (c IdentitySvcClient) GetPluginInfo(ctx context.Context) (*csi.GetPluginInfoResponse, error) {
+	return c.cl.GetPluginInfo(ctx, &csi.GetPluginInfoRequest{})
+}

--- a/pkg/csi/manila/csiclient/interface.go
+++ b/pkg/csi/manila/csiclient/interface.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csiclient
+
+import (
+	"context"
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc"
+	"time"
+)
+
+type Node interface {
+	GetCapabilities(ctx context.Context) (*csi.NodeGetCapabilitiesResponse, error)
+
+	StageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error)
+	UnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error)
+
+	PublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error)
+	UnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error)
+}
+
+type Identity interface {
+	GetPluginInfo(ctx context.Context) (*csi.GetPluginInfoResponse, error)
+	ProbeForever(conn *grpc.ClientConn, singleProbeTimeout time.Duration) error
+}
+
+type Builder interface {
+	NewConnection(endpoint string) (*grpc.ClientConn, error)
+	NewConnectionWithContext(ctx context.Context, endpoint string) (*grpc.ClientConn, error)
+
+	NewNodeServiceClient(conn *grpc.ClientConn) Node
+	NewIdentityServiceClient(conn *grpc.ClientConn) Identity
+}

--- a/pkg/csi/manila/nodeserver.go
+++ b/pkg/csi/manila/nodeserver.go
@@ -200,7 +200,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	// Forward the RPC
 
-	csiConn, err := grpcConnect(ctx, ns.d.fwdEndpoint)
+	csiConn, err := ns.d.csiClientBuilder.NewConnectionWithContext(ctx, ns.d.fwdEndpoint)
 	if err != nil {
 		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
 	}
@@ -208,7 +208,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	req.Secrets = secret
 	req.VolumeContext = volumeCtx
 
-	return csiNodePublishVolume(ctx, csiConn, req)
+	return ns.d.csiClientBuilder.NewNodeServiceClient(csiConn).PublishVolume(ctx, req)
 }
 
 func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
@@ -216,12 +216,12 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	csiConn, err := grpcConnect(ctx, ns.d.fwdEndpoint)
+	csiConn, err := ns.d.csiClientBuilder.NewConnectionWithContext(ctx, ns.d.fwdEndpoint)
 	if err != nil {
 		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
 	}
 
-	return csiNodeUnpublishVolume(ctx, csiConn, req)
+	return ns.d.csiClientBuilder.NewNodeServiceClient(csiConn).UnpublishVolume(ctx, req)
 }
 
 func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
@@ -274,7 +274,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 
 	// Forward the RPC
 
-	csiConn, err := grpcConnect(ctx, ns.d.fwdEndpoint)
+	csiConn, err := ns.d.csiClientBuilder.NewConnectionWithContext(ctx, ns.d.fwdEndpoint)
 	if err != nil {
 		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
 	}
@@ -282,7 +282,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	req.Secrets = stageSecret
 	req.VolumeContext = volumeCtx
 
-	return csiNodeStageVolume(ctx, csiConn, req)
+	return ns.d.csiClientBuilder.NewNodeServiceClient(csiConn).StageVolume(ctx, req)
 }
 
 func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
@@ -294,12 +294,12 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 	delete(ns.nodeStageCache, volumeID(req.VolumeId))
 	ns.nodeStageCacheMtx.Unlock()
 
-	csiConn, err := grpcConnect(ctx, ns.d.fwdEndpoint)
+	csiConn, err := ns.d.csiClientBuilder.NewConnectionWithContext(ctx, ns.d.fwdEndpoint)
 	if err != nil {
 		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
 	}
 
-	return csiNodeUnstageVolume(ctx, csiConn, req)
+	return ns.d.csiClientBuilder.NewNodeServiceClient(csiConn).UnstageVolume(ctx, req)
 }
 
 func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Part of https://github.com/kubernetes/cloud-provider-openstack/issues/714

Continuing in an effort of integrating the csi-sanity test suite into CSI Manila, this is the second patch out of 4:

This PR moves the CSI client into a separate package, which brings `Node`, `Identity` and `Builder` interfaces. This in turn makes it possible to have various implementations for CSI clients - e.g. creating a fake CSI client which is a prerequisite for sanity/unit tests.

**Release note**:
```release-note
NONE
```
