### PR TITLE
Fix error when mounting /var/lib/kubelet/pods

### DIFF
--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -68,9 +68,6 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
-            - name: pods-mount-dir
-              mountPath: /var/lib/kubelet/pods
-              mountPropagation: "Bidirectional"
             - name: kubelet-dir
               mountPath: /var/lib/kubelet
               mountPropagation: "Bidirectional"
@@ -95,10 +92,6 @@ spec:
         - name: kubelet-dir
           hostPath:
             path: /var/lib/kubelet
-            type: Directory
-        - name: pods-mount-dir
-          hostPath:
-            path: /var/lib/kubelet/pods
             type: Directory
         - name: pods-cloud-data
           hostPath:


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes duplicate mount of /var/lib/kubelet and /var/lib/kubelet/pods which results in an error.
Duplicate https://github.com/kubernetes/cloud-provider-openstack/blob/master/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml#L95 introduced by PR #563 

**Which issue this PR fixes**
fixes #772

**Special notes for your reviewer**:
I left /var/lib/kubelet mounted and removed mounting /var/lib/kubelet/pods again

