### PR TITLE
Fix loadbalancer legacy name detection

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -1609,7 +1609,7 @@ func (lbaas *LbaasV2) UpdateLoadBalancer(ctx context.Context, clusterName string
 	}
 
 	name := lbaas.GetLoadBalancerName(ctx, clusterName, service)
-	legacyName := lbaas.GetLoadBalancerName(ctx, clusterName, service)
+	legacyName := lbaas.GetLoadBalancerLegacyName(ctx, clusterName, service)
 	loadbalancer, err := getLoadbalancerByName(lbaas.lb, name, legacyName)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgraded k8s cluster cannot update the loadbalancer:

```
failed to update load balancer hosts for service kube-system/nginx-ingress-controller: failed to find object
```

When the LB has an old-style legacy name, the LB cannot be detected.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix loadbalancer name detection in the UpdateLoadBalancer func
```
