### PR TITLE
[cinder-csi-plugin] NodeGetVolumeStats() implementation

### DIFF
--- a/pkg/csi/cinder/driver.go
+++ b/pkg/csi/cinder/driver.go
@@ -79,6 +79,7 @@ func NewDriver(nodeID, endpoint, cluster string) *CinderDriver {
 		[]csi.NodeServiceCapability_RPC_Type{
 			csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
 			csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
+			csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
 		})
 
 	return d

--- a/pkg/csi/cinder/fake.go
+++ b/pkg/csi/cinder/fake.go
@@ -20,7 +20,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"golang.org/x/net/context"
-	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/mount"
+	"k8s.io/cloud-provider-openstack/pkg/util/mount"
 )
 
 var FakeCluster = "cluster"

--- a/pkg/csi/cinder/fake.go
+++ b/pkg/csi/cinder/fake.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"golang.org/x/net/context"
+	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/mount"
 )
 
 var FakeCluster = "cluster"
@@ -97,3 +98,13 @@ var FakeVolListEmpty = []volumes.Volume{}
 var FakeInstanceID = "321a8b81-3660-43e5-bab8-6470b65ee4e8"
 
 const FakeMaxVolume int64 = 256
+
+var FakeFsStats = mount.FsStats{
+	AvailableBytes:  2100,
+	TotalBytes:      2121,
+	UsedBytes:       21,
+	AvailableInodes: 150,
+	TotalInodes:     200,
+	UsedInodes:      50,
+}
+var FakeBlockDeviceSize = 536870912

--- a/pkg/csi/cinder/fake.go
+++ b/pkg/csi/cinder/fake.go
@@ -99,7 +99,9 @@ var FakeInstanceID = "321a8b81-3660-43e5-bab8-6470b65ee4e8"
 
 const FakeMaxVolume int64 = 256
 
-var FakeFsStats = mount.FsStats{
+var FakeFsStats = &mount.DeviceStats{
+	Block: false,
+
 	AvailableBytes:  2100,
 	TotalBytes:      2121,
 	UsedBytes:       21,
@@ -107,4 +109,9 @@ var FakeFsStats = mount.FsStats{
 	TotalInodes:     200,
 	UsedInodes:      50,
 }
-var FakeBlockDeviceSize = 536870912
+
+var FakeBlockDeviceStats = &mount.DeviceStats{
+	Block: true,
+
+	TotalBytes: 536870912,
+}

--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -30,7 +30,6 @@ import (
 	"google.golang.org/grpc/status"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/util/resizefs"
-	"k8s.io/kubernetes/pkg/volume/util/fs"
 	utilpath "k8s.io/utils/path"
 
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack"
@@ -492,19 +491,43 @@ func (ns *nodeServer) NodeGetVolumeStats(_ context.Context, req *csi.NodeGetVolu
 		return nil, status.Error(codes.InvalidArgument, "Volume path not provided")
 	}
 
-	if err := verifyTargetDir(volumePath); err != nil {
-		return nil, err
+	exists, err := ns.Mount.PathExists(volumePath)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to stats volumePath: %s", err)
+	} else if !exists {
+		return nil, status.Errorf(codes.NotFound, "target: %s not found", volumePath)
 	}
 
-	available, capacity, usage, inodes, inodesFree, inodesUsed, err := fs.FsInfo(volumePath)
+	isBlock, err := ns.Mount.IsBlockDevice(volumePath)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal,
-			"Unable to statfs target %s, err: %s", volumePath, err)
+		return nil, status.Errorf(codes.Internal, "failed to determine if volume is a block device: %s", err)
 	}
+
+	if isBlock {
+		size, err := ns.Mount.GetBlockDeviceSize(volumePath)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to get block device size: %s", err)
+		}
+
+		return &csi.NodeGetVolumeStatsResponse{
+			Usage: []*csi.VolumeUsage{
+				{
+					Total: size,
+					Unit:  csi.VolumeUsage_BYTES,
+				},
+			},
+		}, nil
+	}
+
+	fsStats, err := ns.Mount.GetFileSystemStats(volumePath)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to get filesystem size: %s", err)
+	}
+
 	return &csi.NodeGetVolumeStatsResponse{
 		Usage: []*csi.VolumeUsage{
-			{Total: capacity, Available: available, Used: usage, Unit: csi.VolumeUsage_BYTES},
-			{Total: inodes, Available: inodesFree, Used: inodesUsed, Unit: csi.VolumeUsage_INODES},
+			{Total: fsStats.TotalBytes, Available: fsStats.AvailableBytes, Used: fsStats.UsedBytes, Unit: csi.VolumeUsage_BYTES},
+			{Total: fsStats.TotalInodes, Available: fsStats.AvailableInodes, Used: fsStats.UsedInodes, Unit: csi.VolumeUsage_INODES},
 		},
 	}, nil
 }
