### PR TITLE
[cinder-csi-plugin] Improve Probe() call

### DIFF
--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -41,6 +41,7 @@ func AddExtraFlags(fs *pflag.FlagSet) {
 }
 
 type IOpenStack interface {
+	CheckBlockStorageAPI() error
 	CreateVolume(name string, size int, vtype, availability string, snapshotID string, sourcevolID string, tags *map[string]string) (*volumes.Volume, error)
 	DeleteVolume(volumeID string) error
 	AttachVolume(instanceID, volumeID string) (string, error)

--- a/pkg/csi/cinder/openstack/openstack_mock.go
+++ b/pkg/csi/cinder/openstack/openstack_mock.go
@@ -116,6 +116,11 @@ func (_m *OpenStackMock) GetVolume(volumeID string) (*volumes.Volume, error) {
 	return &fakeVol1, nil
 }
 
+// CheckBlockStorageAPI
+func (_m *OpenStackMock) CheckBlockStorageAPI() error {
+	return nil
+}
+
 // DetachVolume provides a mock function with given fields: instanceID, volumeID
 func (_m *OpenStackMock) DetachVolume(instanceID string, volumeID string) error {
 	ret := _m.Called(instanceID, volumeID)

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/apiversions"
 	volumeexpand "github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach"
@@ -46,6 +47,14 @@ const (
 	diskDetachSteps          = 13
 	volumeDescription        = "Created by OpenStack Cinder CSI driver"
 )
+
+func (os *OpenStack) CheckBlockStorageAPI() error {
+	_, err := apiversions.List(os.blockstorage).AllPages()
+	if err != nil {
+		return err
+	}
+	return nil
+}
 
 // CreateVolume creates a volume of given size
 func (os *OpenStack) CreateVolume(name string, size int, vtype, availability string, snapshotID string, sourcevolID string, tags *map[string]string) (*volumes.Volume, error) {

--- a/pkg/csi/cinder/sanity/fakecloud.go
+++ b/pkg/csi/cinder/sanity/fakecloud.go
@@ -27,6 +27,8 @@ func getfakecloud() *cloud {
 	}
 }
 
+var _ cco.IOpenStack = &cloud{}
+
 // Fake Cloud
 func (cloud *cloud) CreateVolume(name string, size int, vtype, availability string, snapshotID string, sourceVolID string, tags *map[string]string) (*volumes.Volume, error) {
 
@@ -51,6 +53,10 @@ func (cloud *cloud) DeleteVolume(volumeID string) error {
 
 	return nil
 
+}
+
+func (cloud *cloud) CheckBlockStorageAPI() error {
+	return nil
 }
 
 func (cloud *cloud) AttachVolume(instanceID, volumeID string) (string, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**The binaries affected**:

IMPORTANT: Please also add the binary name in the title, e.g.
`[openstack-cloud-controller-manager]: Add UDP protocol support`
unless the PR affects multiple binaries.

- [ ] openstack-cloud-controller-manager
- [x] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
This PR improves probe functionality 

**Which issue this PR fixes**:
fixes #637 

**Special notes for reviewers**:

<!-- e.g. How to test this PR -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
