### PR TITLE
CCM: Set permanent node addresses order

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -686,8 +687,14 @@ func nodeAddresses(srv *servers.Server, networkingOpts NetworkingOpts) ([]v1.Nod
 		return nil, err
 	}
 
-	for network, addrList := range addresses {
-		for _, props := range addrList {
+	var networks []string
+	for k := range addresses {
+		networks = append(networks, k)
+	}
+	sort.Strings(networks)
+
+	for _, network := range networks {
+		for _, props := range addresses[network] {
 			var addressType v1.NodeAddressType
 			if props.IPType == "floating" || network == networkingOpts.PublicNetworkName {
 				addressType = v1.NodeExternalIP

--- a/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -521,13 +520,6 @@ func TestCaller(t *testing.T) {
 	}
 }
 
-// An arbitrary sort.Interface, just for easier comparison
-type AddressSlice []v1.NodeAddress
-
-func (a AddressSlice) Len() int           { return len(a) }
-func (a AddressSlice) Less(i, j int) bool { return a[i].Address < a[j].Address }
-func (a AddressSlice) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-
 func TestNodeAddresses(t *testing.T) {
 	srv := servers.Server{
 		Status:     "ACTIVE",
@@ -579,22 +571,21 @@ func TestNodeAddresses(t *testing.T) {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}
 
-	sort.Sort(AddressSlice(addrs))
-	t.Logf("addresses is %v", addrs)
+	t.Logf("addresses are %v", addrs)
 
 	want := []v1.NodeAddress{
-		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
 		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
-		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
-		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
-		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
 		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
 		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
 		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
 	}
 
 	if !reflect.DeepEqual(want, addrs) {
-		t.Errorf("nodeAddresses returned incorrect value %v", addrs)
+		t.Errorf("nodeAddresses returned incorrect value, want %v", want)
 	}
 }
 
@@ -645,21 +636,20 @@ func TestNodeAddressesCustomPublicNetwork(t *testing.T) {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}
 
-	sort.Sort(AddressSlice(addrs))
-	t.Logf("addresses is %v", addrs)
+	t.Logf("addresses are %v", addrs)
 
 	want := []v1.NodeAddress{
-		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
 		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
-		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
-		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
-		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
 		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
 		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
 	}
 
 	if !reflect.DeepEqual(want, addrs) {
-		t.Errorf("nodeAddresses returned incorrect value %v", addrs)
+		t.Errorf("nodeAddresses returned incorrect value, want %v", want)
 	}
 }
 
@@ -711,19 +701,18 @@ func TestNodeAddressesIPv6Disabled(t *testing.T) {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}
 
-	sort.Sort(AddressSlice(addrs))
-	t.Logf("addresses is %v", addrs)
+	t.Logf("addresses are %v", addrs)
 
 	want := []v1.NodeAddress{
-		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
 		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
-		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
 		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
 		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
 	}
 
 	if !reflect.DeepEqual(want, addrs) {
-		t.Errorf("nodeAddresses returned incorrect value %v", addrs)
+		t.Errorf("nodeAddresses returned incorrect value, want %v", want)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR sets permanent node IP addresses order, sorted by a network name.

**Special notes for your reviewer**:

This is a workaround for the #863 bug report. It doesn't help, when the first interface name appears at the very end after the alphabetical sorting. However this fix prevents LB members modification on each reconciliation loop.

**Release note**:

```release-note
CCM: Set permanent node addresses order, sort networks by name
```
