### PR TITLE
[cinder-csi-plugin] nit: rename SnapshotReadyStatus to snapshotReadyStatus

### DIFF
--- a/pkg/csi/cinder/openstack/openstack_snapshots.go
+++ b/pkg/csi/cinder/openstack/openstack_snapshots.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	SnapshotReadyStatus = "available"
+	snapshotReadyStatus = "available"
 	snapReadyDuration   = 1 * time.Second
 	snapReadyFactor     = 1.2
 	snapReadySteps      = 10
@@ -64,7 +64,7 @@ func (os *OpenStack) CreateSnapshot(name, volID string, tags *map[string]string)
 // operation.  Valid filter keys are:  Name, Status, VolumeID (TenantID has no effect)
 func (os *OpenStack) ListSnapshots(limit, offset int, filters map[string]string) ([]snapshots.Snapshot, error) {
 	// FIXME: honor the limit, offset and filters later
-	opts := snapshots.ListOpts{Status: SnapshotReadyStatus}
+	opts := snapshots.ListOpts{Status: snapshotReadyStatus}
 	pages, err := snapshots.List(os.blockstorage, opts).AllPages()
 	if err != nil {
 		klog.V(3).Infof("Failed to retrieve snapshots from Cinder: %v", err)
@@ -147,5 +147,5 @@ func (os *OpenStack) snapshotIsReady(snapshotID string) (bool, error) {
 		return false, err
 	}
 
-	return snap.Status == SnapshotReadyStatus, nil
+	return snap.Status == snapshotReadyStatus, nil
 }


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
align with other definitions in the code

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. openstack-cloud-controller-manager: Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
