### PR TITLE
magnum-auto-healer: Use Magnum resize API for the worker node repair

### DIFF
--- a/pkg/autohealing/cloudprovider/register/register.go
+++ b/pkg/autohealing/cloudprovider/register/register.go
@@ -96,6 +96,7 @@ func registerOpenStack(cfg config.Config, kubeClient kubernetes.Interface) (clou
 	if err != nil {
 		return nil, fmt.Errorf("failed to find Magnum service endpoint in the region %s: %v", cfg.OpenStack.Region, err)
 	}
+	magnumClient.Microversion = "latest"
 
 	var p cloudprovider.CloudProvider
 	p = openstack.OpenStackCloudProvider{

--- a/pkg/autohealing/controller/controller.go
+++ b/pkg/autohealing/controller/controller.go
@@ -245,7 +245,7 @@ func (c *Controller) getUnhealthyMasterNodes() ([]healthcheck.NodeInfo, error) {
 				continue
 			}
 
-			nodes = append(nodes, healthcheck.NodeInfo{KubeNode: node})
+			nodes = append(nodes, healthcheck.NodeInfo{KubeNode: node, IsWorker: false})
 		}
 	}
 
@@ -281,7 +281,7 @@ func (c *Controller) getUnhealthyWorkerNodes() ([]healthcheck.NodeInfo, error) {
 			log.V(4).Infof("The node %s is created less than the configured check delay, skip", node.Name)
 			continue
 		}
-		nodes = append(nodes, healthcheck.NodeInfo{KubeNode: node})
+		nodes = append(nodes, healthcheck.NodeInfo{KubeNode: node, IsWorker: true})
 	}
 
 	// Do health check

--- a/pkg/autohealing/healthcheck/healthcheck.go
+++ b/pkg/autohealing/healthcheck/healthcheck.go
@@ -30,6 +30,7 @@ type registerPlugin func(config interface{}) (HealthCheck, error)
 // NodeInfo is a wrapper of Node, may contains more information in future.
 type NodeInfo struct {
 	KubeNode apiv1.Node
+	IsWorker bool
 }
 
 type HealthCheck interface {


### PR DESCRIPTION
**What this PR does / why we need it**:
Use Magnum resize API for the worker node repair(resize doesn't support master node yet) which could change the cluster status as expected.

**Which issue this PR fixes**:
fixes #746
Partial-Implements: #648