### PR TITLE
occm: Fix updating lb listener with allowed CIDR

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/gophercloud/gophercloud v0.6.1-0.20191025185032-6ad562af8c1f
 	github.com/gophercloud/utils v0.0.0-20191020172814-bd86af96d544
 	github.com/gorilla/mux v1.7.3
+	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -247,6 +247,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5 h1:UImYN5qQ8tuGpGE16ZmjvcTtTw24zw1
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
+github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -1004,13 +1004,17 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 			listenerChanged := false
 			updateOpts := listeners.UpdateOpts{}
 
-			if connLimit != listener.ConnLimit {
-				updateOpts.ConnLimit = &connLimit
-				listenerChanged = true
-			}
-			if !cpoutil.StringListEqual(listenerAllowedCIDRs, listener.AllowedCIDRs) {
-				updateOpts.AllowedCIDRs = &listenerAllowedCIDRs
-				listenerChanged = true
+			if lbaas.opts.UseOctavia {
+				if connLimit != listener.ConnLimit {
+					updateOpts.ConnLimit = &connLimit
+					listenerChanged = true
+				}
+				if openstackutil.IsOctaviaFeatureSupported(lbaas.lb, openstackutil.OctaviaFeatureVIPACL) {
+					if !cpoutil.StringListEqual(listenerAllowedCIDRs, listener.AllowedCIDRs) {
+						updateOpts.AllowedCIDRs = &listenerAllowedCIDRs
+						listenerChanged = true
+					}
+				}
 			}
 
 			if listenerChanged {


### PR DESCRIPTION
**What this PR does / why we need it**:
Only updating the listener when Octavia supports VIP ACL, also fixes the way for how to check if a feature is supported in the deployed Octavia version.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #829