### PR TITLE
[occm] Support multiple network names

### DIFF
--- a/docs/using-openstack-cloud-controller-manager.md
+++ b/docs/using-openstack-cloud-controller-manager.md
@@ -135,9 +135,9 @@ The options in `Global` section are used for openstack-cloud-controller-manager 
 * `ipv6-support-disabled`
   Indicates whether or not IPv6 is supported. Default: false
 * `public-network-name`
-  The name of Neutron external network. openstack-cloud-controller-manager uses this option when getting the external IP of the Kubernetes node. Default: ""
+  The name of Neutron external network. openstack-cloud-controller-manager uses this option when getting the external IP of the Kubernetes node. Can be specified multiple times. Specified network names will be ORed. Default: ""
 * `internal-network-name`
-  The name of Neutron internal network. openstack-cloud-controller-manager uses this option when getting the internal IP of the Kubernetes node, this is useful if the node has multiple interfaces. Default: ""
+  The name of Neutron internal network. openstack-cloud-controller-manager uses this option when getting the internal IP of the Kubernetes node, this is useful if the node has multiple interfaces. Can be specified multiple times. Specified network names will be ORed. Default: ""
 
 ###  Load Balancer
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In some intricate network designs, it is possible to have multiple networks on different hosts. This PR allows the user to specify multiple network names that may be considered public or private on cluster's nodes.

**Special notes for reviewers**:

I've tried to maintain complete backward compatibility. Due to the way gcfg works, it is possible to specify arrays via repeated use of the same key.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. openstack-cloud-controller-manager: Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] Support multiple network names for config options `internal-network-name` and `public-network-name`.
```
