### PR TITLE
[OCCM] Fix CI

### DIFF
--- a/tests/e2e/cloudprovider/test-lb-service.sh
+++ b/tests/e2e/cloudprovider/test-lb-service.sh
@@ -82,10 +82,31 @@ EOF
 ########################################################################
 function create_deployment {
     printf "\n>>>>>>> Create a Deployment\n"
-    kubectl -n $NAMESPACE get deploy echoserver > /dev/null 2>&1
-    if [ $? -eq 1 ]; then
-        kubectl -n $NAMESPACE run echoserver --image=gcr.io/google-containers/echoserver:1.10 --image-pull-policy=IfNotPresent --port=8080
-    fi
+    cat <<EOF | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echoserver
+  namespace: $NAMESPACE
+  labels:
+    run: echoserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: echoserver
+  template:
+    metadata:
+      labels:
+        run: echoserver
+    spec:
+      containers:
+      - name: echoserver
+        image: gcr.io/google-containers/echoserver:1.10
+        imagePullPolicy: IfNotPresent
+        ports:
+          - containerPort: 8080
+EOF
 }
 
 ########################################################################


### PR DESCRIPTION
**The binaries affected**:

- [ ] All
- [x] openstack-cloud-controller-manager(OCCM)
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
Fix the load balancer service CI job. The new version of `kubectl run` can only create pod, what we expect is a deployment.

**Which issue this PR fixes**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. openstack-cloud-controller-manager: Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/cloud-provider-openstack/992)
<!-- Reviewable:end -->
