### PR TITLE
[OCCM] Add annotation for creating health monitor

### DIFF
--- a/docs/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/expose-applications-using-loadbalancer-type-service.md
@@ -143,6 +143,10 @@ Request Body:
 
   If 'true', the loadbalancer VIP won't be associated with a floating IP. Default is 'false'.
 
+- `loadbalancer.openstack.org/enable-health-monitor`
+
+  Defines whether or not to create health monitor for the load balancer pool, if not specified, use `create-monitor` config. The health monitor can be created or deleted dynamically.
+
 ### Switching between Floating Subnets by using preconfigured Classes
 
 If you have multiple `FloatingIPPools` and/or `FloatingIPSubnets` it might be desirable to offer the user logical meanings for `LoadBalancers` like `internetFacing` or `DMZ` instead of requiring the user to select a dedicated network or subnet ID at the service object level as an annotation.

--- a/docs/using-openstack-cloud-controller-manager.md
+++ b/docs/using-openstack-cloud-controller-manager.md
@@ -162,13 +162,13 @@ Although the openstack-cloud-controller-manager was initially implemented with N
 
   This option is not needed when using Octavia. The worker nodes and the Octavia amphorae are usually in the same subnet, so it's sufficient to config the port security group rules manually for worker nodes, to allow the traffic coming from the the subnet IP range to the node port range(i.e. 30000-32767).
 * `create-monitor`
-  Indicates whether or not to create a health monitor for the service load balancer. If `true`, `monitor-delay`, `monitor-timeout`, and `monitor-max-retries` must also be set. Default: false
+  Indicates whether or not to create a health monitor for the service load balancer. Default: false
 * `monitor-delay`
-  The time, in seconds, between sending probes to members of the load balancer.
+  The time, in seconds, between sending probes to members of the load balancer. Default: 5
 * `monitor-max-retries`
-  The number of successful checks before changing the operating status of the load balancer member to ONLINE. A valid value is from 1 to 10.
+  The number of successful checks before changing the operating status of the load balancer member to ONLINE. A valid value is from 1 to 10. Default: 1
 * `monitor-timeout`
-  The maximum time, in seconds, that a monitor waits to connect backend before it times out.
+  The maximum time, in seconds, that a monitor waits to connect backend before it times out. Default: 3
 * `node-security-group`
   Deprecated.
 * `internal-lb`

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -366,9 +366,16 @@ func ReadConfig(config io.Reader) (Config, error) {
 	}
 	var cfg Config
 
-	// Set default values
+	// Set default values explicitly
 	cfg.LoadBalancer.UseOctavia = true
 	cfg.LoadBalancer.InternalLB = false
+	cfg.LoadBalancer.LBProvider = "amphora"
+	cfg.LoadBalancer.LBMethod = "ROUND_ROBIN"
+	cfg.LoadBalancer.CreateMonitor = false
+	cfg.LoadBalancer.ManageSecurityGroups = false
+	cfg.LoadBalancer.MonitorDelay = MyDuration{5 * time.Second}
+	cfg.LoadBalancer.MonitorTimeout = MyDuration{3 * time.Second}
+	cfg.LoadBalancer.MonitorMaxRetries = 1
 
 	err := gcfg.FatalOnly(gcfg.ReadInto(&cfg, config))
 
