### PR TITLE
[OCCM] Enable OCCM CI job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -8,16 +8,23 @@
               - ^OWNERS$
               - ^SECURITY_CONTACTS$
               - ^.gitignore$
-    # Disable Octavia Job issue-750
-    # cloud-provider-openstack-acceptance-test-lb-octavia:
-    #   jobs:
-    #     - cloud-provider-openstack-acceptance-test-lb-octavia:
-    #         irrelevant-files:
-    #           - ^docs/.*$
-    #           - ^.*\.md$
-    #           - ^OWNERS$
-    #           - ^SECURITY_CONTACTS$
-    #           - ^.gitignore$
+    cloud-provider-openstack-acceptance-test-lb-octavia:
+      jobs:
+        - cloud-provider-openstack-acceptance-test-lb-octavia:
+            files:
+              - ^cmd/openstack-cloud-controller-manager/.*
+              - ^pkg/cloudprovider/.*
+              - ^pkg/util/.*
+              - ^tests/e2e/cloudprovider/.*
+              - ^go.mod$
+              - ^go.sum$
+              - ^Makefile$
+            irrelevant-files:
+              - ^docs/.*$
+              - ^.*\.md$
+              - ^OWNERS$
+              - ^SECURITY_CONTACTS$
+              - ^.gitignore$
     cloud-provider-openstack-format:
       jobs:
         - cloud-provider-openstack-format:
@@ -30,6 +37,12 @@
     cloud-provider-openstack-acceptance-test-keystone-authentication-authorization:
       jobs:
         - cloud-provider-openstack-acceptance-test-keystone-authentication-authorization:
+            files:
+              - ^cmd/k8s-keystone-auth/.*
+              - ^pkg/identity/.*
+              - ^go.mod$
+              - ^go.sum$
+              - ^Makefile$
             irrelevant-files:
               - ^docs/.*$
               - ^.*\.md$
@@ -106,6 +119,7 @@
               - ^pkg/cloudprovider/.*
               - ^go.mod$
               - ^go.sum$
+              - ^Makefile$
             irrelevant-files:
               - ^docs/.*$
               - ^.*\.md$

