### PR TITLE
[cinder-flexvolume-driver] Disable the CI job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -85,15 +85,16 @@
               - ^pkg/util/.*
               - ^go.mod$
               - ^go.sum$
-    cloud-provider-openstack-acceptance-test-flexvolume-cinder:
-      jobs:
-        - cloud-provider-openstack-acceptance-test-flexvolume-cinder:
-            irrelevant-files:
-              - ^docs/.*$
-              - ^.*\.md$
-              - ^OWNERS$
-              - ^SECURITY_CONTACTS$
-              - ^.gitignore$
+    # Disable Cinder FlexVolume Driver Job as it is deprecated in cloud-provider-openstack repo.
+    # cloud-provider-openstack-acceptance-test-flexvolume-cinder:
+    #   jobs:
+    #     - cloud-provider-openstack-acceptance-test-flexvolume-cinder:
+    #         irrelevant-files:
+    #           - ^docs/.*$
+    #           - ^.*\.md$
+    #           - ^OWNERS$
+    #           - ^SECURITY_CONTACTS$
+    #           - ^.gitignore$
     cloud-provider-openstack-acceptance-test-csi-manila:
       jobs:
         - cloud-provider-openstack-acceptance-test-csi-manila:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Thank you for visiting the `Cloud Provider OpenStack` repository!
 
-This Repository hosts various plugins relavant to OpenStack and Kubernetes Integration
+This Repository hosts various plugins relevant to OpenStack and Kubernetes Integration
 
 * [OpenStack Cloud Controller Manager](/docs/openstack-cloud-controller-manager.md/)
 * [Octavia Ingress Controller](/docs/using-octavia-ingress-controller.md/)
@@ -14,6 +14,8 @@ This Repository hosts various plugins relavant to OpenStack and Kubernetes Integ
 * [Manila CSI Plugin](/docs/using-manila-csi-plugin.md/)
 * [Manila Provisioner](/docs/using-manila-provisioner.md/)
 * [Barbican KMS Plugin](/docs/using-barbican-kms-plugin.md/)
+* [Magnum Auto Healer](/docs/using-magnum-auto-healer.md/)
+* Cinder FlexVolume Driver**[DEPRECATED]**
 
 ## Developing
 

--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -54,8 +54,6 @@ spec:
             - mountPath: /etc/config
               name: cloud-config-volume
               readOnly: true
-            - mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-              name: flexvolume-dir
           resources:
             requests:
               cpu: 200m
@@ -64,10 +62,6 @@ spec:
               value: /etc/config/cloud.conf
       hostNetwork: true
       volumes:
-      - hostPath:
-          path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-          type: DirectoryOrCreate
-        name: flexvolume-dir
       - hostPath:
           path: /etc/kubernetes/pki
           type: DirectoryOrCreate

--- a/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
@@ -26,8 +26,6 @@ spec:
         - mountPath: /etc/ssl/certs
           name: ca-certs
           readOnly: true
-        - mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-          name: flexvolume-dir
         - mountPath: /etc/config
           name: cloud-config-volume
           readOnly: true
@@ -41,10 +39,6 @@ spec:
   securityContext:
     runAsUser: 1001
   volumes:
-  - hostPath:
-      path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-      type: DirectoryOrCreate
-    name: flexvolume-dir
   - hostPath:
       path: /etc/kubernetes/pki
       type: DirectoryOrCreate


### PR DESCRIPTION
**The binaries affected**:

IMPORTANT: Please also add the binary name in the title, e.g.
`[openstack-cloud-controller-manager]: Add UDP protocol support`
unless the PR affects multiple binaries.

- [ ] openstack-cloud-controller-manager
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
As Cinder CSI Plugin has more advantages over the FlexVolume plugin. Although FlexVolume plugin is still maintained by Kubernetes developers, new functionality will only be added to CSI, not to FlexVolume.

This PR disables the CI job `cloud-provider-openstack-acceptance-test-flexvolume-cinder`.

**Which issue this PR fixes**:
fixes #

**Special notes for reviewers**:

<!-- e.g. How to test this PR -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
