### PR TITLE
Allow providerID without leading providerName

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -887,6 +887,12 @@ func TestInstanceIDFromProviderID(t *testing.T) {
 			fail:       false,
 		},
 		{
+			// https://github.com/kubernetes/kubernetes/issues/85731
+			providerID: "/7b9cf879-7146-417c-abfd-cb4272f0c935",
+			instanceID: "7b9cf879-7146-417c-abfd-cb4272f0c935",
+			fail:       false,
+		},
+		{
 			providerID: "openstack://7b9cf879-7146-417c-abfd-cb4272f0c935",
 			instanceID: "",
 			fail:       true,
@@ -906,7 +912,7 @@ func TestInstanceIDFromProviderID(t *testing.T) {
 	for _, test := range testCases {
 		instanceID, err := instanceIDFromProviderID(test.providerID)
 		if (err != nil) != test.fail {
-			t.Errorf("%s yielded `err != nil` as %t. expected %t", test.providerID, (err != nil), test.fail)
+			t.Errorf("expected err: %t, got err: %v", test.fail, err)
 		}
 
 		if test.fail {
@@ -914,7 +920,7 @@ func TestInstanceIDFromProviderID(t *testing.T) {
 		}
 
 		if instanceID != test.instanceID {
-			t.Errorf("%s yielded %s. expected %s", test.providerID, instanceID, test.instanceID)
+			t.Errorf("%s yielded %s. expected %q", test.providerID, instanceID, test.instanceID)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Makes the cloudprovider cope with providerIDs that do not have a leading `provider://`, bandaid workaround for https://github.com/kubernetes/kubernetes/issues/85731 and works towards fixing https://github.com/kubernetes/cloud-provider-openstack/issues/856

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```

/kind bug
/assign @chrigl 