### PR TITLE
Read application credentials from clouds.yaml

### DIFF
--- a/docs/provider-configuration.md
+++ b/docs/provider-configuration.md
@@ -134,14 +134,20 @@ with information about domain: `domain-id` or `domain-name`.
   delegate roles to another user (the trustee), and optionally allow the trustee
   to impersonate the trustor. Available trusts are found under the
   `/v3/OS-TRUST/trusts` endpoint of the Keystone API.
-* `UseClouds`: Set this flag to `true` to get authorization credentials from a clouds.yaml file. Options manually set in the `[Global]` section of $CLOUD_CONFIG file will be prioritized over values read from clouds.yaml. The recommended usage is to set the option `CloudsFile` with the path to your clouds.yaml file. However, by default a clouds.yaml file will be looked for in the following locations, in order, if it is not set:
+* `use-clouds`: Set this flag to `true` to get authorization credentials from a clouds.yaml file. Options manually set in the `[Global]` section of $CLOUD_CONFIG file will be prioritized over values read from clouds.yaml. The recommended usage is to set the option `CloudsFile` with the path to your clouds.yaml file. However, by default a clouds.yaml file will be looked for in the following locations, in order, if it is not set:
     1. A file path stored in the environment variable `OS_CLIENT_CONFIG_FILE`
     2. The directory `pkg/cloudprovider/providers/openstack/`
     3. The directory `~/.config/openstack`
     4. The directory `/etc/openstack`
-* `CloudsFile`: Used to specify the path to a clouds.yaml file that you want read authorization data from
-* `Cloud`: Used to specify which named cloud in the clouds.yaml file that you want to use
-
+* `clouds-file`: Used to specify the path to a clouds.yaml file that you want read authorization data from
+* `cloud`: Used to specify which named cloud in the clouds.yaml file that you want to use
+* `application-credential-id`: The ID of an application credential to
+  authenticate with. An `application-credential-secret` has to bet set along
+  with this parameter.
+* `application-credential-name`: The name of an application credential to
+  authenticate with.
+* `application-credential-secret`: The secret of an application credential to
+  authenticate with.
 
 ####  Networking
 

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -220,6 +220,11 @@ func logcfg(cfg Config) {
 	klog.V(5).Infof("TrustID: %s", cfg.Global.TrustID)
 	klog.V(5).Infof("Region: %s", cfg.Global.Region)
 	klog.V(5).Infof("CAFile: %s", cfg.Global.CAFile)
+	klog.V(5).Infof("UseClouds: %s", cfg.Global.UseClouds)
+	klog.V(5).Infof("CloudsFile: %s", cfg.Global.CloudsFile)
+	klog.V(5).Infof("Cloud: %s", cfg.Global.Cloud)
+	klog.V(5).Infof("ApplicationCredentialName: %s", cfg.Global.ApplicationCredentialName)
+	klog.V(5).Infof("ApplicationCredentialID: %s", cfg.Global.ApplicationCredentialID)
 }
 
 func init() {

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -404,6 +404,9 @@ func ReadClouds(cfg *Config) error {
 	cfg.Global.TenantName = replaceEmpty(cfg.Global.TenantName, cloud.AuthInfo.ProjectName)
 	cfg.Global.DomainID = replaceEmpty(cfg.Global.DomainID, cloud.AuthInfo.UserDomainID)
 	cfg.Global.DomainName = replaceEmpty(cfg.Global.DomainName, cloud.AuthInfo.UserDomainName)
+	cfg.Global.ApplicationCredentialID = replaceEmpty(cfg.Global.ApplicationCredentialID, cloud.AuthInfo.ApplicationCredentialID)
+	cfg.Global.ApplicationCredentialName = replaceEmpty(cfg.Global.ApplicationCredentialName, cloud.AuthInfo.ApplicationCredentialName)
+	cfg.Global.ApplicationCredentialSecret = replaceEmpty(cfg.Global.ApplicationCredentialSecret, cloud.AuthInfo.ApplicationCredentialSecret)
 	cfg.Global.Region = replaceEmpty(cfg.Global.Region, cloud.RegionName)
 	cfg.Global.CAFile = replaceEmpty(cfg.Global.CAFile, cloud.CACertFile)
 

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -220,7 +220,7 @@ func logcfg(cfg Config) {
 	klog.V(5).Infof("TrustID: %s", cfg.Global.TrustID)
 	klog.V(5).Infof("Region: %s", cfg.Global.Region)
 	klog.V(5).Infof("CAFile: %s", cfg.Global.CAFile)
-	klog.V(5).Infof("UseClouds: %s", cfg.Global.UseClouds)
+	klog.V(5).Infof("UseClouds: %t", cfg.Global.UseClouds)
 	klog.V(5).Infof("CloudsFile: %s", cfg.Global.CloudsFile)
 	klog.V(5).Infof("Cloud: %s", cfg.Global.Cloud)
 	klog.V(5).Infof("ApplicationCredentialName: %s", cfg.Global.ApplicationCredentialName)


### PR DESCRIPTION
Part of the #640 

Extends #426


## What this PR does / why we need it:

This PR allows to use application credentials, defined inside the clouds.yaml configuration file. Application credentials were considered only when they were defined explicitly inside the cloud provider config file. In addition the documentation was fixed and application credentials fields were added there.