### PR TITLE
Provide more manifest information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,8 +149,8 @@ zz_generated.openapi.go
 /magnum-auto-healer
 /manila-csi-plugin
 /*-amd64
-/*-arm32v7
-/*-arm64v8
+/*-arm
+/*-arm64
 /*-s390x
 /*-ppc64le
 

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -84,6 +84,7 @@
               - cmd/tests/.*
               - ^go.mod$
               - ^go.sum$
+              - ^Makefile$
             irrelevant-files:
               - ^docs/.*$
               - ^.*\.md$
@@ -124,6 +125,7 @@
               - ^pkg/share/manila/shareoptions/validator/.*
               - ^go.mod$
               - ^go.sum$
+              - ^Makefile$
             irrelevant-files:
               - ^docs/.*$
               - ^.*\.md$

--- a/cluster/images/barbican-kms-plugin/Dockerfile
+++ b/cluster/images/barbican-kms-plugin/Dockerfile
@@ -11,10 +11,22 @@
 # limitations under the License.
 
 ARG ALPINE_ARCH=amd64
+# We not using scratch because we need to keep the basic image information
+# from parent image
 FROM ${ALPINE_ARCH}/alpine:3.11
 
 ARG ARCH=amd64
 
-RUN apk add --no-cache ca-certificates
+# Fill out the labels
+LABEL name="barbican-kms-plugin" \
+      license="Apache Version 2.0" \
+      maintainers="Kubernetes Authors" \
+      description="Barbican kms plugin" \
+      architecture=$ARCH \
+      distribution-scope="public" \
+      summary="Barbican kms plugin" \
+      help="none"
 
-ADD magnum-auto-healer-${ARCH} /bin/magnum-auto-healer
+ADD rootfs.tar /
+
+CMD ["sh", "-c", "/bin/barbican-kms-plugin --socketpath ${socketpath} --cloud-config ${cloudconfig}"]

--- a/cluster/images/barbican-kms-plugin/Dockerfile.build
+++ b/cluster/images/barbican-kms-plugin/Dockerfile.build
@@ -5,5 +5,3 @@ LABEL description="Barbican KMS Plugin"
 
 ARG ARCH=amd64
 ADD barbican-kms-plugin-${ARCH} /bin/barbican-kms-plugin
-
-CMD ["sh", "-c", "/bin/barbican-kms-plugin --socketpath ${socketpath} --cloud-config ${cloudconfig}"]

--- a/cluster/images/cinder-csi-plugin/Dockerfile
+++ b/cluster/images/cinder-csi-plugin/Dockerfile
@@ -10,11 +10,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG ALPINE_ARCH=amd64
-FROM ${ALPINE_ARCH}/alpine:3.11
+ARG DEBIAN_ARCH=amd64
+# We not using scratch because we need to keep the basic image information
+# from parent image
+FROM k8s.gcr.io/debian-base-${DEBIAN_ARCH}:1.0.0
 
 ARG ARCH=amd64
 
-RUN apk add --no-cache ca-certificates
+# Fill out the labels
+LABEL name="cinder-csi-plugin" \
+      license="Apache Version 2.0" \
+      maintainers="Kubernetes Authors" \
+      description="Cinder CSI Plugin" \
+      architecture=$ARCH \
+      distribution-scope="public" \
+      summary="Cinder CSI Plugin" \
+      help="none"
 
-ADD magnum-auto-healer-${ARCH} /bin/magnum-auto-healer
+ADD rootfs.tar /
+
+CMD ["/bin/cinder-csi-plugin"]

--- a/cluster/images/cinder-csi-plugin/Dockerfile.build
+++ b/cluster/images/cinder-csi-plugin/Dockerfile.build
@@ -1,7 +1,5 @@
 ARG DEBIAN_ARCH=amd64
 FROM k8s.gcr.io/debian-base-${DEBIAN_ARCH}:1.0.0
-LABEL maintainers="Kubernetes Authors"
-LABEL description="Cinder CSI Plugin"
 
 ARG ARCH=amd64
 
@@ -9,5 +7,3 @@ ARG ARCH=amd64
 RUN clean-install ca-certificates e2fsprogs mount xfsprogs udev
 
 ADD cinder-csi-plugin-${ARCH} /bin/cinder-csi-plugin
-
-CMD ["/bin/cinder-csi-plugin"]

--- a/cluster/images/cinder-flex-volume-driver/Dockerfile
+++ b/cluster/images/cinder-flex-volume-driver/Dockerfile
@@ -11,10 +11,22 @@
 # limitations under the License.
 
 ARG ALPINE_ARCH=amd64
+# We not using scratch because we need to keep the basic image information
+# from parent image
 FROM ${ALPINE_ARCH}/alpine:3.11
 
 ARG ARCH=amd64
 
-RUN apk add --no-cache ca-certificates
+# Fill out the labels
+LABEL name="cinder-flex-volume-driver" \
+      license="Apache Version 2.0" \
+      maintainers="Kubernetes Authors" \
+      description="Cinder flex volume driver" \
+      architecture=$ARCH \
+      distribution-scope="public" \
+      summary="Cinder flex volume driver" \
+      help="none"
 
-ADD magnum-auto-healer-${ARCH} /bin/magnum-auto-healer
+ADD rootfs.tar /
+
+CMD ["/bin/sh"]

--- a/cluster/images/cinder-provisioner/Dockerfile
+++ b/cluster/images/cinder-provisioner/Dockerfile
@@ -11,10 +11,22 @@
 # limitations under the License.
 
 ARG ALPINE_ARCH=amd64
+# We not using scratch because we need to keep the basic image information
+# from parent image
 FROM ${ALPINE_ARCH}/alpine:3.11
 
 ARG ARCH=amd64
 
-RUN apk add --no-cache ca-certificates
+# Fill out the labels
+LABEL name="cinder-provisioner" \
+      license="Apache Version 2.0" \
+      maintainers="Kubernetes Authors" \
+      description="Cinder provisioner" \
+      architecture=$ARCH \
+      distribution-scope="public" \
+      summary="Cinder provisioner" \
+      help="none"
 
-ADD magnum-auto-healer-${ARCH} /bin/magnum-auto-healer
+ADD rootfs.tar /
+
+CMD ["/bin/cinder-provisioner"]

--- a/cluster/images/cinder-provisioner/Dockerfile.build
+++ b/cluster/images/cinder-provisioner/Dockerfile.build
@@ -18,5 +18,3 @@ ARG ARCH=amd64
 RUN apk add --no-cache ca-certificates
 
 ADD cinder-provisioner-${ARCH} /bin/cinder-provisioner
-
-CMD ["/bin/cinder-provisioner"]

--- a/cluster/images/k8s-keystone-auth/Dockerfile
+++ b/cluster/images/k8s-keystone-auth/Dockerfile
@@ -11,10 +11,24 @@
 # limitations under the License.
 
 ARG ALPINE_ARCH=amd64
+# We not using scratch because we need to keep the basic image information
+# from parent image
 FROM ${ALPINE_ARCH}/alpine:3.11
 
 ARG ARCH=amd64
 
-RUN apk add --no-cache ca-certificates
+# Fill out the labels
+LABEL name="k8s-keystone-auth" \
+      license="Apache Version 2.0" \
+      maintainers="Kubernetes Authors" \
+      description="K8s Keystone Auth" \
+      architecture=$ARCH \
+      distribution-scope="public" \
+      summary="K8s Keystone Auth" \
+      help="none"
 
-ADD magnum-auto-healer-${ARCH} /bin/magnum-auto-healer
+ADD rootfs.tar /
+
+EXPOSE 8443
+
+CMD ["/bin/k8s-keystone-auth"]

--- a/cluster/images/k8s-keystone-auth/Dockerfile.build
+++ b/cluster/images/k8s-keystone-auth/Dockerfile.build
@@ -18,7 +18,3 @@ ARG ARCH=amd64
 RUN apk add --no-cache ca-certificates
 
 ADD k8s-keystone-auth-${ARCH} /bin/k8s-keystone-auth
-
-EXPOSE 8443
-
-CMD ["/bin/k8s-keystone-auth"]

--- a/cluster/images/magnum-auto-healer/Dockerfile
+++ b/cluster/images/magnum-auto-healer/Dockerfile
@@ -11,10 +11,22 @@
 # limitations under the License.
 
 ARG ALPINE_ARCH=amd64
+# We not using scratch because we need to keep the basic image information
+# from parent image
 FROM ${ALPINE_ARCH}/alpine:3.11
 
 ARG ARCH=amd64
 
-RUN apk add --no-cache ca-certificates
+# Fill out the labels
+LABEL name="magnum-auto-healer" \
+      license="Apache Version 2.0" \
+      maintainers="Kubernetes Authors" \
+      description="Magnum auto healer" \
+      architecture=$ARCH \
+      distribution-scope="public" \
+      summary="Magnum auto healer" \
+      help="none"
 
-ADD magnum-auto-healer-${ARCH} /bin/magnum-auto-healer
+ADD rootfs.tar /
+
+CMD ["/bin/magnum-auto-healer"]

--- a/cluster/images/manila-csi-plugin/Dockerfile
+++ b/cluster/images/manila-csi-plugin/Dockerfile
@@ -11,10 +11,23 @@
 # limitations under the License.
 
 ARG ALPINE_ARCH=amd64
+# We not using scratch because we need to keep the basic image information
+# from parent image
 FROM ${ALPINE_ARCH}/alpine:3.11
 
 ARG ARCH=amd64
 
-RUN apk add --no-cache ca-certificates
+# Fill out the labels
+LABEL name="manila-csi-plugin" \
+      license="Apache Version 2.0" \
+      maintainers="Kubernetes Authors" \
+      description="Manila CSI Plugin" \
+      architecture=$ARCH \
+      distribution-scope="public" \
+      summary="Manila CSI Plugin" \
+      help="none"
 
-ADD magnum-auto-healer-${ARCH} /bin/magnum-auto-healer
+
+ADD rootfs.tar /
+
+ENTRYPOINT ["/bin/manila-csi-plugin"]

--- a/cluster/images/manila-csi-plugin/Dockerfile.build
+++ b/cluster/images/manila-csi-plugin/Dockerfile.build
@@ -1,11 +1,6 @@
 ARG ALPINE_ARCH=amd64
 FROM ${ALPINE_ARCH}/alpine:3.11
 
-LABEL maintainers="Kubernetes Authors"
-LABEL description="Manila CSI Plugin"
-
 ARG ARCH=amd64
 
 ADD manila-csi-plugin-${ARCH} /bin/manila-csi-plugin
-
-ENTRYPOINT ["/bin/manila-csi-plugin"]

--- a/cluster/images/manila-provisioner/Dockerfile
+++ b/cluster/images/manila-provisioner/Dockerfile
@@ -10,8 +10,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM scratch
+ARG ALPINE_ARCH=amd64
+# We not using scratch because we need to keep the basic image information
+# from parent image
+FROM ${ALPINE_ARCH}/alpine:3.11
+
+ARG ARCH=amd64
+
+# Fill out the labels
+LABEL name="manila-provisioner" \
+      license="Apache Version 2.0" \
+      maintainers="Kubernetes Authors" \
+      description="Manila provisioner" \
+      architecture=$ARCH \
+      distribution-scope="public" \
+      summary="Manila provisioner" \
+      help="none"
 
 ADD rootfs.tar /
 
-CMD ["/bin/sh"]
+ENTRYPOINT ["/bin/manila-provisioner"]

--- a/cluster/images/manila-provisioner/Dockerfile.build
+++ b/cluster/images/manila-provisioner/Dockerfile.build
@@ -18,5 +18,3 @@ ARG ARCH=amd64
 RUN apk add --no-cache ca-certificates
 
 ADD manila-provisioner-${ARCH} /bin/manila-provisioner
-
-ENTRYPOINT ["/bin/manila-provisioner"]

--- a/cluster/images/octavia-ingress-controller/Dockerfile
+++ b/cluster/images/octavia-ingress-controller/Dockerfile
@@ -11,10 +11,22 @@
 # limitations under the License.
 
 ARG ALPINE_ARCH=amd64
+# We not using scratch because we need to keep the basic image information
+# from parent image
 FROM ${ALPINE_ARCH}/alpine:3.11
 
 ARG ARCH=amd64
 
-RUN apk add --no-cache ca-certificates
+# Fill out the labels
+LABEL name="octavia-ingress-controller" \
+      license="Apache Version 2.0" \
+      maintainers="Kubernetes Authors" \
+      description="Octavia ingress controller" \
+      architecture=$ARCH \
+      distribution-scope="public" \
+      summary="Octavia ingress controller" \
+      help="none"
 
-ADD magnum-auto-healer-${ARCH} /bin/magnum-auto-healer
+ADD rootfs.tar /
+
+CMD ["/bin/octavia-ingress-controller"]

--- a/cluster/images/octavia-ingress-controller/Dockerfile.build
+++ b/cluster/images/octavia-ingress-controller/Dockerfile.build
@@ -16,5 +16,3 @@ ARG ARCH=amd64
 
 RUN apk add --no-cache ca-certificates
 ADD octavia-ingress-controller-${ARCH} /bin/octavia-ingress-controller
-
-CMD ["/bin/octavia-ingress-controller"]

--- a/cluster/images/openstack-cloud-controller-manager/Dockerfile
+++ b/cluster/images/openstack-cloud-controller-manager/Dockerfile
@@ -11,10 +11,22 @@
 # limitations under the License.
 
 ARG ALPINE_ARCH=amd64
+# We not using scratch because we need to keep the basic image information
+# from parent image
 FROM ${ALPINE_ARCH}/alpine:3.11
 
 ARG ARCH=amd64
 
-RUN apk add --no-cache ca-certificates
+# Fill out the labels
+LABEL name="openstack-cloud-controller-manager" \
+      license="Apache Version 2.0" \
+      maintainers="Kubernetes Authors" \
+      description="OpenStack cloud controller manager" \
+      architecture=$ARCH \
+      distribution-scope="public" \
+      summary="OpenStack cloud controller manager" \
+      help="none"
 
-ADD magnum-auto-healer-${ARCH} /bin/magnum-auto-healer
+ADD rootfs.tar /
+
+CMD ["/bin/openstack-cloud-controller-manager"]

--- a/cluster/images/openstack-cloud-controller-manager/Dockerfile.build
+++ b/cluster/images/openstack-cloud-controller-manager/Dockerfile.build
@@ -17,5 +17,3 @@ ARG ARCH=amd64
 RUN apk add --no-cache ca-certificates
 
 ADD openstack-cloud-controller-manager-${ARCH} /bin/openstack-cloud-controller-manager
-
-CMD ["/bin/openstack-cloud-controller-manager"]


### PR DESCRIPTION
This provides os information to images, also provide correct arch
argument to arm and arm64 architecture.
relates to #883

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**The binaries affected**:

IMPORTANT: Please also add the binary name in the title, e.g.
`[openstack-cloud-controller-manager]: Add UDP protocol support`
unless the PR affects multiple binaries.

- [*] openstack-cloud-controller-manager
- [*] cinder-csi-plugin
- [*] k8s-keystone-auth
- [*] client-keystone-auth
- [*] octavia-ingress-controller
- [*] manila-csi-plugin
- [*] manila-provisioner
- [*] magnum-auto-healer
- [*] barbican-kms-plugin

**What this PR does / why we need it**:

This provides OS information to images, also provide correct arch arguments to arm and arm64 architecture. Without this fix the image os/arch will depend on build environment which might not be ideal for image it self

**Which issue this PR fixes**:
fixes #966

**Special notes for reviewers**:

<!-- e.g. How to test this PR -->
Run "make upload-images" to check the logs and docker hub
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
