### PR TITLE
[csi-manila] added a basis for compatibility layers

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -275,7 +275,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:53093afbce1ea4297c7083d9ee45a49e38904b95a4178ab15ccb4688e5bfc27b"
+  digest = "1:bfcea53226ffc0700c9d113ba083653fb9d2c91c899c6590659dd13571d9b0f3"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -320,6 +320,7 @@
     "openstack/sharedfilesystems/apiversions",
     "openstack/sharedfilesystems/v2/messages",
     "openstack/sharedfilesystems/v2/shares",
+    "openstack/sharedfilesystems/v2/sharetypes",
     "openstack/sharedfilesystems/v2/snapshots",
     "openstack/utils",
     "pagination",
@@ -1758,6 +1759,7 @@
     "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/apiversions",
     "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/messages",
     "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares",
+    "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharetypes",
     "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/snapshots",
     "github.com/gophercloud/gophercloud/openstack/utils",
     "github.com/gophercloud/gophercloud/pagination",

--- a/examples/manila-csi-plugin/helm-deployment/templates/controllerplugin-statefulset.yaml
+++ b/examples/manila-csi-plugin/helm-deployment/templates/controllerplugin-statefulset.yaml
@@ -70,6 +70,9 @@ spec:
             - "--drivername=$(DRIVER_NAME)"
             - "--share-protocol-selector=$(MANILA_SHARE_PROTO)"
             - "--fwdendpoint=$(FWD_CSI_ENDPOINT)"
+            {{- if .compatibilitySettings }}
+            - "--compatibility-settings={{ .compatibilitySettings }}"
+            {{- end }}
           env:
             - name: DRIVER_NAME
               value: {{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}

--- a/pkg/csi/manila/capabilities/manilacapabilities.go
+++ b/pkg/csi/manila/capabilities/manilacapabilities.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capabilities
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/manilaclient"
+)
+
+type (
+	ManilaCapability   int
+	ManilaCapabilities map[ManilaCapability]bool
+)
+
+const (
+	ManilaCapabilityNone ManilaCapability = iota
+	ManilaCapabilitySnapshot
+	ManilaCapabilityShareFromSnapshot
+)
+
+var (
+	manilaCapabilitiesByShareTypeIDMtx sync.RWMutex
+	manilaCapabilitiesByShareTypeID    = make(map[string]ManilaCapabilities)
+)
+
+func GetManilaCapabilities(shareType string, manilaClient manilaclient.Interface) (ManilaCapabilities, error) {
+	const (
+		snapshotSupport                = "snapshot_support"
+		createShareFromSnapshotSupport = "create_share_from_snapshot_support"
+	)
+
+	manilaCapabilitiesByShareTypeIDMtx.RLock()
+	caps, ok := manilaCapabilitiesByShareTypeID[shareType]
+	manilaCapabilitiesByShareTypeIDMtx.RUnlock()
+
+	strToBool := func(ss interface{}) bool {
+		var b bool
+		if ss != nil {
+			if str, ok := ss.(string); ok {
+				b, _ = strconv.ParseBool(str)
+			}
+		}
+		return b
+	}
+
+	if !ok {
+		manilaCapabilitiesByShareTypeIDMtx.Lock()
+		defer manilaCapabilitiesByShareTypeIDMtx.Unlock()
+
+		extraSpecs, err := shareTypeGetExtraSpecs(shareType, manilaClient)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve extra specs: %v", err)
+		}
+
+		caps = ManilaCapabilities{
+			ManilaCapabilitySnapshot:          strToBool(extraSpecs[snapshotSupport]),
+			ManilaCapabilityShareFromSnapshot: strToBool(extraSpecs[createShareFromSnapshotSupport]),
+		}
+
+		manilaCapabilitiesByShareTypeID[shareType] = caps
+	}
+
+	return caps, nil
+}

--- a/pkg/csi/manila/capabilities/util.go
+++ b/pkg/csi/manila/capabilities/util.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capabilities
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharetypes"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/manilaclient"
+	clouderrors "k8s.io/cloud-provider-openstack/pkg/util/errors"
+)
+
+func shareTypeGetExtraSpecs(shareType string, manilaClient manilaclient.Interface) (sharetypes.ExtraSpecs, error) {
+	extraSpecs, err := manilaClient.GetExtraSpecs(shareType)
+
+	if clouderrors.IsNotFound(err) {
+		// Maybe shareType is share type name, try to get its ID
+
+		id, err := manilaClient.GetShareTypeIDFromName(shareType)
+		if err != nil {
+			if clouderrors.IsNotFound(err) {
+				return extraSpecs, err
+			}
+
+			return extraSpecs, fmt.Errorf("failed to get share type ID for share type %s: %v", shareType, err)
+		}
+
+		return manilaClient.GetExtraSpecs(id)
+	}
+
+	return extraSpecs, err
+}