@@ -471,21 +478,6 @@ func readInstanceID(searchOrder string) (string, error) {
 
 // check opts for OpenStack
 func checkOpenStackOpts(openstackOpts *OpenStack) error {
-	lbOpts := openstackOpts.lbOpts
-
-	// if need to create health monitor for Neutron LB,
-	// monitor-delay, monitor-timeout and monitor-max-retries should be set.
-	if lbOpts.CreateMonitor {
-		if lbOpts.MonitorDelay == (MyDuration{}) {
-			return fmt.Errorf("monitor-delay not set in cloud provider config")
-		}
-		if lbOpts.MonitorTimeout == (MyDuration{}) {
-			return fmt.Errorf("monitor-timeout not set in cloud provider config")
-		}
-		if lbOpts.MonitorMaxRetries == uint(0) {
-			return fmt.Errorf("monitor-max-retries not set in cloud provider config")
-		}
-	}
 	return checkMetadataSearchOrder(openstackOpts.metadataOpts.SearchOrder)
 }
 

--- a/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -346,8 +346,6 @@ func TestToAuthOptions(t *testing.T) {
 }
 
 func TestCheckOpenStackOpts(t *testing.T) {
-	delay := MyDuration{60 * time.Second}
-	timeout := MyDuration{30 * time.Second}
 	tests := []struct {
 		name          string
 		openstackOpts *OpenStack
@@ -356,19 +354,6 @@ func TestCheckOpenStackOpts(t *testing.T) {
 		{
 			name: "test1",
 			openstackOpts: &OpenStack{
-				provider: nil,
-				lbOpts: LoadBalancerOpts{
-					LBVersion:            "v2",
-					SubnetID:             "6261548e-ffde-4bc7-bd22-59c83578c5ef",
-					FloatingNetworkID:    "38b8b5f9-64dc-4424-bf86-679595714786",
-					LBMethod:             "ROUND_ROBIN",
-					LBProvider:           "haproxy",
-					CreateMonitor:        true,
-					MonitorDelay:         delay,
-					MonitorTimeout:       timeout,
-					MonitorMaxRetries:    uint(3),
-					ManageSecurityGroups: true,
-				},
 				metadataOpts: MetadataOpts{
 					SearchOrder: metadata.ConfigDriveID,
 				},
@@ -379,46 +364,6 @@ func TestCheckOpenStackOpts(t *testing.T) {
 			name: "test2",
 			openstackOpts: &OpenStack{
 				provider: nil,
-				lbOpts: LoadBalancerOpts{
-					LBVersion:            "v2",
-					FloatingNetworkID:    "38b8b5f9-64dc-4424-bf86-679595714786",
-					LBMethod:             "ROUND_ROBIN",
-					CreateMonitor:        true,
-					MonitorDelay:         delay,
-					MonitorTimeout:       timeout,
-					MonitorMaxRetries:    uint(3),
-					ManageSecurityGroups: true,
-				},
-				metadataOpts: MetadataOpts{
-					SearchOrder: metadata.ConfigDriveID,
-				},
-			},
-			expectedError: nil,
-		},
-		{
-			name: "test3",
-			openstackOpts: &OpenStack{
-				provider: nil,
-				lbOpts: LoadBalancerOpts{
-					LBVersion:            "v2",
-					SubnetID:             "6261548e-ffde-4bc7-bd22-59c83578c5ef",
-					FloatingNetworkID:    "38b8b5f9-64dc-4424-bf86-679595714786",
-					LBMethod:             "ROUND_ROBIN",
-					CreateMonitor:        true,
-					MonitorTimeout:       timeout,
-					MonitorMaxRetries:    uint(3),
-					ManageSecurityGroups: true,
-				},
-				metadataOpts: MetadataOpts{
-					SearchOrder: metadata.ConfigDriveID,
-				},
-			},
-			expectedError: fmt.Errorf("monitor-delay not set in cloud provider config"),
-		},
-		{
-			name: "test4",
-			openstackOpts: &OpenStack{
-				provider: nil,
 				metadataOpts: MetadataOpts{
 					SearchOrder: "",
 				},
@@ -426,7 +371,7 @@ func TestCheckOpenStackOpts(t *testing.T) {
 			expectedError: fmt.Errorf("invalid value in section [Metadata] with key `search-order`. Value cannot be empty"),
 		},
 		{
-			name: "test5",
+			name: "test3",
 			openstackOpts: &OpenStack{
 				provider: nil,
 				metadataOpts: MetadataOpts{
@@ -436,7 +381,7 @@ func TestCheckOpenStackOpts(t *testing.T) {
 			expectedError: fmt.Errorf("invalid value in section [Metadata] with key `search-order`. Value cannot contain more than 2 elements"),
 		},
 		{
-			name: "test6",
+			name: "test4",
 			openstackOpts: &OpenStack{
 				provider: nil,
 				metadataOpts: MetadataOpts{
@@ -445,46 +390,6 @@ func TestCheckOpenStackOpts(t *testing.T) {
 			},
 			expectedError: fmt.Errorf("invalid element %q found in section [Metadata] with key `search-order`."+
 				"Supported elements include %q and %q", "value1", metadata.ConfigDriveID, metadata.MetadataID),
-		},
-		{
-			name: "test7",
-			openstackOpts: &OpenStack{
-				provider: nil,
-				lbOpts: LoadBalancerOpts{
-					LBVersion:            "v2",
-					SubnetID:             "6261548e-ffde-4bc7-bd22-59c83578c5ef",
-					FloatingNetworkID:    "38b8b5f9-64dc-4424-bf86-679595714786",
-					LBMethod:             "ROUND_ROBIN",
-					CreateMonitor:        true,
-					MonitorDelay:         delay,
-					MonitorTimeout:       timeout,
-					ManageSecurityGroups: true,
-				},
-				metadataOpts: MetadataOpts{
-					SearchOrder: metadata.ConfigDriveID,
-				},
-			},
-			expectedError: fmt.Errorf("monitor-max-retries not set in cloud provider config"),
-		},
-		{
-			name: "test8",
-			openstackOpts: &OpenStack{
-				provider: nil,
-				lbOpts: LoadBalancerOpts{
-					LBVersion:            "v2",
-					SubnetID:             "6261548e-ffde-4bc7-bd22-59c83578c5ef",
-					FloatingNetworkID:    "38b8b5f9-64dc-4424-bf86-679595714786",
-					LBMethod:             "ROUND_ROBIN",
-					CreateMonitor:        true,
-					MonitorDelay:         delay,
-					MonitorMaxRetries:    uint(3),
-					ManageSecurityGroups: true,
-				},
-				metadataOpts: MetadataOpts{
-					SearchOrder: metadata.ConfigDriveID,
-				},
-			},
-			expectedError: fmt.Errorf("monitor-timeout not set in cloud provider config"),
 		},
 	}
 


### PR DESCRIPTION
**The binaries affected**:

- [ ] All
- [x] openstack-cloud-controller-manager(OCCM)
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
Add service annotation `loadbalancer.openstack.org/enable-health-monitor` to define whether or not to create health monitor for the load balancer pool, if not specified, use 'create-monitor' config. The health monitor can be created or deleted dynamically.

The scenaro to use this annotation is to deal with the pod that exposes TCP via SNI (e.g. Envoy) and is performing client certificate validation, in this case the health monitor created will fail. We need provide the capability to customize.

**Which issue this PR fixes**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. openstack-cloud-controller-manager: Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
openstack-cloud-controller-manager: Added a service annotation `loadbalancer.openstack.org/enable-health-monitor` to define whether or not to create health monitor for the load balancer pool.
```