### PR TITLE
[manila-csi-plugin] added AZ/topology support

### DIFF
--- a/cluster/images/manila-csi-plugin/Dockerfile.build
+++ b/cluster/images/manila-csi-plugin/Dockerfile.build
@@ -3,4 +3,6 @@ FROM ${ALPINE_ARCH}/alpine:3.11
 
 ARG ARCH=amd64
 
+RUN apk add --no-cache ca-certificates jq curl
+
 ADD manila-csi-plugin-${ARCH} /bin/manila-csi-plugin

--- a/cmd/manila-csi-plugin/main.go
+++ b/cmd/manila-csi-plugin/main.go
@@ -36,6 +36,8 @@ var (
 	endpoint              string
 	driverName            string
 	nodeID                string
+	nodeAZ                string
+	withTopology          bool
 	protoSelector         string
 	fwdEndpoint           string
 	userAgentData         []string
@@ -124,7 +126,21 @@ func main() {
 			manilaClientBuilder := &manilaclient.ClientBuilder{UserAgent: "manila-csi-plugin", ExtraUserAgentData: userAgentData}
 			csiClientBuilder := &csiclient.ClientBuilder{}
 
-			d, err := manila.NewDriver(nodeID, driverName, endpoint, fwdEndpoint, protoSelector, manilaClientBuilder, csiClientBuilder, compatOpts)
+			d, err := manila.NewDriver(
+				&manila.DriverOpts{
+					DriverName:          driverName,
+					NodeID:              nodeID,
+					NodeAZ:              nodeAZ,
+					WithTopology:        withTopology,
+					ShareProto:          protoSelector,
+					ServerCSIEndpoint:   endpoint,
+					FwdCSIEndpoint:      fwdEndpoint,
+					ManilaClientBuilder: manilaClientBuilder,
+					CSIClientBuilder:    csiClientBuilder,
+					CompatOpts:          compatOpts,
+				},
+			)
+
 			if err != nil {
 				klog.Fatalf("driver initialization failed: %v", err)
 			}
@@ -141,6 +157,10 @@ func main() {
 
 	cmd.PersistentFlags().StringVar(&nodeID, "nodeid", "", "this node's ID")
 	cmd.MarkPersistentFlagRequired("nodeid")
+
+	cmd.PersistentFlags().StringVar(&nodeAZ, "nodeaz", "", "this node's availability zone")
+
+	cmd.PersistentFlags().BoolVar(&withTopology, "with-topology", false, "cluster is topology-aware")
 
 	cmd.PersistentFlags().StringVar(&protoSelector, "share-protocol-selector", "", "specifies which Manila share protocol to use. Valid values are NFS and CEPHFS")
 	cmd.MarkPersistentFlagRequired("share-protocol-selector")

--- a/docs/using-manila-csi-plugin.md
+++ b/docs/using-manila-csi-plugin.md
@@ -13,7 +13,7 @@ The CSI Manila driver is able to create and mount OpenStack Manila shares. Snaps
 * [Deployment](#deployment)
   * [Kubernetes 1.15+](#kubernetes-115)
     * [Verifying the deployment](#verifying-the-deployment)
-    * [Enabling topology-awareness](#enabling-topology-awareness)
+    * [Enabling topology awareness](#enabling-topology-awareness)
 * [Share protocol support matrix](#share-protocol-support-matrix)
 * [For developers](#for-developers)
 
@@ -74,7 +74,7 @@ Optionally, a custom certificate may be sourced via `os-certAuthorityPath` (path
 ### Topology-aware dynamic provisioning
 
 Topology-aware dynamic provisioning makes it possible to reliably provision and use shares that are _not_ equally accessible from all compute nodes due to storage topology constraints.
-With topology-awareness enabled, administrators can specify the mapping between compute and Manila availability zones.
+With topology awareness enabled, administrators can specify the mapping between compute and Manila availability zones.
 Doing so will instruct the CO scheduler to place the workloads+shares only on nodes that are able to reach the underlying storage.
 
 CSI Manila uses `topology.manila.csi.openstack.org/zone` _topology key_ to identify node's affinity to a certain compute availability zone.
@@ -83,7 +83,7 @@ Each node of the cluster then gets labeled with a key/value pair of `topology.ma
 This label may be used as a node selector when defining topology constraints for dynamic provisioning.
 Administrators are also free to pass arbitrary labels, and as long as they are valid node selectors, they will be honored by the scheduler.
 
-[Enabling topology-awareness in Kubernetes](#enabling-topology-awareness)
+[Enabling topology awareness in Kubernetes](#enabling-topology-awareness)
 
 ## Deployment
 
@@ -155,7 +155,7 @@ statefulset.apps/openstack-manila-csi-controllerplugin   1/1     2m8s
 
 To test the deployment further, see `examples/csi-manila-plugin`.
 
-#### Enabling topology-awareness
+#### Enabling topology awareness
 
 If you're deploying CSI Manila with Helm:
 1. Set `csimanila.topologyAwarenessEnabled` to `true`

--- a/docs/using-manila-csi-plugin.md
+++ b/docs/using-manila-csi-plugin.md
@@ -27,6 +27,7 @@ Option | Default value | Description
 `--drivername` | `manila.csi.openstack.org` | Name of this driver
 `--nodeid` | _none_ | ID of this node
 `--nodeaz` | _none_ | Availability zone of this node
+`--with-topology` | _none_ | CSI Manila is topology-aware. See [Topology-aware dynamic provisioning](#topology-aware-dynamic-provisioning) for more info
 `--share-protocol-selector` | _none_ | Specifies which Manila share protocol to use for this instance of the driver. See [supported protocols](#share-protocol-support-matrix) for valid values.
 `--fwdendpoint` | _none_ | [CSI Node Plugin](https://github.com/container-storage-interface/spec/blob/master/spec.md#rpc-interface) endpoint to which all Node Service RPCs are forwarded. Must be able to handle the file-system specified in `share-protocol-selector`. Check out the [Deployment](#deployment) section to see why this is necessary.
 

--- a/docs/using-manila-csi-plugin.md
+++ b/docs/using-manila-csi-plugin.md
@@ -9,9 +9,11 @@ The CSI Manila driver is able to create and mount OpenStack Manila shares. Snaps
   * [Controller Service volume parameters](#controller-service-volume-parameters)
   * [Node Service volume context](#node-service-volume-context)
   * [Secrets, authentication](#secrets-authentication)
+  * [Topology-aware dynamic provisioning](#topology-aware-dynamic-provisioning)
 * [Deployment](#deployment)
   * [Kubernetes 1.15+](#kubernetes-115)
     * [Verifying the deployment](#verifying-the-deployment)
+    * [Enabling topology-awareness](#enabling-topology-awareness)
 * [Share protocol support matrix](#share-protocol-support-matrix)
 * [For developers](#for-developers)
 
@@ -24,19 +26,25 @@ Option | Default value | Description
 `--endpoint` | `unix:///tmp/csi.sock` | CSI Manila's CSI endpoint
 `--drivername` | `manila.csi.openstack.org` | Name of this driver
 `--nodeid` | _none_ | ID of this node
+`--nodeaz` | _none_ | Availability zone of this node
 `--share-protocol-selector` | _none_ | Specifies which Manila share protocol to use for this instance of the driver. See [supported protocols](#share-protocol-support-matrix) for valid values.
 `--fwdendpoint` | _none_ | [CSI Node Plugin](https://github.com/container-storage-interface/spec/blob/master/spec.md#rpc-interface) endpoint to which all Node Service RPCs are forwarded. Must be able to handle the file-system specified in `share-protocol-selector`. Check out the [Deployment](#deployment) section to see why this is necessary.
 
 ### Controller Service volume parameters
 
+_Kubernetes storage class parameters for dynamically provisioned volumes_
+
 Parameter | Required | Description
 ----------|----------|------------
 `type` | _yes_ | Manila [share type](https://wiki.openstack.org/wiki/Manila/Concepts#share_type)
 `shareNetworkID` | _no_ | Manila [share network ID](https://wiki.openstack.org/wiki/Manila/Concepts#share_network)
+`availability` | _no_ | Manila availability zone of the provisioned share. This parameter is opaque to the CO and does not influence placement of workloads that will consume this share, meaning they may be scheduled onto any node of the cluster. If the specified Manila AZ is not equally accessible from all compute nodes of the cluster, use [Topology-aware dynamic provisioning](#topology-aware-dynamic-provisioning).
 `cephfs-mounter` | _no_ | Relevant for CephFS Manila shares. Specifies which mounting method to use with the CSI CephFS driver. Available options are `kernel` and `fuse`, defaults to `fuse`. See [CSI CephFS docs](https://github.com/ceph/ceph-csi/blob/csi-v1.0/docs/deploy-cephfs.md#configuration) for further information.
 `nfs-shareClient` | _no_ | Relevant for NFS Manila shares. Specifies what address has access to the NFS share. Defaults to `0.0.0.0/0`, i.e. anyone. 
 
 ### Node Service volume context
+
+_Kubernetes PV CSI volume attributes for pre-provisioned volumes_
 
 Parameter | Required | Description
 ----------|----------|------------
@@ -62,6 +70,20 @@ Mandatory secrets for _application credential authentication:_ `os-applicationCr
 Mandatory secrets for _trustee authentication:_ `os-trustID`, `os-trusteeID`, `os-trusteePassword`.
 
 Optionally, a custom certificate may be sourced via `os-certAuthorityPath` (path to a PEM file inside the plugin container). By default, the usual TLS verification is performed. To override this behavior and accept insecure certificates, set `os-TLSInsecure` to `true` (defaults to `false`).
+
+### Topology-aware dynamic provisioning
+
+Topology-aware dynamic provisioning makes it possible to reliably provision and use shares that are _not_ equally accessible from all compute nodes due to storage topology constraints.
+With topology-awareness enabled, administrators can specify the mapping between compute and Manila availability zones.
+Doing so will instruct the CO scheduler to place the workloads+shares only on nodes that are able to reach the underlying storage.
+
+CSI Manila uses `topology.manila.csi.openstack.org/zone` _topology key_ to identify node's affinity to a certain compute availability zone.
+Each node of the cluster then gets labeled with a key/value pair of `topology.manila.csi.openstack.org/zone` / value of [`--nodeaz`](#command-line-arguments) cmd arg.
+
+This label may be used as a node selector when defining topology constraints for dynamic provisioning.
+Administrators are also free to pass arbitrary labels, and as long as they are valid node selectors, they will be honored by the scheduler.
+
+[Enabling topology-awareness in Kubernetes](#enabling-topology-awareness)
 
 ## Deployment
 
@@ -132,6 +154,18 @@ statefulset.apps/openstack-manila-csi-controllerplugin   1/1     2m8s
 ```
 
 To test the deployment further, see `examples/csi-manila-plugin`.
+
+#### Enabling topology-awareness
+
+If you're deploying CSI Manila with Helm:
+1. Set `csimanila.topologyAwarenessEnabled` to `true`
+2. Set `csimanila.nodeAZ`. This value will be sourced into the [`--nodeaz`](#command-line-arguments) cmd flag. Bash expressions are also allowed.
+
+If you're deploying CSI Manila manually:
+1. Run the [external-provisioner](https://github.com/kubernetes-csi/external-provisioner) with `--feature-gates=Topology=true` and `--strict-topology` cmd flags.
+2. Run CSI Manila with [`--with-topology`](#command-line-arguments) and set [`--nodeaz`](#command-line-arguments) to node's availability zone. For Nova, the zone may be retrieved via the Metadata service like so: `--nodeaz=$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq .availability_zone)`
+
+See `examples/csi-manila-plugin/topology-aware` for examples on defining topology constraints.
 
 ## Share protocol support matrix
 

--- a/docs/using-manila-csi-plugin.md
+++ b/docs/using-manila-csi-plugin.md
@@ -163,8 +163,8 @@ If you're deploying CSI Manila with Helm:
 2. Set `csimanila.nodeAZ`. This value will be sourced into the [`--nodeaz`](#command-line-arguments) cmd flag. Bash expressions are also allowed.
 
 If you're deploying CSI Manila manually:
-1. Run the [external-provisioner](https://github.com/kubernetes-csi/external-provisioner) with `--feature-gates=Topology=true` and `--strict-topology` cmd flags.
-2. Run CSI Manila with [`--with-topology`](#command-line-arguments) and set [`--nodeaz`](#command-line-arguments) to node's availability zone. For Nova, the zone may be retrieved via the Metadata service like so: `--nodeaz=$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq .availability_zone)`
+1. Run the [external-provisioner](https://github.com/kubernetes-csi/external-provisioner) with `--feature-gates=Topology=true` cmd flag.
+2. Run CSI Manila with [`--with-topology`](#command-line-arguments) and set [`--nodeaz`](#command-line-arguments) to node's availability zone. For Nova, the zone may be retrieved via the Metadata service like so: `--nodeaz=$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq -r .availability_zone)`
 
 See `examples/csi-manila-plugin/topology-aware` for examples on defining topology constraints.
 

--- a/examples/manila-csi-plugin/README.md
+++ b/examples/manila-csi-plugin/README.md
@@ -21,6 +21,10 @@ nfs/
 ├── static-provisioning/
 │   ├── pod.yaml
 │   └── --> preprovisioned-pvc.yaml <--
+├── topology-aware/
+│   ├── pod.yaml
+│   ├── pvc.yaml
+│   └── --> storageclass.yaml <--
 └── --> secrets.yaml <--
 ```
 
@@ -29,6 +33,7 @@ Files marked with `--> ... <--` may need to be customized.
 * `dynamic-provisioning/` : creates a new Manila NFS share and mounts it in a Pod.
 * `static-provisioning/` : fetches an existing Manila NFS share and mounts it in a Pod
 * `snapshot/` : takes a snapshot from a PVC source, restores it into a new share and mounts it in a Pod. Deploy manifests in `dynamic-provisioning/` first 
+* `topology-aware/` : topology-aware dynamic provisioning
 
 Make sure the `provisioner` field in `storageclass.yaml` and `snapshotclass.yaml` matches the driver name in your deployment!
 

--- a/examples/manila-csi-plugin/helm-deployment/templates/controllerplugin-statefulset.yaml
+++ b/examples/manila-csi-plugin/helm-deployment/templates/controllerplugin-statefulset.yaml
@@ -33,6 +33,9 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
+            {{- if $.Values.csimanila.topologyAwarenessEnabled }}
+            - "--feature-gates=Topology=true"
+            {{- end }}
           env:
             - name: ADDRESS
               value: "unix:///var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}/csi-controllerplugin.sock"
@@ -63,16 +66,22 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: "{{ $.Values.csimanila.image.repository }}:{{ $.Values.csimanila.image.tag }}"
-          args:
-            - "--v=5"
-            - "--nodeid=$(NODE_ID)"
-            - "--endpoint=$(CSI_ENDPOINT)"
-            - "--drivername=$(DRIVER_NAME)"
-            - "--share-protocol-selector=$(MANILA_SHARE_PROTO)"
-            - "--fwdendpoint=$(FWD_CSI_ENDPOINT)"
-            {{- if .compatibilitySettings }}
-            - "--compatibility-settings={{ .compatibilitySettings }}"
+          command: ["/bin/sh", "-c",
+            '/bin/manila-csi-plugin
+            --v=5
+            --nodeid=$(NODE_ID)
+            {{- if $.Values.csimanila.topologyAwarenessEnabled }}
+            --with-topology
+            --nodeaz={{ $.Values.csimanila.nodeAZ }}
             {{- end }}
+            --endpoint=$(CSI_ENDPOINT)
+            --drivername=$(DRIVER_NAME)
+            --share-protocol-selector=$(MANILA_SHARE_PROTO)
+            --fwdendpoint=$(FWD_CSI_ENDPOINT)
+            {{- if .compatibilitySettings }}
+            --compatibility-settings={{ .compatibilitySettings }}
+            {{- end }}'
+          ]
           env:
             - name: DRIVER_NAME
               value: {{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}

--- a/examples/manila-csi-plugin/helm-deployment/templates/nodeplugin-daemonset.yaml
+++ b/examples/manila-csi-plugin/helm-deployment/templates/nodeplugin-daemonset.yaml
@@ -62,13 +62,19 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: "{{ $.Values.csimanila.image.repository }}:{{ $.Values.csimanila.image.tag }}"
-          args:
-            - "--v=5"
-            - "--nodeid=$(NODE_ID)"
-            - "--endpoint=$(CSI_ENDPOINT)"
-            - "--drivername=$(DRIVER_NAME)"
-            - "--share-protocol-selector=$(MANILA_SHARE_PROTO)"
-            - "--fwdendpoint=$(FWD_CSI_ENDPOINT)"
+          command: ["/bin/sh", "-c",
+            '/bin/manila-csi-plugin
+            --v=5
+            --nodeid=$(NODE_ID)
+            {{- if $.Values.csimanila.topologyAwarenessEnabled }}
+            --with-topology
+            --nodeaz={{ $.Values.csimanila.nodeAZ }}
+            {{- end }}
+            --endpoint=$(CSI_ENDPOINT)
+            --drivername=$(DRIVER_NAME)
+            --share-protocol-selector=$(MANILA_SHARE_PROTO)
+            --fwdendpoint=$(FWD_CSI_ENDPOINT)'
+          ]
           env:
             - name: DRIVER_NAME
               value: {{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}

--- a/examples/manila-csi-plugin/helm-deployment/values.yaml
+++ b/examples/manila-csi-plugin/helm-deployment/values.yaml
@@ -9,11 +9,17 @@ shareProtocols:
       sockFile: csi.sock
 #  - protocolSelector: CEPHFS
 #    fwdNodePluginEndpoint:
-#      dir: /var/lib/kubelet/plugins/csi-cephfsplugin
+#      dir: /var/lib/kubelet/plugins/cephfs.csi.ceph.com
 #      sockFile: csi.sock
 
-# CSI Manila image spec
+# CSI Manila spec
 csimanila:
+  # Set topologyAwarenessEnabled to true to enable topology-awareness
+  topologyAwarenessEnabled: false
+  # Availability zone for each node. topologyAwarenessEnabled must be set to true for this option to have any effect.
+  # If your Kubernetes cluster runs atop of Nova and want to use Nova AZs as AZs for the nodes of the cluster, uncomment the line below:
+  # nodeAZ: "$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq .availability_zone)"
+  # Image spec
   image:
     repository: manila-csi-plugin
     tag: latest

--- a/examples/manila-csi-plugin/helm-deployment/values.yaml
+++ b/examples/manila-csi-plugin/helm-deployment/values.yaml
@@ -14,7 +14,7 @@ shareProtocols:
 
 # CSI Manila spec
 csimanila:
-  # Set topologyAwarenessEnabled to true to enable topology-awareness
+  # Set topologyAwarenessEnabled to true to enable topology awareness
   topologyAwarenessEnabled: false
   # Availability zone for each node. topologyAwarenessEnabled must be set to true for this option to have any effect.
   # If your Kubernetes cluster runs atop of Nova and want to use Nova AZs as AZs for the nodes of the cluster, uncomment the line below:

--- a/examples/manila-csi-plugin/helm-deployment/values.yaml
+++ b/examples/manila-csi-plugin/helm-deployment/values.yaml
@@ -18,7 +18,7 @@ csimanila:
   topologyAwarenessEnabled: false
   # Availability zone for each node. topologyAwarenessEnabled must be set to true for this option to have any effect.
   # If your Kubernetes cluster runs atop of Nova and want to use Nova AZs as AZs for the nodes of the cluster, uncomment the line below:
-  # nodeAZ: "$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq .availability_zone)"
+  # nodeAZ: "$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq -r .availability_zone)"
   # Image spec
   image:
     repository: manila-csi-plugin

--- a/examples/manila-csi-plugin/nfs/topology-aware/pod.yaml
+++ b/examples/manila-csi-plugin/nfs/topology-aware/pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: new-nfs-share-pod
+spec:
+  containers:
+    - name: web-server
+      image: nginx
+      imagePullPolicy: IfNotPresent
+      volumeMounts:
+        - name: mypvc
+          mountPath: /var/lib/www
+  volumes:
+    - name: mypvc
+      persistentVolumeClaim:
+        claimName: new-nfs-share-pvc
+        readOnly: false

--- a/examples/manila-csi-plugin/nfs/topology-aware/pvc.yaml
+++ b/examples/manila-csi-plugin/nfs/topology-aware/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: new-nfs-share-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: csi-manila-nfs-az
+

--- a/examples/manila-csi-plugin/nfs/topology-aware/storageclass.yaml
+++ b/examples/manila-csi-plugin/nfs/topology-aware/storageclass.yaml
@@ -1,0 +1,37 @@
+# Topology constraints example:
+#
+# Let's have two Manila AZs: manila-zone-1, manila-zone-2
+# Let's have six Nova AZs: nova-{1..6}
+#
+# manila-zone-1 is accessible from nodes in nova-{1,2,3} only
+# manila-zone-2 is accessible from nodes in nova-{4,5,6} only
+#
+# We're provisioning into manila-zone-1
+# allowedTopologies reflects the topology constraints
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-manila-nfs-az
+provisioner: nfs.manila.csi.openstack.org
+parameters:
+  type: default
+  availability: manila-zone-1
+  
+  csi.storage.k8s.io/provisioner-secret-name: csi-manila-secrets
+  csi.storage.k8s.io/provisioner-secret-namespace: default
+  csi.storage.k8s.io/node-stage-secret-name: csi-manila-secrets
+  csi.storage.k8s.io/node-stage-secret-namespace: default
+  csi.storage.k8s.io/node-publish-secret-name: csi-manila-secrets
+  csi.storage.k8s.io/node-publish-secret-namespace: default
+allowedTopologies:
+  - matchLabelExpressions:
+    - key: topology.manila.csi.openstack.org/zone
+      values:
+        - nova-1
+        - nova-2
+        - nova-3
+    # ...or you may use other node labels:
+    # - key: my-zone-label
+    #   values:
+    #     - nodes-that-can-reach-manila-az-1

--- a/pkg/csi/manila/controllerserver.go
+++ b/pkg/csi/manila/controllerserver.go
@@ -153,9 +153,9 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 
 	var accessibleTopology []*csi.Topology
 	if cs.d.withTopology {
-		// All requisite topologies are considered valid. Nodes from those zones are required to be able to reach the storage.
+		// All requisite/preferred topologies are considered valid. Nodes from those zones are required to be able to reach the storage.
 		// The operator is responsible for making sure that provided topology keys are valid and present on the nodes of the cluster.
-		accessibleTopology = req.GetAccessibilityRequirements().GetRequisite()
+		accessibleTopology = req.GetAccessibilityRequirements().GetPreferred()
 	}
 
 	return &csi.CreateVolumeResponse{

--- a/pkg/csi/manila/controllerserver.go
+++ b/pkg/csi/manila/controllerserver.go
@@ -151,11 +151,19 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		}
 	}
 
+	var accessibleTopology []*csi.Topology
+	if cs.d.withTopology {
+		// All requisite topologies are considered valid. Nodes from those zones are required to be able to reach the storage.
+		// The operator is responsible for making sure that provided topology keys are valid and present on the nodes of the cluster.
+		accessibleTopology = req.GetAccessibilityRequirements().GetRequisite()
+	}
+
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
-			VolumeId:      share.ID,
-			ContentSource: req.GetVolumeContentSource(),
-			CapacityBytes: int64(sizeInGiB) * bytesInGiB,
+			VolumeId:           share.ID,
+			ContentSource:      req.GetVolumeContentSource(),
+			AccessibleTopology: accessibleTopology,
+			CapacityBytes:      int64(sizeInGiB) * bytesInGiB,
 			VolumeContext: map[string]string{
 				"shareID":        share.ID,
 				"shareAccessID":  accessRight.ID,

--- a/pkg/csi/manila/driver.go
+++ b/pkg/csi/manila/driver.go
@@ -35,11 +35,29 @@ import (
 	"k8s.io/klog"
 )
 
+type DriverOpts struct {
+	DriverName   string
+	NodeID       string
+	NodeAZ       string
+	WithTopology bool
+	ShareProto   string
+
+	ServerCSIEndpoint string
+	FwdCSIEndpoint    string
+
+	ManilaClientBuilder manilaclient.Builder
+	CSIClientBuilder    csiclient.Builder
+
+	CompatOpts *options.CompatibilityOptions
+}
+
 type Driver struct {
-	nodeID     string
-	name       string
-	version    string
-	shareProto string
+	nodeID       string
+	nodeAZ       string
+	withTopology bool
+	name         string
+	version      string
+	shareProto   string
 
 	serverEndpoint string
 	fwdEndpoint    string
@@ -66,6 +84,7 @@ type nonBlockingGRPCServer struct {
 const (
 	specVersion   = "1.2.0"
 	driverVersion = "0.9.0"
+	topologyKey   = "topology.manila.csi.openstack.org/zone"
 )
 
 var (
@@ -80,37 +99,45 @@ func argNotEmpty(val, name string) error {
 	return nil
 }
 
-func NewDriver(nodeID, driverName, endpoint, fwdEndpoint, shareProto string, manilaClientBuilder manilaclient.Builder, csiClientBuilder csiclient.Builder, compatOpts *options.CompatibilityOptions) (*Driver, error) {
-	for k, v := range map[string]string{"node ID": nodeID, "driver name": driverName, "driver endpoint": endpoint, "FWD endpoint": fwdEndpoint, "share protocol selector": shareProto} {
+func NewDriver(o *DriverOpts) (*Driver, error) {
+	for k, v := range map[string]string{"node ID": o.NodeID, "driver name": o.DriverName, "driver endpoint": o.ServerCSIEndpoint, "FWD endpoint": o.FwdCSIEndpoint, "share protocol selector": o.ShareProto} {
 		if err := argNotEmpty(v, k); err != nil {
 			return nil, err
 		}
 	}
 
-	klog.Infof("Driver: %s version: %s CSI spec version: %s", driverName, driverVersion, specVersion)
+	klog.Infof("Driver: %s version: %s CSI spec version: %s", o.DriverName, driverVersion, specVersion)
 
 	d := &Driver{
-		nodeID:              nodeID,
-		name:                driverName,
-		serverEndpoint:      endpoint,
-		fwdEndpoint:         fwdEndpoint,
-		shareProto:          strings.ToUpper(shareProto),
-		compatOpts:          compatOpts,
-		manilaClientBuilder: manilaClientBuilder,
-		csiClientBuilder:    csiClientBuilder,
+		nodeID:              o.NodeID,
+		nodeAZ:              o.NodeAZ,
+		withTopology:        o.WithTopology,
+		name:                o.DriverName,
+		serverEndpoint:      o.ServerCSIEndpoint,
+		fwdEndpoint:         o.FwdCSIEndpoint,
+		shareProto:          strings.ToUpper(o.ShareProto),
+		compatOpts:          o.CompatOpts,
+		manilaClientBuilder: o.ManilaClientBuilder,
+		csiClientBuilder:    o.CSIClientBuilder,
 	}
 
 	getShareAdapter(d.shareProto) // The program will terminate with a non-zero exit code if the share protocol selector is wrong
 	klog.Infof("Operating on %s shares", d.shareProto)
 
-	serverProto, serverAddr, err := parseGRPCEndpoint(endpoint)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse server endpoint address %s: %v", endpoint, err)
+	if d.withTopology {
+		klog.Infof("Topology-awareness enabled, node availability zone: %s", d.nodeAZ)
+	} else {
+		klog.Info("Topology-awareness disabled")
 	}
 
-	fwdProto, fwdAddr, err := parseGRPCEndpoint(fwdEndpoint)
+	serverProto, serverAddr, err := parseGRPCEndpoint(o.ServerCSIEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse proxy client address %s: %v", fwdEndpoint, err)
+		return nil, fmt.Errorf("failed to parse server endpoint address %s: %v", o.ServerCSIEndpoint, err)
+	}
+
+	fwdProto, fwdAddr, err := parseGRPCEndpoint(o.FwdCSIEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse proxy client address %s: %v", o.FwdCSIEndpoint, err)
 	}
 
 	d.serverEndpoint = endpointAddress(serverProto, serverAddr)

--- a/pkg/csi/manila/driver.go
+++ b/pkg/csi/manila/driver.go
@@ -125,9 +125,9 @@ func NewDriver(o *DriverOpts) (*Driver, error) {
 	klog.Infof("Operating on %s shares", d.shareProto)
 
 	if d.withTopology {
-		klog.Infof("Topology-awareness enabled, node availability zone: %s", d.nodeAZ)
+		klog.Infof("Topology awareness enabled, node availability zone: %s", d.nodeAZ)
 	} else {
-		klog.Info("Topology-awareness disabled")
+		klog.Info("Topology awareness disabled")
 	}
 
 	serverProto, serverAddr, err := parseGRPCEndpoint(o.ServerCSIEndpoint)

--- a/pkg/csi/manila/identityserver.go
+++ b/pkg/csi/manila/identityserver.go
@@ -48,15 +48,27 @@ func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*c
 }
 
 func (ids *identityServer) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
-	return &csi.GetPluginCapabilitiesResponse{
-		Capabilities: []*csi.PluginCapability{
-			{
-				Type: &csi.PluginCapability_Service_{
-					Service: &csi.PluginCapability_Service{
-						Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,
-					},
+	caps := []*csi.PluginCapability{
+		{
+			Type: &csi.PluginCapability_Service_{
+				Service: &csi.PluginCapability_Service{
+					Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,
 				},
 			},
 		},
+	}
+
+	if ids.d.withTopology {
+		caps = append(caps, &csi.PluginCapability{
+			Type: &csi.PluginCapability_Service_{
+				Service: &csi.PluginCapability_Service{
+					Type: csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS,
+				},
+			},
+		})
+	}
+
+	return &csi.GetPluginCapabilitiesResponse{
+		Capabilities: caps,
 	}, nil
 }

--- a/pkg/csi/manila/nodeserver.go
+++ b/pkg/csi/manila/nodeserver.go
@@ -310,9 +310,17 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 }
 
 func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
-	return &csi.NodeGetInfoResponse{
+	nodeInfo := &csi.NodeGetInfoResponse{
 		NodeId: ns.d.nodeID,
-	}, nil
+	}
+
+	if ns.d.withTopology {
+		nodeInfo.AccessibleTopology = &csi.Topology{
+			Segments: map[string]string{topologyKey: ns.d.nodeAZ},
+		}
+	}
+
+	return nodeInfo, nil
 }
 
 func (ns *nodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {

--- a/pkg/csi/manila/options/shareoptions.go
+++ b/pkg/csi/manila/options/shareoptions.go
@@ -21,9 +21,10 @@ import (
 )
 
 type ControllerVolumeContext struct {
-	Protocol       string `name:"protocol" matches:"^(?i)CEPHFS|NFS$"`
-	Type           string `name:"type" value:"default:default"`
-	ShareNetworkID string `name:"shareNetworkID" value:"optional"`
+	Protocol         string `name:"protocol" matches:"^(?i)CEPHFS|NFS$"`
+	Type             string `name:"type" value:"default:default"`
+	ShareNetworkID   string `name:"shareNetworkID" value:"optional"`
+	AvailabilityZone string `name:"availability" value:"optional"`
 
 	// Adapter options
 

--- a/pkg/csi/manila/sanity/sanity_test.go
+++ b/pkg/csi/manila/sanity/sanity_test.go
@@ -38,7 +38,20 @@ func TestDriver(t *testing.T) {
 	endpoint := path.Join(basePath, "csi.sock")
 	fwdEndpoint := "unix:///fake-fwd-endpoint"
 
-	d, err := manila.NewDriver("node", "fake.manila.csi.openstack.org", endpoint, fwdEndpoint, "NFS", &fakeManilaClientBuilder{}, &fakeCSIClientBuilder{}, &options.CompatibilityOptions{})
+	d, err := manila.NewDriver(
+		&manila.DriverOpts{
+			DriverName:          "fake.manila.csi.openstack.org",
+			NodeID:              "node",
+			WithTopology:        true,
+			NodeAZ:              "fake-az",
+			ShareProto:          "NFS",
+			ServerCSIEndpoint:   endpoint,
+			FwdCSIEndpoint:      fwdEndpoint,
+			ManilaClientBuilder: &fakeManilaClientBuilder{},
+			CSIClientBuilder:    &fakeCSIClientBuilder{},
+			CompatOpts:          &options.CompatibilityOptions{},
+		})
+
 	if err != nil {
 		t.Fatalf("failed to initialize CSI Manila driver: %v", err)
 	}

--- a/pkg/csi/manila/util.go
+++ b/pkg/csi/manila/util.go
@@ -239,15 +239,15 @@ func validateDeleteSnapshotRequest(req *csi.DeleteSnapshotRequest) error {
 	return nil
 }
 
-func verifyVolumeCompatibility(sizeInGiB int, req *csi.CreateVolumeRequest, share *shares.Share, shareOpts *options.ControllerVolumeContext, compatOpts *options.CompatibilityOptions, shareTypeCaps capabilities.ManilaCapabilities) error {
-	coalesceValue := func(v string) string {
-		if v == "" {
-			return "<none>"
-		}
-
-		return v
+func coalesceValue(v string) string {
+	if v == "" {
+		return "<none>"
 	}
 
+	return v
+}
+
+func verifyVolumeCompatibility(sizeInGiB int, req *csi.CreateVolumeRequest, share *shares.Share, shareOpts *options.ControllerVolumeContext, compatOpts *options.CompatibilityOptions, shareTypeCaps capabilities.ManilaCapabilities) error {
 	if share.Size != sizeInGiB {
 		return fmt.Errorf("size mismatch: wanted %d, got %d", share.Size, sizeInGiB)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**The binaries affected**:

- [ ] openstack-cloud-controller-manager
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [x] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:

This PR adds support for Manila AZs and topology.

Documentation, examples, Helm chart and the sanity test have been updated as well.

**Which issue this PR fixes**:
fixes #938 

Our take on availability zones is two-fold:
* we provide users with a way of specifying Manila AZs via a storage class parameter
* this parameter is completely opaque to the CO and doesn't contribute to scheduling decisions on compute nodes
* this is sufficient because usually all compute nodes should have connectivity to the storage
* not always, though: if the nodes are partitioned into their own compute AZs and only certain compute AZs are able to reach a subset of Manila AZs, the cluster operator is able to deploy csi-manila with topology-awareness enabled and define the mapping between compute and storage AZs in StorageClasses

A couple of user-facing changes:
* added new StorageClass parameter `availability` : specifies AZ for Manila side of things
* added `--with-topology` cmd flag: enables topology-awareness of the driver (i.e. enables advertising of `VOLUME_ACCESSIBILITY_CONSTRAINTS` CSI capability)
* added `--nodeaz` cmd flag: sets the AZ of the node
* Helm chart:
  * added `csimanila.enableTopologyAwareness` into values.yaml: passes `--with-topology` and `--nodeaz`  to the manila-csi-plugin executable
  * added `csimanila.nodeAZ` into values.yaml: this value is sources into the `--nodeaz` cmd arg



```release-note
manila-csi-plugin: added support for Manila availability zones and topology-aware dynamic provisioning
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/cloud-provider-openstack/939)
<!-- Reviewable:end -->
