### PR TITLE
Disable Octavia CI job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -8,15 +8,6 @@
               - ^OWNERS$
               - ^SECURITY_CONTACTS$
               - ^.gitignore$
-    cloud-provider-openstack-acceptance-test-lb-octavia:
-      jobs:
-        - cloud-provider-openstack-acceptance-test-lb-octavia:
-            irrelevant-files:
-              - ^docs/.*$
-              - ^.*\.md$
-              - ^OWNERS$
-              - ^SECURITY_CONTACTS$
-              - ^.gitignore$
     cloud-provider-openstack-format:
       jobs:
         - cloud-provider-openstack-format:
@@ -119,3 +110,12 @@
               - ^OWNERS$
               - ^SECURITY_CONTACTS$
               - ^.gitignore$
+    # cloud-provider-openstack-acceptance-test-lb-octavia:
+      # jobs:
+        - # cloud-provider-openstack-acceptance-test-lb-octavia:
+            # irrelevant-files:
+              # - ^docs/.*$
+              # - ^.*\.md$
+              # - ^OWNERS$
+              # - ^SECURITY_CONTACTS$
+              # - ^.gitignore$


### PR DESCRIPTION
OpenLab is unable to run octavia service for sometime, 
disable ocatvia CI job till then

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
