### PR TITLE
Improve the issue and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,18 @@
-<!-- This form is for bug reports and feature requests! -->
+<!--
+Please add the affected binary name in the title unless multiple binaries are affected, e.g.
+[cinder-csi-plugin] Cannot delete PV
+For openstack-cloud-controller-manager, you can use [occm] for short.
+
+All the currently maintained binaries are:
+* openstack-cloud-controller-manager (occm)
+* cinder-csi-plugin
+* manila-csi-plugin
+* k8s-keystone-auth
+* client-keystone-auth
+* octavia-ingress-controller
+* magnum-auto-healer
+* barbican-kms-plugin
+-->
 
 **Is this a BUG REPORT or FEATURE REQUEST?**:
 
@@ -6,18 +20,6 @@
 >
 > /kind bug
 > /kind feature
-
-**The binaries affected**:
-
-- [ ] openstack-cloud-controller-manager
-- [ ] cinder-csi-plugin
-- [ ] k8s-keystone-auth
-- [ ] client-keystone-auth
-- [ ] octavia-ingress-controller
-- [ ] manila-csi-plugin
-- [ ] manila-provisioner
-- [ ] magnum-auto-healer
-- [ ] barbican-kms-plugin
 
 **What happened**:
 
@@ -32,6 +34,6 @@
 
 
 **Environment**:
-- openstack-cloud-controller-manager version:
+- openstack-cloud-controller-manager(or other related binary) version:
 - OpenStack version:
 - Others:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,24 +1,22 @@
-**The binaries affected**:
-
 <!--
-1. Please add the binary name in the title, e.g. `[cinder-csi-plugin]: Add UDP protocol support` unless the PR affects multiple binaries.
-2. Use `[OCCM]` for openstack-cloud-controller-manager.
-3. Insert 'x' in '[ ]' for tick, i.e. [x] cinder-csi-plugin
--->
+Please add the affected binary name in the title unless multiple binaries are affected, e.g.
+[cinder-csi-plugin] Fix volume deletion
+For openstack-cloud-controller-manager, you can use [occm] for short.
 
-- [ ] All
-- [ ] openstack-cloud-controller-manager(OCCM)
-- [ ] cinder-csi-plugin
-- [ ] k8s-keystone-auth
-- [ ] client-keystone-auth
-- [ ] octavia-ingress-controller
-- [ ] manila-csi-plugin
-- [ ] magnum-auto-healer
-- [ ] barbican-kms-plugin
+All the currently maintained binaries are:
+* openstack-cloud-controller-manager (occm)
+* cinder-csi-plugin
+* manila-csi-plugin
+* k8s-keystone-auth
+* client-keystone-auth
+* octavia-ingress-controller
+* magnum-auto-healer
+* barbican-kms-plugin
+-->
 
 **What this PR does / why we need it**:
 
-**Which issue this PR fixes**:
+**Which issue this PR fixes(if applicable)**:
 fixes #
 
 **Special notes for reviewers**:


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Adding binary name in the title can make it clear for the reviewers, developers and other interested parties to understand better about what changed.

Remove `The binaries affected` section as it duplicates the purpose.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. openstack-cloud-controller-manager: Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
