### PR TITLE
[cinder-csi-plugin] Add error handling for errors during az retrieval from MetaData service

### DIFF
--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -455,6 +455,9 @@ func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 	}
 
 	zone, err := getAvailabilityZoneMetadataService(ns.Metadata)
+	if err != nil {
+		return nil, status.Error(codes.Internal, fmt.Sprintf("retrieving availability zone from MetaData service failed with error %v", err))
+	}
 	topology := &csi.Topology{Segments: map[string]string{topologyKey: zone}}
 
 	maxVolume := ns.Cloud.GetMaxVolLimit()


### PR DESCRIPTION

**The binaries affected**:

- [ ] openstack-cloud-controller-manager
- [x] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
Currently we ignore errors returned when we're not able to retrieve the az from the metadata service. Just wondered why my zone label was just empty (without errors anywhere) on nodes even though the metadata service was down :)

**Which issue this PR fixes**:
fixes #

**Special notes for reviewers**:

<!-- e.g. How to test this PR -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
