### PR TITLE
[cinder-csi-plugin] Backport fixes to 1.17

### DIFF
--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -212,7 +212,7 @@ func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 			klog.V(3).Infof("ControllerUnpublishVolume assuming volume %s is detached, because node %s does not exist", volumeID, instanceID)
 			return &csi.ControllerUnpublishVolumeResponse{}, nil
 		}
-		return nil, status.Error(codes.Internal, fmt.Sprintf("ControllerUnpublishVolume GetInstanceByID failed with error %v", err))
+		return nil, status.Error(codes.Internal, fmt.Sprintf("ControllerUnpublishVolume GetInstanceByID failed with error: %v", err))
 	}
 
 	err = cs.Cloud.DetachVolume(instanceID, volumeID)

--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -284,10 +284,13 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	m := ns.Mount
 	notMnt, err := m.IsLikelyNotMountPointDetach(targetPath)
 	if err != nil && !mount.IsCorruptedMnt(err) {
+		klog.V(4).Infof("NodeUnpublishVolume: unable to unmount volume: %v", err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	if notMnt && !mount.IsCorruptedMnt(err) {
-		return nil, status.Error(codes.NotFound, "Volume not mounted")
+		// the volume is not mounted at all. There is no need for retrying to unmount.
+		klog.V(4).Infoln("NodeUnpublishVolume: skipping... not mounted any more")
+		return &csi.NodeUnpublishVolumeResponse{}, nil
 	}
 
 	err = m.UnmountPath(targetPath)
@@ -416,6 +419,7 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 	_, err := ns.Cloud.GetVolume(volumeID)
 	if err != nil {
 		if cpoerrors.IsNotFound(err) {
+			klog.V(4).Infof("NodeUnstageVolume: Unable to find volume: %v", err)
 			return nil, status.Error(codes.NotFound, "Volume not found")
 		}
 		return nil, status.Error(codes.Internal, fmt.Sprintf("GetVolume failed with error %v", err))
@@ -425,10 +429,13 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 
 	notMnt, err := m.IsLikelyNotMountPointDetach(stagingTargetPath)
 	if err != nil && !mount.IsCorruptedMnt(err) {
+		klog.V(4).Infof("NodeUnstageVolume: unable to unmount volume: %v", err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	if notMnt && !mount.IsCorruptedMnt(err) {
-		return nil, status.Error(codes.NotFound, "Volume not mounted")
+		// the volume is not mounted at all. There is no need for retrying to unmount.
+		klog.V(4).Infoln("NodeUnstageVolume: skipping... not mounted any more")
+		return &csi.NodeUnstageVolumeResponse{}, nil
 	}
 
 	err = m.UnmountPath(stagingTargetPath)


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Backport #925 , #897 to release-1.17 
**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. openstack-cloud-controller-manager: Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
