### PR TITLE
[DMT][TEST] check current CI env allow multi-archs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -185,3 +185,20 @@
               - ^OWNERS$
               - ^SECURITY_CONTACTS$
               - ^.gitignore$
+
+
+    cloud-provider-openstack-multinode-csi-migration-test:
+      jobs:
+        - cloud-provider-openstack-multinode-csi-migration-test:
+            files:
+              - ^pkg/cloudprovider/.*
+              - ^go.mod$
+              - ^go.sum$
+              - ^Makefile$
+            irrelevant-files:
+              - ^docs/.*$
+              - ^.*\.md$
+              - ^OWNERS$
+              - ^SECURITY_CONTACTS$
+              - ^.gitignore$
+

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ IMAGE_NAMES	?= openstack-cloud-controller-manager cinder-flex-volume-driver \
 			   octavia-ingress-controller manila-provisioner manila-csi-plugin \
 			   barbican-kms-plugin magnum-auto-healer
 ARCH		?= amd64
-ARCHS		?= amd64 arm arm64 ppc64le s390x
+ARCHS		:= amd64 arm arm64 ppc64le s390x
 BUILD_CMDS	?= openstack-cloud-controller-manager cinder-provisioner \
 			   cinder-flex-volume-driver cinder-csi-plugin k8s-keystone-auth \
 			   client-keystone-auth octavia-ingress-controller manila-provisioner \


### PR DESCRIPTION
[DO not merge this]
This PR only for triggering CI to verify current CI environment is ready
for multi-archs

**The binaries affected**:

<!--
1. Please add the binary name in the title, e.g. `[cinder-csi-plugin]: Add UDP protocol support` unless the PR affects multiple binaries.
2. Use `[OCCM]` for openstack-cloud-controller-manager.
3. Insert 'x' in '[ ]' for tick, i.e. [x] cinder-csi-plugin
-->

- [ ] All
- [ ] openstack-cloud-controller-manager(OCCM)
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:

**Which issue this PR fixes**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. openstack-cloud-controller-manager: Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
