### PR TITLE
[All] Update docker image tag to v1.18.0

### DIFF
--- a/manifests/barbican-kms/pod.yaml
+++ b/manifests/barbican-kms/pod.yaml
@@ -1,11 +1,11 @@
-apiVersion: v1 
-kind: Pod 
-metadata: 
+apiVersion: v1
+kind: Pod
+metadata:
  name: barbican-kms
-spec: 
-  containers: 
-    - name: barbican-kms 
-      image: docker.io/k8scloudprovider/barbican-kms-plugin:latest
+spec:
+  containers:
+    - name: barbican-kms
+      image: docker.io/k8scloudprovider/barbican-kms-plugin:v1.18.0
       args:
         - "--socketpath=/kms/kms.sock"
         - "--cloud-config=/etc/kubernetes/cloud-config"

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -81,7 +81,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: cinder-csi-plugin
-          image: docker.io/k8scloudprovider/cinder-csi-plugin:latest
+          image: docker.io/k8scloudprovider/cinder-csi-plugin:v1.18.0
           args :
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -48,7 +48,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: docker.io/k8scloudprovider/cinder-csi-plugin:latest
+          image: docker.io/k8scloudprovider/cinder-csi-plugin:v1.18.0
           args :
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"

--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: openstack-cloud-controller-manager
-          image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:latest
+          image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.18.0
           args:
             - /bin/openstack-cloud-controller-manager
             - --v=1

--- a/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   containers:
     - name: openstack-cloud-controller-manager
-      image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:latest
+      image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.18.0
       args:
         - /bin/openstack-cloud-controller-manager
         - --v=1

--- a/manifests/magnum-auto-healer/magnum-auto-healer.yaml
+++ b/manifests/magnum-auto-healer/magnum-auto-healer.yaml
@@ -88,7 +88,7 @@ spec:
         node-role.kubernetes.io/master: ""
       containers:
         - name: magnum-auto-healer
-          image: docker.io/k8scloudprovider/magnum-auto-healer:latest
+          image: docker.io/k8scloudprovider/magnum-auto-healer:v1.18.0
           imagePullPolicy: Always
           args:
             - /bin/magnum-auto-healer

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -51,7 +51,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: "manila-csi-plugin:latest"
+          image: docker.io/k8scloudprovider/manila-csi-plugin:v1.18.0
           args:
             - "--v=5"
             - "--nodeid=$(NODE_ID)"

--- a/manifests/webhook/k8s-keystone-auth-ds.yaml
+++ b/manifests/webhook/k8s-keystone-auth-ds.yaml
@@ -28,7 +28,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: k8s-keystone-auth
-          image: docker.io/k8scloudprovider/k8s-keystone-auth:latest
+          image: docker.io/k8scloudprovider/k8s-keystone-auth:v1.18.0
           args:
             - /bin/k8s-keystone-auth
             - --v=10

--- a/manifests/webhook/k8s-keystone-auth-pod.yaml
+++ b/manifests/webhook/k8s-keystone-auth-pod.yaml
@@ -12,7 +12,7 @@ spec:
   serviceAccountName: k8s-keystone
   containers:
     - name: k8s-keystone-auth
-      image: docker.io/k8scloudprovider/k8s-keystone-auth:latest
+      image: docker.io/k8scloudprovider/k8s-keystone-auth:v1.18.0
       args:
         - /bin/k8s-keystone-auth
         - --v=10


### PR DESCRIPTION
**The binaries affected**:

<!--
1. Please add the binary name in the title, e.g. `[cinder-csi-plugin]: Add UDP protocol support` unless the PR affects multiple binaries.
2. Use `[OCCM]` for openstack-cloud-controller-manager.
3. Insert 'x' in '[ ]' for tick, i.e. [x] cinder-csi-plugin
-->

- [x] All
- [ ] openstack-cloud-controller-manager(OCCM)
- [ ] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:
Update docker image tag in the example manifest files for release v1.18.0

**Which issue this PR fixes**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. openstack-cloud-controller-manager: Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
