### PR TITLE
Add support for creating loadbalancer's VIP using Neutron Network ID

### DIFF
--- a/docs/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/expose-applications-using-loadbalancer-type-service.md
@@ -91,6 +91,10 @@ Request Body:
 
   VIP subnet ID of load balancer created.
 
+- loadbalancer.openstack.org/network-id
+
+  The network ID which will allocate virtual IP for loadbalancer.
+
 - loadbalancer.openstack.org/port-id
 
   The VIP port ID for load balancer created.

--- a/docs/provider-configuration.md
+++ b/docs/provider-configuration.md
@@ -201,6 +201,10 @@ file.
 * `subnet-id`: Used to specify the ID of the subnet you want to
   create your loadbalancer on. Can be found at Network > Networks. Click on the
   respective network to get its subnets.
+* `network-id`: Used to specify the ID of the network you want to create your
+  loadbalancer on. A subnet with available IP addresses will be selected to
+  create loadbalancer's virtual IP. In case of Octavia, preference will be given
+  to IPv4 over IPv6 subnets.
 * `manage-security-groups`: Determines whether or not the load
   balancer should automatically manage the security group rules. Valid values
   are `true` and `false`. The default is `false`. When `true` is specified

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -115,6 +115,7 @@ type LoadBalancerOpts struct {
 	LBVersion            string              `gcfg:"lb-version"`          // overrides autodetection. Only support v2.
 	UseOctavia           bool                `gcfg:"use-octavia"`         // uses Octavia V2 service catalog endpoint
 	SubnetID             string              `gcfg:"subnet-id"`           // overrides autodetection.
+	NetworkID            string              `gcfg:"network-id"`          // If specified, will create virtual ip from a subnet in network which has available IP addresses
 	FloatingNetworkID    string              `gcfg:"floating-network-id"` // If specified, will create floating ip for loadbalancer, or do not create floating ip.
 	FloatingSubnetID     string              `gcfg:"floating-subnet-id"`  // If specified, will create floating ip for loadbalancer in this particular floating pool subnetwork.
 	LBClasses            map[string]*LBClass // Predefined named Floating networks and subnets
@@ -134,6 +135,7 @@ type LBClass struct {
 	FloatingNetworkID string `gcfg:"floating-network-id,omitempty"`
 	FloatingSubnetID  string `gcfg:"floating-subnet-id,omitempty"`
 	SubnetID          string `gcfg:"subnet-id,omitempty"`
+	NetworkID         string `gcfg:"network-id,omitempty"`
 }
 
 // BlockStorageOpts is used to talk to Cinder service


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Add support for creating loadbalancer's VIP using Neutron Network ID.

In addition to Subnet ID, Neutron LBaaS v2 API support creation of loadbalancers using Neutron Network ID. A subnet is chosen from network which has available IP addresses. In case of Octavia backend, IPv4 subnets are preferred over IPv6 subnets.


**Special notes for your reviewer**:

The network ID can be specified in cloud-config file or by using the annotation `loadbalancer.openstack.org/network-id`

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note

```
