### PR TITLE
check block model then skip mount check

### DIFF
--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -281,6 +281,11 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 		}
 	}
 
+	if blk := volumeCapability.GetBlock(); blk != nil {
+		// If block volume, do nothing
+		return &csi.NodeUnpublishVolumeResponse{}, nil
+	}
+
 	m := ns.Mount
 	notMnt, err := m.IsLikelyNotMountPointDetach(targetPath)
 	if err != nil && !mount.IsCorruptedMnt(err) {
@@ -423,6 +428,11 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 			return nil, status.Error(codes.NotFound, "Volume not found")
 		}
 		return nil, status.Error(codes.Internal, fmt.Sprintf("GetVolume failed with error %v", err))
+	}
+
+	if blk := volumeCapability.GetBlock(); blk != nil {
+		// If block volume, do nothing
+		return &csi.NodeUnstageVolumeResponse{}, nil
 	}
 
 	m := ns.Mount


### PR DESCRIPTION
and in order to be consistent to other functions such
as NodeStageVolume, NodePublishVolume etc, use this
skip method instead for this kind of situation

Fixes #902 

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**The binaries affected**:

IMPORTANT: Please also add the binary name in the title, e.g.
`[openstack-cloud-controller-manager]: Add UDP protocol support`
unless the PR affects multiple binaries.

- [ ] openstack-cloud-controller-manager
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:


**Which issue this PR fixes**:
fixes #

**Special notes for reviewers**:

<!-- e.g. How to test this PR -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
