### PR TITLE
[docs] Fix formatting of Service annotations

### DIFF
--- a/docs/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/expose-applications-using-loadbalancer-type-service.md
@@ -71,67 +71,67 @@ Request Body:
 
 ### Service annotations
 
-- loadbalancer.openstack.org/floating-network-id
+- `loadbalancer.openstack.org/floating-network-id`
 
   The public network id which will allocate public IP for loadbalancer. This annotation works when the value of `service.beta.kubernetes.io/openstack-internal-load-balancer` is false.
 
-- loadbalancer.openstack.org/floating-subnet
+- `loadbalancer.openstack.org/floating-subnet`
 
   A public network can have several subnets. This annotation is one of subnets' name.
 
-- loadbalancer.openstack.org/floating-subnet-id
+- `loadbalancer.openstack.org/floating-subnet-id`
 
   This annotation is one of subnets' id in a public network.
 
-- loadbalancer.openstack.org/class
+- `loadbalancer.openstack.org/class`
 
   The name of a preconfigured class in the config file. The annotation of floating-subnet-id and floating-network-id won't work if you use class annotation. See the section below for how it works.
 
-- loadbalancer.openstack.org/subnet-id
+- `loadbalancer.openstack.org/subnet-id`
 
   VIP subnet ID of load balancer created.
 
-- loadbalancer.openstack.org/network-id
+- `loadbalancer.openstack.org/network-id`
 
   The network ID which will allocate virtual IP for loadbalancer.
 
-- loadbalancer.openstack.org/port-id
+- `loadbalancer.openstack.org/port-id`
 
   The VIP port ID for load balancer created.
 
-- loadbalancer.openstack.org/connection-limit
+- `loadbalancer.openstack.org/connection-limit`
 
   The maximum number of connections per second allowed for the listener. Positive integer or -1 for unlimited (default).
 
-- loadbalancer.openstack.org/keep-floatingip
+- `loadbalancer.openstack.org/keep-floatingip`
 
   If 'true', the floating IP will **NOT** be deleted. Default is 'false'.
 
-- loadbalancer.openstack.org/proxy-protocol
+- `loadbalancer.openstack.org/proxy-protocol`
 
   If 'true', the protocol for listener will be set as `PROXY`. Default is 'false'.
 
-- loadbalancer.openstack.org/x-forwarded-for
+- `loadbalancer.openstack.org/x-forwarded-for`
 
   If 'true', `X-Forwarded-For` is inserted into the HTTP headers which contains the original client IP address so that the backend HTTP service is able to get the real source IP of the request. Only applies when using Octavia.
 
-- loadbalancer.openstack.org/timeout-client-data
+- `loadbalancer.openstack.org/timeout-client-data`
 
   Frontend client inactivity timeout in milliseconds for the load balancer.
 
-- loadbalancer.openstack.org/timeout-member-connect
+- `loadbalancer.openstack.org/timeout-member-connect`
 
   Backend member connection timeout in milliseconds for the load balancer.
 
-- loadbalancer.openstack.org/timeout-member-data
+- `loadbalancer.openstack.org/timeout-member-data`
 
   Backend member inactivity timeout in milliseconds for the load balancer.
 
-- loadbalancer.openstack.org/timeout-tcp-inspect
+- `loadbalancer.openstack.org/timeout-tcp-inspect`
 
   Time to wait for additional TCP packets for content inspection in milliseconds for the load balancer.
 
-- service.beta.kubernetes.io/openstack-internal-load-balancer
+- `service.beta.kubernetes.io/openstack-internal-load-balancer`
 
   If 'true', the loadbalancer VIP won't be associated with a floating IP. Default is 'false'.
 


### PR DESCRIPTION
**The binaries affected**: **N/A**

- [ ] openstack-cloud-controller-manager
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
Fixes formatting of Service object annotations in `expose-applications-using-loadbalancer-type-service.md` docs.

**Which issue this PR fixes**:

**Special notes for reviewers**:

**Release note**:

```release-note
NONE
```
