### PR TITLE
[manila-provisioner]: Added AvailabilityZone option to CreateOpts struct for manila share pv

### DIFF
--- a/pkg/share/manila/share.go
+++ b/pkg/share/manila/share.go
@@ -135,12 +135,13 @@ func buildCreateRequest(
 	}
 
 	return &shares.CreateOpts{
-		ShareProto:     shareOptions.Protocol,
-		ShareNetworkID: shareOptions.OSShareNetworkID,
-		Size:           storageSize,
-		Name:           shareName,
-		ShareType:      shareOptions.Type,
-		Metadata:       metadata,
+		ShareProto:       shareOptions.Protocol,
+		ShareNetworkID:   shareOptions.OSShareNetworkID,
+		Size:             storageSize,
+		Name:             shareName,
+		ShareType:        shareOptions.Type,
+		Metadata:         metadata,
+		AvailabilityZone: shareOptions.Zones,
 	}, nil
 }
 


### PR DESCRIPTION
**The binaries affected**:

- [ ] openstack-cloud-controller-manager
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [x] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
The AvailablityZone option was lost for creating manila share persistent volume. Such an option comes from StorageClass and used for the right location of created share (it depends from topology or StorageClass share options).

**Which issue this PR fixes**:
fixes https://github.com/kubernetes/cloud-provider-openstack/issues/899

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
