### PR TITLE
[cinder-csi-plugin] upgrade snapshot to v2.1.1 

### DIFF
--- a/docs/using-cinder-csi-plugin.md
+++ b/docs/using-cinder-csi-plugin.md
@@ -81,7 +81,7 @@ You should make sure following similar pods are ready before proceed:
 
 ```
 NAME                                READY   STATUS    RESTARTS   AGE
-csi-cinder-controllerplugin         4/4     Running   0          29h
+csi-cinder-controllerplugin         5/5     Running   0          29h
 csi-cinder-nodeplugin               2/2     Running   0          46h
 ```
 
@@ -207,8 +207,10 @@ Note: `allowedTopologies` can be specified in storage class to restrict the topo
 
 Following prerequisite needed for volume snapshot feature to work.
 
-1. Enable `--feature-gates=VolumeSnapshotDataSource=true` in kube-apiserver
-2. Make sure, your csi deployment contains external-snapshotter sidecar container, external-snapshotter sidecar container will create three crd's for snapshot management VolumeSnapshot,VolumeSnapshotContent, and VolumeSnapshotClass. external-snapshotter is a part of `csi-cinder-controllerplugin`
+1. Download all yaml files from [snapshot crd](https://github.com/kubernetes-csi/external-snapshotter/tree/v2.1.1/config/crd)
+2. Apply all yaml files downloaded at step 1) by using `kubectl apply -f ` command, as currently there is no released yaml file from `external-snapshotter` community.
+3. Download all yaml files from [snapshot-controller](https://github.com/kubernetes-csi/external-snapshotter/tree/master/deploy/kubernetes/snapshot-controller) and optionally update all namespaces from `default` to `kube-system` in the yaml files.
+4. Apply all yaml files downloaded at step 3) by using `kubectl apply -f ` command.
 
 Supported parameters for VolumeSnapshotClass:
 * `force-create`: Support creating snapshot for a volume in in-use status.

--- a/examples/cinder-csi-plugin/snapshot/example.yaml
+++ b/examples/cinder-csi-plugin/snapshot/example.yaml
@@ -6,11 +6,12 @@ provisioner: cinder.csi.openstack.org
 
 ---
 
-apiVersion: snapshot.storage.k8s.io/v1alpha1
+apiVersion: snapshot.storage.k8s.io/v1beta1
 kind: VolumeSnapshotClass
 metadata:
   name: csi-cinder-snapclass
-snapshotter: cinder.csi.openstack.org
+driver: cinder.csi.openstack.org
+deletionPolicy: Delete
 parameters:
   force-create: "false"
 

--- a/examples/cinder-csi-plugin/snapshot/snapshotcreate.yaml
+++ b/examples/cinder-csi-plugin/snapshot/snapshotcreate.yaml
@@ -1,9 +1,8 @@
-apiVersion: snapshot.storage.k8s.io/v1alpha1
+apiVersion: snapshot.storage.k8s.io/v1beta1
 kind: VolumeSnapshot
 metadata:
   name: new-snapshot-demo
 spec:
-  snapshotClassName: csi-cinder-snapclass
+  volumeSnapshotClassName: csi-cinder-snapclass
   source:
-    name: pvc-snapshot-demo
-    kind: PersistentVolumeClaim
+    persistentVolumeClaimName: pvc-snapshot-demo

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin-rbac.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin-rbac.yaml
@@ -96,20 +96,15 @@ metadata:
   name: csi-snapshotter-role
 rules:
   - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
+  # Secret permission is optional.
+  # Enable it if your driver needs secret.
+  # For example, `csi.storage.k8s.io/snapshotter-secret-name` is set in VolumeSnapshotClass.
+  # See https://kubernetes-csi.github.io/docs/secrets-and-credentials.html for more details.
+  #  - apiGroups: [""]
+  #    resources: ["secrets"]
+  #    verbs: ["get", "list"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
@@ -117,15 +112,8 @@ rules:
     resources: ["volumesnapshotcontents"]
     verbs: ["create", "get", "list", "watch", "update", "delete"]
   - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshots"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshots/status"]
+    resources: ["volumesnapshotcontents/status"]
     verbs: ["update"]
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["create", "list", "watch", "delete"]
-
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -59,7 +59,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v1.2.2
+          image: quay.io/k8scsi/csi-snapshotter:v2.1.1
           args:
             - "--csi-address=$(ADDRESS)"
           env:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**The binaries affected**:

IMPORTANT: Please also add the binary name in the title, e.g.
`[openstack-cloud-controller-manager]: Add UDP protocol support`
unless the PR affects multiple binaries.

- [ ] openstack-cloud-controller-manager
- [x] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
update snapshot side car container to v2.1.1

upgrade snapshot to v2.1.1

    https://github.com/kubernetes-csi/external-snapshotter/releases
    has a broken update when upgrade to 2.0.0

    so the upgrade of the side car container including:
    1) upgrade the version
    2) honor the split of snapshot controller and snapshotter
    3) update rbac
    4) update example according to the v1beta1 definition


**Which issue this PR fixes**:
xref #951 

**Special notes for reviewers**:

<!-- e.g. How to test this PR -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
[cinder-csi-plugin] updated external-snapshotter to v2.1.1
```
