### PR TITLE
[manila-csi-plugin] updates to k8s manifests and helm chart

### DIFF
--- a/examples/manila-csi-plugin/helm-deployment/values.yaml
+++ b/examples/manila-csi-plugin/helm-deployment/values.yaml
@@ -21,7 +21,7 @@ csimanila:
   # nodeAZ: "$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq -r .availability_zone)"
   # Image spec
   image:
-    repository: manila-csi-plugin
+    repository: k8scloudprovider/manila-csi-plugin
     tag: latest
     pullPolicy: IfNotPresent
 

--- a/manifests/manila-csi-plugin/csi-controllerplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-controllerplugin.yaml
@@ -40,6 +40,8 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
+            # To enable topology awareness in csi-provisioner, uncomment the following line:
+            # - "--feature-gates=Topology=true"
           env:
             - name: ADDRESS
               value: "unix:///var/lib/kubelet/plugins/manila.csi.openstack.org/csi-controllerplugin.sock"
@@ -65,14 +67,20 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: "manila-csi-plugin:latest"
-          args:
-            - "--v=5"
-            - "--nodeid=$(NODE_ID)"
-            - "--endpoint=$(CSI_ENDPOINT)"
-            - "--drivername=$(DRIVER_NAME)"
-            - "--share-protocol-selector=$(MANILA_SHARE_PROTO)"
-            - "--fwdendpoint=$(FWD_CSI_ENDPOINT)"
+          image: "k8scloudprovider/manila-csi-plugin:latest"
+          command: ["/bin/sh", "-c",
+            '/bin/manila-csi-plugin
+            --v=5
+            --nodeid=$(NODE_ID)
+            --endpoint=$(CSI_ENDPOINT)
+            --drivername=$(DRIVER_NAME)
+            --share-protocol-selector=$(MANILA_SHARE_PROTO)
+            --fwdendpoint=$(FWD_CSI_ENDPOINT)'
+            # To enable topology awareness and retrieve compute node AZs from the OpenStack Metadata Service, add the following flags:
+            # --with-topology
+            # --nodeaz=$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq -r .availability_zone)
+            # Those flags need to be added to csi-nodeplugin.yaml as well.
+          ]
           env:
             - name: DRIVER_NAME
               value: manila.csi.openstack.org

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -51,14 +51,20 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: "manila-csi-plugin:latest"
-          args:
-            - "--v=5"
-            - "--nodeid=$(NODE_ID)"
-            - "--endpoint=$(CSI_ENDPOINT)"
-            - "--drivername=$(DRIVER_NAME)"
-            - "--share-protocol-selector=$(MANILA_SHARE_PROTO)"
-            - "--fwdendpoint=$(FWD_CSI_ENDPOINT)"
+          image: "k8scloudprovider/manila-csi-plugin:latest"
+          command: ["/bin/sh", "-c",
+            '/bin/manila-csi-plugin
+            --v=5
+            --nodeid=$(NODE_ID)
+            --endpoint=$(CSI_ENDPOINT)
+            --drivername=$(DRIVER_NAME)
+            --share-protocol-selector=$(MANILA_SHARE_PROTO)
+            --fwdendpoint=$(FWD_CSI_ENDPOINT)'
+            # To enable topology awareness and retrieve compute node AZs from the OpenStack Metadata Service, add the following flags:
+            # --with-topology
+            # --nodeaz=$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq -r .availability_zone)
+            # Those flags need to be added to csi-controllerplugin.yaml as well.
+          ]
           env:
             - name: DRIVER_NAME
               value: manila.csi.openstack.org


### PR DESCRIPTION
**The binaries affected**:

<!--
1. Please add the binary name in the title, e.g. `[cinder-csi-plugin]: Add UDP protocol support` unless the PR affects multiple binaries.
2. Use `[OCCM]` for openstack-cloud-controller-manager.
3. Insert 'x' in '[ ]' for tick, i.e. [x] cinder-csi-plugin
-->

- [ ] All
- [ ] openstack-cloud-controller-manager(OCCM)
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [x] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:

Until now, the provided k8s manifests and the Helm chart have referenced `manila-csi-plugin` image, which is incorrect.

* reference images from the k8scloudprovider Docker hub repo
* also added notes about enabling topology awareness

**Which issue this PR fixes**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. openstack-cloud-controller-manager: Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @adisky @ramineni
