### PR TITLE
[cinder-csi-plugin] Make Keystone probe period configurable separetely

### DIFF
--- a/cmd/cinder-csi-plugin/main.go
+++ b/cmd/cinder-csi-plugin/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -31,10 +32,11 @@ import (
 )
 
 var (
-	endpoint    string
-	nodeID      string
-	cloudconfig string
-	cluster     string
+	endpoint            string
+	nodeID              string
+	cloudconfig         string
+	cluster             string
+	keystoneProbePeriod string
 )
 
 func init() {
@@ -84,6 +86,8 @@ func main() {
 
 	cmd.PersistentFlags().StringVar(&cluster, "cluster", "", "The identifier of the cluster that the plugin is running in.")
 
+	cmd.PersistentFlags().StringVar(&keystoneProbePeriod, "keystone-probe-period", "0s", "The period of keystone authentication probe")
+
 	openstack.AddExtraFlags(pflag.CommandLine)
 
 	logs.InitLogs()
@@ -122,6 +126,13 @@ func handle() {
 		return
 	}
 
-	d.SetupDriver(cloud, mount, metadatda)
+	// Initialize keystone probe period
+	period, err := time.ParseDuration(keystoneProbePeriod)
+	if err != nil {
+		klog.Warningf("Failed to parse duration: %v", err)
+		period = time.Duration(0)
+	}
+
+	d.SetupDriver(cloud, mount, metadatda, period)
 	d.Run()
 }

--- a/pkg/csi/cinder/driver.go
+++ b/pkg/csi/cinder/driver.go
@@ -18,6 +18,7 @@ package cinder
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
@@ -47,6 +48,8 @@ type CinderDriver struct {
 	ids *identityServer
 	cs  *controllerServer
 	ns  *nodeServer
+
+	keystoneProbePeriod time.Duration
 
 	vcap  []*csi.VolumeCapability_AccessMode
 	cscap []*csi.ControllerServiceCapability
@@ -134,11 +137,12 @@ func (d *CinderDriver) GetVolumeCapabilityAccessModes() []*csi.VolumeCapability_
 	return d.vcap
 }
 
-func (d *CinderDriver) SetupDriver(cloud openstack.IOpenStack, mount mount.IMount, metadata openstack.IMetadata) {
+func (d *CinderDriver) SetupDriver(cloud openstack.IOpenStack, mount mount.IMount, metadata openstack.IMetadata, keystoneProbePeriod time.Duration) {
 
 	d.ids = NewIdentityServer(d)
 	d.cs = NewControllerServer(d, cloud)
 	d.ns = NewNodeServer(d, mount, metadata, cloud)
+	d.keystoneProbePeriod = keystoneProbePeriod
 
 }
 

--- a/pkg/csi/cinder/identityserver.go
+++ b/pkg/csi/cinder/identityserver.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cinder
 
 import (
+	"time"
+
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -26,7 +28,8 @@ import (
 )
 
 type identityServer struct {
-	Driver *CinderDriver
+	Driver       *CinderDriver
+	lastAuthTime time.Time
 }
 
 func (ids *identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
@@ -47,8 +50,14 @@ func (ids *identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPlugin
 }
 
 func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
-
-	_, err := openstack.CreateOpenStackProvider()
+	var err error
+	now := time.Now()
+	if now.Sub(ids.lastAuthTime) > ids.Driver.keystoneProbePeriod {
+		_, err = openstack.CreateOpenStackProvider()
+		ids.lastAuthTime = now
+	} else {
+		_, err = openstack.GetOpenStackProvider()
+	}
 	if err != nil {
 		klog.V(3).Infof("Failed to CreateOpenStackProvider: %v", err)
 		return nil, status.Error(codes.FailedPrecondition, "Failed to communicate with openstack")

--- a/pkg/csi/cinder/sanity/sanity_test.go
+++ b/pkg/csi/cinder/sanity/sanity_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder"
 
@@ -29,8 +30,9 @@ func TestDriver(t *testing.T) {
 	c := getfakecloud()
 	fakemnt := &fakemount{}
 	fakemet := &fakemetadata{}
+	duration := time.Duration(0)
 
-	d.SetupDriver(c, fakemnt, fakemet)
+	d.SetupDriver(c, fakemnt, fakemet, duration)
 
 	// TODO: Stop call
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**The binaries affected**:
- [x] cinder-csi-plugin

**What this PR does / why we need it**:
* First motivation is we want to use livenessProbe: https://github.com/kubernetes-csi/livenessprobe for checking nodeplugin status.
* livenessProbe uses Probe(). In cinder-csi-plugin, it calls Keystone request every time.
* We want to check gRPC server itself every 2 secs or something, but we don't want to create requests to Keystone in same frequency.
* new flag `keystone-probe-period` make possible to use another period for checking keystone

<!-- e.g. How to test this PR -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add new flag `keystone-probe-period`
```
