### PR TITLE
Remove loading config from Env Variables

### DIFF
--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -116,7 +116,8 @@ func CreateOpenStackProvider() (IOpenStack, error) {
 	// Get config from file
 	cfg, err := GetConfigFromFile(configFile)
 	if err != nil {
-		cfg = Config{Config: openstack_provider.ConfigFromEnv()}
+		klog.Errorf("GetConfigFromFile %s failed with error: %v", configFile, err)
+		return nil, err
 	}
 	logcfg(cfg)
 

--- a/pkg/csi/cinder/openstack/openstack_test.go
+++ b/pkg/csi/cinder/openstack/openstack_test.go
@@ -22,10 +22,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gophercloud/gophercloud"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
-	openstack_provider "k8s.io/cloud-provider-openstack/pkg/cloudprovider/providers/openstack"
 )
 
 var fakeFileName = "cloud.conf"
@@ -82,42 +80,6 @@ region=` + fakeRegion + `
 
 	// Assert
 	assert.Equal(expectedOpts, actualAuthOpts)
-}
-
-// Test GetConfigFromEnv
-func TestGetConfigFromEnv(t *testing.T) {
-	env := clearEnviron(t)
-	defer resetEnviron(t, env)
-
-	// init env
-	os.Setenv("OS_AUTH_URL", fakeAuthUrl)
-	os.Setenv("OS_USERNAME", fakeUserName)
-	os.Setenv("OS_PASSWORD", fakePassword)
-	os.Setenv("OS_TENANT_ID", fakeTenantID)
-	os.Setenv("OS_DOMAIN_ID", fakeDomainID)
-	os.Setenv("OS_REGION_NAME", fakeRegion)
-
-	// Init assert
-	assert := assert.New(t)
-
-	expectedAuthOpts := gophercloud.AuthOptions{
-		IdentityEndpoint: fakeAuthUrl,
-		Username:         fakeUserName,
-		Password:         fakePassword,
-		TenantID:         fakeTenantID,
-		DomainID:         fakeDomainID,
-		AllowReauth:      true,
-		Scope: &gophercloud.AuthScope{
-			ProjectID: fakeTenantID,
-		},
-	}
-
-	// Invoke openstack_provider.ConfigFromEnv
-	actualAuthOpts := openstack_provider.ConfigFromEnv()
-
-	// Assert
-	assert.Equal(fakeRegion, actualAuthOpts.Global.Region)
-	assert.Equal(expectedAuthOpts, actualAuthOpts.Global.ToAuthOptions())
 }
 
 func TestUserAgentFlag(t *testing.T) {

--- a/pkg/volume/cinder/volumeservice/connection.go
+++ b/pkg/volume/cinder/volumeservice/connection.go
@@ -48,15 +48,18 @@ func AddExtraFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVar(&userAgentData, "user-agent", nil, "Extra data to add to gophercloud user-agent. Use multiple times to add more than one component.")
 }
 
-func getConfigFromEnv() cinderConfig {
-	cfg := cinderConfig{Config: openstack_provider.ConfigFromEnv()}
+// getConfigFromEnv() is no longer supported
+// func getConfigFromEnv() cinderConfig {
+// 	cfg := cinderConfig{Config: openstack_provider.ConfigFromEnv()}
 
-	cfg.Cinder.Endpoint = os.Getenv("OS_CINDER_ENDPOINT")
-	return cfg
-}
+// 	cfg.Cinder.Endpoint = os.Getenv("OS_CINDER_ENDPOINT")
+// 	return cfg
+// }
 
 func getConfig(configFilePath string) (cinderConfig, error) {
-	config := getConfigFromEnv()
+	// Support from loading from Env is no longer supported. kubernetes/kubernetes#81117
+	// config := getConfigFromEnv()
+	var config cinderConfig
 	if configFilePath != "" {
 		var configFile *os.File
 		configFile, err := os.Open(configFilePath)

--- a/pkg/volume/cinder/volumeservice/connection_test.go
+++ b/pkg/volume/cinder/volumeservice/connection_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package volumeservice
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"reflect"
 	"strings"
@@ -32,35 +31,6 @@ var fakeAuthUrl = "https://169.254.169.254/identity/v3"
 var fakeTenantID = "c869168a828847f39f7f06edd7305637"
 var fakeDomainID = "2a73b8f597c04551a0fdc8e95544be8a"
 var fakeRegion = "RegionOne"
-
-// Test GetConfigFromEnv
-func TestGetConfigFromEnv(t *testing.T) {
-	env := clearEnviron(t)
-	defer resetEnviron(t, env)
-
-	// init env
-	os.Setenv("OS_AUTH_URL", fakeAuthUrl)
-	os.Setenv("OS_USERNAME", fakeUserName)
-	os.Setenv("OS_PASSWORD", fakePassword)
-	os.Setenv("OS_TENANT_ID", fakeTenantID)
-	os.Setenv("OS_DOMAIN_ID", fakeDomainID)
-	os.Setenv("OS_REGION_NAME", fakeRegion)
-
-	// Init assert
-	assert := assert.New(t)
-
-	// Invoke GetConfigFromEnv
-	cfg, err := getConfig("")
-	assert.Nil(err)
-
-	// Assert
-	assert.Equal(cfg.Global.AuthURL, fakeAuthUrl)
-	assert.Equal(cfg.Global.Username, fakeUserName)
-	assert.Equal(cfg.Global.Password, fakePassword)
-	assert.Equal(cfg.Global.TenantID, fakeTenantID)
-	assert.Equal(cfg.Global.DomainID, fakeDomainID)
-	assert.Equal(cfg.Global.Region, fakeRegion)
-}
 
 func TestUserAgentFlag(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR is to drop support to load config from Env .
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #823 
https://github.com/kubernetes/kubernetes/issues/81117

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Removed support to load config from env variables.
```
