### PR TITLE
Fix the file filtering in CI jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -8,19 +8,20 @@
               - ^OWNERS$
               - ^SECURITY_CONTACTS$
               - ^.gitignore$
+              - ^.*\.sh$
     cloud-provider-openstack-acceptance-test-lb-octavia:
       jobs:
         - cloud-provider-openstack-acceptance-test-lb-octavia:
             files:
-              - ^cmd/openstack-cloud-controller-manager/.*
-              - ^pkg/cloudprovider/.*
-              - ^pkg/util/.*
-              - ^tests/e2e/cloudprovider/.*
+              - cmd/openstack-cloud-controller-manager/.*
+              - pkg/cloudprovider/.*
+              - pkg/util/.*
+              - tests/e2e/cloudprovider/.*
               - ^go.mod$
               - ^go.sum$
               - ^Makefile$
             irrelevant-files:
-              - ^docs/.*$
+              - docs/.*$
               - ^.*\.md$
               - ^OWNERS$
               - ^SECURITY_CONTACTS$
@@ -34,6 +35,7 @@
               - ^OWNERS$
               - ^SECURITY_CONTACTS$
               - ^.gitignore$
+              - ^.*\.sh$
     cloud-provider-openstack-acceptance-test-keystone-authentication-authorization:
       jobs:
         - cloud-provider-openstack-acceptance-test-keystone-authentication-authorization:
@@ -50,28 +52,38 @@
               - ^OWNERS$
               - ^SECURITY_CONTACTS$
               - ^.gitignore$
-    cloud-provider-openstack-acceptance-test-k8s-cinder:
-      jobs:
-        - cloud-provider-openstack-acceptance-test-k8s-cinder:
-            irrelevant-files:
-              - ^docs/.*$
-              - ^.*\.md$
-              - ^OWNERS$
-              - ^SECURITY_CONTACTS$
-              - ^.gitignore$
+    # Disable the job for Kubernetes in-tree cinder function.
+    # cloud-provider-openstack-acceptance-test-k8s-cinder:
+    #   jobs:
+    #     - cloud-provider-openstack-acceptance-test-k8s-cinder:
+    #         irrelevant-files:
+    #           - ^docs/.*$
+    #           - ^.*\.md$
+    #           - ^OWNERS$
+    #           - ^SECURITY_CONTACTS$
+    #           - ^.gitignore$
     # Disable Standalone Cinder Driver Job as it is deprecated
     # cloud-provider-openstack-acceptance-test-standalone-cinder:
-    #  jobs:
-    #    - cloud-provider-openstack-acceptance-test-standalone-cinder:
-    #        irrelevant-files:
-    #          - ^docs/.*$
-    #          - ^.*\.md$
-    #          - ^OWNERS$
-    #          - ^SECURITY_CONTACTS$
-    #          - ^.gitignore$
+    #   jobs:
+    #     - cloud-provider-openstack-acceptance-test-standalone-cinder:
+    #         irrelevant-files:
+    #           - ^docs/.*$
+    #           - ^.*\.md$
+    #           - ^OWNERS$
+    #           - ^SECURITY_CONTACTS$
+    #           - ^.gitignore$
     cloud-provider-openstack-acceptance-test-csi-cinder:
       jobs:
         - cloud-provider-openstack-acceptance-test-csi-cinder:
+            files:
+              - cmd/cinder-csi-plugin/.*
+              - pkg/csi/cinder/.*
+              - pkg/util/.*
+              - pkg/cloudprovider/providers/openstack/.*
+              - test/.*
+              - cmd/tests/.*
+              - ^go.mod$
+              - ^go.sum$
             irrelevant-files:
               - ^docs/.*$
               - ^.*\.md$


### PR DESCRIPTION
**The binaries affected**:

**What this PR does / why we need it**:
- Do not run cloud-provider-openstack-unittest and cloud-provider-openstack-format for shell script
- Disable the job for Kubernetes in-tree cinder function. I don't know when and why it was added, but don't think it's needed for CPO.
- Add files filtering for the job cloud-provider-openstack-acceptance-test-csi-cinder
- Do not use `^` in the files regular expression for some jobs, I found sometimes that's not working

**Which issue this PR fixes**:
fixes #

**Special notes for reviewers**:

<!-- e.g. How to test this PR -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
