### PR TITLE
nit: Add v flag for containers

### DIFF
--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -50,6 +50,7 @@ spec:
         - name: csi-provisioner
           image: quay.io/k8scsi/csi-provisioner:v1.4.0
           args:
+            - "--v=5"
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
           env:
@@ -62,6 +63,7 @@ spec:
         - name: csi-snapshotter
           image: quay.io/k8scsi/csi-snapshotter:v1.2.2
           args:
+            - "--v=5"
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
@@ -90,6 +92,7 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--cloud-config=$(CLOUD_CONFIG)"
             - "--cluster=$(CLUSTER_NAME)"
+            - "--v=5"
           env:
             - name: NODE_ID
               valueFrom:

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -54,6 +54,7 @@ spec:
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--cloud-config=$(CLOUD_CONFIG)"
+            - "--v=5"
           env:
             - name: NODE_ID
               valueFrom:

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -268,8 +268,6 @@ func (cs *controllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
 	name := req.Name
 	volumeId := req.SourceVolumeId
-	// No description from csi.CreateSnapshotRequest now
-	description := ""
 
 	if name == "" {
 		return nil, status.Error(codes.InvalidArgument, "Snapshot name must be provided in CreateSnapshot request")
@@ -301,7 +299,7 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 
 	} else {
 		// TODO: Delegate the check to openstack itself and ignore the conflict
-		snap, err = cs.Cloud.CreateSnapshot(name, volumeId, description, &req.Parameters)
+		snap, err = cs.Cloud.CreateSnapshot(name, volumeId, &req.Parameters)
 		if err != nil {
 			klog.V(3).Infof("Failed to Create snapshot: %v", err)
 			return nil, status.Error(codes.Internal, fmt.Sprintf("CreateSnapshot failed with error %v", err))

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -49,7 +49,7 @@ type IOpenStack interface {
 	GetAttachmentDiskPath(instanceID, volumeID string) (string, error)
 	GetVolume(volumeID string) (*volumes.Volume, error)
 	GetVolumesByName(name string) ([]volumes.Volume, error)
-	CreateSnapshot(name, volID, description string, tags *map[string]string) (*snapshots.Snapshot, error)
+	CreateSnapshot(name, volID string, tags *map[string]string) (*snapshots.Snapshot, error)
 	ListSnapshots(limit, offset int, filters map[string]string) ([]snapshots.Snapshot, error)
 	DeleteSnapshot(snapID string) error
 	GetSnapshotByNameAndVolumeID(n string, volumeId string) ([]snapshots.Snapshot, error)

--- a/pkg/csi/cinder/openstack/openstack_mock.go
+++ b/pkg/csi/cinder/openstack/openstack_mock.go
@@ -225,13 +225,13 @@ func (_m *OpenStackMock) ListSnapshots(limit int, offset int, filters map[string
 	return r0, r1
 }
 
-// CreateSnapshot provides a mock function with given fields: name, volID, description, tags
-func (_m *OpenStackMock) CreateSnapshot(name string, volID string, description string, tags *map[string]string) (*snapshots.Snapshot, error) {
-	ret := _m.Called(name, volID, description, tags)
+// CreateSnapshot provides a mock function with given fields: name, volID, tags
+func (_m *OpenStackMock) CreateSnapshot(name string, volID string, tags *map[string]string) (*snapshots.Snapshot, error) {
+	ret := _m.Called(name, volID, tags)
 
 	var r0 *snapshots.Snapshot
-	if rf, ok := ret.Get(0).(func(string, string, string, *map[string]string) *snapshots.Snapshot); ok {
-		r0 = rf(name, volID, description, tags)
+	if rf, ok := ret.Get(0).(func(string, string, *map[string]string) *snapshots.Snapshot); ok {
+		r0 = rf(name, volID, tags)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*snapshots.Snapshot)
@@ -239,8 +239,8 @@ func (_m *OpenStackMock) CreateSnapshot(name string, volID string, description s
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string, string, *map[string]string) error); ok {
-		r1 = rf(name, volID, description, tags)
+	if rf, ok := ret.Get(1).(func(string, string, *map[string]string) error); ok {
+		r1 = rf(name, volID, tags)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/csi/cinder/openstack/openstack_snapshots.go
+++ b/pkg/csi/cinder/openstack/openstack_snapshots.go
@@ -32,15 +32,17 @@ const (
 	snapReadyDuration   = 1 * time.Second
 	snapReadyFactor     = 1.2
 	snapReadySteps      = 10
+
+	snapshotDescription = "Created by OpenStack Cinder CSI driver"
 )
 
 // CreateSnapshot issues a request to take a Snapshot of the specified Volume with the corresponding ID and
 // returns the resultant gophercloud Snapshot Item upon success
-func (os *OpenStack) CreateSnapshot(name, volID, description string, tags *map[string]string) (*snapshots.Snapshot, error) {
+func (os *OpenStack) CreateSnapshot(name, volID string, tags *map[string]string) (*snapshots.Snapshot, error) {
 	opts := &snapshots.CreateOpts{
 		VolumeID:    volID,
 		Name:        name,
-		Description: description,
+		Description: snapshotDescription,
 	}
 	if tags != nil {
 		opts.Metadata = *tags

--- a/pkg/csi/cinder/sanity/fakecloud.go
+++ b/pkg/csi/cinder/sanity/fakecloud.go
@@ -128,15 +128,14 @@ func notFoundError() error {
 	return gophercloud.ErrDefault404{}
 }
 
-func (cloud *cloud) CreateSnapshot(name, volID, description string, tags *map[string]string) (*snapshots.Snapshot, error) {
+func (cloud *cloud) CreateSnapshot(name, volID string, tags *map[string]string) (*snapshots.Snapshot, error) {
 
 	snap := &snapshots.Snapshot{
-		ID:          randString(10),
-		Name:        name,
-		Status:      "Available",
-		VolumeID:    volID,
-		Description: description,
-		CreatedAt:   time.Now(),
+		ID:        randString(10),
+		Name:      name,
+		Status:    "Available",
+		VolumeID:  volID,
+		CreatedAt: time.Now(),
 	}
 
 	cloud.snapshots[snap.ID] = snap


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**The binaries affected**:

IMPORTANT: Please also add the binary name in the title, e.g.
`[openstack-cloud-controller-manager]: Add UDP protocol support`
unless the PR affects multiple binaries.

- [ ] openstack-cloud-controller-manager
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:


**Which issue this PR fixes**:
fixes #

**Special notes for reviewers**:

<!-- e.g. How to test this PR -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
