### PR TITLE
[k8s-keystone-auth] Add e2e test script

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -43,6 +43,7 @@
               - ^go.mod$
               - ^go.sum$
               - ^Makefile$
+              - ^tests/e2e/k8s-keystone-auth/.*
             irrelevant-files:
               - ^docs/.*$
               - ^.*\.md$

--- a/tests/e2e/k8s-keystone-auth/test-authz.sh
+++ b/tests/e2e/k8s-keystone-auth/test-authz.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+OS_CONTEXT_NAME=${OS_CONTEXT_NAME:-""}
+AUTH_POLICY_CONFIGMAP=${AUTH_POLICY_CONFIGMAP:-""}
+AUTH_POLICY_CONFIGMAP=${AUTH_POLICY_CONFIGMAP:-""}
+
+function log {
+  local msg=$1
+  printf "\n>>>>>>> ${FUNCNAME[1]}: ${msg}\n"
+}
+
+########################################################################
+# Desc: Test authorization policy that grant users with member role in
+#       project demo can get/list pods in default namespace.
+# Params: N/A
+########################################################################
+function test_auth_policy {
+  log "Update configmap ${AUTH_POLICY_CONFIGMAP}"
+
+  cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${AUTH_POLICY_CONFIGMAP}
+  namespace: kube-system
+data:
+  policies: |
+    [
+      {
+        "users": {
+          "projects": ["demo"],
+          "roles": ["member"]
+        },
+        "resource_permissions": {
+          "default/pods": ["get", "list"]
+        }
+      }
+    ]
+EOF
+
+  local end=$((SECONDS+120))
+  while true; do
+    kubectl --context ${OS_CONTEXT_NAME} get pod
+    [ $? -eq 0 ] && break || true
+    [ $SECONDS -gt $end ] && log "FAIL: OpenStack user should be able to get pods" && exit -1
+    sleep 5
+  done
+
+  kubectl --context ${OS_CONTEXT_NAME} -n kube-system get pod
+  if [ $? -eq 0 ]; then
+    log "FAIL: OpenStack user should not be able to get pods in kube-system namespace"
+    exit -1
+  fi
+
+  log "PASS"
+}
+
+########################################################################
+# Desc: Test the role mappings that give the Keystone users with role of
+#       member the group name member
+# Params: N/A
+########################################################################
+function test_auth_role_mapping {
+  log "Update configmap ${ROLE_MAPPING_CONFIGMAP}"
+
+  cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${ROLE_MAPPING_CONFIGMAP}
+  namespace: kube-system
+data:
+  syncConfig: |
+    role-mappings:
+      - keystone-role: member
+        groups: ["member"]
+EOF
+
+  kubectl create role mytest --verb=get,list --resource=deployments
+  kubectl create rolebinding mytest --role=mytest --group=member
+
+  local end=$((SECONDS+120))
+  while true; do
+    kubectl --context ${OS_CONTEXT_NAME} get deployments
+    [ $? -eq 0 ] && break || true
+    [ $SECONDS -gt $end ] && log "FAIL: OpenStack user should be able to get deployments" && exit -1
+    sleep 5
+  done
+
+  kubectl --context ${OS_CONTEXT_NAME} -n kube-system get deployments
+  if [ $? -eq 0 ]; then
+    log "FAIL: OpenStack user should not be able to get deployments in kube-system namespace"
+    exit -1
+  fi
+
+  kubectl delete role mytest
+  kubectl delete rolebinding mytest
+  log "PASS"
+}
+
+test_auth_policy
+test_auth_role_mapping


### PR DESCRIPTION
**The binaries affected**:

- [ ] openstack-cloud-controller-manager
- [ ] cinder-csi-plugin
- [x] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
Add a test script for k8s-keystone-auth webhook.

Follow-up PRs:

* Change the k8s-keystone-auth CI job in openlab repo to call this script for testing.

**Which issue this PR fixes**:
fixes #954

**Special notes for reviewers**:

**Release note**:
```release-note
NONE
```
