### PR TITLE
WIP: Add e2e test for snapshot

### DIFF
--- a/pkg/csi/cinder/utils.go
+++ b/pkg/csi/cinder/utils.go
@@ -87,3 +87,6 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 	}
 	return resp, err
 }
+
+
+

--- a/tests/e2e/csi/cinder/cinder-testdriver.go
+++ b/tests/e2e/csi/cinder/cinder-testdriver.go
@@ -39,11 +39,12 @@ func initCinderDriver(name string, manifests ...string) testsuites.TestDriver {
 				"xfs",
 			),
 			Capabilities: map[testsuites.Capability]bool{
-				testsuites.CapPersistence: true,
-				testsuites.CapFsGroup:     true,
-				testsuites.CapExec:        true,
-				testsuites.CapMultiPODs:   true,
-				testsuites.CapBlock:       true,
+				testsuites.CapPersistence:        true,
+				testsuites.CapFsGroup:            true,
+				testsuites.CapExec:               true,
+				testsuites.CapMultiPODs:          true,
+				testsuites.CapBlock:              true,
+				testsuites.CapSnapshotDataSource: true,
 			},
 		},
 		manifests: manifests,
@@ -65,6 +66,7 @@ var _ testsuites.TestDriver = &cinderDriver{}
 
 // var _ testsuites.PreprovisionedVolumeTestDriver = &cinderDriver{}
 // var _ testsuites.PreprovisionedPVTestDriver = &cinderDriver{}
+var _ testsuites.SnapshottableTestDriver = &cinderDriver{}
 var _ testsuites.DynamicPVTestDriver = &cinderDriver{}
 
 func (d *cinderDriver) GetDriverInfo() *testsuites.DriverInfo {

--- a/tests/e2e/csi/cinder/csi-volumes.go
+++ b/tests/e2e/csi/cinder/csi-volumes.go
@@ -17,7 +17,7 @@ var CSITestSuites = []func() testsuites.TestSuite{
 	testsuites.InitProvisioningTestSuite,
 	testsuites.InitVolumeModeTestSuite,
 	//testsuites.InitVolumeIOTestSuite,
-	//testsuites.InitSnapshottableTestSuite,
+	testsuites.InitSnapshottableTestSuite,
 	//testsuites.InitMultiVolumeTestSuite,
 }
 


### PR DESCRIPTION
**The binaries affected**:

<!--
1. Please add the binary name in the title, e.g. `[cinder-csi-plugin]: Add UDP protocol support` unless the PR affects multiple binaries.
2. Use `[OCCM]` for openstack-cloud-controller-manager.
3. Insert 'x' in '[ ]' for tick, i.e. [x] cinder-csi-plugin
-->

- [ ] All
- [ ] openstack-cloud-controller-manager(OCCM)
- [x] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] manila-provisioner
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:

**Which issue this PR fixes**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. openstack-cloud-controller-manager: Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
