### PR TITLE
Improve the guideline of getting started

### DIFF
--- a/docs/getting-started-provider-dev.md
+++ b/docs/getting-started-provider-dev.md
@@ -120,19 +120,12 @@ sudo yum install -y -q git gcc etcd
 You will also need a recent version of Go and set your environment variables.
 
 ```
-GO_VERSION=1.13
+GO_VERSION=1.13.4
 GO_ARCH=linux-amd64
 curl -o go.tgz https://dl.google.com/go/go${GO_VERSION}.${GO_ARCH}.tar.gz
 sudo tar -C /usr/local/ -xvzf go.tgz
 export GOROOT=/usr/local/go
 export GOPATH=$HOME/go
-```
-
-Install go dependency management tool dep
-
-```
-curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-
 ```
 
 Finally, set up your Git identity and GitHub integrations.
@@ -148,7 +141,7 @@ and versioning information.
 
 Following the [GitHub Workflow](https://github.com/kubernetes/community/blob/master/contributors/guide/github-workflow.md) guidelines for Kubernetes development, set up your environment and get the latest development repository. Begin by forking both the Kubernetes and Cloud-Provider-OpenStack projects into your GitHub into your local workspace (or bringing your current fork up to date with the current state of both repositories).
 
-`make` will build, test, and package this project. This project uses [go dep](https://golang.github.io/dep/) for dependency management.
+`make` will build, test, and package this project. This project uses [go modules](https://github.com/golang/go/wiki/Modules) for dependency management since v1.17.
 
 Set up some environment variables to help download the repositories
 


### PR DESCRIPTION
The doc of getting-started needs some updates:
1. Use go modules for dependency management since v1.17.
2. Need to update the go version from 1.13 to 1.13.4 because
k8s need it when make cross (https://github.com/kubernetes/kubernetes/pull/82809).

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**The binaries affected**:

IMPORTANT: Please also add the binary name in the title, e.g.
`[openstack-cloud-controller-manager]: Add UDP protocol support`
unless the PR affects multiple binaries.

- [ ] openstack-cloud-controller-manager
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:


**Which issue this PR fixes**:
fixes #964

**Special notes for reviewers**:

<!-- e.g. How to test this PR -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
