### PR TITLE
Multi region support

### DIFF
--- a/examples/cinder-csi-plugin/nginx.yaml
+++ b/examples/cinder-csi-plugin/nginx.yaml
@@ -34,8 +34,8 @@ spec:
     - containerPort: 80
       protocol: TCP
     volumeMounts:
-    - mountPath: /var/lib/www/html
-      name: csi-data-cinderplugin
+      - mountPath: /var/lib/www/html
+        name: csi-data-cinderplugin
   volumes:
   - name: csi-data-cinderplugin
     persistentVolumeClaim:

--- a/examples/cinder-csi-plugin/nginx.yaml
+++ b/examples/cinder-csi-plugin/nginx.yaml
@@ -31,11 +31,11 @@ spec:
     imagePullPolicy: IfNotPresent
     name: nginx
     ports:
-      - containerPort: 80
-        protocol: TCP
+    - containerPort: 80
+      protocol: TCP
     volumeMounts:
-      - mountPath: /var/lib/www/html
-        name: csi-data-cinderplugin
+    - mountPath: /var/lib/www/html
+      name: csi-data-cinderplugin
   volumes:
   - name: csi-data-cinderplugin
     persistentVolumeClaim:

--- a/examples/cinder-csi-plugin/nginx.yaml
+++ b/examples/cinder-csi-plugin/nginx.yaml
@@ -14,7 +14,7 @@ metadata:
   name: csi-pvc-cinderplugin
 spec:
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi
@@ -27,17 +27,17 @@ metadata:
   name: nginx
 spec:
   containers:
-    - image: nginx
-      imagePullPolicy: IfNotPresent
-      name: nginx
-      ports:
-        - containerPort: 80
-          protocol: TCP
-      volumeMounts:
-        - mountPath: /var/lib/www/html
-          name: csi-data-cinderplugin
+  - image: nginx
+    imagePullPolicy: IfNotPresent
+    name: nginx
+    ports:
+      - containerPort: 80
+        protocol: TCP
+    volumeMounts:
+      - mountPath: /var/lib/www/html
+        name: csi-data-cinderplugin
   volumes:
-    - name: csi-data-cinderplugin
-      persistentVolumeClaim:
-        claimName: csi-pvc-cinderplugin
-        readOnly: false
+  - name: csi-data-cinderplugin
+    persistentVolumeClaim:
+      claimName: csi-pvc-cinderplugin
+      readOnly: false

--- a/examples/cinder-csi-plugin/nginx.yaml
+++ b/examples/cinder-csi-plugin/nginx.yaml
@@ -6,41 +6,38 @@ kind: StorageClass
 metadata:
   name: csi-sc-cinderplugin
 provisioner: cinder.csi.openstack.org
-volumeBindingMode: WaitForFirstConsumer
+
 ---
-apiVersion: apps/v1
-kind: StatefulSet
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: csi-pvc-cinderplugin
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: csi-sc-cinderplugin
+
+---
+apiVersion: v1
+kind: Pod
 metadata:
   name: nginx
-  labels:
-    app: nginx
 spec:
-  serviceName: nginx
-  replicas: 4
-  template:
-    metadata:
+  containers:
+    - image: nginx
+      imagePullPolicy: IfNotPresent
       name: nginx
-      labels:
-        app: nginx
-    spec:
-      containers:
-        - name: nginx
-          image: nginx
-          imagePullPolicy: IfNotPresent
-          volumeMounts:
-            - mountPath: /var/lib/www/html
-              name: csi-data-cinderplugin
-      restartPolicy: Always
-  selector:
-    matchLabels:
-      app: nginx
-  volumeClaimTemplates:
-    - metadata:
-        name: csi-data-cinderplugin
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
-        storageClassName: csi-sc-cinderplugin
+      ports:
+        - containerPort: 80
+          protocol: TCP
+      volumeMounts:
+        - mountPath: /var/lib/www/html
+          name: csi-data-cinderplugin
+  volumes:
+    - name: csi-data-cinderplugin
+      persistentVolumeClaim:
+        claimName: csi-pvc-cinderplugin
+        readOnly: false

--- a/examples/cinder-csi-plugin/nginx.yaml
+++ b/examples/cinder-csi-plugin/nginx.yaml
@@ -6,38 +6,41 @@ kind: StorageClass
 metadata:
   name: csi-sc-cinderplugin
 provisioner: cinder.csi.openstack.org
