### PR TITLE
[octavia-ingress-controller] Support TLS in Ingress

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	k8s.io/kubernetes v1.17.0
 	k8s.io/utils v0.0.0-20191114184206-e782cd3c129f
 	sigs.k8s.io/sig-storage-lib-external-provisioner v0.0.0-20190807214443-c525773885fc
+	software.sslmate.com/src/go-pkcs12 v0.0.0-20190209200317-47dd539968c4
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -852,5 +852,7 @@ sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06 h1:zD2Iem
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06/go.mod h1:/ULNhyfzRopfcjskuui0cTITekDduZ7ycKN3oUT9R18=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
+software.sslmate.com/src/go-pkcs12 v0.0.0-20190209200317-47dd539968c4 h1:bgAHvGcJ9+ho1l9ItDc5F14pNQ4iZnd65UHEYwJLbrI=
+software.sslmate.com/src/go-pkcs12 v0.0.0-20190209200317-47dd539968c4/go.mod h1:/xvNRWUqm0+/ZMiF4EX00vrSCMsE4/NHb+Pt3freEeQ=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=
 vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=

--- a/pkg/util/openstack/keymanager.go
+++ b/pkg/util/openstack/keymanager.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/keymanager/v1/secrets"
+)
+
+// EnsureSecret creates a secret if it doesn't exist.
+func EnsureSecret(client *gophercloud.ServiceClient, name string, secretType string, payload string) (string, error) {
+	secret, err := GetSecret(client, name)
+	if err != nil {
+		if err == ErrNotFound {
+			// Create a new one
+			return CreateSecret(client, name, secretType, payload)
+		}
+
+		return "", err
+	}
+
+	return secret.SecretRef, nil
+}
+
+// GetSecret returns the secret by name
+func GetSecret(client *gophercloud.ServiceClient, name string) (*secrets.Secret, error) {
+	listOpts := secrets.ListOpts{
+		Name: name,
+	}
+	allPages, err := secrets.List(client, listOpts).AllPages()
+	if err != nil {
+		return nil, err
+	}
+	allSecrets, err := secrets.ExtractSecrets(allPages)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(allSecrets) == 0 {
+		return nil, ErrNotFound
+	}
+	if len(allSecrets) > 1 {
+		return nil, ErrMultipleResults
+	}
+
+	return &allSecrets[0], nil
+}
+
+// CreateSecret creates a secret in Barbican, returns the secret url.
+func CreateSecret(client *gophercloud.ServiceClient, name string, secretType string, payload string) (string, error) {
+	createOpts := secrets.CreateOpts{
+		Name:                   name,
+		Algorithm:              "aes",
+		Mode:                   "cbc",
+		BitLength:              256,
+		PayloadContentType:     secretType,
+		PayloadContentEncoding: "base64",
+		Payload:                payload,
+		SecretType:             secrets.OpaqueSecret,
+	}
+	secret, err := secrets.Create(client, createOpts).Extract()
+	if err != nil {
+		return "", err
+	}
+	return secret.SecretRef, nil
+}
+
+// ParseSecretID return secret ID from serectRef
+func ParseSecretID(ref string) (string, error) {
+	parts := strings.Split(ref, "/")
+	if len(parts) < 2 {
+		return "", fmt.Errorf("Could not parse %s", ref)
+	}
+
+	return parts[len(parts)-1], nil
+}
+
+// DeleteSecrets deletes all the secrets that including the name string.
+func DeleteSecrets(client *gophercloud.ServiceClient, partName string) error {
+	listOpts := secrets.ListOpts{
+		SecretType: secrets.OpaqueSecret,
+	}
+	allPages, err := secrets.List(client, listOpts).AllPages()
+	if err != nil {
+		return err
+	}
+	allSecrets, err := secrets.ExtractSecrets(allPages)
+	if err != nil {
+		return err
+	}
+
+	for _, s := range allSecrets {
+		if strings.Contains(s.Name, partName) {
+			secretID, err := ParseSecretID(s.SecretRef)
+			if err != nil {
+				return err
+			}
+			err = secrets.Delete(client, secretID).ExtractErr()
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/util/openstack/loadbalancer.go
+++ b/pkg/util/openstack/loadbalancer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package openstack
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -24,9 +25,13 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/apiversions"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
+	"github.com/gophercloud/gophercloud/pagination"
 	version "github.com/hashicorp/go-version"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"
+
+	cpoerrors "k8s.io/cloud-provider-openstack/pkg/util/errors"
 )
 
 const (
@@ -43,6 +48,12 @@ const (
 
 var (
 	octaviaVersion string
+
+	// ErrNotFound is used to inform that the object is missing
+	ErrNotFound = errors.New("failed to find object")
+
+	// ErrMultipleResults is used when we unexpectedly get back multiple results
+	ErrMultipleResults = errors.New("multiple results where only one expected")
 )
 
 // getOctaviaVersion returns the current Octavia API version.
@@ -151,4 +162,107 @@ func CreateListener(client *gophercloud.ServiceClient, lbID string, opts listene
 	}
 
 	return listener, nil
+}
+
+// GetLoadbalancerByName retrieves loadbalancer object
+func GetLoadbalancerByName(client *gophercloud.ServiceClient, name string) (*loadbalancers.LoadBalancer, error) {
+	opts := loadbalancers.ListOpts{
+		Name: name,
+	}
+	allPages, err := loadbalancers.List(client, opts).AllPages()
+	if err != nil {
+		return nil, err
+	}
+	loadbalancerList, err := loadbalancers.ExtractLoadBalancers(allPages)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(loadbalancerList) > 1 {
+		return nil, ErrMultipleResults
+	}
+	if len(loadbalancerList) == 0 {
+		return nil, ErrNotFound
+	}
+
+	return &loadbalancerList[0], nil
+}
+
+// GetListenerByName gets a listener by its name, raise error if not found or get multiple ones.
+func GetListenerByName(client *gophercloud.ServiceClient, name string, lbID string) (*listeners.Listener, error) {
+	opts := listeners.ListOpts{
+		Name:           name,
+		LoadbalancerID: lbID,
+	}
+	pager := listeners.List(client, opts)
+	var listenerList []listeners.Listener
+
+	err := pager.EachPage(func(page pagination.Page) (bool, error) {
+		v, err := listeners.ExtractListeners(page)
+		if err != nil {
+			return false, err
+		}
+		listenerList = append(listenerList, v...)
+		if len(listenerList) > 1 {
+			return false, ErrMultipleResults
+		}
+		return true, nil
+	})
+	if err != nil {
+		if cpoerrors.IsNotFound(err) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	if len(listenerList) == 0 {
+		return nil, ErrNotFound
+	}
+
+	return &listenerList[0], nil
+}
+
+// GetPoolByName gets a pool by its name, raise error if not found or get multiple ones.
+func GetPoolByName(client *gophercloud.ServiceClient, name string, lbID string) (*pools.Pool, error) {
+	var listenerPools []pools.Pool
+
+	opts := pools.ListOpts{
+		Name:           name,
+		LoadbalancerID: lbID,
+	}
+	err := pools.List(client, opts).EachPage(func(page pagination.Page) (bool, error) {
+		v, err := pools.ExtractPools(page)
+		if err != nil {
+			return false, err
+		}
+		listenerPools = append(listenerPools, v...)
+		if len(listenerPools) > 1 {
+			return false, ErrMultipleResults
+		}
+		return true, nil
+	})
+	if err != nil {
+		if cpoerrors.IsNotFound(err) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	if len(listenerPools) == 0 {
+		return nil, ErrNotFound
+	} else if len(listenerPools) > 1 {
+		return nil, ErrMultipleResults
+	}
+
+	return &listenerPools[0], nil
+}
+
+// DeleteLoadbalancer deletes a loadbalancer with all its child objects.
+func DeleteLoadbalancer(client *gophercloud.ServiceClient, lbID string) error {
+	err := loadbalancers.Delete(client, lbID, loadbalancers.DeleteOpts{Cascade: true}).ExtractErr()
+	if err != nil && !cpoerrors.IsNotFound(err) {
+		return fmt.Errorf("error deleting loadbalancer %s: %v", lbID, err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
**The binaries affected**:

- [ ] openstack-cloud-controller-manager
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [x] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
Support to create TLS Ingress.

This implementation for octavia-ingress-controller requires the TLS secret must exist when creating the Ingress. In the future, we could consider to create the secret on the fly with integration of e.g. cert-manager.

The TLS support requires OpenStack Barbican deployed in the cloud, TLS Ingress creation will fail if Barbican is not available.

**Which issue this PR fixes**:
fixes #287

**Special notes for reviewers**:
Steps to test:

1. Preprae for the TLS secret, make sure to specify the server name in the CN field of the certificate, in this example, we use `www.example.com` as the server name.

    ```
    $ ll
    total 32
    -rw-rw-r-- 1 ubuntu ubuntu 1346 Feb  7 11:01 ca.crt
    -rw-rw-r-- 1 ubuntu ubuntu 1038 Feb  4 21:39 www.example.com.crt
    -rw-rw-r-- 1 ubuntu ubuntu  887 Feb  4 21:39 www.example.com.key
    $ openssl x509 -noout -text -in www.example.com.crt
    Certificate:
    ...
            Subject: C = NZ, ST = Wellington, L = Wellington, O = Catalyst, OU = Lingxian, CN = www.example.com
    ...
    $ kubectl create secret tls tls-secret --cert www.example.com.crt --key www.example.com.key
    $ kubectl describe secret tls-secret
    Name:         tls-secret
    Namespace:    default
    Labels:       <none>
    Annotations:  <none>

    Type:  kubernetes.io/tls

    Data
    ====
    tls.key:  887 bytes
    tls.crt:  1038 bytes
    ```
2. Create the Ingress

    ```
    cat <<EOF | kubectl apply -f -
    ---
    apiVersion: networking.k8s.io/v1beta1
    kind: Ingress
    metadata:
      name: test-octavia-ingress
      annotations:
        kubernetes.io/ingress.class: "openstack"
        octavia.ingress.kubernetes.io/internal: "false"
    spec:
      backend:
        serviceName: default-http-backend
        servicePort: 80
      tls:
        - secretName: tls-secret
      rules:
      - host: www.example.com
        http:
          paths:
          - path: /hostname
            backend:
              serviceName: hostname
              servicePort: 8080
    EOF
    ```

3. Check a secret created in OpenStack Barbican.

    ```
    $ openstack secret list
    +------------------------------------------------------------------------------------+------------------------------------------------------------------+---------------------------+--------+-----------------------------------------+-----------+------------+-------------+------+------------+
    | Secret href                                                                        | Name                                                             | Created                   | Status | Content types                           | Algorithm | Bit length | Secret type | Mode | Expiration |
    +------------------------------------------------------------------------------------+------------------------------------------------------------------+---------------------------+--------+-----------------------------------------+-----------+------------+-------------+------+------------+
    | http://128.110.154.166/key-manager/v1/secrets/c1b1ac4c-eced-4dee-8d61-efaaf13c4639 | kube_ingress_lingxiank8s_default_test-octavia-ingress_tls-secret | 2020-02-09T10:11:12+00:00 | ACTIVE | {'default': 'application/octet-stream'} | aes       |        256 | opaque      | cbc  | None       |
    +------------------------------------------------------------------------------------+------------------------------------------------------------------+---------------------------+--------+-----------------------------------------+-----------+------------+-------------+------+------------+
    ```

4. Verify https connection

    ```
    $ kubectl get ing
    NAME                   HOSTS             ADDRESS        PORTS     AGE
    test-octavia-ingress   www.example.com   172.24.5.218   80, 443   102s
    $ ip=172.24.5.218
    $ curl --cacert ca.crt --resolve www.example.com:443:$ip https://www.example.com/hostname
    hostname-544845f9c6-t9tnv
    ```

[Here](https://asciinema.org/a/299553?speed=2&cols=180&rows=40) is a live demo.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/cloud-provider-openstack/927)
<!-- Reviewable:end -->
