### PR TITLE
Add e2e tests for cinder CSI

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -64,6 +64,20 @@
               - ^OWNERS$
               - ^SECURITY_CONTACTS$
               - ^.gitignore$
+    cloud-provider-openstack-e2e-test-csi-cinder:
+      jobs:
+        - cloud-provider-openstack-e2e-test-csi-cinder:
+            files:
+              - ^pkg/csi/cinder/.*
+              - ^pkg/util/.*
+              - ^go.mod$
+              - ^go.sum$
+            irrelevant-files:
+              - ^docs/.*$
+              - ^.*\.md$
+              - ^OWNERS$
+              - ^SECURITY_CONTACTS$
+              - ^.gitignore$
     cloud-provider-openstack-acceptance-test-flexvolume-cinder:
       jobs:
         - cloud-provider-openstack-acceptance-test-flexvolume-cinder:
@@ -85,7 +99,7 @@
               - ^.*\.md$
               - ^OWNERS$
               - ^SECURITY_CONTACTS$
-              - ^.gitignore$              
+              - ^.gitignore$
     cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.14:
       jobs:
         - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.14:

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ test: unit functional
 check: work fmt vet lint import-boss
 
 unit: work
-	go test -tags=unit $(shell go list ./... | sed -e '/sanity/ { N; d; }') $(TESTARGS)
+	go test -tags=unit $(shell go list ./... | sed -e '/sanity/ { N; d; }' | sed -e '/tests/ {N; d;}' | sed -e '/test/ {N; d;}') $(TESTARGS)
 
 functional:
 	@echo "$@ not yet implemented"

