### PR TITLE
Added permissions to coordination api for CCM

### DIFF
--- a/cluster/addons/rbac/cloud-controller-manager-roles.yaml
+++ b/cluster/addons/rbac/cloud-controller-manager-roles.yaml
@@ -6,6 +6,14 @@ items:
     name: system:cloud-controller-manager
   rules:
   - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - get
+    - create
+    - update
+  - apiGroups:
     - ""
     resources:
     - events


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

When deploying CCM with the RBAC settings from https://github.com/kubernetes/cloud-provider-openstack/tree/master/cluster/addons/rbac, it is not allowed to use the coordination API.

Also see comment: https://github.com/kubernetes/cloud-provider-openstack/issues/829#issuecomment-557504452

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
