### PR TITLE
fix duplicate sg

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -25,3 +25,13 @@ func StringListEqual(list1, list2 []string) bool {
 
 	return s1.Equal(s2)
 }
+
+// Contains is checking does array contain single word
+func Contains(array []string, word string) bool {
+	for _, item := range array {
+		if item == word {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
I am getting following error when using manage security groups with octavia loadbalancer:

```
  Warning  SyncLoadBalancerFailed  16m                  service-controller  Error syncing load balancer: failed to ensure load balancer: failed when reconciling security groups for LB service ingress-nginx-internal/ingress-nginx-internal: failed to update security group for port 3a656944-3bee-4062-bb3b-f01d835d8134: Bad request with: [PUT https://foobar.com/v2.0/ports/3a656944-3bee-4062-bb3b-f01d835d8134], error message: {"NeutronError": {"message": "Invalid input for security_groups. Reason: Duplicate items in the list: '2d8cd47a-5ad1-428b-88be-88d5f8fa596c'.", "type": "HTTPBadRequest", "detail": ""}}
```

This PR will check does the SG already exist in port SGs - if yes then it will not append that.