### PR TITLE
[OCCM] Set default value for some options

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -365,6 +365,11 @@ func ReadConfig(config io.Reader) (Config, error) {
 		return Config{}, fmt.Errorf("no OpenStack cloud provider config file given")
 	}
 	var cfg Config
+
+	// Set default values
+	cfg.LoadBalancer.UseOctavia = true
+	cfg.LoadBalancer.InternalLB = false
+
 	err := gcfg.FatalOnly(gcfg.ReadInto(&cfg, config))
 
 	klog.V(5).Infof("Config, loaded from the config file:")


### PR DESCRIPTION
**The binaries affected**:

- [x] openstack-cloud-controller-manager
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
Support Octavia by default as load balancer implementation in openstack-cloud-controller-manager.

**Which issue this PR fixes**:
fixes #

**Special notes for reviewers**:
Document has already been changed in PR #962

**Release note**:
```release-note
openstack-cloud-controller-manager: Support OpenStack Octavia by default as load balancer implementation
```
