### PR TITLE
[openstack-cloud-controller-manager]: Fix version flag

### DIFF
--- a/cmd/openstack-cloud-controller-manager/main.go
+++ b/cmd/openstack-cloud-controller-manager/main.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/component-base/logs"
 	_ "k8s.io/component-base/metrics/prometheus/restclient" // for client metric registration
 	_ "k8s.io/component-base/metrics/prometheus/version"    // for version metric registration
-	"k8s.io/component-base/version/verflag"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/cmd/cloud-controller-manager/app"
 	cloudcontrollerconfig "k8s.io/kubernetes/cmd/cloud-controller-manager/app/config"
@@ -58,6 +57,10 @@ func init() {
 	mux := http.NewServeMux()
 	healthz.InstallHandler(mux)
 }
+
+var (
+	versionFlag bool
+)
 
 func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
@@ -91,7 +94,10 @@ the cloud specific control loops shipped with Kubernetes.`,
 			})
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			verflag.PrintAndExitIfRequested()
+			if versionFlag {
+				version.PrintVersionAndExit()
+			}
+
 			utilflag.PrintFlags(cmd.Flags())
 
 			c, err := s.Config(KnownControllers(), ControllersDisabledByDefault.List())
@@ -112,6 +118,8 @@ the cloud specific control loops shipped with Kubernetes.`,
 	for _, f := range namedFlagSets.FlagSets {
 		fs.AddFlagSet(f)
 	}
+
+	fs.BoolVar(&versionFlag, "version", false, "Print version and exit")
 
 	openstack.AddExtraFlags(pflag.CommandLine)
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,5 +16,15 @@ limitations under the License.
 
 package version
 
+import (
+	"fmt"
+	"os"
+)
+
 // Version is set by the linker flags in the Makefile.
 var Version string
+
+func PrintVersionAndExit() {
+	fmt.Printf("%s\n", Version)
+	os.Exit(0)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**The binaries affected**:

- [X] openstack-cloud-controller-manager
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
Adds a custom `--version` flag to `openstack-cloud-controller-manager`.

**Which issue this PR fixes**:
Fixes #907 

**Special notes for reviewers**:
I tried to do this as cleanly as possible, adding a new global `bool` var and a `BoolVar` flag to the already created `FlagSet` here: 

https://github.com/kubernetes/cloud-provider-openstack/blob/d38032ff1a7da28a0648d8f6e3ac5d3750f1a53f/cmd/openstack-cloud-controller-manager/main.go#L110

If you're running `--help` you'll see that the usage output includes the new flag:
```
...
--version Print version and exit
...
```

I removed the `verflag.PrintAndExitIfRequested()` which was the function that in the end printed something along the lines of: `Kubernetes v0.0.0-master+$Format:%h$` and exited with `0`. 

I have added a util function in the `version` package, this function prints `version.Version` and exits with `0`.

Also, IMHO using the CLI package `cobra` in OCCM is overkill but i can understand that this is something inherited or just moved over from the in-tree code of `k/k` back in the days.

The rest of the binaries lacks a `--version` flag as far as i've investigated, there's different flavors on how to write CLI's and especially when it comes to the CLI flags. 

I can create a tracking PR to add more or less the same `--version` flags as in the OCCM for the rest of the binaries, reusing the `version` package.

**Release note**:

```release-note
NONE
```
