### PR TITLE
[cinder-csi-plugin] Fix csi cinder sanity testing failures 

### DIFF
--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -257,10 +257,14 @@ func TestControllerPublishVolume(t *testing.T) {
 
 	// Fake request
 	fakeReq := &csi.ControllerPublishVolumeRequest{
-		VolumeId:         FakeVolID,
-		NodeId:           FakeNodeID,
-		VolumeCapability: nil,
-		Readonly:         false,
+		VolumeId: FakeVolID,
+		NodeId:   FakeNodeID,
+		VolumeCapability: &csi.VolumeCapability{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{},
+			},
+		},
+		Readonly: false,
 	}
 
 	// Expected Result

--- a/pkg/csi/cinder/sanity/fakecloud.go
+++ b/pkg/csi/cinder/sanity/fakecloud.go
@@ -1,6 +1,7 @@
 package sanity
 
 import (
+	"fmt"
 	"math/rand"
 	"time"
 
@@ -226,6 +227,9 @@ func randString(n int) string {
 }
 
 func (cloud *cloud) GetInstanceByID(instanceID string) (*servers.Server, error) {
+	if _, ok := cloud.instances[cinder.FakeInstanceID]; !ok {
+		cloud.instances[cinder.FakeInstanceID] = &servers.Server{}
+	}
 	inst, ok := cloud.instances[instanceID]
 
 	if !ok {
@@ -245,7 +249,7 @@ func (cloud *cloud) GetMaxVolLimit() int64 {
 
 func (cloud *cloud) GetMetadataOpts() cpo.MetadataOpts {
 	var m cpo.MetadataOpts
-	m.SearchOrder = ""
+	m.SearchOrder = fmt.Sprintf("%s,%s", "configDrive", "metadataService")
 	return m
 }
 

--- a/pkg/csi/cinder/sanity/fakemount.go
+++ b/pkg/csi/cinder/sanity/fakemount.go
@@ -2,14 +2,33 @@ package sanity
 
 import (
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder"
-	mount2 "k8s.io/cloud-provider-openstack/pkg/util/mount"
+	cpomount "k8s.io/cloud-provider-openstack/pkg/util/mount"
+	exec "k8s.io/utils/exec/testing"
 	"k8s.io/utils/mount"
 )
 
 type fakemount struct {
 }
 
-// fake mount
+var mInstance *mount.FakeMounter
+
+// NewFakeMounter returns fake mounter instance
+func newFakeMounter() *mount.FakeMounter {
+	if mInstance == nil {
+		mInstance = &mount.FakeMounter{
+			MountPoints: []mount.MountPoint{},
+		}
+	}
+	return mInstance
+}
+
+// NewFakeSafeFormatAndMounter returns base Fake mounter instance
+func newFakeSafeFormatAndMounter() *mount.SafeFormatAndMount {
+	return &mount.SafeFormatAndMount{
+		Interface: newFakeMounter(),
+		Exec:      &exec.FakeExec{DisableScripts: true},
+	}
+}
 
 func (m *fakemount) ScanForAttach(devicePath string) error {
 	return nil
@@ -36,7 +55,7 @@ func (m *fakemount) GetDevicePath(volumeID string) (string, error) {
 }
 
 func (m *fakemount) GetBaseMounter() *mount.SafeFormatAndMount {
-	return nil
+	return newFakeSafeFormatAndMounter()
 }
 
 func (m *fakemount) MakeDir(pathname string) error {
@@ -52,6 +71,6 @@ func (m *fakemount) PathExists(path string) (bool, error) {
 	return false, nil
 }
 
-func (m *fakemount) GetDeviceStats(path string) (*mount2.DeviceStats, error) {
-	return nil, nil
+func (m *fakemount) GetDeviceStats(path string) (*cpomount.DeviceStats, error) {
+	return cinder.FakeFsStats, nil
 }

--- a/pkg/csi/cinder/sanity/sanity_test.go
+++ b/pkg/csi/cinder/sanity/sanity_test.go
@@ -6,9 +6,9 @@ import (
 	"path"
 	"testing"
 
-	"k8s.io/cloud-provider-openstack/pkg/csi/cinder"
-
 	"github.com/kubernetes-csi/csi-test/pkg/sanity"
+	"k8s.io/cloud-provider-openstack/pkg/csi/cinder"
+	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack"
 )
 
 // start sanity test for driver
@@ -23,14 +23,15 @@ func TestDriver(t *testing.T) {
 	socket := path.Join(basePath, "csi.sock")
 	endpoint := "unix://" + socket
 	cluster := "kubernetes"
-	nodeID := "45678"
+	nodeID := "fake-node"
 
 	d := cinder.NewDriver(nodeID, endpoint, cluster)
-	c := getfakecloud()
+	fakecloudprovider := getfakecloud()
+	openstack.OsInstance = fakecloudprovider
 	fakemnt := &fakemount{}
 	fakemet := &fakemetadata{}
 
-	d.SetupDriver(c, fakemnt, fakemet)
+	d.SetupDriver(fakecloudprovider, fakemnt, fakemet)
 
 	// TODO: Stop call
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**The binaries affected**:

IMPORTANT: Please also add the binary name in the title, e.g.
`[openstack-cloud-controller-manager]: Add UDP protocol support`
unless the PR affects multiple binaries.

- [ ] openstack-cloud-controller-manager
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
This PR brings us closer to csi spec conformance of cinder csi driver. Failures are brought down to 2. Partially fixes #793 


Summarizing 2 Failures:

[Fail] ListSnapshots [Controller Server] [It] should return next token when a limited number of entries are requested 
/home/necuser/code/pkg/mod/github.com/kubernetes-csi/csi-test@v2.2.0+incompatible/pkg/sanity/controller.go:1827

[Fail] Node Service [It] should work 
/home/necuser/code/pkg/mod/github.com/kubernetes-csi/csi-test@v2.2.0+incompatible/pkg/sanity/node.go:781

The above failures require pagination support in snashopts and some refactoring of mount package to fix the failures. Would be taken up in followup PR 

**Which issue this PR fixes**:
fixes #

**Special notes for reviewers**:

<!-- e.g. How to test this PR -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
