### PR TITLE
[cinder-csi-plugin] Add availability zone topology awareness for ephemeral storage

### DIFF
--- a/examples/cinder-csi-plugin/inline/inline-example.yaml
+++ b/examples/cinder-csi-plugin/inline/inline-example.yaml
@@ -15,7 +15,7 @@ spec:
     csi:
       driver: cinder.csi.openstack.org
       volumeAttributes:
-          capacity: 1Gi # default is 1Gi
+        capacity: 1Gi # default is 1Gi
       readOnly: false  # default is false
       fsType: ext4 # default is ext4
 

--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -129,7 +129,7 @@ func TestNodePublishVolumeEphermeral(t *testing.T) {
 	properties := map[string]string{"cinder.csi.openstack.org/cluster": FakeCluster}
 	fvolName := fmt.Sprintf("ephemeral-%s", FakeVolID)
 
-	omock.On("CreateVolume", fvolName, 2, "", "", "", "", &properties).Return(&FakeVol, nil)
+	omock.On("CreateVolume", fvolName, 2, "", "nova", "", "", &properties).Return(&FakeVol, nil)
 
 	omock.On("AttachVolume", FakeNodeID, FakeVolID).Return(FakeVolID, nil)
 	omock.On("WaitDiskAttached", FakeNodeID, FakeVolID).Return(nil)


### PR DESCRIPTION
* cinder-csi-plugin

**What this PR does / why we need it**:

Add availability zone support for ephemeral storage.

**Which issue this PR fixes(if applicable)**:
fixes #1018

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:

```release-note
[cinder-csi-plugin] Add availability zone topology awareness for ephemeral storage
```
