### PR TITLE
nit , cinder csi: remove default verbose flag

### DIFF
--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -37,7 +37,6 @@ spec:
         - name: csi-attacher
           image: quay.io/k8scsi/csi-attacher:v2.0.0
           args:
-            - "--v=5"
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
           env:
@@ -73,7 +72,6 @@ spec:
         - name: csi-resizer
           image: quay.io/k8scsi/csi-resizer:v0.3.0
           args:
-            - "--v=5"
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS


### PR DESCRIPTION
during some debug found some logs are not enabled by default
and not consistent for all containers as well, add this PR
to make them verbose and consistent across pod

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**The binaries affected**:

IMPORTANT: Please also add the binary name in the title, e.g.
`[openstack-cloud-controller-manager]: Add UDP protocol support`
unless the PR affects multiple binaries.

- [ ] openstack-cloud-controller-manager
- [x] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:


**Which issue this PR fixes**:
fixes #

**Special notes for reviewers**:

<!-- e.g. How to test this PR -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
