### PR TITLE
Bad cmd arg in doc

### DIFF
--- a/docs/using-barbican-kms-plugin.md
+++ b/docs/using-barbican-kms-plugin.md
@@ -12,7 +12,7 @@ The following installation steps assumes that you have a Kubernetes cluster(v1.1
 
 1. Create 256bit(32 byte) cbc key and store in barbican
 ```
-$ openstack secret order create --name k8s_key --algorithm aes --mode cbc --bit-length 256 key  --payload-content-type=application/octet-stream key
+$ openstack secret order create --name k8s_key --algorithm aes --mode cbc --bit-length 256 --payload-content-type=application/octet-stream key
 +----------------+-----------------------------------------------------------------------+
 | Field          | Value                                                                 |
 +----------------+-----------------------------------------------------------------------+


### PR DESCRIPTION
Yields
```
-bash-4.2# openstack secret order create --name k8s_key --algorithm aes --mode cbc --bit-length 256 key  --payload-content-type=application/octet-stream key
usage: openstack secret order create [-h] [-f {json,shell,table,value,yaml}]
                                     [-c COLUMN] [--max-width <integer>]
                                     [--fit-width] [--print-empty]
                                     [--noindent] [--prefix PREFIX]
                                     [--name NAME] [--algorithm ALGORITHM]
                                     [--bit-length BIT_LENGTH] [--mode MODE]
                                     [--payload-content-type PAYLOAD_CONTENT_TYPE]
                                     [--expiration EXPIRATION]
                                     [--request-type REQUEST_TYPE]
                                     [--subject-dn SUBJECT_DN]
                                     [--source-container-ref SOURCE_CONTAINER_REF]
                                     [--ca-id CA_ID] [--profile PROFILE]
                                     [--request-file REQUEST_FILE]
                                     type

```
When run with latest client


Set to
`-bash-4.2# openstack secret order create --name k8s_key --algorithm aes --mode cbc --bit-length 256 --payload-content-type=application/octet-stream key`
Removing a typo for the documentation. 