### PR TITLE
Update the doc of getting-started-provider-dev

### DIFF
--- a/docs/getting-started-provider-dev.md
+++ b/docs/getting-started-provider-dev.md
@@ -251,7 +251,7 @@ cloud-controller-manager-roles.yaml
 you need use following command to create ClusterRole and ClusterRoleBinding
 otherwise the cloud-controller-manager is not able to access k8s API.
 ```
-./cluster/kubectl.sh create -f cluster/addons/rbac/
+./cluster/kubectl.sh create -f $working_dir/cloud-provider-openstack/cluster/addons/rbac/
 ```
 
 Have a good time with OpenStack and Kubernetes!


### PR DESCRIPTION
Update the instruction "./cluster/kubectl.sh create -f cluster/addons/rbac/"
to avoid error arised.

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. openstack-cloud-controller-manager: Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