--- a/cmd/tests/cinder_csi_e2e_suite_test.go
+++ b/cmd/tests/cinder_csi_e2e_suite_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/reporters"
+	"github.com/onsi/gomega"
+	_ "k8s.io/cloud-provider-openstack/test"
+	"k8s.io/kubernetes/test/e2e/framework"
+	frameworkconfig "k8s.io/kubernetes/test/e2e/framework/config"
+)
+
+func init() {
+	frameworkconfig.CopyFlags(frameworkconfig.Flags, flag.CommandLine)
+	framework.RegisterCommonFlags(flag.CommandLine)
+	framework.RegisterClusterFlags(flag.CommandLine)
+	framework.AfterReadingAllFlags(&framework.TestContext)
+}
+
+func Test(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	var r []ginkgo.Reporter
+	if framework.TestContext.ReportDir != "" {
+		if err := os.MkdirAll(framework.TestContext.ReportDir, 0755); err != nil {
+			log.Fatalf("Failed creating report directory: %v", err)
+		} else {
+			r = append(r, reporters.NewJUnitReporter(path.Join(framework.TestContext.ReportDir, fmt.Sprintf("junit_%v%02d.xml", framework.TestContext.ReportPrefix, config.GinkgoConfig.ParallelNode))))
+		}
+	}
+	log.Printf("Starting e2e run %q on Ginkgo node %d", framework.RunID, config.GinkgoConfig.ParallelNode)
+
+	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "Cinder CSI Suite", r)
+}
+
+func main() {
+	flag.Parse()
+	Test(&testing.T{})
+}

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 )
 
 replace (
+	github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.0-rc9
 	k8s.io/api => k8s.io/kubernetes/staging/src/k8s.io/api v0.0.0-20191105135202-3d13137d1b45
 	k8s.io/apiextensions-apiserver => k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver v0.0.0-20191105135202-3d13137d1b45
 	k8s.io/apimachinery => k8s.io/kubernetes/staging/src/k8s.io/apimachinery v0.0.0-20191105135202-3d13137d1b45

--- a/go.sum
+++ b/go.sum
@@ -108,11 +108,13 @@ github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r
 github.com/docker/go-connections v0.3.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/libnetwork v0.0.0-20180830151422-a9cd636e3789/go.mod h1:93m0aTqz6z+g32wla4l4WxTrdtvBRmVzYRkYvasA5Z8=
+github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e h1:p1yVGRW3nmb85p1Sh1ZJSDm4A4iKLS5QNbvUHMgGu/M=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -192,6 +194,7 @@ github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4er
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 h1:ZgQEtGgCBiWRM39fZuwSd1LwSqqSW0hOdXCYYDX0R3I=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.2.0 h1:28o5sBqPkBsMGnC6b4MvE2TzSr5/AT4c/1fLqVGIwlk=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -676,6 +679,7 @@ k8s.io/kubernetes/staging/src/k8s.io/cluster-bootstrap v0.0.0-20191105135202-3d1
 k8s.io/kubernetes/staging/src/k8s.io/code-generator v0.0.0-20191105135202-3d13137d1b45/go.mod h1:0msqAWw6krnf6hgzwYoPw/3El6qGk9Zs794aMbEz2os=
 k8s.io/kubernetes/staging/src/k8s.io/component-base v0.0.0-20191105135202-3d13137d1b45 h1:UAkVzwL2eFDIwbKo3wMgVVO4i4MLJx4HRMuQMzIwyHs=
 k8s.io/kubernetes/staging/src/k8s.io/component-base v0.0.0-20191105135202-3d13137d1b45/go.mod h1:pVoMriOrCK9bn7ygqwV0chUEC3/gEE8mifrAIasX6Hw=
+k8s.io/kubernetes/staging/src/k8s.io/cri-api v0.0.0-20191105135202-3d13137d1b45 h1:S9vX7CFiqo9R5SPDtZPE7Zrtyn00Gtp3PrY2BPLFa24=
 k8s.io/kubernetes/staging/src/k8s.io/cri-api v0.0.0-20191105135202-3d13137d1b45/go.mod h1:6A/okAaI8CT6bZLcANTcsyczTXAK5et0mNN7ZIFmyeI=
 k8s.io/kubernetes/staging/src/k8s.io/csi-translation-lib v0.0.0-20191105135202-3d13137d1b45 h1:ELTGRLw+GX/oV8org5jECkq5BGFWTuq5mMVqGvr3azM=
 k8s.io/kubernetes/staging/src/k8s.io/csi-translation-lib v0.0.0-20191105135202-3d13137d1b45/go.mod h1:7M0MTjJgx3R3qWa7kfHLDEpDVFHsmgt3K4zbOnXrA1o=
@@ -684,6 +688,7 @@ k8s.io/kubernetes/staging/src/k8s.io/kube-controller-manager v0.0.0-201911051352
 k8s.io/kubernetes/staging/src/k8s.io/kube-controller-manager v0.0.0-20191105135202-3d13137d1b45/go.mod h1:c7r1MlCkXv94cLQimvdU/T4yd4gLySiBqaqvULD8acE=
 k8s.io/kubernetes/staging/src/k8s.io/kube-proxy v0.0.0-20191105135202-3d13137d1b45/go.mod h1:u8/4SNyg0o8T9ETAo/ZfaT0HFBIcJIqAQZbvlyORc0c=
 k8s.io/kubernetes/staging/src/k8s.io/kube-scheduler v0.0.0-20191105135202-3d13137d1b45/go.mod h1:VLZ2e1uf+/b4YudLJ5dKrUxR0s+1c9YDKP3aWjMPqic=
+k8s.io/kubernetes/staging/src/k8s.io/kubectl v0.0.0-20191105135202-3d13137d1b45 h1:CjFWORlXSINf4D1o4MpfqRZXnNyVCCGUy4IDghwdb18=
 k8s.io/kubernetes/staging/src/k8s.io/kubectl v0.0.0-20191105135202-3d13137d1b45/go.mod h1:QA2OA5c8ATTVUQZGXcaxAkoU+ikSBhF+CjVXEgs94os=
 k8s.io/kubernetes/staging/src/k8s.io/kubelet v0.0.0-20191105135202-3d13137d1b45/go.mod h1:dm5QNofitgxRLzyx95GAvm416hc+3VE8bRQ8vgXdOyw=
 k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20191105135202-3d13137d1b45/go.mod h1:p5mlnbB8n6iSUWB8o4wGiHT86RM8rMBqUYHl5FjC/+0=

--- a/test/cinder-testdriver.go
+++ b/test/cinder-testdriver.go
@@ -1,0 +1,100 @@
+package test
+
+import (
+	"fmt"
+
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/storage/testpatterns"
+	"k8s.io/kubernetes/test/e2e/storage/testsuites"
+)
+
+type cinderDriver struct {
+	driverInfo testsuites.DriverInfo
+	manifests  []string
+}
+
+var Cinderdriver = InitCinderDriver
+
+type cinderVolume struct {
+	ID               string
+	Name             string
+	Status           string
+	AvailabilityZone string
+	f                *framework.Framework
+}
+
+// initCinderDriver returns cinderDriver that implements TestDriver interface
+func initCinderDriver(name string, manifests ...string) testsuites.TestDriver {
+	return &cinderDriver{
+		driverInfo: testsuites.DriverInfo{
+			Name:        name,
+			MaxFileSize: testpatterns.FileSizeLarge,
+			SupportedFsType: sets.NewString(
+				"", // Default fsType
+				"ext2",
+				"ext3",
+				"ext4",
+				"xfs",
+			),
+			Capabilities: map[testsuites.Capability]bool{
+				testsuites.CapPersistence: true,
+				testsuites.CapFsGroup:     true,
+				testsuites.CapExec:        true,
+				testsuites.CapMultiPODs:   true,
+			},
+		},
+		manifests: manifests,
+	}
+}
+
+func InitCinderDriver() testsuites.TestDriver {
+
+	return initCinderDriver("cinder.csi.openstack.org",
+		"cinder-csi-controllerplugin.yaml",
+		"cinder-csi-controllerplugin-rbac.yaml",
+		"cinder-csi-nodeplugin.yaml",
+		"cinder-csi-nodeplugin-rbac.yaml",
+		"csi-secret-cinderplugin.yaml")
+
+}
+
+var _ testsuites.TestDriver = &cinderDriver{}
+
+// var _ testsuites.PreprovisionedVolumeTestDriver = &cinderDriver{}
+// var _ testsuites.PreprovisionedPVTestDriver = &cinderDriver{}
+var _ testsuites.DynamicPVTestDriver = &cinderDriver{}
+
+func (d *cinderDriver) GetDriverInfo() *testsuites.DriverInfo {
+	return &d.driverInfo
+}
+
+func (d *cinderDriver) SkipUnsupportedTest(pattern testpatterns.TestPattern) {
+}
+
+func (d *cinderDriver) GetDynamicProvisionStorageClass(config *testsuites.PerTestConfig, fsType string) *storagev1.StorageClass {
+	provisioner := "cinder.csi.openstack.org"
+	parameters := map[string]string{}
+	if fsType != "" {
+		parameters["fsType"] = fsType
+	}
+	ns := config.Framework.Namespace.Name
+	suffix := fmt.Sprintf("%s-sc", d.driverInfo.Name)
+
+	return testsuites.GetStorageClass(provisioner, parameters, nil, ns, suffix)
+}
+
+func (d *cinderDriver) GetClaimSize() string {
+	return "2Gi"
+}
+
+func (d *cinderDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestConfig, func()) {
+	config := &testsuites.PerTestConfig{
+		Driver:    d,
+		Prefix:    "cinder",
+		Framework: f,
+	}
+
+	return config, func() {}
+}

--- a/test/csi-volumes.go
+++ b/test/csi-volumes.go
@@ -1,0 +1,33 @@
+package test
+
+import (
+	"path"
+
+	. "github.com/onsi/ginkgo"
+	_ "github.com/onsi/gomega"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/testfiles"
+	"k8s.io/kubernetes/test/e2e/storage/testsuites"
+	"k8s.io/kubernetes/test/e2e/storage/utils"
+)
+
+var CSITestSuites = []func() testsuites.TestSuite{
+	testsuites.InitVolumesTestSuite,
+	testsuites.InitSubPathTestSuite,
+	testsuites.InitProvisioningTestSuite,
+	//testsuites.InitVolumeIOTestSuite,
+	//testsuites.InitVolumeModeTestSuite,
+	//testsuites.InitSnapshottableTestSuite,
+	//testsuites.InitMultiVolumeTestSuite,
+}
+
+// This executes testSuites for csi volumes.
+var _ = utils.SIGDescribe("[cinder-csi-e2e] CSI Volumes", func() {
+	testfiles.AddFileSource(testfiles.RootFileSource{Root: path.Join(framework.TestContext.RepoRoot, "../../manifests/cinder-csi-plugin/")})
+
+	curDriver := Cinderdriver()
+	Context(testsuites.GetDriverNameWithFeatureTags(curDriver), func() {
+		testsuites.DefineTestSuite(curDriver, CSITestSuites)
+	})
+
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR adds e2e test framework for cinder CSI driver.
This PR enables only dynamic provisioning tests.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #690 

**Special notes for your reviewer**:
PR to enable the job in openlab is here https://github.com/theopenlab/openlab-zuul-jobs/pull/690
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Adds e2e test framework for cinder csi driver.
```