-
+volumeBindingMode: WaitForFirstConsumer
 ---
-apiVersion: v1
-kind: PersistentVolumeClaim
+apiVersion: apps/v1
+kind: StatefulSet
 metadata:
-  name: csi-pvc-cinderplugin
+  name: nginx
+  labels:
+    app: nginx
 spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
-  storageClassName: csi-sc-cinderplugin
-
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: nginx 
-spec:
-  containers:
-  - image: nginx
-    imagePullPolicy: IfNotPresent
-    name: nginx
-    ports:
-    - containerPort: 80
-      protocol: TCP
-    volumeMounts:
-      - mountPath: /var/lib/www/html
-        name: csi-data-cinderplugin 
-  volumes:
-  - name: csi-data-cinderplugin
-    persistentVolumeClaim:
-      claimName: csi-pvc-cinderplugin
-      readOnly: false
+  serviceName: nginx
+  replicas: 4
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /var/lib/www/html
+              name: csi-data-cinderplugin
+      restartPolicy: Always
+  selector:
+    matchLabels:
+      app: nginx
+  volumeClaimTemplates:
+    - metadata:
+        name: csi-data-cinderplugin
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+        storageClassName: csi-sc-cinderplugin

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -33,8 +33,6 @@ spec:
         app: csi-cinder-controllerplugin
     spec:
       serviceAccount: csi-cinder-controller-sa
-      imagePullSecrets:
-        - name: temp
       containers:
         - name: csi-attacher
           image: quay.io/k8scsi/csi-attacher:v2.0.0
@@ -86,14 +84,13 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: cinder-csi-plugin
-          image: gitlab.rd.alphanetworks.tv/ajbe/openstack-temp/cinder-csi-plugin:45
+          image: docker.io/k8scloudprovider/cinder-csi-plugin:latest
           args :
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--cloud-config=$(CLOUD_CONFIG)"
             - "--cluster=$(CLUSTER_NAME)"
-            - "--v=5"
           env:
             - name: NODE_ID
               valueFrom:

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -33,6 +33,8 @@ spec:
         app: csi-cinder-controllerplugin
     spec:
       serviceAccount: csi-cinder-controller-sa
+      imagePullSecrets:
+        - name: temp
       containers:
         - name: csi-attacher
           image: quay.io/k8scsi/csi-attacher:v2.0.0
@@ -51,6 +53,7 @@ spec:
           image: quay.io/k8scsi/csi-provisioner:v1.4.0
           args:
             - "--csi-address=$(ADDRESS)"
+            - "--feature-gates=Topology=true"
             - "--timeout=3m"
           env:
             - name: ADDRESS
@@ -83,13 +86,14 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: cinder-csi-plugin
-          image: docker.io/k8scloudprovider/cinder-csi-plugin:latest
+          image: gitlab.rd.alphanetworks.tv/ajbe/openstack-temp/cinder-csi-plugin:45
           args :
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--cloud-config=$(CLOUD_CONFIG)"
             - "--cluster=$(CLUSTER_NAME)"
+            - "--v=5"
           env:
             - name: NODE_ID
               valueFrom:

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -17,8 +17,6 @@ spec:
     spec:
       serviceAccount: csi-cinder-node-sa
       hostNetwork: true
-      imagePullSecrets:
-        - name: temp
       containers:
         - name: node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
@@ -50,13 +48,12 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: gitlab.rd.alphanetworks.tv/ajbe/openstack-temp/cinder-csi-plugin:45
+          image: gdocker.io/k8scloudprovider/cinder-csi-plugin:latest
           args :
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--cloud-config=$(CLOUD_CONFIG)"
-            - "--v=5"
           env:
             - name: NODE_ID
               valueFrom:

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -48,7 +48,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: gdocker.io/k8scloudprovider/cinder-csi-plugin:latest
+          image: docker.io/k8scloudprovider/cinder-csi-plugin:latest
           args :
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -17,6 +17,8 @@ spec:
     spec:
       serviceAccount: csi-cinder-node-sa
       hostNetwork: true
+      imagePullSecrets:
+        - name: temp
       containers:
         - name: node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
