### PR TITLE
[cinder-csi-plugin] Allow force create snapshot

### DIFF
--- a/docs/using-cinder-csi-plugin.md
+++ b/docs/using-cinder-csi-plugin.md
@@ -32,7 +32,7 @@ Check [kubernetes CSI Docs](https://kubernetes-csi.github.io/docs/) for flag det
 
 ### Deploy
 
-If you already created the `cloud-config` secret used by the [cloud-controller-manager](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/using-controller-manager-with-kubeadm.md#steps), remove the file ```manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml``` and then jump directly to the `kubectl apply ...` command.
+If you already created the `cloud-config` secret used by the [cloud-controller-manager](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/using-openstack-cloud-controller-manager.md#steps), remove the file ```manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml``` from [manifests](https://github.com/kubernetes/cloud-provider-openstack/tree/master/manifests/cinder-csi-plugin) and then jump directly to the `kubectl apply ...` command.
 
 Encode your ```$CLOUD_CONFIG``` file content using base64.
 
@@ -58,7 +58,7 @@ volumes:
     type: Directory
 ```
 
-Then call following command by using existing manifests:
+Then call following command by using existing [manifests](https://github.com/kubernetes/cloud-provider-openstack/tree/master/manifests/cinder-csi-plugin):
 
 ```kubectl -f manifests/cinder-csi-plugin apply```
 
@@ -100,7 +100,7 @@ Events:               <none>
 ### Example Nginx application usage
 
 After performing above steps, you can try to create StorageClass, PersistentVolumeClaim and pod to consume it.
-Try following command:
+Try following command by using [examples](https://github.com/kubernetes/cloud-provider-openstack/blob/master/examples/cinder-csi-plugin/nginx.yaml):
 
 ```kubectl -f examples/cinder-csi-plugin/nginx.yaml create```
 

--- a/docs/using-cinder-csi-plugin.md
+++ b/docs/using-cinder-csi-plugin.md
@@ -197,8 +197,10 @@ Following prerequisite needed for volume snapshot feature to work.
 1. Enable `--feature-gates=VolumeSnapshotDataSource=true` in kube-apiserver
 2. Make sure, your csi deployment contains external-snapshotter sidecar container, external-snapshotter sidecar container will create three crd's for snapshot management VolumeSnapshot,VolumeSnapshotContent, and VolumeSnapshotClass. external-snapshotter is a part of `csi-cinder-controllerplugin`
 
-For Snapshot Creation and Volume Restore, please follow below steps:
+Supported parameters for VolumeSnapshotClass:
+* `force-create`: Support creating snapshot for a volume in in-use status.
 
+For Snapshot Creation and Volume Restore, please follow below steps:
 * Create Storage Class, Snapshot Class and PVC    
 ```
 $ kubectl -f examples/cinder-csi-plugin/snapshot/example.yaml create
@@ -206,6 +208,7 @@ storageclass.storage.k8s.io/csi-sc-cinderplugin created
 volumesnapshotclass.snapshot.storage.k8s.io/csi-cinder-snapclass created
 persistentvolumeclaim/pvc-snapshot-demo created
 ```
+
 * Verify that pvc is bounded
 ``` 
 $ kubectl get pvc --all-namespaces
@@ -216,7 +219,7 @@ default     pvc-snapshot-demo   Bound    pvc-4699fa78-4149-4772-b900-9536891fe20
 ```
 $ kubectl -f examples/cinder-csi-plugin/snapshot/snapshotcreate.yaml create
 volumesnapshot.snapshot.storage.k8s.io/new-snapshot-demo created
-```       
+```
 * Verify that snapshot is created    
 ```
 $ kubectl get volumesnapshot 

--- a/examples/cinder-csi-plugin/snapshot/example.yaml
+++ b/examples/cinder-csi-plugin/snapshot/example.yaml
@@ -11,6 +11,8 @@ kind: VolumeSnapshotClass
 metadata:
   name: csi-cinder-snapclass
 snapshotter: cinder.csi.openstack.org
+parameters:
+  force-create: "false"
 
 ---
 


### PR DESCRIPTION
**The binaries affected**:

<!--
1. Please add the binary name in the title, e.g. `[cinder-csi-plugin]: Add UDP protocol support` unless the PR affects multiple binaries.
2. Use `[OCCM]` for openstack-cloud-controller-manager.
3. Insert 'x' in '[ ]' for tick, i.e. [x] cinder-csi-plugin
-->

- [ ] All
- [ ] openstack-cloud-controller-manager(OCCM)
- [x] cinder-csi-plugin
- [ ] k8s-keystone-auth
- [ ] client-keystone-auth
- [ ] octavia-ingress-controller
- [ ] manila-csi-plugin
- [ ] magnum-auto-healer
- [ ] barbican-kms-plugin

**What this PR does / why we need it**:

**Which issue this PR fixes**:
fixes #832 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. openstack-cloud-controller-manager: Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[cinder-csi-plugin] Added `force-create` parameter in VolumeSnapshotClass to support creating snapshot for a volume in in-use status.
```
