### PR TITLE
Fix the build on non linux OS

### DIFF
--- a/pkg/util/blockdevice/blockdevice_unsupported.go
+++ b/pkg/util/blockdevice/blockdevice_unsupported.go
@@ -19,10 +19,17 @@ limitations under the License.
 package blockdevice
 
 import (
-	"k8s.io/klog"
+	"errors"
 )
 
+func IsBlockDevice(path string) (bool, error) {
+	return false, errors.New("IsBlockDevice is not implemented for this OS")
+}
+
+func GetBlockDeviceSize(path string) (int64, error) {
+	return -1, errors.New("GetBlockDeviceSize is not implemented for this OS")
+}
+
 func RescanBlockDeviceGeometry(devicePath string, deviceMountPath string, newSize int64) error {
-	klog.V(1).Info("RescanBlockDeviceGeometry is not implemented for this OS")
-	return nil
+	return errors.New("RescanBlockDeviceGeometry is not implemented for this OS")
 }

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -104,9 +104,9 @@ func (m *Mount) GetDeviceStats(path string) (*DeviceStats, error) {
 	return &DeviceStats{
 		Block: false,
 
-		AvailableBytes: int64(statfs.Bavail) * statfs.Bsize,
-		TotalBytes:     int64(statfs.Blocks) * statfs.Bsize,
-		UsedBytes:      (int64(statfs.Blocks) - int64(statfs.Bfree)) * statfs.Bsize,
+		AvailableBytes: int64(statfs.Bavail) * int64(statfs.Bsize),
+		TotalBytes:     int64(statfs.Blocks) * int64(statfs.Bsize),
+		UsedBytes:      (int64(statfs.Blocks) - int64(statfs.Bfree)) * int64(statfs.Bsize),
 
 		AvailableInodes: int64(statfs.Ffree),
 		TotalInodes:     int64(statfs.Files),


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Currently the build for me on darwin OS fails with:
```
$ make cinder-csi-plugin
CGO_ENABLED=0 GOOS=darwin go build \
		-ldflags "-w -s -X 'k8s.io/cloud-provider-openstack/pkg/version.Version=6567dc99'" \
		-o cinder-csi-plugin \
		cmd/cinder-csi-plugin/main.go
# k8s.io/cloud-provider-openstack/pkg/util/mount
pkg/util/mount/mount.go:83:18: undefined: blockdevice.IsBlockDevice
pkg/util/mount/mount.go:86:16: undefined: blockdevice.GetBlockDeviceSize
pkg/util/mount/mount.go:107:40: invalid operation: int64(statfs.Bavail) * statfs.Bsize (mismatched types int64 and uint32)
pkg/util/mount/mount.go:108:40: invalid operation: int64(statfs.Blocks) * statfs.Bsize (mismatched types int64 and uint32)
pkg/util/mount/mount.go:109:64: invalid operation: (int64(statfs.Blocks) - int64(statfs.Bfree)) * statfs.Bsize (mismatched types int64 and uint32)
^Cmake: *** [cinder-csi-plugin] Interrupt: 2

```

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. openstack-cloud-controller-manager: Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
