### PR TITLE
[DOC] Extended the note for removing Manila Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This Repository hosts various plugins relevant to OpenStack and Kubernetes Integ
 
 > NOTE: Cinder Standalone Provisioner, Manila Provisioner and Cinder FlexVolume Driver were removed since release v1.18.0.
 
+> Version 1.17 was the last release of Manila Provisioner, which is unmaintained from now on. Due to dependency issues, we removed the code from master but it is still accessible in the [release-1.17](https://github.com/kubernetes/cloud-provider-openstack/tree/release-1.17) branch. Please consider migrating to Manila CSI Plugin.
+
 ## Developing
 
 Please Refer [Getting Started Guide](/docs/getting-started-provider-dev.md/) for setting up development environment.


### PR DESCRIPTION
**The binaries affected**:

<!--
1. Please add the binary name in the title, e.g. `[cinder-csi-plugin]: Add UDP protocol support` unless the PR affects multiple binaries.
2. Use `[OCCM]` for openstack-cloud-controller-manager.
3. Insert 'x' in '[ ]' for tick, i.e. [x] cinder-csi-plugin
-->

- [ ] All
- [ ] openstack-cloud-controller-manager(OCCM)
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:

Clarified the situation of removing Manila Provisioner from master. 

**Which issue this PR fixes**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. openstack-cloud-controller-manager: Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
