### PR TITLE
[cinder-csi-plugin] Allow force create snapshot

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,7 @@ fixes #
 **Release note**:
 <!--
 1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
-2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. openstack-cloud-controller-manager: Deprecate Neutron-LBaaS support.
+2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
 3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
 -->
 ```release-note

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -85,6 +85,18 @@
               - go.mod$
               - go.sum$
               - Makefile$
+    cloud-provider-openstack-multinode-csi-migration-test:
+      jobs:
+        - cloud-provider-openstack-multinode-csi-migration-test:
+            files:
+              - cmd/cinder-csi-plugin/.*
+              - manifests/cinder-csi-plugin/.*
+              - pkg/csi/cinder/.*
+              - pkg/util/.*
+              - go.mod$
+              - go.sum$
+              - Makefile$
+              - .zuul.yaml$
     cloud-provider-openstack-acceptance-test-csi-manila:
       jobs:
         - cloud-provider-openstack-acceptance-test-csi-manila:

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ endif
 import-boss:
 ifndef HAS_IMPORT_BOSS
 	echo "installing import-boss"
-	GO111MODULE=off go get -u k8s.io/code-generator/cmd/import-boss
+	go get -u k8s.io/code-generator/cmd/import-boss
 endif
 	hack/verify-import-boss.sh
 

--- a/docs/getting-started-provider-dev.md
+++ b/docs/getting-started-provider-dev.md
@@ -251,7 +251,7 @@ cloud-controller-manager-roles.yaml
 you need use following command to create ClusterRole and ClusterRoleBinding
 otherwise the cloud-controller-manager is not able to access k8s API.
 ```
-./cluster/kubectl.sh create -f cluster/addons/rbac/
+./cluster/kubectl.sh create -f $working_dir/cloud-provider-openstack/cluster/addons/rbac/
 ```
 
 Have a good time with OpenStack and Kubernetes!

--- a/docs/using-cinder-csi-plugin.md
+++ b/docs/using-cinder-csi-plugin.md
@@ -32,7 +32,7 @@ Check [kubernetes CSI Docs](https://kubernetes-csi.github.io/docs/) for flag det
 
 ### Deploy
 
-If you already created the `cloud-config` secret used by the [cloud-controller-manager](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/using-controller-manager-with-kubeadm.md#steps), remove the file ```manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml``` and then jump directly to the `kubectl apply ...` command.
+If you already created the `cloud-config` secret used by the [cloud-controller-manager](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/using-openstack-cloud-controller-manager.md#steps), remove the file ```manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml``` from [manifests](https://github.com/kubernetes/cloud-provider-openstack/tree/master/manifests/cinder-csi-plugin) and then jump directly to the `kubectl apply ...` command.
 
 Encode your ```$CLOUD_CONFIG``` file content using base64.
 
@@ -58,7 +58,7 @@ volumes:
     type: Directory
 ```
 
