### PR TITLE
[openstack-cloud-controller-manager] Docs: Mention that x-forwarded-for is only supported in LBaas Octavia

### DIFF
--- a/docs/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/expose-applications-using-loadbalancer-type-service.md
@@ -113,7 +113,7 @@ Request Body:
 
 - loadbalancer.openstack.org/x-forwarded-for
 
-  If 'true', `X-Forwarded-For` is inserted into the HTTP headers which contains the original client IP address so that the backend HTTP service is able to get the real source IP of the request.
+  If 'true', `X-Forwarded-For` is inserted into the HTTP headers which contains the original client IP address so that the backend HTTP service is able to get the real source IP of the request. Only applies when using Octavia.
 
 - loadbalancer.openstack.org/timeout-client-data
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Docs update. Mention that x-forwarded-for is only supported in LBaas Octavia

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