@@ -48,12 +50,13 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: docker.io/k8scloudprovider/cinder-csi-plugin:latest
+          image: gitlab.rd.alphanetworks.tv/ajbe/openstack-temp/cinder-csi-plugin:45
           args :
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--cloud-config=$(CLOUD_CONFIG)"
+            - "--v=5"
           env:
             - name: NODE_ID
               valueFrom:
@@ -95,7 +98,7 @@ spec:
         - name: pods-cloud-data
           hostPath:
             path: /var/lib/cloud/data
-            type: Directory
+            type: DirectoryOrCreate
         - name: pods-probe-dir
           hostPath:
             path: /dev

--- a/manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml
+++ b/manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml
@@ -1,10 +1,10 @@
-## This YAML file contains secret objects,
-## which are necessary to run csi cinder plugin.
-#
-#kind: Secret
-#apiVersion: v1
-#metadata:
-#  name: cloud-config
-#  namespace: kube-system
-#data:
-#  cloud.conf: W0dsb2JhbF0KdXNlcm5hbWUgPSBhZG1pbgpwYXNzd29yZCA9IG5vbW9yZXNlY3JldApkb21haW4tbmFtZSA9IGRlZmF1bHQKYXV0aC11cmwgPSBodHRwOi8vMTkyLjE2OC4yMDAuOS9pZGVudGl0eQp0ZW5hbnQtaWQgPSBjYzM0YjExZmY5NWQ0MjMwOTA4MWQwYmQ0NmMwZmY4OQpyZWdpb24gPSBSZWdpb25PbmUK
+# This YAML file contains secret objects,
+# which are necessary to run csi cinder plugin.
+
+kind: Secret
+apiVersion: v1
+metadata:
+  name: cloud-config
+  namespace: kube-system
+data:
+  cloud.conf: W0dsb2JhbF0KdXNlcm5hbWUgPSBhZG1pbgpwYXNzd29yZCA9IG5vbW9yZXNlY3JldApkb21haW4tbmFtZSA9IGRlZmF1bHQKYXV0aC11cmwgPSBodHRwOi8vMTkyLjE2OC4yMDAuOS9pZGVudGl0eQp0ZW5hbnQtaWQgPSBjYzM0YjExZmY5NWQ0MjMwOTA4MWQwYmQ0NmMwZmY4OQpyZWdpb24gPSBSZWdpb25PbmUK

