### PR TITLE
[k8s-keystone-auth] Fix e2e test script

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -43,7 +43,7 @@
               - ^go.mod$
               - ^go.sum$
               - ^Makefile$
-              - ^tests/e2e/k8s-keystone-auth/.*
+              - tests/e2e/k8s-keystone-auth/.*
             irrelevant-files:
               - ^docs/.*$
               - ^.*\.md$

--- a/tests/e2e/k8s-keystone-auth/test-authz.sh
+++ b/tests/e2e/k8s-keystone-auth/test-authz.sh
@@ -2,7 +2,7 @@
 
 OS_CONTEXT_NAME=${OS_CONTEXT_NAME:-""}
 AUTH_POLICY_CONFIGMAP=${AUTH_POLICY_CONFIGMAP:-""}
-AUTH_POLICY_CONFIGMAP=${AUTH_POLICY_CONFIGMAP:-""}
+ROLE_MAPPING_CONFIGMAP=${ROLE_MAPPING_CONFIGMAP:-""}
 
 function log {
   local msg=$1
@@ -38,7 +38,8 @@ data:
     ]
 EOF
 
-  local end=$((SECONDS+120))
+  # The default value of '--authorization-webhook-cache-authorized-ttl' is 5min
+  local end=$((SECONDS+300))
   while true; do
     kubectl --context ${OS_CONTEXT_NAME} get pod
     [ $? -eq 0 ] && break || true
@@ -79,7 +80,8 @@ EOF
   kubectl create role mytest --verb=get,list --resource=deployments
   kubectl create rolebinding mytest --role=mytest --group=member
 
-  local end=$((SECONDS+120))
+  # The default value of '--authorization-webhook-cache-authorized-ttl' is 5min
+  local end=$((SECONDS+300))
   while true; do
     kubectl --context ${OS_CONTEXT_NAME} get deployments
     [ $? -eq 0 ] && break || true


### PR DESCRIPTION
**The binaries affected**:

- [ ] openstack-cloud-controller-manager
- [ ] cinder-csi-plugin
- [x] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
This PR is aiming to make sure the CI job for k8s-keystone-auth is working as expected.

**Which issue this PR fixes**:
fixes #954

**Special notes for reviewers**:

<!-- e.g. How to test this PR -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
