### PR TITLE
[manila-csi-plugin] CSI sidecar containers version bump

### DIFF
--- a/examples/manila-csi-plugin/helm-deployment/values.yaml
+++ b/examples/manila-csi-plugin/helm-deployment/values.yaml
@@ -49,14 +49,14 @@ controllerplugin:
   provisioner:
     image:
       repository: quay.io/k8scsi/csi-provisioner
-      tag: v1.3.0
+      tag: v1.4.0
       pullPolicy: IfNotPresent
     resources: {}
   # CSI external-snapshotter container spec
   snapshotter:
     image:
       repository: quay.io/k8scsi/csi-snapshotter
-      tag: v1.2.0
+      tag: v1.2.2
       pullPolicy: IfNotPresent
     resources: {}
   nodeSelector: {}

--- a/manifests/manila-csi-plugin/csi-controllerplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-controllerplugin.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: openstack-manila-csi-controllerplugin
       containers:
         - name: provisioner
-          image: "quay.io/k8scsi/csi-provisioner:v1.3.0"
+          image: "quay.io/k8scsi/csi-provisioner:v1.4.0"
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -48,7 +48,7 @@ spec:
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
         - name: snapshotter
-          image: "quay.io/k8scsi/csi-snapshotter:v1.2.0"
+          image: "quay.io/k8scsi/csi-snapshotter:v1.2.2"
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
**The binaries affected**:

- [ ] openstack-cloud-controller-manager
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [x] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
This PR bumps the versions for csi-provisioner and csi-snapshotter sidecar containers in csi-manila deployments. The update was supposed to be a part of https://github.com/kubernetes/cloud-provider-openstack/pull/846 but got lost along the way.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
manila-csi-plugin: bumped csi-provisioner to 1.4.0 and csi-snapshotter to 1.2.2
```
