### PR TITLE
Barbican KMS: use persistent client

### DIFF
--- a/pkg/kms/barbican/fake_barbican.go
+++ b/pkg/kms/barbican/fake_barbican.go
@@ -5,7 +5,6 @@ import "encoding/hex"
 type FakeBarbican struct {
 }
 
-func (client *FakeBarbican) GetSecret(cfg Config) ([]byte, error) {
+func (client *FakeBarbican) GetSecret(keyID string) ([]byte, error) {
 	return hex.DecodeString("6368616e676520746869732070617373")
-
 }

--- a/pkg/kms/server/server_test.go
+++ b/pkg/kms/server/server_test.go
@@ -12,7 +12,6 @@ import (
 var s = new(KMSserver)
 
 func TestInitConfig(t *testing.T) {
-
 }
 
 func TestVersion(t *testing.T) {
@@ -38,5 +37,4 @@ func TestEncryptDecrypt(t *testing.T) {
 		t.Log(err)
 		t.FailNow()
 	}
-
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

It adds a persistent barbican client and avoid keystone auth on every Encryption/Decryption call.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #787

**Special notes for your reviewer**:

@adisky I'm probably missing some not obvious use cases, which led to the current logic. Feel free to correct me if I'm wrong.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Barbican KMS: use persistent client
```
