### PR TITLE
[occm] make cascade deletion configurable

### DIFF
--- a/docs/using-openstack-cloud-controller-manager.md
+++ b/docs/using-openstack-cloud-controller-manager.md
@@ -173,7 +173,8 @@ Although the openstack-cloud-controller-manager was initially implemented with N
   Deprecated.
 * `internal-lb`
   Determines whether or not to create an internal load balancer (no floating IP) by default. Default: false.
-
+* `cascade-delete`
+  Determines whether or not to perform cascade deletion of load balancers. Default: true.
 ### Metadata
 
 * `search-order`

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -132,7 +132,8 @@ type LoadBalancerOpts struct {
 	MonitorMaxRetries    uint                `gcfg:"monitor-max-retries"`
 	ManageSecurityGroups bool                `gcfg:"manage-security-groups"`
 	NodeSecurityGroupIDs []string            // Do not specify, get it automatically when enable manage-security-groups. TODO(FengyunPan): move it into cache
-	InternalLB           bool                `gcfg:"internal-lb"` // default false
+	InternalLB           bool                `gcfg:"internal-lb"`    // default false
+	CascadeDelete        bool                `gcfg:"cascade-delete"` // applicable only if use-octavia is set to True
 }
 
 // LBClass defines the corresponding floating network, floating subnet or internal subnet ID
@@ -378,6 +379,7 @@ func ReadConfig(config io.Reader) (Config, error) {
 	cfg.LoadBalancer.MonitorDelay = MyDuration{5 * time.Second}
 	cfg.LoadBalancer.MonitorTimeout = MyDuration{3 * time.Second}
 	cfg.LoadBalancer.MonitorMaxRetries = 1
+	cfg.LoadBalancer.CascadeDelete = true
 
 	err := gcfg.FatalOnly(gcfg.ReadInto(&cfg, config))
 

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -1857,7 +1857,7 @@ func (lbaas *LbaasV2) EnsureLoadBalancerDeleted(ctx context.Context, clusterName
 	}
 
 	// delete the loadbalancer and all its sub-resources.
-	if lbaas.opts.UseOctavia {
+	if lbaas.opts.UseOctavia && lbaas.opts.CascadeDelete {
 		deleteOpts := loadbalancers.DeleteOpts{Cascade: true}
 		if err := loadbalancers.Delete(lbaas.lb, loadbalancer.ID, deleteOpts).ExtractErr(); err != nil {
 			return fmt.Errorf("failed to delete loadbalancer %s: %v", loadbalancer.ID, err)


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Make cascade deletion of load balancers configurable

If octavia is used, occm tries to perform cascade deletion of load balancers. Some Octavia provider drivers might not support cascade deletion, therefore this PR makes cascade deletion option configurable. By default, cascade deletion is enabled.

**Special notes for reviewers**:
Cascade deletion can be enabled/disabled by setting `cascade-delete` option in cloud-config file.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
[openstack-cloud-controller-manager] Make cascade deletion configurable when Octavia is enabled.
```
