### PR TITLE
Update alpine base image from 3.7 to 3.11

### DIFF
--- a/cluster/images/barbican-kms-plugin/Dockerfile
+++ b/cluster/images/barbican-kms-plugin/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.11
 LABEL maintainers="Kubernetes Authors"
 LABEL description="Barbican KMS Plugin"
 

--- a/cluster/images/cinder-provisioner/Dockerfile
+++ b/cluster/images/cinder-provisioner/Dockerfile
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.7
+FROM alpine:3.11
 
 RUN apk add --no-cache ca-certificates
 

--- a/cluster/images/controller-manager/Dockerfile
+++ b/cluster/images/controller-manager/Dockerfile
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.7
+FROM alpine:3.11
 
 RUN apk add --no-cache ca-certificates
 

--- a/cluster/images/flex-volume-driver/Dockerfile
+++ b/cluster/images/flex-volume-driver/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.7
+FROM alpine:3.11
 
 # add bash
 RUN apk --no-cache add bash

--- a/cluster/images/magnum-auto-healer/Dockerfile
+++ b/cluster/images/magnum-auto-healer/Dockerfile
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM alpine:3.7
+FROM alpine:3.11
 
 RUN apk add --no-cache ca-certificates
 ADD magnum-auto-healer /bin/

--- a/cluster/images/manila-csi-plugin/Dockerfile
+++ b/cluster/images/manila-csi-plugin/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.11
 LABEL maintainers="Kubernetes Authors"
 LABEL description="Manila CSI Plugin"
 

--- a/cluster/images/manila-provisioner/Dockerfile
+++ b/cluster/images/manila-provisioner/Dockerfile
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.7
+FROM alpine:3.11
 
 RUN apk add --no-cache ca-certificates
 

--- a/cluster/images/octavia-ingress-controller/Dockerfile
+++ b/cluster/images/octavia-ingress-controller/Dockerfile
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM alpine:3.7
+FROM alpine:3.11
 
 RUN apk add --no-cache ca-certificates
 ADD octavia-ingress-controller /bin/

--- a/cluster/images/webhook/Dockerfile
+++ b/cluster/images/webhook/Dockerfile
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.7
+FROM alpine:3.11
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**The binaries affected**:

IMPORTANT: Please also add the binary name in the title, e.g.
`[openstack-cloud-controller-manager]: Add UDP protocol support`
unless the PR affects multiple binaries.

- [ ] openstack-cloud-controller-manager
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
The docker base image `alpine:3.7` is outdated and is replaced by the current release `3.11`.
There are several vulnerabilities reported in these old base images (e.g. for the included packages busybox-1.27.2-r11 and ssl_client-1.27.2-r11).

The affected images are:
- k8scloudprovider/openstack-cloud-controller-manager
- k8scloudprovider/barbican-kms-plugin
- k8scloudprovider/cinder-provisioner
- k8scloudprovider/cinder-flex-volume-driver
- k8scloudprovider/magnum-auto-healer
- k8scloudprovider/manila-csi-plugin
- k8scloudprovider/manila-provisioner
- k8scloudprovider/octavia-ingress-controller
- k8scloudprovider/k8s-keystone-auth

**Which issue this PR fixes**:

**Special notes for reviewers**:

<!-- e.g. How to test this PR -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/cloud-provider-openstack/926)
<!-- Reviewable:end -->
