### PR TITLE
Mitigate CVE-2019-11255

### DIFF
--- a/examples/manila-csi-plugin/helm-deployment/values.yaml
+++ b/examples/manila-csi-plugin/helm-deployment/values.yaml
@@ -49,14 +49,14 @@ controllerplugin:
   provisioner:
     image:
       repository: quay.io/k8scsi/csi-provisioner
-      tag: v1.3.0
+      tag: v1.3.1
       pullPolicy: IfNotPresent
     resources: {}
   # CSI external-snapshotter container spec
   snapshotter:
     image:
       repository: quay.io/k8scsi/csi-snapshotter
-      tag: v1.2.0
+      tag: v1.2.2
       pullPolicy: IfNotPresent
     resources: {}
   nodeSelector: {}

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -47,7 +47,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.3.0
+          image: quay.io/k8scsi/csi-provisioner:v1.3.1
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -58,7 +58,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v1.2.0
+          image: quay.io/k8scsi/csi-snapshotter:v1.2.2
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -69,7 +69,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.2.0
+          image: quay.io/k8scsi/csi-resizer:v0.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/manifests/manila-csi-plugin/csi-controllerplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-controllerplugin.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: openstack-manila-csi-controllerplugin
       containers:
         - name: provisioner
-          image: "quay.io/k8scsi/csi-provisioner:v1.3.0"
+          image: "quay.io/k8scsi/csi-provisioner:v1.3.1"
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -48,7 +48,7 @@ spec:
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
         - name: snapshotter
-          image: "quay.io/k8scsi/csi-snapshotter:v1.2.0"
+          image: "quay.io/k8scsi/csi-snapshotter:v1.2.2"
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Mitigate CVE-2019-11255 by bumping external-provisioner, external-snapshotter and external-resizer image versions.

**Release note**:
```release-note
Mitigate CVE-2019-11255 by bumping external-provisioner image version to v1.2.2, external-snapshotter to v1.2.2, external-resizer to v0.3.0. CVE announcement: https://groups.google.com/forum/#!topic/kubernetes-security-announce/aXiYN0q4uIw
```