### PR TITLE
Bump Go version in make.sh helper script

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -20,4 +20,4 @@
 # GOPATH and handle all of the Go ENV stuff for you.  All you need is Docker
 docker run -it -v "$PWD":/go/src/k8s.io/cloud-provider-openstack:z \
 	-w /go/src/k8s.io/cloud-provider-openstack \
-	golang:1.12 make $1
+	golang:1.13 make $1


### PR DESCRIPTION
**What this PR does / why we need it**:
See #1007

**Which issue this PR fixes(if applicable)**:
Fixes #1007 

**Special notes for reviewers**:
We could consider adding a argument to pass in the Go-version, not sure how this script is used out there though. I'm using it occasionally.

**Release note**:
```release-note
None
```
