### PR TITLE
Core: Enable OpenStack API debugger, when verbosity is set to 6

### DIFF
--- a/docs/getting-started-provider-dev.md
+++ b/docs/getting-started-provider-dev.md
@@ -15,6 +15,7 @@ enabled.
    + [Getting and Building Cloud Provider OpenStack](#getting-and-building-cloud-provider-openstack)
    + [Getting and Building Kubernetes](#getting-and-building-kubernetes)
    + [Running the Cloud Provider](#running-the-cloud-provider)
+ * [Troubleshooting](#troubleshooting)
 
 ## Prerequisites
 
@@ -119,7 +120,7 @@ sudo yum install -y -q git gcc etcd
 You will also need a recent version of Go and set your environment variables.
 
 ```
-GO_VERSION=1.12
+GO_VERSION=1.13
 GO_ARCH=linux-amd64
 curl -o go.tgz https://dl.google.com/go/go${GO_VERSION}.${GO_ARCH}.tar.gz
 sudo tar -C /usr/local/ -xvzf go.tgz
@@ -252,3 +253,7 @@ otherwise the cloud-controller-manager is not able to access k8s API.
 ```
 
 Have a good time with OpenStack and Kubernetes!
+
+## Troubleshooting
+
+You can increase a log level verbosity (`-v` parameter) to know better what is happening during the OpenStack Cloud Controller Manager runtime. Setting the log level to **6** allows you to see OpeStack API JSON requests and responses. It is recommended to set a `--concurrent-service-syncs` parameter to **1** for a better output tracking.

--- a/docs/getting-started-provider-dev.md
+++ b/docs/getting-started-provider-dev.md
@@ -256,4 +256,4 @@ Have a good time with OpenStack and Kubernetes!
 
 ## Troubleshooting
 
-You can increase a log level verbosity (`-v` parameter) to know better what is happening during the OpenStack Cloud Controller Manager runtime. Setting the log level to **6** allows you to see OpeStack API JSON requests and responses. It is recommended to set a `--concurrent-service-syncs` parameter to **1** for a better output tracking.
+You can increase a log level verbosity (`-v` parameter) to know better what is happening during the OpenStack Cloud Controller Manager runtime. Setting the log level to **6** allows you to see OpenStack API JSON requests and responses. It is recommended to set a `--concurrent-service-syncs` parameter to **1** for a better output tracking.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20190620071333-e64a0ec8b42a // indirect
 	github.com/emicklei/go-restful v2.9.6+incompatible // indirect
 	github.com/evanphx/json-patch v4.5.0+incompatible // indirect
+	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/google/go-cmp v0.3.1 // indirect

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -514,19 +514,19 @@ func NewOpenStackClient(cfg *AuthOpts, userAgent string, extraUserAgent ...strin
 		}
 	}
 
+	config := &tls.Config{}
+	config.InsecureSkipVerify = cfg.TLSInsecure == "true"
+
 	if caPool != nil {
-		config := &tls.Config{}
 		config.RootCAs = caPool
-		config.InsecureSkipVerify = cfg.TLSInsecure == "true"
-		provider.HTTPClient.Transport = netutil.SetOldTransportDefaults(&http.Transport{TLSClientConfig: config})
 	}
 
+	provider.HTTPClient.Transport = netutil.SetOldTransportDefaults(&http.Transport{TLSClientConfig: config})
+
 	if klog.V(6) {
-		provider.HTTPClient = http.Client{
-			Transport: &client.RoundTripper{
-				Rt:     &http.Transport{},
-				Logger: &logger{},
-			},
+		provider.HTTPClient.Transport = &client.RoundTripper{
+			Rt:     provider.HTTPClient.Transport,
+			Logger: &logger{},
 		}
 	}
 

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -252,10 +252,11 @@ func LogCfg(cfg Config) {
 type logger struct{}
 
 func (l logger) Printf(format string, args ...interface{}) {
+	debugger := klog.V(6)
 	// extra check in case, when verbosity has been changed dynamically
-	if klog.V(6) {
+	if debugger {
 		for _, v := range strings.Split(fmt.Sprintf(format, args...), "\n") {
-			klog.V(6).Info(v)
+			debugger.Info(v)
 		}
 	}
 }

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -202,7 +202,7 @@ type AuthOpts struct {
 	CAFile           string `gcfg:"ca-file" mapstructure:"ca-file" name:"os-certAuthorityPath" value:"optional"`
 
 	// Manila only options
-	TLSInsecure string `name:"os-TLSInsecure" value:"optional" dependsOn:"os-certAuthority|os-certAuthorityPath" matches:"^true|false$"`
+	TLSInsecure string `name:"os-TLSInsecure" value:"optional" matches:"^true|false$"`
 	// backward compatibility with the manila-csi-plugin
 	CAFileContents  string `name:"os-certAuthority" value:"optional"`
 	TrusteeID       string `name:"os-trusteeID" value:"optional" dependsOn:"os-trustID"`


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds verbose OpenStack API request/response debugging, when `--v=6` (or higher) verbosity is set.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

fixes #840 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Core: Enable OpenStack API debugger, when verbosity is set to 6 or higher
```
