### PR TITLE
[manila-csi-plugin] report fully qualified version

### DIFF
--- a/pkg/csi/manila/driver.go
+++ b/pkg/csi/manila/driver.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila/csiclient"
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila/manilaclient"
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila/options"
+	"k8s.io/cloud-provider-openstack/pkg/version"
 	"k8s.io/klog"
 )
 
@@ -56,7 +57,7 @@ type Driver struct {
 	nodeAZ       string
 	withTopology bool
 	name         string
-	version      string
+	fqVersion    string // Fully qualified version in format {driverVersion}@{CPO version}
 	shareProto   string
 
 	serverEndpoint string
@@ -106,9 +107,8 @@ func NewDriver(o *DriverOpts) (*Driver, error) {
 		}
 	}
 
-	klog.Infof("Driver: %s version: %s CSI spec version: %s", o.DriverName, driverVersion, specVersion)
-
 	d := &Driver{
+		fqVersion:           fmt.Sprintf("%s@%s", driverVersion, version.Version),
 		nodeID:              o.NodeID,
 		nodeAZ:              o.NodeAZ,
 		withTopology:        o.WithTopology,
@@ -120,6 +120,10 @@ func NewDriver(o *DriverOpts) (*Driver, error) {
 		manilaClientBuilder: o.ManilaClientBuilder,
 		csiClientBuilder:    o.CSIClientBuilder,
 	}
+
+	klog.Info("Driver: ", d.name)
+	klog.Info("Driver version: ", d.fqVersion)
+	klog.Info("CSI spec version: ", specVersion)
 
 	getShareAdapter(d.shareProto) // The program will terminate with a non-zero exit code if the share protocol selector is wrong
 	klog.Infof("Operating on %s shares", d.shareProto)

--- a/pkg/csi/manila/identityserver.go
+++ b/pkg/csi/manila/identityserver.go
@@ -34,7 +34,7 @@ func (ids *identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPlugin
 
 	return &csi.GetPluginInfoResponse{
 		Name:          ids.d.name,
-		VendorVersion: driverVersion,
+		VendorVersion: ids.d.fqVersion,
 	}, nil
 }
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Currently, manila-csi-plugin is reporting only the driver's semantic version. This PR makes it so that the cloud-provider-openstack's version is part of the reported version too. This will help identify the exact version of the driver e.g. when troubleshooting a problem.

The format used for the fully qualified version is `{driver version}@{CPO version}`, where "CPO version" is passed in via linker flags in Makefile as a git hash:

https://github.com/kubernetes/cloud-provider-openstack/blob/b2335ad887a06e28acdf56e2d0933289bcb0ddfe/Makefile#L34-L35

It's advertised in:
* logs during initialization
* identity service's `GetPluginInfoResponse`

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. openstack-cloud-controller-manager: Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
