### PR TITLE
[cinder-csi-pugin] Support reconcile volume attachements

### DIFF
--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -269,6 +269,13 @@ func (cs *controllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 				CapacityBytes: int64(v.Size * 1024 * 1024 * 1024),
 			},
 		}
+
+		status := &csi.ListVolumesResponse_VolumeStatus{}
+		for _, attachment := range v.Attachments {
+			status.PublishedNodeIds = append(status.PublishedNodeIds, attachment.ServerID)
+		}
+		ventry.Status = status
+
 		ventries = append(ventries, &ventry)
 	}
 	return &csi.ListVolumesResponse{

--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -327,12 +327,16 @@ func TestListVolumes(t *testing.T) {
 					VolumeId:      FakeVol1.ID,
 					CapacityBytes: int64(FakeVol1.Size * 1024 * 1024 * 1024),
 				},
+				Status: &csi.ListVolumesResponse_VolumeStatus{
+					PublishedNodeIds: []string{FakeNodeID},
+				},
 			},
 			{
 				Volume: &csi.Volume{
 					VolumeId:      FakeVol3.ID,
 					CapacityBytes: int64(FakeVol3.Size * 1024 * 1024 * 1024),
 				},
+				Status: &csi.ListVolumesResponse_VolumeStatus{},
 			},
 		},
 		NextToken: "",

--- a/pkg/csi/cinder/driver.go
+++ b/pkg/csi/cinder/driver.go
@@ -72,6 +72,7 @@ func NewDriver(nodeID, endpoint, cluster string) *CinderDriver {
 			csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS,
 			csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 			csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
+			csi.ControllerServiceCapability_RPC_LIST_VOLUMES_PUBLISHED_NODES,
 		})
 	d.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER})
 


### PR DESCRIPTION
**The binaries affected**:

- [ ] openstack-cloud-controller-manager
- [x] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
For supporting VolumeAttachment reconcile, adding capability.
Related: https://github.com/kubernetes-csi/external-attacher/pull/184

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
[cinder-csi-pugin] Support LIST_VOLUMES_PUBLISHED_NODES capability.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/cloud-provider-openstack/976)
<!-- Reviewable:end -->
