### PR TITLE
[csi-manila] fixed incorrect behaviour discovered by csi-sanity test suite

### DIFF
--- a/pkg/csi/manila/controllerserver.go
+++ b/pkg/csi/manila/controllerserver.go
@@ -230,7 +230,7 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 
 	if sourceShare, res.err = manilaClient.GetShareByID(req.GetSourceVolumeId()); res.err != nil {
 		if isManilaErrNotFound(res.err) {
-			return nil, status.Errorf(codes.InvalidArgument, "failed to create a snapshot (%s) for share %s because the share doesn't exist: %v", req.GetName(), req.GetSourceVolumeId(), err)
+			return nil, status.Errorf(codes.NotFound, "failed to create a snapshot (%s) for share %s because the share doesn't exist: %v", req.GetName(), req.GetSourceVolumeId(), err)
 		}
 
 		return nil, status.Errorf(codes.Internal, "failed to retrieve source share %s when creating a snapshot (%s): %v", req.GetSourceVolumeId(), req.GetName(), res.err)
@@ -251,7 +251,7 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		}
 
 		if isManilaErrNotFound(res.err) {
-			return nil, status.Errorf(codes.InvalidArgument, "failed to create a snapshot (%s) for share %s because the share doesn't exist: %v", req.GetName(), req.GetSourceVolumeId(), err)
+			return nil, status.Errorf(codes.NotFound, "failed to create a snapshot (%s) for share %s because the share doesn't exist: %v", req.GetName(), req.GetSourceVolumeId(), err)
 		}
 
 		return nil, status.Errorf(codes.Internal, "failed to create a snapshot (%s) of share %s: %v", req.GetName(), req.GetSourceVolumeId(), res.err)
@@ -378,7 +378,7 @@ func (cs *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 	}
 
 	if share.Status != shareAvailable {
-		return nil, status.Errorf(codes.InvalidArgument, "share %s is in an unexpected state: wanted %s, got %s", share.ID, shareAvailable, share.Status)
+		return nil, status.Errorf(codes.Internal, "share %s is in an unexpected state: wanted %s, got %s", share.ID, shareAvailable, share.Status)
 	}
 
 	if !compareProtocol(share.ShareProto, cs.d.shareProto) {

--- a/pkg/csi/manila/controllerserver.go
+++ b/pkg/csi/manila/controllerserver.go
@@ -229,6 +229,10 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 	// Retrieve the source share
 
 	if sourceShare, res.err = manilaClient.GetShareByID(req.GetSourceVolumeId()); res.err != nil {
+		if isManilaErrNotFound(res.err) {
+			return nil, status.Errorf(codes.InvalidArgument, "failed to create a snapshot (%s) for share %s because the share doesn't exist: %v", req.GetName(), req.GetSourceVolumeId(), err)
+		}
+
 		return nil, status.Errorf(codes.Internal, "failed to retrieve source share %s when creating a snapshot (%s): %v", req.GetSourceVolumeId(), req.GetName(), res.err)
 	}
 
@@ -246,10 +250,14 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 			return nil, status.Errorf(codes.DeadlineExceeded, "deadline exceeded while waiting for snapshot %s of share %s to become available", snapshot.ID, req.GetSourceVolumeId())
 		}
 
+		if isManilaErrNotFound(res.err) {
+			return nil, status.Errorf(codes.InvalidArgument, "failed to create a snapshot (%s) for share %s because the share doesn't exist: %v", req.GetName(), req.GetSourceVolumeId(), err)
+		}
+
 		return nil, status.Errorf(codes.Internal, "failed to create a snapshot (%s) of share %s: %v", req.GetName(), req.GetSourceVolumeId(), res.err)
 	}
 
