### PR TITLE
Add serviceName to SS of octavia-ingress-controller

### DIFF
--- a/docs/using-octavia-ingress-controller.md
+++ b/docs/using-octavia-ingress-controller.md
@@ -136,6 +136,7 @@ spec:
   selector:
     matchLabels:
       k8s-app: octavia-ingress-controller
+  serviceName: octavia-ingress-controller
   template:
     metadata:
       labels:


### PR DESCRIPTION

**What this PR does / why we need it**:

When applying current statefulSet sample, the error heppens like

```
$ kubectl apply -f octavia/deployment.yaml
error: error validating "octavia/deployment.yaml":
  error validating data: ValidationError(StatefulSet.spec):
  missing required field "serviceName" in io.k8s.api.apps.v1.State..
```

So this adds serviceName for avoiding the error.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
