### PR TITLE
Auth: bring back identity v2 support

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -547,7 +547,7 @@ func NewOpenStackClient(cfg *AuthOpts, userAgent string, extraUserAgent ...strin
 	}
 
 	opts := cfg.ToAuthOptions()
-	err = openstack.AuthenticateV3(provider, &opts, gophercloud.EndpointOpts{})
+	err = openstack.Authenticate(provider, opts)
 
 	return provider, err
 }

--- a/pkg/cloudprovider/providers/openstack/openstack_routes_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_routes_test.go
@@ -31,10 +31,11 @@ func TestRoutes(t *testing.T) {
 	const clusterName = "ignored"
 
 	cfg := ConfigFromEnv()
+	testConfigFromEnv(t, &cfg)
 
 	os, err := NewOpenStack(cfg)
 	if err != nil {
-		testConfigFromEnv(t, "Failed to construct/authenticate OpenStack: %s", err)
+		t.Fatalf("Failed to construct/authenticate OpenStack: %s", err)
 	}
 
 	vms := getServers(os)

--- a/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -729,15 +729,17 @@ func TestNodeAddressesIPv6Disabled(t *testing.T) {
 
 func TestNewOpenStack(t *testing.T) {
 	cfg := ConfigFromEnv()
+	testConfigFromEnv(t, &cfg)
 
 	_, err := NewOpenStack(cfg)
 	if err != nil {
-		testConfigFromEnv(t, "Failed to construct/authenticate OpenStack: %s", err)
+		t.Fatalf("Failed to construct/authenticate OpenStack: %s", err)
 	}
 }
 
 func TestLoadBalancer(t *testing.T) {
 	cfg := ConfigFromEnv()
+	testConfigFromEnv(t, &cfg)
 
 	versions := []string{"v2"}
 
@@ -747,7 +749,7 @@ func TestLoadBalancer(t *testing.T) {
 
 		os, err := NewOpenStack(cfg)
 		if err != nil {
-			testConfigFromEnv(t, "Failed to construct/authenticate OpenStack: %s", err)
+			t.Fatalf("Failed to construct/authenticate OpenStack: %s", err)
 		}
 
 		lb, ok := os.LoadBalancer()
@@ -805,10 +807,11 @@ var diskPathRegexp = regexp.MustCompile("/dev/disk/(?:by-id|by-path)/")
 
 func TestVolumes(t *testing.T) {
 	cfg := ConfigFromEnv()
+	testConfigFromEnv(t, &cfg)
 
 	os, err := NewOpenStack(cfg)
 	if err != nil {
-		testConfigFromEnv(t, "Failed to construct/authenticate OpenStack: %s", err)
+		t.Fatalf("Failed to construct/authenticate OpenStack: %s", err)
 	}
 
 	tags := map[string]string{
@@ -1088,9 +1091,8 @@ func resetEnviron(t *testing.T, items []string) {
 	}
 }
 
-func testConfigFromEnv(t *testing.T, msg string, err error) {
-	if err.Error() == "You must provide a password to authenticate" {
+func testConfigFromEnv(t *testing.T, cfg *Config) {
+	if cfg.Global.AuthURL == "" {
 		t.Skip("No config found in environment")
 	}
-	t.Fatalf("Failed to construct/authenticate OpenStack: %s", err)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Keystone V2 support was removed due to the auth code refactoring in #733. This PR should bring the support back.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #803

**Special notes for your reviewer**:

In #733 I accidentally used the `openstack.AuthenticateV3` instead of the `openstack.Authenticate` func. `openstack.Authenticate` is a wrapper around the `AuthenticateV2` and `AuthenticateV3`, therefore it should be fine to call it to keep the identity v2 support.

**Release note**:

```release-note
Fix the bug, when keystone v2 support was removed
```
