### PR TITLE
[cinder-csi-plugin] Add cloning docs

### DIFF
--- a/docs/using-cinder-csi-plugin.md
+++ b/docs/using-cinder-csi-plugin.md
@@ -270,7 +270,7 @@ brw-rw----    1 root     disk      202, 23296 Mar 12 04:23 /dev/xvda
 
 ### Volume Expansion
 
-1. As Volume Expansion is an alpha feature. Make sure you have enabled it in Kubernetes API server using `--feature-gates=ExpandCSIVolumes=true` flag.
+1. As of kubernetes v1.16, Volume Expansion is a beta feature and enabled by default.
 2. Make sure to set `allowVolumeExpansion` to `true` in Storage class spec.
 3. Deploy the application.
 
@@ -320,7 +320,8 @@ $ kubectl exec nginx -- df -h /var/lib/www/html
 Filesystem      Size  Used Avail Use% Mounted on
 /dev/vdb        2.0G   27M  1.97G   1% /var/lib/www/html
 ```
-## Inline Volumes
+### Inline Volumes
+
 This feature allows CSI volumes to be directly embedded in the Pod specification instead of a PersistentVolume. Volumes specified in this way are ephemeral and do not persist across Pod restarts. As of Kubernetes v1.16 this feature is beta so enabled by default. To enable this feature for CSI Driver, `volumeLifecycleModes` needs to be specified in [CSIDriver](https://github.com/kubernetes/cloud-provider-openstack/blob/master/manifests/cinder-csi-plugin/csi-cinder-driver.yaml) object. The driver can run in `Persistent` mode, `Ephemeral` or in both modes. `podInfoOnMount` must be `true` to use this feature. 
 
 Example:
@@ -349,6 +350,19 @@ Volumes:
     Optional:    false
 
 ```
+
+### Volume Cloning
+
+As of Kubernetes v1.16, volume cloning is beta feature and enabled by default.
+This feature enables support of cloning a volume from existing PVCs.
+
+Following prerequisites needed for volume cloning to work :
+1. The source PVC must be bound and available (not in use).
+2. source and destination PVCs must be in the same namespace.
+3. Cloning is only supported within the same Storage Class. Destination volume must
+   be the same storage class as the source
+
+Sample yamls can be found [here](https://github.com/kubernetes/cloud-provider-openstack/tree/master/examples/cinder-csi-plugin/clone)
 
 ## Running Sanity Tests
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**The binaries affected**:

IMPORTANT: Please also add the binary name in the title, e.g.
`[openstack-cloud-controller-manager]: Add UDP protocol support`
unless the PR affects multiple binaries.

- [ ] openstack-cloud-controller-manager
- [x] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
This PR adds documentation for Volume Cloning feature.

**Which issue this PR fixes**:
fixes #644

**Special notes for reviewers**:

<!-- e.g. How to test this PR -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
