### PR TITLE
Cinder CSI: Restore the original microversion, when the resize was made

### DIFF
--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -256,8 +256,16 @@ func (os *OpenStack) ExpandVolume(volumeID string, newSize int) error {
 	createOpts := volumeexpand.ExtendSizeOpts{
 		NewSize: newSize,
 	}
+
+	// save initial microversion
+	mv := os.blockstorage.Microversion
 	os.blockstorage.Microversion = "3.42"
+
 	err := volumeexpand.ExtendSize(os.blockstorage, volumeID, createOpts).ExtractErr()
+
+	// restore initial microversion
+	os.blockstorage.Microversion = mv
+
 	return err
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In case, when the Cinder API doesn't support the **3.42** microversion, the whole cinder client can fail. This PR covers this case and restores the original microversion version, once the resize is performed. The similar change was already discussed in https://github.com/kubernetes/cloud-provider-openstack/pull/748#discussion_r321064005

**Release note**:

```release-note
Cinder CSI: Restore the original microversion, when the resize was made
```