@@ -612,23 +635,4 @@ func getNodeID(mount mount.IMount, iMetadata openstack.IMetadata, order string) 
 		return "", err
 	}
 	return nodeID, nil
-}
-
-func verifyTargetDir(target string) error {
-	if target == "" {
-		return status.Error(codes.InvalidArgument,
-			"target path required")
-	}
-
-	_, err := os.Stat(target)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return status.Errorf(codes.NotFound,
-				"target: %s not found", target)
-		}
-		return status.Errorf(codes.Internal,
-			"failed to stat target, err: %s", err.Error())
-	}
-
-	return nil
 }

--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -381,7 +381,7 @@ func TestNodeExpandVolume(t *testing.T) {
 
 }
 
-func TestNodeGetVolumeStats(t *testing.T) {
+func TestNodeGetVolumeStatsBlock(t *testing.T) {
 
 	// Init assert
 	assert := assert.New(t)

--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -20,6 +20,9 @@ import (
 	"fmt"
 	"testing"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -379,4 +382,20 @@ func TestNodeExpandVolume(t *testing.T) {
 	// Assert
 	assert.Equal(expectedRes, actualRes)
 
+}
+
+func TestNodeGetVolumeStats(t *testing.T) {
+
+	// Init assert
+	assert := assert.New(t)
+
+	// Fake request
+	fakeReq := &csi.NodeGetVolumeStatsRequest{
+		VolumeId:   FakeVolName,
+		VolumePath: FakeDevicePath,
+	}
+
+	// Invoke NodeGetVolumeStats
+	_, err := fakeNs.NodeGetVolumeStats(FakeCtx, fakeReq)
+	assert.Equal(status.Error(codes.Internal, "Unable to statfs target /dev/xxx, err: no such file or directory"), err)
 }

--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -397,5 +397,5 @@ func TestNodeGetVolumeStats(t *testing.T) {
 
 	// Invoke NodeGetVolumeStats
 	_, err := fakeNs.NodeGetVolumeStats(FakeCtx, fakeReq)
-	assert.Equal(status.Error(codes.Internal, "Unable to statfs target /dev/xxx, err: no such file or directory"), err)
+	assert.Equal(status.Error(codes.NotFound, "target: /dev/xxx not found"), err)
 }

--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -385,6 +385,7 @@ func TestNodeGetVolumeStatsBlock(t *testing.T) {
 
 	// Init assert
 	assert := assert.New(t)
+	mmock.ExpectedCalls = nil
 
 	// Fake request
 	fakeReq := &csi.NodeGetVolumeStatsRequest{
@@ -412,6 +413,7 @@ func TestNodeGetVolumeStatsBlock(t *testing.T) {
 func TestNodeGetVolumeStatsFs(t *testing.T) {
 	// Init assert
 	assert := assert.New(t)
+	mmock.ExpectedCalls = nil
 
 	// Fake request
 	fakeReq := &csi.NodeGetVolumeStatsRequest{

--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -395,11 +395,10 @@ func TestNodeGetVolumeStatsBlock(t *testing.T) {
 
 	mmock.On("PathExists", FakeDevicePath).Return(true, nil)
 	// Invoke NodeGetVolumeStats with a block device
-	mmock.On("IsBlockDevice", FakeDevicePath).Return(true, nil)
-	mmock.On("GetBlockDeviceSize", FakeDevicePath).Return(int64(FakeBlockDeviceSize), nil)
+	mmock.On("GetDeviceStats", FakeDevicePath).Return(FakeBlockDeviceStats, nil)
 	expectedBlockRes := &csi.NodeGetVolumeStatsResponse{
 		Usage: []*csi.VolumeUsage{
-			{Total: int64(FakeBlockDeviceSize), Unit: csi.VolumeUsage_BYTES},
+			{Total: FakeBlockDeviceStats.TotalBytes, Unit: csi.VolumeUsage_BYTES},
 		},
 	}
 
@@ -411,6 +410,7 @@ func TestNodeGetVolumeStatsBlock(t *testing.T) {
 }
 
 func TestNodeGetVolumeStatsFs(t *testing.T) {
+
 	// Init assert
 	assert := assert.New(t)
 	mmock.ExpectedCalls = nil
@@ -422,8 +422,7 @@ func TestNodeGetVolumeStatsFs(t *testing.T) {
 	}
 
 	mmock.On("PathExists", FakeDevicePath).Return(true, nil)
-	mmock.On("IsBlockDevice", FakeDevicePath).Return(false, nil)
-	mmock.On("GetFileSystemStats", FakeDevicePath).Return(FakeFsStats, nil)
+	mmock.On("GetDeviceStats", FakeDevicePath).Return(FakeFsStats, nil)
 	expectedFsRes := &csi.NodeGetVolumeStatsResponse{
 		Usage: []*csi.VolumeUsage{
 			{Total: FakeFsStats.TotalBytes, Available: FakeFsStats.AvailableBytes, Used: FakeFsStats.UsedBytes, Unit: csi.VolumeUsage_BYTES},
@@ -435,4 +434,5 @@ func TestNodeGetVolumeStatsFs(t *testing.T) {
 
 	assert.NoError(err)
 	assert.Equal(expectedFsRes, fsRes)
+
 }

--- a/pkg/csi/cinder/sanity/fakemount.go
+++ b/pkg/csi/cinder/sanity/fakemount.go
@@ -2,7 +2,7 @@ package sanity
 
 import (
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder"
-	mount2 "k8s.io/cloud-provider-openstack/pkg/csi/cinder/mount"
+	mount2 "k8s.io/cloud-provider-openstack/pkg/util/mount"
 	"k8s.io/utils/mount"
 )
 

--- a/pkg/csi/cinder/sanity/fakemount.go
+++ b/pkg/csi/cinder/sanity/fakemount.go
@@ -48,18 +48,10 @@ func (m *fakemount) MakeFile(pathname string) error {
 	return nil
 }
 
-func (m *fakemount) PathExists(devicePath string) (bool, error) {
+func (m *fakemount) PathExists(path string) (bool, error) {
 	return false, nil
 }
 
-func (m *fakemount) GetBlockDeviceSize(volumePath string) (int64, error) {
-	return 0, nil
-}
-
-func (m *fakemount) GetFileSystemStats(volumePath string) (mount2.FsStats, error) {
-	return mount2.FsStats{}, nil
-}
-
-func (m *fakemount) IsBlockDevice(devicePath string) (bool, error) {
-	return true, nil
+func (m *fakemount) GetDeviceStats(path string) (*mount2.DeviceStats, error) {
+	return nil, nil
 }

--- a/pkg/csi/cinder/sanity/fakemount.go
+++ b/pkg/csi/cinder/sanity/fakemount.go
@@ -2,6 +2,7 @@ package sanity
 
 import (
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder"
+	mount2 "k8s.io/cloud-provider-openstack/pkg/csi/cinder/mount"
 	"k8s.io/utils/mount"
 )
 
@@ -45,4 +46,20 @@ func (m *fakemount) MakeDir(pathname string) error {
 // MakeFile creates an empty file
 func (m *fakemount) MakeFile(pathname string) error {
 	return nil
+}
+
+func (m *fakemount) PathExists(devicePath string) (bool, error) {
+	return false, nil
+}
+
+func (m *fakemount) GetBlockDeviceSize(volumePath string) (int64, error) {
+	return 0, nil
+}
+
+func (m *fakemount) GetFileSystemStats(volumePath string) (mount2.FsStats, error) {
+	return mount2.FsStats{}, nil
+}
+
+func (m *fakemount) IsBlockDevice(devicePath string) (bool, error) {
+	return true, nil
 }

--- a/pkg/util/mount/mount_mock.go
+++ b/pkg/util/mount/mount_mock.go
@@ -35,36 +35,10 @@ func (_m *MountMock) PathExists(volumePath string) (bool, error) {
 	return ret.Bool(0), ret.Error(1)
 }
 
-func (_m *MountMock) GetBlockDeviceSize(volumePath string) (int64, error) {
-	ret := _m.Called(volumePath)
+func (_m *MountMock) GetDeviceStats(path string) (*DeviceStats, error) {
+	ret := _m.Called(path)
 
-	return ret.Get(0).(int64), ret.Error(1)
-}
-
-func (_m *MountMock) GetFileSystemStats(volumePath string) (FsStats, error) {
-	ret := _m.Called(volumePath)
-
-	return ret.Get(0).(FsStats), ret.Error(1)
-}
-
-func (_m *MountMock) IsBlockDevice(devicePath string) (bool, error) {
-	ret := _m.Called(devicePath)
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = rf(devicePath)
-	} else {
-		r0 = ret.Bool(0)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(devicePath)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return ret.Get(0).(*DeviceStats), ret.Error(1)
 }
 
 // NewFakeMounter returns fake mounter instance

--- a/pkg/util/mount/mount_mock.go
+++ b/pkg/util/mount/mount_mock.go
@@ -211,11 +211,6 @@ func (_m *MountMock) GetBaseMounter() *mount.SafeFormatAndMount {
 			output: []byte("UUID=\"1b47881a-1563-4896-a178-eec887b759de\" \n TYPE=\"ext4\""),
 			err:    nil,
 		},
-		{
-			cmd:    "blockdev",
-			output: []byte("536870912"),
-			err:    nil,
-		},
 	}
 
 	fakeexec := &exec.FakeExec{}

--- a/pkg/util/mount/mount_mock.go
+++ b/pkg/util/mount/mount_mock.go
@@ -29,6 +29,44 @@ type MountMock struct {
 	mock.Mock
 }
 
+func (_m *MountMock) PathExists(volumePath string) (bool, error) {
+	ret := _m.Called(volumePath)
+
+	return ret.Bool(0), ret.Error(1)
+}
+
+func (_m *MountMock) GetBlockDeviceSize(volumePath string) (int64, error) {
+	ret := _m.Called(volumePath)
+
+	return ret.Get(0).(int64), ret.Error(1)
+}
+
+func (_m *MountMock) GetFileSystemStats(volumePath string) (FsStats, error) {
+	ret := _m.Called(volumePath)
+
+	return ret.Get(0).(FsStats), ret.Error(1)
+}
+
+func (_m *MountMock) IsBlockDevice(devicePath string) (bool, error) {
+	ret := _m.Called(devicePath)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(devicePath)
+	} else {
+		r0 = ret.Bool(0)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(devicePath)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // NewFakeMounter returns fake mounter instance
 func NewFakeMounter() *mount.FakeMounter {
 	return &mount.FakeMounter{
@@ -171,6 +209,11 @@ func (_m *MountMock) GetBaseMounter() *mount.SafeFormatAndMount {
 		{
 			cmd:    "blkid",
 			output: []byte("UUID=\"1b47881a-1563-4896-a178-eec887b759de\" \n TYPE=\"ext4\""),
+			err:    nil,
+		},
+		{
+			cmd:    "blockdev",
+			output: []byte("536870912"),
 			err:    nil,
 		},
 	}


### PR DESCRIPTION
**The binaries affected**:

- [ ] openstack-cloud-controller-manager
- [x] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
Knowing Volume capabilities helps to sleep at night (also, capacity planning).

**Which issue this PR fixes**:
fixes https://github.com/kubernetes/cloud-provider-openstack/issues/669

**Special notes for reviewers**:

The test is ugly right now. Should I mock a `resizefs` call?

**Release note**:
```release-note
cinder-csi-plugin: Added support for GET_VOLUME_STATS node capability
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/cloud-provider-openstack/941)
<!-- Reviewable:end -->
