### PR TITLE
Update docs for make commands

### DIFF
--- a/docs/getting-started-provider-dev.md
+++ b/docs/getting-started-provider-dev.md
@@ -1,6 +1,6 @@
 # Getting Started with Cloud Provider OpenStack Development
 
-This guide will help you get started with building a development environment for you 
+This guide will help you get started with building a development environment for you
 to build and run a single node Kubernetes cluster with the OpenStack Cloud Provider
 enabled.
 
@@ -129,7 +129,7 @@ export GOPATH=$HOME/go
 
 Finally, set up your Git identity and GitHub integrations.
 
-More comprehensive setup instructions are available in the 
+More comprehensive setup instructions are available in the
 [Development Guide](https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#building-kubernetes-on-a-local-osshell-environment)
 in the Kubernetes repository. When in doubt, check there for additional setup
 and versioning information.
@@ -161,10 +161,20 @@ git clone https://github.com/{user}/cloud-provider-openstack
 cd cloud-provider-openstack
 ```
 
-If you want to build the provider:
+If you want to build the plugins for single architecture:
 
 ```
+# ARCH default to amd64
+export ARCH=arm64
 make build
+```
+
+And if you want to build the plugins for multiple architectures:
+
+```
+# ARCHS default to 'amd64 arm arm64 ppc64le s390x'
+export ARCHS='amd64 arm arm64 ppc64le s390x'
+make build-all-archs
 ```
 
 If you want to run unit tests:
@@ -234,7 +244,7 @@ export KUBECONFIG=/var/run/kubernetes/admin.kubeconfig
 ./cluster/kubectl.sh
 ```
 
-The cluster/addons/rbac has a set of yaml files, currently it has 
+The cluster/addons/rbac has a set of yaml files, currently it has
 cloud-controller-manager-role-bindings.yaml
 cloud-controller-manager-roles.yaml
 
@@ -245,6 +255,106 @@ otherwise the cloud-controller-manager is not able to access k8s API.
 ```
 
 Have a good time with OpenStack and Kubernetes!
+
+## Publish Container images
+
+We allow build and publish container images for multiple architectures.
+
+### Build and push images
+
+To build and push all supported images for all architecture.
+
+```
+# default value of VERSION is "{part of latest commit id}-dirty"
+export VERSION=latest
+# default registry is "k8scloudprovider"
+export REGISTRY=k8scloudprovider
+# No need to provide "DOCKER_PASSWORD" and "DOCKER_USERNAME" if environment already logged in.
+export DOCKER_PASSWORD=password
+export DOCKER_USERNAME=username
+
+# default value for IMAGE_NAMES includes all supported images.
+export IMAGE_NAMES='openstack-cloud-controller-manager cinder-flex-volume-driver cinder-provisioner cinder-csi-plugin k8s-keystone-auth octavia-ingress-controller manila-provisioner manila-csi-plugin barbican-kms-plugin magnum-auto-healer'
+# default value for ARCHS includes all supported architectures.
+export ARCHS='amd64 arm arm64 ppc64le s390x'
+
+make upload-images
+```
+
+Here's example to explain `make upload-images`
+`upload-images` will first build images with architectures.
+For example with `REGISTRY=k8scloudprovider`, `VERSION=latest`, `IMAGE_NAMES=openstack-cloud-controller-manager`,
+and `ARCHS=arm64 amd64` will build following two images
+- `k8scloudprovider/openstack-cloud-controller-manager-arm64:latest`
+- `k8scloudprovider/openstack-cloud-controller-manager-amd64:latest`
+
+Second, it will than upload above two images.
+And finally, it will build image manifest to upload image `k8scloudprovider/openstack-cloud-controller-manager:latest` (with no architecture in image name).
+
+Image `k8scloudprovider/openstack-cloud-controller-manager:latest` will support two different `OS/ARCH` tag: `linux/arm64` and `linux/amd64`.
+
+From this point all images are ready in image repositories.
+To start using image with specific architecture. You can use `--platform` or without if you plan to use default platform:
+
+```
+docker pull --platform=linux/amd64 k8scloudprovider/openstack-cloud-controller-manager:latest
+```
+
+Or you can use image with architecture tagged in name:
+
+```
+docker pull k8scloudprovider/openstack-cloud-controller-manager-amd64:latest
+```
+
+Note that since image `k8scloudprovider/openstack-cloud-controller-manager:latest` is build by manifest,
+the image digest for image pull from `k8scloudprovider/openstack-cloud-controller-manager:latest` will be different to
+image you pull from `k8scloudprovider/openstack-cloud-controller-manager-amd64:latest`.
+
+### Only Build Image
+
+It's generally more recommended to use `make upload-images` to build and push image.
+But you might need to build image and run test on it if you're running a test job to verify that image.
+
+To prepare default environment variables:
+
+```
+# default value of VERSION is "{part of latest commit id}-dirty"
+export VERSION=latest
+
+# default value for IMAGE_NAMES includes all supported images.
+export IMAGE_NAMES='openstack-cloud-controller-manager magnum-auto-healer'
+# default value for ARCHS includes all supported architectures.
+```
+
+If you not plan to build image, you can directly run `make images-all-archs` to support build for all specified images with all specified architectures.
+
+```
+export ARCHS='amd64 arm arm64 ppc64le s390x'
+make images-all-archs
+```
+
+If you plan to build image for single architecture, you can either specify `ARCHS` as `amd64` or run below commands
+
+```
+export ARCH=amd64
+make build-images
+```
+
+Or if you wish to ony build for specific architecture with specific image
+
+```
+export ARCH=amd64
+make image-openstack-cloud-controller-manager
+```
+In case of building images, by default, images built are appended with this -$ARCH tag at the end.
+For example, for the above case, openstack-cloud-controller-manager-amd64 is built.
+In case needed without it, tag it separately as required.
+
+```
+docker image tag openstack-cloud-controller-manager-amd64:latest openstack-cloud-controller-manager:latest
+```
+
+This will create image with tag `openstack-cloud-controller-manager:latest` in your local environment.
 
 ## Troubleshooting
 

--- a/docs/using-barbican-kms-plugin.md
+++ b/docs/using-barbican-kms-plugin.md
@@ -58,13 +58,13 @@ region = <region>
 key-id = <key-id>
 ```
 
-4. Clone the cloud-provider-openstack repo and build the docker image for barbican-kms-plugin
+4. Clone the cloud-provider-openstack repo and build the docker image for barbican-kms-plugin in architecture amd64
 ```
 $ git clone https://github.com/kubernetes/cloud-provider-openstack.git $GOPATH/k8s.io/src/
 $ cd $GOPATH/k8s.io/src/cloud-provider-openstack/
-$ make build barbican-kms-plugin
-$ cp barbican-kms-plugin cluster/images/barbican-kms-plugin
-$ docker build -t docker.io/k8scloudprovider/barbican-kms-plugin:latest cluster/images/barbican-kms-plugin
+$ export ARCH=amd64
+$ export VERSION=latest
+$ make image-barbican-kms-plugin
 ```
 
 5. Run the KMS Plugin in docker container
@@ -73,7 +73,7 @@ $ docker run -d --volume=/var/lib/kms:/var/lib/kms \
 --volume=/etc/kubernetes:/etc/kubernetes \
 -e socketpath=/var/lib/kms/kms.sock \
 -e cloudconfig=/etc/kubernetes/cloud-config \
-docker.io/k8scloudprovider/barbican-kms-plugin:latest
+docker.io/k8scloudprovider/barbican-kms-plugin-amd64:latest
 ```
 6. Create /etc/kubernetes/encryption-config.yaml
 ```

--- a/release-procedure.md
+++ b/release-procedure.md
@@ -21,7 +21,8 @@ $ git checkout -b release-X.Y upstream/release-X.Y
 $ git tag -s -m "Release for cloud-provider-openstack to support Kubernetes release x" vX.Y.Z
 $ git push upstream vX.Y.Z
 ```
-3. Build and push images to dockerhub. Provide `ARCHS` if needs to push only for specific types of architecture (for example `ARCHS='arm64v8 amd64'` or `ARCHS='amd64'`).
+3. Build and push images to dockerhub. Provide `ARCHS` if needs to push only for specific types of architecture (for example `ARCHS='arm64 amd64'` or `ARCHS='amd64'`).
+Don't need to provide `DOCKER_USERNAME` and `DOCKER_PASSWORD` if you already logged in.
 
 ```
 GOOS=linux DOCKER_USERNAME=user DOCKER_PASSWORD=my_password REGISTRY=docker.io/k8scloudprovider VERSION=vX.Y.Z make upload-images


### PR DESCRIPTION
This update current docs with correct make commands,
also added more make commands information regarding build and push
images for multiple architectures.
relates to  #883 
This document  depends on [1]
[1] https://github.com/kubernetes/cloud-provider-openstack/pull/967
**The binaries affected**:

<!--
1. Please add the binary name in the title, e.g. `[cinder-csi-plugin]: Add UDP protocol support` unless the PR affects multiple binaries.
2. Use `[OCCM]` for openstack-cloud-controller-manager.
3. Insert 'x' in '[ ]' for tick, i.e. [x] cinder-csi-plugin
-->

- [x] All
- [ ] openstack-cloud-controller-manager(OCCM)
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:

**Which issue this PR fixes**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. openstack-cloud-controller-manager: Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
