### PR TITLE
[k8s-keystone-auth] Disable the CI job for k8s-keystone-auth in release-1.17

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -27,15 +27,16 @@
               - ^OWNERS$
               - ^SECURITY_CONTACTS$
               - ^.gitignore$
-    cloud-provider-openstack-acceptance-test-keystone-authentication-authorization:
-      jobs:
-        - cloud-provider-openstack-acceptance-test-keystone-authentication-authorization:
-            irrelevant-files:
-              - ^docs/.*$
-              - ^.*\.md$
-              - ^OWNERS$
-              - ^SECURITY_CONTACTS$
-              - ^.gitignore$
+    # Disable this job only for release-1.17 branch because the job was refactored since release-1.18
+    # cloud-provider-openstack-acceptance-test-keystone-authentication-authorization:
+    #   jobs:
+    #     - cloud-provider-openstack-acceptance-test-keystone-authentication-authorization:
+    #         irrelevant-files:
+    #           - ^docs/.*$
+    #           - ^.*\.md$
+    #           - ^OWNERS$
+    #           - ^SECURITY_CONTACTS$
+    #           - ^.gitignore$
     cloud-provider-openstack-acceptance-test-k8s-cinder:
       jobs:
         - cloud-provider-openstack-acceptance-test-k8s-cinder:


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Disable this job only for release-1.17 branch because the job was refactored since release-1.18

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```