### PR TITLE
Add variable export in cloud controller doc

### DIFF
--- a/docs/using-controller-manager-with-kubeadm.md
+++ b/docs/using-controller-manager-with-kubeadm.md
@@ -56,6 +56,7 @@
    Update `cloud.conf` configuration in `manifests/controller-manager/cloud-config-secret.yaml`:
 
     ```shell
+    export CLOUD_CONFIG=/etc/kubernetes/cloud-config
     kubectl create secret -n kube-system generic cloud-config --from-literal=cloud.conf="$(cat $CLOUD_CONFIG)" --dry-run -o yaml > manifests/controller-manager/cloud-config-secret.yaml
     kubectl -f manifests/controller-manager/cloud-config-secret.yaml apply
     ```


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds export variable CLOUD_CONFIG so that the `kubectl create secret` command doesn't hang.

**Special notes for your reviewer**:
People can figure it out by their own, but it is just to be precise in the documentation