-Then call following command by using existing manifests:
+Then call following command by using existing [manifests](https://github.com/kubernetes/cloud-provider-openstack/tree/master/manifests/cinder-csi-plugin):
 
 ```kubectl -f manifests/cinder-csi-plugin apply```
 
@@ -100,7 +100,7 @@ Events:               <none>
 ### Example Nginx application usage
 
 After performing above steps, you can try to create StorageClass, PersistentVolumeClaim and pod to consume it.
-Try following command:
+Try following command by using [examples](https://github.com/kubernetes/cloud-provider-openstack/blob/master/examples/cinder-csi-plugin/nginx.yaml):
 
 ```kubectl -f examples/cinder-csi-plugin/nginx.yaml create```
 

--- a/docs/using-openstack-cloud-controller-manager.md
+++ b/docs/using-openstack-cloud-controller-manager.md
@@ -135,9 +135,9 @@ The options in `Global` section are used for openstack-cloud-controller-manager 
 * `ipv6-support-disabled`
   Indicates whether or not IPv6 is supported. Default: false
 * `public-network-name`
-  The name of Neutron external network. openstack-cloud-controller-manager uses this option when getting the external IP of the Kubernetes node. Default: ""
+  The name of Neutron external network. openstack-cloud-controller-manager uses this option when getting the external IP of the Kubernetes node. Can be specified multiple times. Specified network names will be ORed. Default: ""
 * `internal-network-name`
-  The name of Neutron internal network. openstack-cloud-controller-manager uses this option when getting the internal IP of the Kubernetes node, this is useful if the node has multiple interfaces. Default: ""
+  The name of Neutron internal network. openstack-cloud-controller-manager uses this option when getting the internal IP of the Kubernetes node, this is useful if the node has multiple interfaces. Can be specified multiple times. Specified network names will be ORed. Default: ""
 
 ###  Load Balancer
 

--- a/examples/cinder-csi-plugin/snapshot/example.yaml
+++ b/examples/cinder-csi-plugin/snapshot/example.yaml
@@ -11,6 +11,8 @@ kind: VolumeSnapshotClass
 metadata:
   name: csi-cinder-snapclass
 snapshotter: cinder.csi.openstack.org
+parameters:
+  snapshot-inuse-volumes: "false"
 
 ---
 

--- a/examples/manila-csi-plugin/helm-deployment/values.yaml
+++ b/examples/manila-csi-plugin/helm-deployment/values.yaml
@@ -21,7 +21,7 @@ csimanila:
   # nodeAZ: "$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq -r .availability_zone)"
   # Image spec
   image:
-    repository: manila-csi-plugin
+    repository: k8scloudprovider/manila-csi-plugin
     tag: latest
     pullPolicy: IfNotPresent
 

--- a/manifests/manila-csi-plugin/csi-controllerplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-controllerplugin.yaml
@@ -40,6 +40,8 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
+            # To enable topology awareness in csi-provisioner, uncomment the following line:
+            # - "--feature-gates=Topology=true"
           env:
             - name: ADDRESS
               value: "unix:///var/lib/kubelet/plugins/manila.csi.openstack.org/csi-controllerplugin.sock"
@@ -65,14 +67,20 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: "manila-csi-plugin:latest"
-          args:
-            - "--v=5"
-            - "--nodeid=$(NODE_ID)"
-            - "--endpoint=$(CSI_ENDPOINT)"
-            - "--drivername=$(DRIVER_NAME)"
-            - "--share-protocol-selector=$(MANILA_SHARE_PROTO)"
-            - "--fwdendpoint=$(FWD_CSI_ENDPOINT)"
+          image: "k8scloudprovider/manila-csi-plugin:latest"
+          command: ["/bin/sh", "-c",
+            '/bin/manila-csi-plugin
+            --v=5
+            --nodeid=$(NODE_ID)
+            --endpoint=$(CSI_ENDPOINT)
+            --drivername=$(DRIVER_NAME)
+            --share-protocol-selector=$(MANILA_SHARE_PROTO)
+            --fwdendpoint=$(FWD_CSI_ENDPOINT)'
+            # To enable topology awareness and retrieve compute node AZs from the OpenStack Metadata Service, add the following flags:
+            # --with-topology
+            # --nodeaz=$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq -r .availability_zone)
+            # Those flags need to be added to csi-nodeplugin.yaml as well.
+          ]
           env:
             - name: DRIVER_NAME
               value: manila.csi.openstack.org

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -51,14 +51,20 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: "manila-csi-plugin:latest"
-          args:
-            - "--v=5"
-            - "--nodeid=$(NODE_ID)"
-            - "--endpoint=$(CSI_ENDPOINT)"
-            - "--drivername=$(DRIVER_NAME)"
-            - "--share-protocol-selector=$(MANILA_SHARE_PROTO)"
-            - "--fwdendpoint=$(FWD_CSI_ENDPOINT)"
+          image: "k8scloudprovider/manila-csi-plugin:latest"
+          command: ["/bin/sh", "-c",
+            '/bin/manila-csi-plugin
+            --v=5
+            --nodeid=$(NODE_ID)
+            --endpoint=$(CSI_ENDPOINT)
+            --drivername=$(DRIVER_NAME)
+            --share-protocol-selector=$(MANILA_SHARE_PROTO)
+            --fwdendpoint=$(FWD_CSI_ENDPOINT)'
+            # To enable topology awareness and retrieve compute node AZs from the OpenStack Metadata Service, add the following flags:
+            # --with-topology
+            # --nodeaz=$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq -r .availability_zone)
+            # Those flags need to be added to csi-controllerplugin.yaml as well.
+          ]
           env:
             - name: DRIVER_NAME
               value: manila.csi.openstack.org

--- a/pkg/csi/cinder/openstack/openstack_snapshots.go
+++ b/pkg/csi/cinder/openstack/openstack_snapshots.go
@@ -20,6 +20,7 @@ package openstack
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
@@ -34,15 +35,26 @@ const (
 	snapReadySteps      = 10
 
 	snapshotDescription = "Created by OpenStack Cinder CSI driver"
+	snapshotForceCreate = "snapshot-inuse-volumes"
 )
 
 // CreateSnapshot issues a request to take a Snapshot of the specified Volume with the corresponding ID and
 // returns the resultant gophercloud Snapshot Item upon success
 func (os *OpenStack) CreateSnapshot(name, volID string, tags *map[string]string) (*snapshots.Snapshot, error) {
+
+	force := false
+	// if no flag given, then force will be false by default
+	// if flag it given , check it
+	if item, ok := (*tags)[snapshotForceCreate]; ok {
+		force, _ = strconv.ParseBool(item)
+		delete(*tags, snapshotForceCreate)
+	}
+	// Force the creation of snapshot even the Volume is in in-use state
 	opts := &snapshots.CreateOpts{
 		VolumeID:    volID,
 		Name:        name,
 		Description: snapshotDescription,
+		Force:       force,
 	}
 	if tags != nil {
 		opts.Metadata = *tags

--- a/pkg/csi/manila/driver.go
+++ b/pkg/csi/manila/driver.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila/csiclient"
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila/manilaclient"
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila/options"
+	"k8s.io/cloud-provider-openstack/pkg/version"
 	"k8s.io/klog"
 )
 
@@ -56,7 +57,7 @@ type Driver struct {
 	nodeAZ       string
 	withTopology bool
 	name         string
-	version      string
+	fqVersion    string // Fully qualified version in format {driverVersion}@{CPO version}
 	shareProto   string
 
 	serverEndpoint string
@@ -106,9 +107,8 @@ func NewDriver(o *DriverOpts) (*Driver, error) {
 		}
 	}
 
-	klog.Infof("Driver: %s version: %s CSI spec version: %s", o.DriverName, driverVersion, specVersion)
-
 	d := &Driver{
+		fqVersion:           fmt.Sprintf("%s@%s", driverVersion, version.Version),
 		nodeID:              o.NodeID,
 		nodeAZ:              o.NodeAZ,
 		withTopology:        o.WithTopology,
@@ -120,6 +120,10 @@ func NewDriver(o *DriverOpts) (*Driver, error) {
 		manilaClientBuilder: o.ManilaClientBuilder,
 		csiClientBuilder:    o.CSIClientBuilder,
 	}
+
+	klog.Info("Driver: ", d.name)
+	klog.Info("Driver version: ", d.fqVersion)
+	klog.Info("CSI spec version: ", specVersion)
 
 	getShareAdapter(d.shareProto) // The program will terminate with a non-zero exit code if the share protocol selector is wrong
 	klog.Infof("Operating on %s shares", d.shareProto)

--- a/pkg/csi/manila/identityserver.go
+++ b/pkg/csi/manila/identityserver.go
@@ -34,7 +34,7 @@ func (ids *identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPlugin
 
 	return &csi.GetPluginInfoResponse{
 		Name:          ids.d.name,
-		VendorVersion: driverVersion,
+		VendorVersion: ids.d.fqVersion,
 	}, nil
 }
 


### PR DESCRIPTION
**The binaries affected**:

<!--
1. Please add the binary name in the title, e.g. `[cinder-csi-plugin]: Add UDP protocol support` unless the PR affects multiple binaries.
2. Use `[OCCM]` for openstack-cloud-controller-manager.
3. Insert 'x' in '[ ]' for tick, i.e. [x] cinder-csi-plugin
-->

- [ ] All
- [ ] openstack-cloud-controller-manager(OCCM)
- [x] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:

**Which issue this PR fixes**:
fixes #832 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. openstack-cloud-controller-manager: Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