-	if res.err = verifySnapshotCompatibility(sourceShare, snapshot, req); res.err != nil {
+	if res.err = verifySnapshotCompatibility(snapshot, req); res.err != nil {
 		return nil, status.Errorf(codes.AlreadyExists, "a snapshot named %s already exists, but is incompatible with the request: %v", req.GetName(), res.err)
 	}
 
@@ -332,7 +340,58 @@ func (cs *controllerServer) ControllerGetCapabilities(ctx context.Context, req *
 }
 
 func (cs *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "")
+	if err := validateValidateVolumeCapabilitiesRequest(req); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	osOpts, err := options.NewOpenstackOptions(req.GetSecrets())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid OpenStack secrets: %v", err)
+	}
+
+	for _, volCap := range req.GetVolumeCapabilities() {
+		if volCap.GetBlock() != nil {
+			return &csi.ValidateVolumeCapabilitiesResponse{Message: "block access type is not allowed"}, nil
+		}
+
+		if volCap.GetMount() == nil {
+			return &csi.ValidateVolumeCapabilitiesResponse{Message: "volume must be accessible via filesystem API"}, nil
+		}
+
+		if volCap.GetAccessMode().GetMode() == csi.VolumeCapability_AccessMode_UNKNOWN {
+			return &csi.ValidateVolumeCapabilitiesResponse{Message: "unknown volume access mode"}, nil
+		}
+	}
+
+	manilaClient, err := cs.d.manilaClientBuilder.New(osOpts)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "failed to create Manila v2 client: %v", err)
+	}
+
+	share, err := manilaClient.GetShareByID(req.GetVolumeId())
+	if err != nil {
+		if isManilaErrNotFound(err) {
+			return nil, status.Errorf(codes.NotFound, "share %s not found: %v", req.GetVolumeId(), err)
+		}
+
+		return nil, status.Errorf(codes.Internal, "failed to retrieve share %s: %v", req.GetVolumeId(), err)
+	}
+
+	if share.Status != shareAvailable {
+		return nil, status.Errorf(codes.InvalidArgument, "share %s is in an unexpected state: wanted %s, got %s", share.ID, shareAvailable, share.Status)
+	}
+
+	if !compareProtocol(share.ShareProto, cs.d.shareProto) {
+		return nil, status.Errorf(codes.InvalidArgument, "share protocol mismatch: wanted %s, got %s", cs.d.shareProto, share.ShareProto)
+	}
+
+	return &csi.ValidateVolumeCapabilitiesResponse{
+		Confirmed: &csi.ValidateVolumeCapabilitiesResponse_Confirmed{
+			VolumeContext:      req.GetVolumeContext(),
+			VolumeCapabilities: req.GetVolumeCapabilities(),
+			Parameters:         req.GetParameters(),
+		},
+	}, nil
 }
 
 func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {

--- a/pkg/csi/manila/controllerserver.go
+++ b/pkg/csi/manila/controllerserver.go
@@ -378,7 +378,11 @@ func (cs *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 	}
 
 	if share.Status != shareAvailable {
-		return nil, status.Errorf(codes.Internal, "share %s is in an unexpected state: wanted %s, got %s", share.ID, shareAvailable, share.Status)
+		if share.Status == shareCreating {
+			return nil, status.Errorf(codes.Unavailable, "share %s is in transient creating state", share.ID)
+		}
+
+		return nil, status.Errorf(codes.FailedPrecondition, "share %s is in an unexpected state: wanted %s, got %s", share.ID, shareAvailable, share.Status)
 	}
 
 	if !compareProtocol(share.ShareProto, cs.d.shareProto) {

--- a/pkg/csi/manila/nodeserver.go
+++ b/pkg/csi/manila/nodeserver.go
@@ -156,12 +156,12 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	shareOpts, err := options.NewNodeVolumeContext(req.GetVolumeContext())
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid volume parameters: %v", err)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid volume context: %v", err)
 	}
 
 	osOpts, err := options.NewOpenstackOptions(req.GetSecrets())
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid volume secret: %v", err)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid OpenStack secrets: %v", err)
 	}
 
 	volID := volumeID(req.GetVolumeId())
@@ -240,12 +240,12 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 
 	shareOpts, err := options.NewNodeVolumeContext(req.GetVolumeContext())
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid volume parameters: %v", err)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid volume context: %v", err)
 	}
 
 	osOpts, err := options.NewOpenstackOptions(req.GetSecrets())
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid volume secret: %v", err)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid OpenStack secrets: %v", err)
 	}
 
 	volID := volumeID(req.GetVolumeId())

--- a/pkg/csi/manila/nodeserver.go
+++ b/pkg/csi/manila/nodeserver.go
@@ -79,7 +79,11 @@ func (ns *nodeServer) buildVolumeContext(volID volumeID, shareOpts *options.Node
 	}
 
 	if share.Status != shareAvailable {
-		return nil, nil, status.Errorf(codes.InvalidArgument, "invalid share status for volume %s (share ID %s): expected 'available', got '%s'",
+		if share.Status == shareCreating {
+			return nil, nil, status.Errorf(codes.Unavailable, "share %s for volume %s is in transient creating state", share.ID, volID)
+		}
+
+		return nil, nil, status.Errorf(codes.FailedPrecondition, "invalid share status for volume %s (share ID %s): expected 'available', got '%s'",
 			volID, share.ID, share.Status)
 	}
 

--- a/pkg/csi/manila/volumesource.go
+++ b/pkg/csi/manila/volumesource.go
@@ -18,7 +18,6 @@ package manila
 
 import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -81,7 +80,7 @@ func (volumeFromSnapshot) create(req *csi.CreateVolumeRequest, shareName string,
 
 	snapshot, err := manilaClient.GetSnapshotByID(snapshotSource.GetSnapshotId())
 	if err != nil {
-		if _, ok := err.(gophercloud.ErrResourceNotFound); ok {
+		if isManilaErrNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "source snapshot %s not found: %v", snapshotSource.GetSnapshotId(), err)
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Part of #714

Continuing in an effort of integrating the csi-sanity test suite into CSI Manila, this is the third patch out of 4:

While testing the driver against the csi-sanity test suite, following errors were found:

* missing ValidateVolumeCapabilities in Controller Plugin
* validateNode{Unstage,Unpublish}Request functions were missing checks for empty staging/target paths
* verifySnapshotCompatibility's check for source volume ID was incorrect

this PR fixes the issues mentioned above and cleans up the codebase a bit

**Release note**:
```release-note
NONE
```