--- a/pkg/csi/manila/compatibility/compatibility.go
+++ b/pkg/csi/manila/compatibility/compatibility.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compatibility
+
+import (
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/capabilities"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/csiclient"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/manilaclient"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/options"
+)
+
+type Layer interface {
+	SupplementCapability(compatOpts *options.CompatibilityOptions, dstShare *shares.Share, dstShareAccessRight *shares.AccessRight, req *csi.CreateVolumeRequest, fwdEndpoint string, manilaClient manilaclient.Interface, csiClientBuilder csiclient.Builder) error
+}
+
+// Certain share protocols may not support certain Manila capabilities
+// in a given share type. This map forms a compatibility layer which
+// fills in the feature gap with in-driver functionality.
+var compatCaps = map[string]map[capabilities.ManilaCapability]Layer{}
+
+func FindCompatibilityLayer(shareProto string, wantsCap capabilities.ManilaCapability, shareTypeCaps capabilities.ManilaCapabilities) Layer {
+	if layers, ok := compatCaps[shareProto]; ok {
+		if hasCapability := shareTypeCaps[wantsCap]; !hasCapability {
+			if compatCapability, ok := layers[wantsCap]; ok {
+				return compatCapability
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/csi/manila/driver.go
+++ b/pkg/csi/manila/driver.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc"
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila/csiclient"
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila/manilaclient"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/options"
 	"k8s.io/klog"
 )
 
@@ -42,6 +43,8 @@ type Driver struct {
 
 	serverEndpoint string
 	fwdEndpoint    string
+
+	compatOpts *options.CompatibilityOptions
 
 	ids *identityServer
 	cs  *controllerServer
@@ -76,7 +79,7 @@ func argNotEmpty(val, name string) error {
 	return nil
 }
 
-func NewDriver(nodeID, driverName, endpoint, fwdEndpoint, shareProto string, manilaClientBuilder manilaclient.Builder, csiClientBuilder csiclient.Builder) (*Driver, error) {
+func NewDriver(nodeID, driverName, endpoint, fwdEndpoint, shareProto string, manilaClientBuilder manilaclient.Builder, csiClientBuilder csiclient.Builder, compatOpts *options.CompatibilityOptions) (*Driver, error) {
 	for k, v := range map[string]string{"node ID": nodeID, "driver name": driverName, "driver endpoint": endpoint, "FWD endpoint": fwdEndpoint, "share protocol selector": shareProto} {
 		if err := argNotEmpty(v, k); err != nil {
 			return nil, err
@@ -91,6 +94,7 @@ func NewDriver(nodeID, driverName, endpoint, fwdEndpoint, shareProto string, man
 		serverEndpoint:      endpoint,
 		fwdEndpoint:         fwdEndpoint,
 		shareProto:          strings.ToUpper(shareProto),
+		compatOpts:          compatOpts,
 		manilaClientBuilder: manilaClientBuilder,
 		csiClientBuilder:    csiClientBuilder,
 	}

--- a/pkg/csi/manila/manilaclient/client.go
+++ b/pkg/csi/manila/manilaclient/client.go
@@ -20,20 +20,12 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/messages"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharetypes"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/snapshots"
 )
 
 type Client struct {
 	c *gophercloud.ServiceClient
-}
-
-func (c Client) GetUserMessages(opts messages.ListOptsBuilder) ([]messages.Message, error) {
-	allPages, err := messages.List(c.c, opts).AllPages()
-	if err != nil {
-		return nil, err
-	}
-
-	return messages.ExtractMessages(allPages)
 }
 
 func (c Client) GetShareByID(shareID string) (*shares.Share, error) {
@@ -59,6 +51,10 @@ func (c Client) DeleteShare(shareID string) error {
 
 func (c Client) GetExportLocations(shareID string) ([]shares.ExportLocation, error) {
 	return shares.GetExportLocations(c.c, shareID).Extract()
+}
+
+func (c Client) SetShareMetadata(shareID string, opts shares.SetMetadataOptsBuilder) (map[string]string, error) {
+	return shares.SetMetadata(c.c, shareID, opts).Extract()
 }
 
 func (c Client) GetAccessRights(shareID string) ([]shares.AccessRight, error) {
@@ -88,4 +84,30 @@ func (c Client) CreateSnapshot(opts snapshots.CreateOptsBuilder) (*snapshots.Sna
 
 func (c Client) DeleteSnapshot(snapID string) error {
 	return snapshots.Delete(c.c, snapID).ExtractErr()
+}
+
+func (c Client) GetExtraSpecs(shareTypeID string) (sharetypes.ExtraSpecs, error) {
+	return sharetypes.GetExtraSpecs(c.c, shareTypeID).Extract()
+}
+
+func (c Client) GetShareTypes() ([]sharetypes.ShareType, error) {
+	allPages, err := sharetypes.List(c.c, sharetypes.ListOpts{}).AllPages()
+	if err != nil {
+		return nil, err
+	}
+
+	return sharetypes.ExtractShareTypes(allPages)
+}
+
+func (c Client) GetShareTypeIDFromName(shareTypeName string) (string, error) {
+	return sharetypes.IDFromName(c.c, shareTypeName)
+}
+
+func (c Client) GetUserMessages(opts messages.ListOptsBuilder) ([]messages.Message, error) {
+	allPages, err := messages.List(c.c, opts).AllPages()
+	if err != nil {
+		return nil, err
+	}
+
+	return messages.ExtractMessages(allPages)
 }

--- a/pkg/csi/manila/manilaclient/interface.go
+++ b/pkg/csi/manila/manilaclient/interface.go
@@ -19,6 +19,7 @@ package manilaclient
 import (
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/messages"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharetypes"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/snapshots"
 	openstack_provider "k8s.io/cloud-provider-openstack/pkg/cloudprovider/providers/openstack"
 )
@@ -31,6 +32,8 @@ type Interface interface {
 
 	GetExportLocations(shareID string) ([]shares.ExportLocation, error)
 
+	SetShareMetadata(shareID string, opts shares.SetMetadataOptsBuilder) (map[string]string, error)
+
 	GetAccessRights(shareID string) ([]shares.AccessRight, error)
 	GrantAccess(shareID string, opts shares.GrantAccessOptsBuilder) (*shares.AccessRight, error)
 
@@ -38,6 +41,10 @@ type Interface interface {
 	GetSnapshotByName(snapName string) (*snapshots.Snapshot, error)
 	CreateSnapshot(opts snapshots.CreateOptsBuilder) (*snapshots.Snapshot, error)
 	DeleteSnapshot(snapID string) error
+
+	GetExtraSpecs(shareTypeID string) (sharetypes.ExtraSpecs, error)
+	GetShareTypes() ([]sharetypes.ShareType, error)
+	GetShareTypeIDFromName(shareTypeName string) (string, error)
 
 	GetUserMessages(opts messages.ListOptsBuilder) ([]messages.Message, error)
 }

--- a/pkg/csi/manila/options/compatibilityoptions.go
+++ b/pkg/csi/manila/options/compatibilityoptions.go
@@ -17,8 +17,8 @@ import "k8s.io/cloud-provider-openstack/pkg/share/manila/shareoptions/validator"
 
 type CompatibilityOptions struct {
 	CreateShareFromSnapshotEnabled         string `name:"CreateShareFromSnapshotEnabled" value:"default:false" matches:"^true|false$"`
-	CreateShareFromSnapshotRetries         string `name:"CreateShareFromSnapshotRetries" value:"default:10" matches:"^\d+$"`
-	CreateShareFromSnapshotBackoffInterval string `name:"CreateShareFromSnapshotBackoffInterval" value:"default:5" matches:"^\d+$"`
+	CreateShareFromSnapshotRetries         string `name:"CreateShareFromSnapshotRetries" value:"default:10" matches:"^[0-9]+$"`
+	CreateShareFromSnapshotBackoffInterval string `name:"CreateShareFromSnapshotBackoffInterval" value:"default:5" matches:"^[0-9]+$"`
 }
 
 var (

--- a/pkg/csi/manila/options/compatibilityoptions.go
+++ b/pkg/csi/manila/options/compatibilityoptions.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import "k8s.io/cloud-provider-openstack/pkg/share/manila/shareoptions/validator"
+
+type CompatibilityOptions struct {
+	CreateShareFromSnapshotEnabled         string `name:"CreateShareFromSnapshotEnabled" value:"default:false" matches:"^true|false$"`
+	CreateShareFromSnapshotRetries         string `name:"CreateShareFromSnapshotRetries" value:"default:10" matches:"^\d+$"`
+	CreateShareFromSnapshotBackoffInterval string `name:"CreateShareFromSnapshotBackoffInterval" value:"default:5" matches:"^\d+$"`
+}
+
+var (
+	compatOptionsValidator = validator.New(&CompatibilityOptions{})
+)
+
+func NewCompatibilityOptions(data map[string]string) (*CompatibilityOptions, error) {
+	opts := &CompatibilityOptions{}
+	return opts, compatOptionsValidator.Populate(data, opts)
+}

--- a/pkg/csi/manila/sanity/fakemanilaclient.go
+++ b/pkg/csi/manila/sanity/fakemanilaclient.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sanity
 
 import (
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharetypes"
 	"strconv"
 
 	"github.com/gophercloud/gophercloud"
@@ -122,6 +123,22 @@ func (c fakeManilaClient) GetExportLocations(shareID string) ([]shares.ExportLoc
 	}
 
 	return []shares.ExportLocation{{Path: "fake-server:/fake-path"}}, nil
+}
+
+func (c fakeManilaClient) SetShareMetadata(shareID string, opts shares.SetMetadataOptsBuilder) (map[string]string, error) {
+	return nil, nil
+}
+
+func (c fakeManilaClient) GetExtraSpecs(shareTypeID string) (sharetypes.ExtraSpecs, error) {
+	return map[string]interface{}{"snapshot_support": "True", "create_share_from_snapshot_support": "True"}, nil
+}
+
+func (c fakeManilaClient) GetShareTypes() ([]sharetypes.ShareType, error) {
+	return nil, nil
+}
+
+func (c fakeManilaClient) GetShareTypeIDFromName(shareTypeName string) (string, error) {
+	return "", nil
 }
 
 func (c fakeManilaClient) GetAccessRights(shareID string) ([]shares.AccessRight, error) {

--- a/pkg/csi/manila/sanity/sanity_test.go
+++ b/pkg/csi/manila/sanity/sanity_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/kubernetes-csi/csi-test/pkg/sanity"
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/options"
 )
 
 func TestDriver(t *testing.T) {
@@ -37,7 +38,7 @@ func TestDriver(t *testing.T) {
 	endpoint := path.Join(basePath, "csi.sock")
 	fwdEndpoint := "unix:///fake-fwd-endpoint"
 
-	d, err := manila.NewDriver("node", "fake.manila.csi.openstack.org", endpoint, fwdEndpoint, "NFS", &fakeManilaClientBuilder{}, &fakeCSIClientBuilder{})
+	d, err := manila.NewDriver("node", "fake.manila.csi.openstack.org", endpoint, fwdEndpoint, "NFS", &fakeManilaClientBuilder{}, &fakeCSIClientBuilder{}, &options.CompatibilityOptions{})
 	if err != nil {
 		t.Fatalf("failed to initialize CSI Manila driver: %v", err)
 	}

--- a/pkg/csi/manila/util/manila.go
+++ b/pkg/csi/manila/util/manila.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/manilaclient"
+)
+
+func GetChosenExportLocation(shareID string, manilaClient manilaclient.Interface) (*shares.ExportLocation, error) {
+	availableExportLocations, err := manilaClient.GetExportLocations(shareID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve export locations: %v", err)
+	}
+
+	return ChooseExportLocation(availableExportLocations)
+}
+
+// Chooses one ExportLocation according to the below rules:
+// 1. Path is not empty
+// 2. IsAdminOnly == false
+// 3. Preferred == true are preferred over Preferred == false
+// 4. Locations with lower slice index are preferred over locations with higher slice index
+func ChooseExportLocation(locs []shares.ExportLocation) (*shares.ExportLocation, error) {
+	var (
+		foundMatchingNotPreferred = false
+		matchingNotPreferred      *shares.ExportLocation
+	)
+
+	for _, loc := range locs {
+		if loc.IsAdminOnly || strings.TrimSpace(loc.Path) == "" {
+			continue
+		}
+
+		if loc.Preferred {
+			return &loc, nil
+		}
+
+		if !foundMatchingNotPreferred {
+			matchingNotPreferred = &loc
+			foundMatchingNotPreferred = true
+		}
+	}
+
+	if foundMatchingNotPreferred {
+		return matchingNotPreferred, nil
+	}
+
+	return nil, errors.New("cannot find any non-admin export location")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Part of https://github.com/kubernetes/cloud-provider-openstack/issues/720

This PR:
* adds `capabilities` package: handles retrieval and recognizing of Manila capabilities from share types' extra specs
* adds `compatibility` package: contains an abstraction for compatibility layers. The idea is that if a certain capability is reported as missing, AND there exists compatibility layer for this capability of a certain share protocol, the driver will use the compatibility layer to fill in the missing caps.
* controller server now checks for available compat layers if necessary, specifically for the `create_share_from_snapshot_support` capability
* added `--compatibility-settings=...,SETTINGS` cmd flag - there are no actual compat settings yet so no documentation changes needed for now

Once this PR gets through, I'll be pushing another one that adds `create_share_from_snapshot_support` compatibility layer for native CephFS.

**Release note**:
```release-note
NONE
```
