### PR TITLE
Auth: Ability to set insecure TLS auth without the custom CA

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -197,7 +197,7 @@ type AuthOpts struct {
 	CAFile           string `gcfg:"ca-file" mapstructure:"ca-file" name:"os-certAuthorityPath" value:"optional"`
 
 	// Manila only options
-	TLSInsecure string `name:"os-TLSInsecure" value:"optional" dependsOn:"os-certAuthority|os-certAuthorityPath" matches:"^true|false$"`
+	TLSInsecure string `name:"os-TLSInsecure" value:"optional" matches:"^true|false$"`
 	// backward compatibility with the manila-csi-plugin
 	CAFileContents  string `name:"os-certAuthority" value:"optional"`
 	TrusteeID       string `name:"os-trusteeID" value:"optional" dependsOn:"os-trustID"`
@@ -522,12 +522,12 @@ func NewOpenStackClient(cfg *AuthOpts, userAgent string, extraUserAgent ...strin
 		}
 	}
 
+	config := &tls.Config{}
 	if caPool != nil {
-		config := &tls.Config{}
 		config.RootCAs = caPool
-		config.InsecureSkipVerify = cfg.TLSInsecure == "true"
-		provider.HTTPClient.Transport = netutil.SetOldTransportDefaults(&http.Transport{TLSClientConfig: config})
 	}
+	config.InsecureSkipVerify = cfg.TLSInsecure == "true"
+	provider.HTTPClient.Transport = netutil.SetOldTransportDefaults(&http.Transport{TLSClientConfig: config})
 
 	if cfg.TrustID != "" {
 		opts := cfg.ToAuth3Options()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

This PR allows to specify an insecure TLS connection independently on whether the custom CA was set.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

This is a follow up for the #735

**Release note**:
```release-note
Auth: Ability to set insecure TLS auth without the custom CA
```
