### PR TITLE
Do not Delete LB in Case of Security Group Reconciliation Errors

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -1336,9 +1336,7 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 	if lbaas.opts.ManageSecurityGroups {
 		err := lbaas.ensureSecurityGroup(clusterName, apiService, nodes, loadbalancer)
 		if err != nil {
-			// cleanup what was created so far
-			_ = lbaas.EnsureLoadBalancerDeleted(ctx, clusterName, apiService)
-			return status, err
+			return status, fmt.Errorf("Error reconciling security groups for LB service %v/%v: %v", apiService.Namespace, apiService.Name, err)
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

This fixes the lbaas control loop's EnsureLoadBalancer() function so it no longer deletes the LB if something went wrong when reconciling the LB's security groups. With the current master, if you have an LB service and associated LB already up and running and working fine, and then during a reconcile loop (which shouldn't change anything) e.g. the OpenStack API is down temporarily at the wrong moment (i.e. if it's still up during the LB and listener reconciliation, but then down during the SG reconciliation), then the whole LB will be deleted. We saw this exact thing happen in a real world customer application, which went offline because of if (the LB is recreated shortly after, but likely with a different floating IP).

Deleting the LB in case of errors in a "reconcile" (rather than "create") function seems just wrong, and all the other parts of EnsureLoadBalancer() don't do it either: E.g. if a transient error occurs when creating a listener, we just return it and leave the LB in a half-created state (https://github.com/kubernetes/cloud-provider-openstack/blob/8f386afd4e0c2b21061f1013235a0af16767281f/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go#L1033-L1036), and the service controller will catch that error and re-queue the work item (https://github.com/kubernetes/kubernetes/blob/3fe7a570001ae0a6773da34a2eee7246ef416094/pkg/controller/service/service_controller.go#L255-L256) so the LB creation will go through eventually.

This PR just fixes the SG reconciliation to follow the same pattern. It seems to me that the current "delete LB in case an an error" approach was originally not part of a "reconcile" function but of a "create" function, where it would've made more sense.

The same bug is present in the legacy in-tree openstack cloud provider; I've submitted a corresponding PR there (https://github.com/kubernetes/kubernetes/pull/82264).

**Which issue this PR fixes** 

https://github.com/kubernetes/kubernetes/issues/35056

**Special notes for your reviewer**:

**Release note**:

```release-note
Do not delete managed LB in case of security group reconciliation errors
```
