### PR TITLE
[magnum-auto-healer] Support updating cluster health status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/googleapis/gnostic v0.3.1 // indirect
-	github.com/gophercloud/gophercloud v0.10.1-0.20200423022346-456b0b69b115
+	github.com/gophercloud/gophercloud v0.11.1-0.20200518183226-7aec46f32c19
 	github.com/gophercloud/utils v0.0.0-20200423144003-7c72efc7435d
 	github.com/gorilla/mux v1.7.3
 	github.com/hashicorp/go-version v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -292,6 +292,8 @@ github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEo
 github.com/gophercloud/gophercloud v0.6.1-0.20191122030953-d8ac278c1c9d/go.mod h1:ozGNgr9KYOVATV5jsgHl/ceCDXGuguqOZAzoQ/2vcNM=
 github.com/gophercloud/gophercloud v0.10.1-0.20200423022346-456b0b69b115 h1:y/1giyvszT6UVoiQ9JtY6Kx/PEa9iqa45NqlivcvDmM=
 github.com/gophercloud/gophercloud v0.10.1-0.20200423022346-456b0b69b115/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
+github.com/gophercloud/gophercloud v0.11.1-0.20200518183226-7aec46f32c19 h1:Amaxs7PsvtzbahUHadno+OZI0IrMqwbPhoGUVLdM1NA=
+github.com/gophercloud/gophercloud v0.11.1-0.20200518183226-7aec46f32c19/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
 github.com/gophercloud/utils v0.0.0-20200423144003-7c72efc7435d h1:fduaPzWwIfvOMLuHk2Al3GZH0XbUqG8MbElPop+Igzs=
 github.com/gophercloud/utils v0.0.0-20200423144003-7c72efc7435d/go.mod h1:ehWUbLQJPqS0Ep+CxeD559hsm9pthPXadJNKwZkp43w=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=

--- a/pkg/autohealing/cloudprovider/cloudprovider.go
+++ b/pkg/autohealing/cloudprovider/cloudprovider.go
@@ -33,6 +33,9 @@ type CloudProvider interface {
 	// GetName returns the cloud provider name.
 	GetName() string
 
+	// Update cluster health status.
+	UpdateHealthStatus([]healthcheck.NodeInfo, []healthcheck.NodeInfo) error
+
 	// Repair triggers the node repair process in the cloud.
 	Repair([]healthcheck.NodeInfo) error
 

--- a/pkg/autohealing/healthcheck/healthcheck.go
+++ b/pkg/autohealing/healthcheck/healthcheck.go
@@ -29,8 +29,9 @@ type registerPlugin func(config interface{}) (HealthCheck, error)
 
 // NodeInfo is a wrapper of Node, may contains more information in future.
 type NodeInfo struct {
-	KubeNode apiv1.Node
-	IsWorker bool
+	KubeNode    apiv1.Node
+	IsWorker    bool
+	FailedCheck string
 }
 
 type HealthCheck interface {
@@ -42,6 +43,9 @@ type HealthCheck interface {
 
 	// IsWorkerSupported checks if the health check plugin supports worker node.
 	IsWorkerSupported() bool
+
+	// GetName returns name of the health check plugin
+	GetName() string
 }
 
 // NodeController is to avoid circle reference.
@@ -76,6 +80,7 @@ func CheckNodes(checkers []HealthCheck, nodes []NodeInfo, controller NodeControl
 	for _, node := range nodes {
 		for _, checker := range checkers {
 			if !checker.Check(node, controller) {
+				node.FailedCheck = checker.GetName()
 				unhealthyNodes = append(unhealthyNodes, node)
 				break
 			}

--- a/pkg/autohealing/healthcheck/plugin_endpoint.go
+++ b/pkg/autohealing/healthcheck/plugin_endpoint.go
@@ -62,6 +62,11 @@ type EndpointCheck struct {
 	Token string `mapstructure:"token"`
 }
 
+// GetName returns name of the health check
+func (check *EndpointCheck) GetName() string {
+	return "EndpointCheck"
+}
+
 // IsMasterSupported checks if the health check plugin supports master node.
 func (check *EndpointCheck) IsMasterSupported() bool {
 	return true

--- a/pkg/autohealing/healthcheck/plugin_nodecondition.go
+++ b/pkg/autohealing/healthcheck/plugin_nodecondition.go
@@ -73,6 +73,11 @@ func (check *NodeConditionCheck) Check(node NodeInfo, controller NodeController)
 	return true
 }
 
+// GetName returns name of the health check
+func (check *NodeConditionCheck) GetName() string {
+	return "NodeConditionCheck"
+}
+
 // IsMasterSupported checks if the health check plugin supports master node.
 func (check *NodeConditionCheck) IsMasterSupported() bool {
 	return true


### PR DESCRIPTION
- [ ] All
- [ ] openstack-cloud-controller-manager(OCCM)
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [x] magnum-auto-healer
- [ ] barbican-kms-plugin

**Which issue this PR fixes**:
fixes #984 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
```release-note
[magnum-auto-healer] Support updating the health status for Magnum cluster.
```
