### PR TITLE
[manila-csi-plugin] Probe() must be forwarded to partner node plugin

### DIFF
--- a/pkg/csi/manila/csiclient/builder.go
+++ b/pkg/csi/manila/csiclient/builder.go
@@ -49,6 +49,8 @@ var (
 			return err
 		}),
 	}
+
+	_ Builder = &ClientBuilder{}
 )
 
 func NewNodeSvcClient(conn *grpc.ClientConn) *NodeSvcClient {

--- a/pkg/csi/manila/csiclient/client.go
+++ b/pkg/csi/manila/csiclient/client.go
@@ -24,6 +24,11 @@ import (
 	"time"
 )
 
+var (
+	_ Node     = &NodeSvcClient{}
+	_ Identity = &IdentitySvcClient{}
+)
+
 type NodeSvcClient struct {
 	cl csi.NodeClient
 }
@@ -50,6 +55,10 @@ func (c *NodeSvcClient) UnpublishVolume(ctx context.Context, req *csi.NodeUnpubl
 
 type IdentitySvcClient struct {
 	cl csi.IdentityClient
+}
+
+func (c IdentitySvcClient) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
+	return c.cl.Probe(ctx, req)
 }
 
 func (c IdentitySvcClient) ProbeForever(conn *grpc.ClientConn, singleProbeTimeout time.Duration) error {

--- a/pkg/csi/manila/csiclient/interface.go
+++ b/pkg/csi/manila/csiclient/interface.go
@@ -35,6 +35,7 @@ type Node interface {
 
 type Identity interface {
 	GetPluginInfo(ctx context.Context) (*csi.GetPluginInfoResponse, error)
+	Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error)
 	ProbeForever(conn *grpc.ClientConn, singleProbeTimeout time.Duration) error
 }
 

--- a/pkg/csi/manila/identityserver.go
+++ b/pkg/csi/manila/identityserver.go
@@ -18,7 +18,6 @@ package manila
 
 import (
 	"context"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -40,7 +39,12 @@ func (ids *identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPlugin
 }
 
 func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
-	return &csi.ProbeResponse{}, nil
+	csiConn, err := ids.d.csiClientBuilder.NewConnectionWithContext(ctx, ids.d.fwdEndpoint)
+	if err != nil {
+		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ids.d.fwdEndpoint, err))
+	}
+
+	return ids.d.csiClientBuilder.NewIdentityServiceClient(csiConn).Probe(ctx, req)
 }
 
 func (ids *identityServer) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {

--- a/pkg/csi/manila/identityserver.go
+++ b/pkg/csi/manila/identityserver.go
@@ -41,7 +41,7 @@ func (ids *identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPlugin
 func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
 	csiConn, err := ids.d.csiClientBuilder.NewConnectionWithContext(ctx, ids.d.fwdEndpoint)
 	if err != nil {
-		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ids.d.fwdEndpoint, err))
+		return nil, status.Error(codes.FailedPrecondition, fmtGrpcConnError(ids.d.fwdEndpoint, err))
 	}
 
 	return ids.d.csiClientBuilder.NewIdentityServiceClient(csiConn).Probe(ctx, req)

--- a/pkg/csi/manila/sanity/fakecsiclient.go
+++ b/pkg/csi/manila/sanity/fakecsiclient.go
@@ -25,7 +25,17 @@ import (
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila/csiclient"
 )
 
+var (
+	_ csiclient.Builder  = &fakeCSIClientBuilder{}
+	_ csiclient.Identity = &fakeIdentitySvcClient{}
+	_ csiclient.Node     = &fakeNodeSvcClient{}
+)
+
 type fakeIdentitySvcClient struct{}
+
+func (c fakeIdentitySvcClient) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
+	return &csi.ProbeResponse{}, nil
+}
 
 func (c fakeIdentitySvcClient) GetPluginInfo(context.Context) (*csi.GetPluginInfoResponse, error) {
 	return &csi.GetPluginInfoResponse{


### PR DESCRIPTION
**The binaries affected**:

- [ ] openstack-cloud-controller-manager
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [x] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:

csi-manila is built using proxy architecture - it relies on a partner node plugin to do the node operations (e.g. mounts) on behalf of csi-manila.

Querying csi-manila for its readiness ([`Probe` RPC](https://github.com/container-storage-interface/spec/blob/master/spec.md#probe) of the CSI Identity Service) means querying the partner node plugin as well.

This PR:
* adds `Probe` function to the `csiclient.Interface` interface
* forwards `Probe` to the partner node plugin

<!-- e.g. How to test this PR -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
