### PR TITLE
[cinder-csi-plugin] Add metadata search order

### DIFF
--- a/docs/using-cinder-csi-plugin.md
+++ b/docs/using-cinder-csi-plugin.md
@@ -41,6 +41,12 @@ Encode your ```$CLOUD_CONFIG``` file content using base64.
 Update ```cloud.conf``` configuration in ```manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml``` file
 by using the result of the above command.
 
+> NOTE: In OpenStack, the compute instance uses either config drive or metadata service to retrieve instance-specific data. As the cluster administrator, you are able to config the order in the cloud config file for cinder-csi-plugin, the default configuration is as follows:
+```
+[Metadata]
+search-order = configDrive,metadataService
+```
+
 > NOTE: if your openstack cloud has cert (which means you already has cafile definition in cloud-config), please make sure that you also updated the volumes list of `cinder-csi-controllerplugin.yaml` and `cinder-csi-nodeplugin.yaml` to include the cacert. e.g following sample then mount the volume to the pod as well.
 
 ```

--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -147,7 +147,7 @@ func nodePublishEphermeral(req *csi.NodePublishVolumeRequest, ns *nodeServer) (*
 
 	// attach volume
 	// for attach volume we need to have information about node.
-	nodeID, err := getNodeID(ns.Mount, ns.Metadata)
+	nodeID, err := getNodeID(ns.Mount, ns.Metadata, ns.Cloud.GetMetadataOpts().SearchOrder)
 	if err != nil {
 		klog.V(3).Infof("Ephermal Volume Attach: Failed to get Instance ID: %v", err)
 		return nil, status.Error(codes.Internal, fmt.Sprintf("Ephermal Volume Attach: Failed to get Instance ID: %v", err))
@@ -448,7 +448,7 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 
 func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
 
-	nodeID, err := getNodeID(ns.Mount, ns.Metadata)
+	nodeID, err := getNodeID(ns.Mount, ns.Metadata, ns.Cloud.GetMetadataOpts().SearchOrder)
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("NodeGetInfo failed with error %v", err))
 	}
@@ -523,6 +523,7 @@ func getNodeIDMountProvider(m mount.IMount) (string, error) {
 		klog.V(3).Infof("Failed to GetInstanceID: %v", err)
 		return "", err
 	}
+	klog.V(5).Infof("getNodeIDMountProvider return node id %s", nodeID)
 
 	return nodeID, nil
 }
@@ -533,6 +534,7 @@ func getNodeIDMetdataService(m openstack.IMetadata) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	klog.V(5).Infof("getNodeIDMetdataService return node id %s", nodeID)
 	return nodeID, nil
 }
 
@@ -545,17 +547,28 @@ func getAvailabilityZoneMetadataService(m openstack.IMetadata) (string, error) {
 	return zone, nil
 }
 
-func getNodeID(mount mount.IMount, metadata openstack.IMetadata) (string, error) {
-	// First try to get instance id from mount provider
-	nodeID, err := getNodeIDMountProvider(mount)
-	if err == nil {
-		return nodeID, nil
+func getNodeID(mount mount.IMount, iMetadata openstack.IMetadata, order string) (string, error) {
+	elements := strings.Split(order, ",")
+
+	var nodeID string
+	var err error
+	for _, id := range elements {
+		id = strings.TrimSpace(id)
+		switch id {
+		case metadata.ConfigDriveID:
+			nodeID, err = getNodeIDMountProvider(mount)
+		case metadata.MetadataID:
+			nodeID, err = getNodeIDMetdataService(iMetadata)
+		default:
+			err = fmt.Errorf("%s is not a valid metadata search order option. Supported options are %s and %s", id, metadata.ConfigDriveID, metadata.MetadataID)
+		}
+		if err == nil {
+			break
+		}
 	}
 
-	klog.V(3).Infof("Trying to GetInstanceID from metadata service")
-	nodeID, err = getNodeIDMetdataService(metadata)
 	if err != nil {
-		klog.V(3).Infof("Failed to GetInstanceID from metadata service: %v", err)
+		klog.Errorf("Failed to GetInstanceID from config drive or metadata service: %v", err)
 		return "", err
 	}
 	return nodeID, nil

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -17,6 +17,7 @@ limitations under the License.
 package openstack
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/gophercloud/gophercloud"
@@ -27,6 +28,7 @@ import (
 	"github.com/spf13/pflag"
 	gcfg "gopkg.in/gcfg.v1"
 	openstack_provider "k8s.io/cloud-provider-openstack/pkg/cloudprovider/providers/openstack"
+	md "k8s.io/cloud-provider-openstack/pkg/util/metadata"
 	"k8s.io/klog"
 )
 
@@ -58,6 +60,7 @@ type IOpenStack interface {
 	GetInstanceByID(instanceID string) (*servers.Server, error)
 	ExpandVolume(volumeID string, size int) error
 	GetMaxVolLimit() int64
+	GetMetadataOpts() openstack_provider.MetadataOpts
 }
 
 type OpenStack struct {
@@ -65,6 +68,7 @@ type OpenStack struct {
 	blockstorage *gophercloud.ServiceClient
 	bsOpts       BlockStorageOpts
 	epOpts       gophercloud.EndpointOpts
+	metadataOpts openstack_provider.MetadataOpts
 }
 
 type BlockStorageOpts struct {
@@ -142,12 +146,18 @@ func CreateOpenStackProvider() (IOpenStack, error) {
 		return nil, err
 	}
 
+	// if no search order given, use default
+	if len(cfg.Config.Metadata.SearchOrder) == 0 {
+		cfg.Config.Metadata.SearchOrder = fmt.Sprintf("%s,%s", md.ConfigDriveID, md.MetadataID)
+	}
+
 	// Init OpenStack
 	OsInstance = &OpenStack{
 		compute:      computeclient,
 		blockstorage: blockstorageclient,
 		bsOpts:       cfg.BlockStorage,
 		epOpts:       epOpts,
+		metadataOpts: cfg.Config.Metadata,
 	}
 
 	return OsInstance, nil

--- a/pkg/csi/cinder/openstack/openstack_instances.go
+++ b/pkg/csi/cinder/openstack/openstack_instances.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	cpo "k8s.io/cloud-provider-openstack/pkg/cloudprovider/providers/openstack"
 )
 
 // GetInstanceByID returns server with specified instanceID
@@ -11,4 +12,9 @@ func (os *OpenStack) GetInstanceByID(instanceID string) (*servers.Server, error)
 		return nil, err
 	}
 	return server, nil
+}
+
+// GetInstanceByID returns server with specified instanceID
+func (os *OpenStack) GetMetadataOpts() cpo.MetadataOpts {
+	return os.metadataOpts
 }

--- a/pkg/csi/cinder/openstack/openstack_mock.go
+++ b/pkg/csi/cinder/openstack/openstack_mock.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/stretchr/testify/mock"
+	cpo "k8s.io/cloud-provider-openstack/pkg/cloudprovider/providers/openstack"
 )
 
 var fakeVol1 = volumes.Volume{
@@ -344,4 +345,10 @@ func (_m *OpenStackMock) ExpandVolume(volumeID string, size int) error {
 	}
 
 	return r0
+}
+
+func (_m *OpenStackMock) GetMetadataOpts() cpo.MetadataOpts {
+	var m cpo.MetadataOpts
+	m.SearchOrder = "configDrive"
+	return m
 }

--- a/pkg/csi/cinder/sanity/fakecloud.go
+++ b/pkg/csi/cinder/sanity/fakecloud.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	cpo "k8s.io/cloud-provider-openstack/pkg/cloudprovider/providers/openstack"
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder"
 )
 
@@ -215,4 +216,10 @@ func (cloud *cloud) ExpandVolume(volumeID string, size int) error {
 
 func (cloud *cloud) GetMaxVolLimit() int64 {
 	return 256
+}
+
+func (cloud *cloud) GetMetadataOpts() cpo.MetadataOpts {
+	var m cpo.MetadataOpts
+	m.SearchOrder = ""
+	return m
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**The binaries affected**:

IMPORTANT: Please also add the binary name in the title, e.g.
`[openstack-cloud-controller-manager]: Add UDP protocol support`
unless the PR affects multiple binaries.

- [ ] openstack-cloud-controller-manager
- [x] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:


**Which issue this PR fixes**:
fixes #859 

**Special notes for reviewers**:

<!-- e.g. How to test this PR -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
for CSI cinder, the search-order defined in cloud.conf is honored , so you can
provide a string like `configDrive,metadataService` or `metadataService,configDrive` to
define the order to get meta from. 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/cloud-provider-openstack/920)
<!-- Reviewable:end -->
