### PR TITLE
[OCCM] Print error messages, when OpenStack client returns error

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -865,16 +865,19 @@ func (os *OpenStack) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 
 	network, err := os.NewNetworkV2()
 	if err != nil {
+		klog.Errorf("Failed to create an OpenStack Network client: %v", err)
 		return nil, false
 	}
 
 	compute, err := os.NewComputeV2()
 	if err != nil {
+		klog.Errorf("Failed to create an OpenStack Compute client: %v", err)
 		return nil, false
 	}
 
 	lb, err := os.NewLoadBalancerV2()
 	if err != nil {
+		klog.Errorf("Failed to create an OpenStack LoadBalancer client: %v", err)
 		return nil, false
 	}
 
@@ -970,6 +973,7 @@ func (os *OpenStack) Routes() (cloudprovider.Routes, bool) {
 
 	network, err := os.NewNetworkV2()
 	if err != nil {
+		klog.Errorf("Failed to create an OpenStack Network client: %v", err)
 		return nil, false
 	}
 
@@ -986,6 +990,7 @@ func (os *OpenStack) Routes() (cloudprovider.Routes, bool) {
 
 	compute, err := os.NewComputeV2()
 	if err != nil {
+		klog.Errorf("Failed to create an OpenStack Compute client: %v", err)
 		return nil, false
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Now OCCM prints error message, when a required endpoint cannot be found.

**Special notes for reviewers**:

Due to #977 OCCM stopped to work silently, there were no errors showed in logs. It took a while to debug the root cause.

**Release note**:

```release-note
None
```

/cc @rfranzke
/assign @lingxiankong 