### PR TITLE
Remove inactive repo owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,16 +1,9 @@
 approvers:
 - adisky
-- anguslees
 - chrigl
 - dims
-- dixudx
-- FengyunPan2
-- flaper87
-- hogepodge
 - lingxiankong
-- NickrenREN
 - ramineni
-- rootfs
 - zetaab
 reviewers:
 - adisky
@@ -28,4 +21,5 @@ reviewers:
 - NickrenREN
 - ramineni
 - ricolin
+- rootfs
 - zetaab

--- a/pkg/ingress/OWNERS
+++ b/pkg/ingress/OWNERS
@@ -1,6 +1,0 @@
-approvers:
-- dims
-- lingxiankong
-reviewers:
-- dims
-- lingxiankong


### PR DESCRIPTION
**The binaries affected**:

- [x] openstack-cloud-controller-manager
- [x] cinder-csi-plugin
- [x] k8s-keystone-auth
- [x] client-keystone-auth
- [x] octavia-ingress-controller
- [x] manila-csi-plugin
- [x] manila-provisioner
- [x] magnum-auto-healer
- [x] barbican-kms-plugin

**What this PR does / why we need it**:
Remove inactive owners based on https://github.com/kubernetes/cloud-provider-openstack/graphs/contributors?from=2019-06-01&to=2020-03-06&type=c

**Which issue this PR fixes**:
fixes #

**Special notes for reviewers**:

<!-- e.g. How to test this PR -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```