--- a/tests/e2e/cloudprovider/test-lb-service.sh
+++ b/tests/e2e/cloudprovider/test-lb-service.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+
+# This script is used for the openlab CI job cloud-provider-openstack-acceptance-test-lb-octavia.
+# See https://github.com/theopenlab/openlab-zuul-jobs/blob/master/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml#L104
+#
+# Prerequisites:
+#   - This script is supposed to be running on a host has access to kubernetes cluster.
+#   - kubectl is ready to talk with the kubernetes cluster.
+#   - It's recommended to run the script on a host with as less proxies to the public as possible, otherwise the
+#     x-forwarded-for test will probably fail.
+#   - This script is not responsible for resource clean up if there is test case fails.
+
+TIMEOUT=${TIMEOUT:-300}
+FLOATING_IP=${FLOATING_IP:-""}
+NAMESPACE="octavia-lb-test"
+
+########################################################################
+## Name: wait_for_service
+## Desc: Waits for a k8s service until it gets a valid IP address
+## Params:
+##   - (required) A k8s service name
+########################################################################
+function wait_for_service {
+  local service_name=$1
+
+  end=$(($(date +%s) + ${TIMEOUT}))
+  while true; do
+    ipaddr=$(kubectl -n $NAMESPACE describe service ${service_name} | grep 'LoadBalancer Ingress' | awk -F":" '{print $2}' | tr -d ' ')
+    if [ "x${ipaddr}" != "x" ]; then
+      printf "\n>>>>>>> Service ${service_name} is created successfully, IP: ${ipaddr}\n"
+      export ipaddr=${ipaddr}
+      break
+    fi
+    sleep 3
+    now=$(date +%s)
+    [ $now -gt $end ] && printf "\n>>>>>>> FAIL: Failed to wait for the Service ${service_name} created in time\n" && exit -1
+  done
+}
+
+########################################################################
+## Name: wait_for_service_deleted
+## Desc: Waits for a k8s service deleted.
+## Params:
+##   - (required) A k8s service name
+########################################################################
+function wait_for_service_deleted {
+    local service_name=$1
+
+    end=$(($(date +%s) + ${TIMEOUT}))
+    while true; do
+        svc=$(kubectl -n $NAMESPACE get service | grep ${service_name})
+        if [[ "x${svc}" == "x" ]]; then
+            printf "\n>>>>>>> Service ${service_name} deleted\n"
+            break
+        fi
+        sleep 3
+        now=$(date +%s)
+        [ $now -gt $end ] && printf "\n>>>>>>> FAIL: Failed to wait for the Service ${service_name} deleted\n" && exit -1
+    done
+}
+
+########################################################################
+## Name: create_namespace
+## Desc: Makes sure the namespace exists.
+## Params: None
+########################################################################
+function create_namespace {
+    printf "\n>>>>>>> Create Namespace ${NAMESPACE}\n"
+    kubectl -n $NAMESPACE get deploy echoserver > /dev/null 2>&1
+    cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${NAMESPACE}
+EOF
+}
+
+########################################################################
+## Name: create_deployment
+## Desc: Makes sure the echoserver service Deployment is running
+## Params: None
+########################################################################
+function create_deployment {
+    printf "\n>>>>>>> Create a Deployment\n"
+    kubectl -n $NAMESPACE get deploy echoserver > /dev/null 2>&1
+    if [ $? -eq 1 ]; then
+        kubectl -n $NAMESPACE run echoserver --image=gcr.io/google-containers/echoserver:1.10 --image-pull-policy=IfNotPresent --port=8080
+    fi
+}
+
+########################################################################
+## Name: test_basic
+## Desc: Create a k8s service and send request to the service external
+##       IP
+## Params: None
+########################################################################
+function test_basic {
+    local service="test-basic"
+
+    printf "\n>>>>>>> Create Service ${service}\n"
+    cat <<EOF | kubectl apply -f -
+kind: Service
+apiVersion: v1
+metadata:
+  name: ${service}
+  namespace: $NAMESPACE
+spec:
+  type: LoadBalancer
+  loadBalancerIP: ${FLOATING_IP}
+  selector:
+    run: echoserver
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+EOF
+
+    printf "\n>>>>>>> Waiting for the Service ${service} creation finished\n"
+    wait_for_service ${service}
+
+    printf "\n>>>>>>> Sending request to the Service ${service}\n"
+    podname=$(curl -s http://${ipaddr} | grep Hostname | awk -F':' '{print $2}' | cut -d ' ' -f2)
+    if [[ "$podname" =~ "echoserver" ]]; then
+        printf "\n>>>>>>> Expected: Get correct response from Service ${service}\n"
+    else
+        printf "\n>>>>>>> FAIL: Get incorrect response from Service ${service}, expected: echoserver, actual: $podname\n"
+        exit -1
+    fi
+
+    printf "\n>>>>>>> Delete Service ${service}\n"
+    kubectl -n $NAMESPACE delete service ${service}
+}
+
+########################################################################
+## Name: test_forwarded
+## Desc: Create a k8s service that gets the original client IP
+## Params: None
+########################################################################
+function test_forwarded {
+    local service="test-x-forwarded-for"
+    local public_ip=$(curl -s ifconfig.me)
+    local local_ip=$(ip route get 8.8.8.8 | head -1 | awk '{print $7}')
+
+    printf "\n>>>>>>> Create the Service ${service}\n"
+    cat <<EOF | kubectl apply -f -
+kind: Service
+apiVersion: v1
+metadata:
+  name: ${service}
+  namespace: $NAMESPACE
+  annotations:
+    loadbalancer.openstack.org/x-forwarded-for: "true"
+spec:
+  type: LoadBalancer
+  loadBalancerIP: ${FLOATING_IP}
+  selector:
+    run: echoserver
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+EOF
+
+    printf "\n>>>>>>> Waiting for the Service ${service} creation finished\n"
+    wait_for_service ${service}
+
+    printf "\n>>>>>>> Sending request to the Service ${service}\n"
+    orig_ip=$(curl -s http://${ipaddr} | grep  x-forwarded-for | awk -F'=' '{print $2}')
+    if [[ "${orig_ip}" != "${local_ip}" && "${orig_ip}" != "${public_ip}" ]]; then
+        printf "\n>>>>>>> FAIL: Get incorrect response from Service ${service}, orig_ip: ${local_ip}, public_ip: ${public_ip}\n"
+        exit -1
+    else
+        printf "\n>>>>>>> Expected: Get correct response from Service ${service}\n"
+    fi
+
+    printf "\n>>>>>>> Delete Service ${service}\n"
+    kubectl -n $NAMESPACE delete service ${service}
+}
+
+create_namespace
+create_deployment
+test_basic
+test_forwarded
+
+printf "\n>>>>>>> Delete k8s resources\n"
+kubectl -n ${NAMESPACE} delete deploy echoserver


### PR DESCRIPTION
**The binaries affected**:

IMPORTANT: Please also add the binary name in the title, e.g.
`[openstack-cloud-controller-manager]: Add UDP protocol support`
unless the PR affects multiple binaries.

- [x] openstack-cloud-controller-manager
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
The script will be used for the CI job cloud-provider-openstack-acceptance-test-lb-octavia, the job will be re-enabled after the openlab change https://github.com/theopenlab/openlab-zuul-jobs/pull/792 is ready.

**Which issue this PR fixes**:
fixes #750

**Special notes for reviewers**:
Currently, the test is running against an existing Kubernetes cluster in Catalyst Cloud, so the job has to be running in serial to avoid conflict, this is acceptable given the current development work of openstack-cloud-controller-manager is not so busy.

<!-- e.g. How to test this PR -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
