### PR TITLE
add Zuul CI job for csi-manila

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -72,15 +72,18 @@
               - ^pkg/util/.*
               - ^go.mod$
               - ^go.sum$
+    cloud-provider-openstack-acceptance-test-flexvolume-cinder:
+      jobs:
+        - cloud-provider-openstack-acceptance-test-flexvolume-cinder:
             irrelevant-files:
               - ^docs/.*$
               - ^.*\.md$
               - ^OWNERS$
               - ^SECURITY_CONTACTS$
               - ^.gitignore$
-    cloud-provider-openstack-acceptance-test-flexvolume-cinder:
+    cloud-provider-openstack-acceptance-test-csi-manila:
       jobs:
-        - cloud-provider-openstack-acceptance-test-flexvolume-cinder:
+        - cloud-provider-openstack-acceptance-test-csi-manila:
             irrelevant-files:
               - ^docs/.*$
               - ^.*\.md$

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -84,6 +84,15 @@
     cloud-provider-openstack-acceptance-test-csi-manila:
       jobs:
         - cloud-provider-openstack-acceptance-test-csi-manila:
+            files:
+              - ^cmd/manila-csi-plugin/.*
+              - ^examples/manila-csi-plugin/.*
+              - ^pkg/csi/manila/.*
+              - ^pkg/util/errors/.*
+              - ^pkg/cloudprovider/providers/openstack/.*
+              - ^pkg/share/manila/shareoptions/validator/.*
+              - ^go.mod$
+              - ^go.sum$
             irrelevant-files:
               - ^docs/.*$
               - ^.*\.md$


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds Zuul CI job for the Manila CSI plugin

**Which issue this PR fixes**: fixes https://github.com/kubernetes/cloud-provider-openstack/issues/630

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
