### PR TITLE
OCCM: Support 'loadBalancerSourceRanges' for Service

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -267,7 +267,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:08ea11524c106b664f4fd84f2734f318dda486b4b4a9e78c55fb4dcb9d4129a8"
+  digest = "1:53093afbce1ea4297c7083d9ee45a49e38904b95a4178ab15ccb4688e5bfc27b"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -291,6 +291,7 @@
     "openstack/identity/v3/extensions/trusts",
     "openstack/identity/v3/tokens",
     "openstack/keymanager/v1/secrets",
+    "openstack/loadbalancer/v2/apiversions",
     "openstack/loadbalancer/v2/l7policies",
     "openstack/loadbalancer/v2/listeners",
     "openstack/loadbalancer/v2/loadbalancers",
@@ -318,7 +319,7 @@
     "testhelper/client",
   ]
   pruneopts = "UT"
-  revision = "aa85070daf8982f91c77f1aa4269c4f52bf7b4b6"
+  revision = "3d65851f4b6868efed5114aeb499305b0ff86870"
 
 [[projects]]
   branch = "master"
@@ -1718,6 +1719,7 @@
     "github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/trusts",
     "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens",
     "github.com/gophercloud/gophercloud/openstack/keymanager/v1/secrets",
+    "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/apiversions",
     "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies",
     "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners",
     "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers",

--- a/pkg/util/openstack/loadbalancer.go
+++ b/pkg/util/openstack/loadbalancer.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/apiversions"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
+)
+
+const (
+	OctaviaFeatureTags   = 0
+	OctaviaFeatureVIPACL = 1
+
+	loadbalancerActiveInitDelay = 1 * time.Second
+	loadbalancerActiveFactor    = 1.2
+	loadbalancerActiveSteps     = 19
+
+	activeStatus = "ACTIVE"
+	errorStatus  = "ERROR"
+)
+
+var (
+	octaviaVersion float64
+)
+
+// getOctaviaVersion returns the current Octavia API version.
+func getOctaviaVersion(client *gophercloud.ServiceClient) (float64, error) {
+	if octaviaVersion != 0 {
+		return octaviaVersion, nil
+	}
+
+	var defaultVer = 0.0
+	allPages, err := apiversions.List(client).AllPages()
+	if err != nil {
+		return defaultVer, err
+	}
+	versions, err := apiversions.ExtractAPIVersions(allPages)
+	if err != nil {
+		return defaultVer, err
+	}
+	if len(versions) == 0 {
+		return defaultVer, fmt.Errorf("API versions for Octavia not found")
+	}
+
+	klog.V(4).Infof("Found Octavia API versions: %v", versions)
+
+	// The current version is always the last one in the list
+	cur := versions[len(versions)-1]
+	octaviaVersion, err = strconv.ParseFloat(strings.TrimLeft(cur.ID, "v"), 32)
+	if err != nil {
+		return defaultVer, err
+	}
+
+	klog.V(4).Infof("The current Octavia API version: %v", octaviaVersion)
+
+	return octaviaVersion, nil
+}
+
+// IsOctaviaFeatureSupported returns true if the given feature is supported in Octavia
+func IsOctaviaFeatureSupported(client *gophercloud.ServiceClient, feature int) bool {
+	version, err := getOctaviaVersion(client)
+	if err != nil {
+		klog.Warningf("Failed to get current Octavia API version: %v", err)
+		return false
+	}
+
+	switch feature {
+	case OctaviaFeatureVIPACL:
+		if version >= 2.12 {
+			return true
+		}
+	case OctaviaFeatureTags:
+		if version >= 2.5 {
+			return true
+		}
+	default:
+		klog.V(4).Infof("Feature %d not recognized", feature)
+	}
+
+	return false
+}
+
+func waitLoadbalancerActive(client *gophercloud.ServiceClient, loadbalancerID string) error {
+	backoff := wait.Backoff{
+		Duration: loadbalancerActiveInitDelay,
+		Factor:   loadbalancerActiveFactor,
+		Steps:    loadbalancerActiveSteps,
+	}
+
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		loadbalancer, err := loadbalancers.Get(client, loadbalancerID).Extract()
+		if err != nil {
+			return false, err
+		}
+		if loadbalancer.ProvisioningStatus == activeStatus {
+			return true, nil
+		} else if loadbalancer.ProvisioningStatus == errorStatus {
+			return true, fmt.Errorf("loadbalancer has gone into ERROR state")
+		} else {
+			return false, nil
+		}
+
+	})
+
+	return err
+}
+
+// UpdateListener updates a listener and wait for the lb active
+func UpdateListener(client *gophercloud.ServiceClient, lbID string, listenerID string, opts listeners.UpdateOpts) error {
+	if _, err := listeners.Update(client, listenerID, opts).Extract(); err != nil {
+		return err
+	}
+
+	if err := waitLoadbalancerActive(client, lbID); err != nil {
+		return fmt.Errorf("failed to wait for load balancer ACTIVE after updating listener: %v", err)
+	}
+
+	return nil
+}
+
+// CreateListener creates a new listener
+func CreateListener(client *gophercloud.ServiceClient, lbID string, opts listeners.CreateOpts) (*listeners.Listener, error) {
+	listener, err := listeners.Create(client, opts).Extract()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := waitLoadbalancerActive(client, lbID); err != nil {
+		return nil, fmt.Errorf("failed to wait for load balancer ACTIVE after creating listener: %v", err)
+	}
+
+	return listener, nil
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// StringListEqual compares two string list, returns true if they have the same items, order doesn't matter
+func StringListEqual(list1, list2 []string) bool {
+	if len(list1) == 0 && len(list2) == 0 {
+		return true
+	}
+
+	if len(list1) != len(list2) {
+		return false
+	}
+
+	s1 := sets.String{}
+	for _, s := range list1 {
+		s1.Insert(s)
+	}
+	s2 := sets.String{}
+	for _, s := range list2 {
+		s2.Insert(s)
+	}
+
+	return s1.Equal(s2)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Support 'loadBalancerSourceRanges' for Service(Octavia based).

If specified, the Service will be restricted to the specified client IP ranges.

Only Octavia(API version >= v2.12) is supported, otherwise `loadBalancerSourceRanges` is ignored.

Example:
```
kind: Service
apiVersion: v1
metadata:
  name: test
  namespace: default
spec:
  type: LoadBalancer
  loadBalancerSourceRanges:
    - 192.168.32.1/24
  selector:
    run: echoserver
  ports:
    - protocol: TCP
      port: 80
      targetPort: 8080
```

**Which issue this PR fixes**:
fixes #770

**Special notes for your reviewer**:
This PR also contains a little bit refactoring by moving OpenStack API calls to a repo level util file. In the future, all OpenStack related API calls should live there to avoid code duplication.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```