--- a/manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml
+++ b/manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml
@@ -1,10 +1,10 @@
-# This YAML file contains secret objects,
-# which are necessary to run csi cinder plugin.
-
-kind: Secret
-apiVersion: v1
-metadata:
-  name: cloud-config
-  namespace: kube-system
-data:
-  cloud.conf: W0dsb2JhbF0KdXNlcm5hbWUgPSBhZG1pbgpwYXNzd29yZCA9IG5vbW9yZXNlY3JldApkb21haW4tbmFtZSA9IGRlZmF1bHQKYXV0aC11cmwgPSBodHRwOi8vMTkyLjE2OC4yMDAuOS9pZGVudGl0eQp0ZW5hbnQtaWQgPSBjYzM0YjExZmY5NWQ0MjMwOTA4MWQwYmQ0NmMwZmY4OQpyZWdpb24gPSBSZWdpb25PbmUK
+## This YAML file contains secret objects,
+## which are necessary to run csi cinder plugin.
+#
+#kind: Secret
+#apiVersion: v1
+#metadata:
+#  name: cloud-config
+#  namespace: kube-system
+#data:
+#  cloud.conf: W0dsb2JhbF0KdXNlcm5hbWUgPSBhZG1pbgpwYXNzd29yZCA9IG5vbW9yZXNlY3JldApkb21haW4tbmFtZSA9IGRlZmF1bHQKYXV0aC11cmwgPSBodHRwOi8vMTkyLjE2OC4yMDAuOS9pZGVudGl0eQp0ZW5hbnQtaWQgPSBjYzM0YjExZmY5NWQ0MjMwOTA4MWQwYmQ0NmMwZmY4OQpyZWdpb24gPSBSZWdpb25PbmUK

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -295,7 +295,6 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-
 		cloud, err := NewOpenStack(cfg)
 		if err != nil {
 			klog.V(1).Infof("New openstack client created failed with config")
@@ -453,9 +452,6 @@ func readInstanceID(searchOrder string) (string, error) {
 	// First, try to get data from metadata service because local
 	// data might be changed by accident
 	md, err := metadata.Get(searchOrder)
-
-	klog.V(5).Infoln(md)
-
 	if err == nil {
 		return md.UUID, nil
 	}

--- a/pkg/cloudprovider/providers/openstack/openstack_client.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_client.go
@@ -18,6 +18,7 @@ package openstack
 
 import (
 	"fmt"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 )

--- a/pkg/cloudprovider/providers/openstack/openstack_client.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_client.go
@@ -18,7 +18,6 @@ package openstack
 
 import (
 	"fmt"
-
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 )
@@ -35,12 +34,21 @@ func (os *OpenStack) NewNetworkV2() (*gophercloud.ServiceClient, error) {
 }
 
 // NewComputeV2 creates a ServiceClient that may be used with the nova v2 API
-func (os *OpenStack) NewComputeV2() (*gophercloud.ServiceClient, error) {
+func (os *OpenStack) NewComputeV2(region string) (*gophercloud.ServiceClient, error) {
+	lregion := ""
+
+	if region == "" {
+		lregion = os.region
+	} else {
+		lregion = region
+	}
+
 	compute, err := openstack.NewComputeV2(os.provider, gophercloud.EndpointOpts{
-		Region: os.region,
+		Region: lregion,
 	})
+
 	if err != nil {
-		return nil, fmt.Errorf("failed to find compute v2 endpoint for region %s: %v", os.region, err)
+		return nil, fmt.Errorf("failed to find compute v2 endpoint for region %s: %v", lregion, err)
 	}
 	return compute, nil
 }

--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -19,7 +19,7 @@ package openstack
 import (
 	"context"
 	"fmt"
-	"k8s.io/cloud-provider-openstack/pkg/util/errors"
+
 	"regexp"
 	"strings"
 
@@ -30,6 +30,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/cloud-provider-openstack/pkg/util/errors"
 	"k8s.io/cloud-provider-openstack/pkg/util/metadata"
 )
 
@@ -180,7 +181,6 @@ func (os *OpenStack) InstanceID() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		klog.V(4).Info(os)
 		os.localInstanceID = id
 	}
 	return os.localInstanceID, nil

--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -157,9 +157,13 @@ func (i *Instances) InstanceShutdownByProviderID(ctx context.Context, providerID
 		return false, err
 	}
 
-	server, err := servers.Get(i.compute, instanceID).Extract()
-	if err != nil {
-		return false, err
+	var server *servers.Server
+	for _, region := range regions {
+		compute, err := i.os.NewComputeV2(region)
+		server, err = servers.Get(compute, instanceID).Extract()
+		if err != nil {
+			continue
+		}
 	}
 
 	// SHUTOFF is the only state where we can detach volumes immediately

--- a/pkg/cloudprovider/providers/openstack/openstack_routes_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_routes_test.go
@@ -84,7 +84,7 @@ func TestRoutes(t *testing.T) {
 }
 
 func getServers(os *OpenStack) []servers.Server {
-	c, err := os.NewComputeV2()
+	c, err := os.NewComputeV2("")
 	opts := servers.ListOpts{
 		Status: "ACTIVE",
 	}

--- a/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -286,7 +286,7 @@ func (os *OpenStack) AttachDisk(instanceID, volumeID string) (string, error) {
 		return "", err
 	}
 
-	cClient, err := os.NewComputeV2()
+	cClient, err := os.NewComputeV2("")
 	if err != nil {
 		return "", err
 	}
@@ -338,7 +338,7 @@ func (os *OpenStack) DetachDisk(instanceID, volumeID string) error {
 	if volume.Status != volumeInUseStatus {
 		return fmt.Errorf("can not detach volume %s, its status is %s", volume.Name, volume.Status)
 	}
-	cClient, err := os.NewComputeV2()
+	cClient, err := os.NewComputeV2("")
 	if err != nil {
 		return err
 	}
@@ -596,7 +596,7 @@ func (os *OpenStack) DiskIsAttached(instanceID, volumeID string) (bool, error) {
 
 // DiskIsAttachedByName queries if a volume is attached to a compute instance by name
 func (os *OpenStack) DiskIsAttachedByName(nodeName types.NodeName, volumeID string) (bool, string, error) {
-	cClient, err := os.NewComputeV2()
+	cClient, err := os.NewComputeV2("")
 	if err != nil {
 		return false, "", err
 	}
@@ -633,7 +633,7 @@ func (os *OpenStack) DisksAreAttached(instanceID string, volumeIDs []string) (ma
 // DisksAreAttachedByName queries if a list of volumes are attached to a compute instance by name
 func (os *OpenStack) DisksAreAttachedByName(nodeName types.NodeName, volumeIDs []string) (map[string]bool, error) {
 	attached := make(map[string]bool)
-	cClient, err := os.NewComputeV2()
+	cClient, err := os.NewComputeV2("")
 	if err != nil {
 		return attached, err
 	}

--- a/pkg/csi/cinder/driver.go
+++ b/pkg/csi/cinder/driver.go
@@ -28,8 +28,9 @@ import (
 )
 
 const (
-	driverName  = "cinder.csi.openstack.org"
-	topologyKey = "topology." + driverName + "/zone"
+	driverName        = "cinder.csi.openstack.org"
+	topologyKey       = "topology." + driverName + "/zone"
+	topologyRegionKey = "topology." + driverName + "/region"
 )
 
 var (

--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -136,7 +136,7 @@ func nodePublishEphermeral(req *csi.NodePublishVolumeRequest, ns *nodeServer) (*
 	}
 
 	// TODO: About AZ and Volume type
-	evol, err := ns.Cloud.CreateVolume(volName, size, "", "", "", &properties)
+	evol, err := ns.Cloud.CreateVolume(volName, size, "", "", "", "", &properties)
 
 	if err != nil {
 		klog.V(3).Infof("Failed to Create Ephermal Volume: %v", err)
@@ -446,8 +446,11 @@ func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 		return nil, status.Error(codes.Internal, fmt.Sprintf("NodeGetInfo failed with error %v", err))
 	}
 
+	// Get Node
+	server, err := ns.Cloud.GetInstanceByID(nodeID)
+
 	zone, err := getAvailabilityZoneMetadataService(ns.Metadata)
-	topology := &csi.Topology{Segments: map[string]string{topologyKey: zone}}
+	topology := &csi.Topology{Segments: map[string]string{topologyKey: zone, topologyRegionKey: server.Metadata["region"]}}
 
 	maxVolume := ns.Cloud.GetMaxVolLimit()
 

--- a/pkg/csi/cinder/openstack/openstack_instances.go
+++ b/pkg/csi/cinder/openstack/openstack_instances.go
@@ -1,14 +1,40 @@
 package openstack
 
 import (
+	"errors"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"k8s.io/klog"
 )
 
 // GetInstanceByID returns server with specified instanceID
 func (os *OpenStack) GetInstanceByID(instanceID string) (*servers.Server, error) {
-	server, err := servers.Get(os.compute, instanceID).Extract()
-	if err != nil {
-		return nil, err
+	var server *servers.Server = nil
+
+	for _, region := range regions {
+		var err error
+		var compute *gophercloud.ServiceClient
+
+		compute, err = openstack.NewComputeV2(os.provider, gophercloud.EndpointOpts{
+			Region: region,
+		})
+
+		klog.V(5).Infof("Trying To Find Instance %s in Region %s", instanceID, region)
+		server, err = servers.Get(compute, instanceID).Extract()
+		if err != nil {
+			continue
+		}
+
+		server.Metadata["region"] = region
+		klog.V(5).Infof("Instance %s Found in Region %s", instanceID, region)
+		break
 	}
+
+	if server == nil {
+		klog.V(5).Infof("Instance %s Not Found", instanceID)
+		return nil, errors.New("failed to find server")
+	}
+
 	return server, nil
 }


### PR DESCRIPTION
This is a very drafty attempt to support multi-region in both the cloud provider and the CSI  cinder plugin as per #885 

**The binaries affected**:

- [x] openstack-cloud-controller-manager
- [x] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
This adds support for running cluster in multiple regions.

A common deployment topology with OpenStack deployment is to spawn multiple cinder/nova clusters with a single keystone one. In this case, this project doesn't work as we would expect it to work in a single region, multi AZ deployment.

**Which issue this PR fixes**:
fixes #885 

**Special notes for reviewers**:

this is clearly a draft since 1. we are newbies with GO and 2. it's a first working version as per all the test we are running.

It's not ready for merge but before going any further we would like to see it there is any chance for this to get merged, and what would be your advice with it comes to good practices & general idea of our solution.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added support for multi-region clusters in the CCM
Added support for multi-region clusters in the csi cinder plugin
```
