### PR TITLE
Parse and follow klog CLI flags

### DIFF
--- a/cmd/client-keystone-auth/main.go
+++ b/cmd/client-keystone-auth/main.go
@@ -177,6 +177,7 @@ func main() {
 	pflag.StringVar(&applicationCredentialID, "application-credential-id", os.Getenv("OS_APPLICATION_CREDENTIAL_ID"), "Application Credential ID")
 	pflag.StringVar(&applicationCredentialName, "application-credential-name", os.Getenv("OS_APPLICATION_CREDENTIAL_NAME"), "Application Credential Name")
 	pflag.StringVar(&applicationCredentialSecret, "application-credential-secret", os.Getenv("OS_APPLICATION_CREDENTIAL_SECRET"), "Application Credential Secret")
+	pflag.CommandLine.AddGoFlagSet(klogFlags)
 	kflag.InitFlags()
 
 	// Generate Gophercloud Auth Options based on input data from stdin

--- a/cmd/octavia-ingress-controller/main.go
+++ b/cmd/octavia-ingress-controller/main.go
@@ -17,28 +17,9 @@ limitations under the License.
 package main
 
 import (
-	"flag"
 	"k8s.io/cloud-provider-openstack/pkg/ingress/cmd"
-	"k8s.io/klog"
 )
 
 func main() {
-
-	// Glog requires this otherwise it complains.
-	flag.CommandLine.Parse(nil)
-	// This is a temporary hack to enable proper logging until upstream dependencies
-	// are migrated to fully utilize klog instead of glog.
-	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
-	klog.InitFlags(klogFlags)
-
-	// Sync the glog and klog flags.
-	flag.CommandLine.VisitAll(func(f1 *flag.Flag) {
-		f2 := klogFlags.Lookup(f1.Name)
-		if f2 != nil {
-			value := f1.Value.String()
-			f2.Value.Set(value)
-		}
-	})
-
 	cmd.Execute()
 }

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -250,9 +250,9 @@ func LogCfg(cfg Config) {
 	klog.V(5).Infof("ApplicationCredentialName: %s", cfg.Global.ApplicationCredentialName)
 }
 
-type logger struct{}
+type Logger struct{}
 
-func (l logger) Printf(format string, args ...interface{}) {
+func (l Logger) Printf(format string, args ...interface{}) {
 	debugger := klog.V(6)
 
 	// extra check in case, when verbosity has been changed dynamically
@@ -531,7 +531,7 @@ func NewOpenStackClient(cfg *AuthOpts, userAgent string, extraUserAgent ...strin
 	if klog.V(6) {
 		provider.HTTPClient.Transport = &client.RoundTripper{
 			Rt:     provider.HTTPClient.Transport,
-			Logger: &logger{},
+			Logger: &Logger{},
 		}
 	}
 

--- a/pkg/identity/keystone/token_getter.go
+++ b/pkg/identity/keystone/token_getter.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gophercloud/utils/client"
 	"io/ioutil"
 	certutil "k8s.io/client-go/util/cert"
-	openstack_provider "k8s.io/cloud-provider-openstack/pkg/cloudprovider/providers/openstack"
+	cpo "k8s.io/cloud-provider-openstack/pkg/cloudprovider/providers/openstack"
 	"k8s.io/cloud-provider-openstack/pkg/version"
 	"k8s.io/klog"
 	"net/http"
@@ -101,7 +101,7 @@ func GetToken(options Options) (*tokens3.Token, error) {
 		}
 		provider.HTTPClient.Transport = &client.RoundTripper{
 			Rt:     provider.HTTPClient.Transport,
-			Logger: &openstack_provider.Logger{},
+			Logger: &cpo.Logger{},
 		}
 	}
 

--- a/pkg/identity/keystone/token_getter.go
+++ b/pkg/identity/keystone/token_getter.go
@@ -22,9 +22,12 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	tokens3 "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
+	"github.com/gophercloud/utils/client"
 	"io/ioutil"
 	certutil "k8s.io/client-go/util/cert"
+	openstack_provider "k8s.io/cloud-provider-openstack/pkg/cloudprovider/providers/openstack"
 	"k8s.io/cloud-provider-openstack/pkg/version"
+	"k8s.io/klog"
 	"net/http"
 )
 
@@ -41,7 +44,7 @@ func GetToken(options Options) (*tokens3.Token, error) {
 	var setTransport bool
 
 	// Create new identity client
-	client, err := openstack.NewClient(options.AuthOptions.IdentityEndpoint)
+	provider, err := openstack.NewClient(options.AuthOptions.IdentityEndpoint)
 	if err != nil {
 		msg := fmt.Errorf("failed: Initializing openstack authentication client: %v", err)
 		return token, msg
@@ -51,7 +54,7 @@ func GetToken(options Options) (*tokens3.Token, error) {
 
 	userAgent := gophercloud.UserAgent{}
 	userAgent.Prepend(fmt.Sprintf("client-keystone-auth/%s", version.Version))
-	client.UserAgent = userAgent
+	provider.UserAgent = userAgent
 
 	if options.ClientCertPath != "" && options.ClientKeyPath != "" {
 		clientCert, err := ioutil.ReadFile(options.ClientCertPath)
@@ -89,10 +92,20 @@ func GetToken(options Options) (*tokens3.Token, error) {
 
 	if setTransport {
 		transport := &http.Transport{Proxy: http.ProxyFromEnvironment, TLSClientConfig: tlsConfig}
-		client.HTTPClient.Transport = transport
+		provider.HTTPClient.Transport = transport
 	}
 
-	v3Client, err := openstack.NewIdentityV3(client, gophercloud.EndpointOpts{})
+	if klog.V(6) {
+		if provider.HTTPClient.Transport == nil {
+			provider.HTTPClient.Transport = http.DefaultTransport
+		}
+		provider.HTTPClient.Transport = &client.RoundTripper{
+			Rt:     provider.HTTPClient.Transport,
+			Logger: &openstack_provider.Logger{},
+		}
+	}
+
+	v3Client, err := openstack.NewIdentityV3(provider, gophercloud.EndpointOpts{})
 	if err != nil {
 		msg := fmt.Errorf("failed: Initializing openstack authentication client: %v", err)
 		return token, msg

--- a/pkg/ingress/cmd/root.go
+++ b/pkg/ingress/cmd/root.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -29,6 +30,7 @@ import (
 
 	"k8s.io/cloud-provider-openstack/pkg/ingress/config"
 	"k8s.io/cloud-provider-openstack/pkg/ingress/controller"
+	"k8s.io/klog"
 )
 
 var (
@@ -70,6 +72,10 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.ingress_openstack.yaml)")
 	rootCmd.PersistentFlags().BoolVar(&isDebug, "debug", false, "Print more detailed information.")
+
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
+	rootCmd.PersistentFlags().AddGoFlagSet(klogFlags)
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
**The binaries affected**:

<!--
1. Please add the binary name in the title, e.g. `[cinder-csi-plugin]: Add UDP protocol support` unless the PR affects multiple binaries.
2. Use `[OCCM]` for openstack-cloud-controller-manager.
3. Insert 'x' in '[ ]' for tick, i.e. [x] cinder-csi-plugin
-->

- [ ] All
- [ ] openstack-cloud-controller-manager(OCCM)
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [x] client-keystone-auth
- [x] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:

This PR adds an ability to parse and follow klog CLI flags

**Which issue this PR fixes**:
fixes #981 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. openstack-cloud-controller-manager: Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Parse klog verbosity flags in octavia-ingress-controller and client-keystone-auth
```
