### PR TITLE
update reviewers list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,18 +7,12 @@ approvers:
 - zetaab
 reviewers:
 - adisky
-- anguslees
 - chrigl
 - dims
-- dixudx
 - Fedosin
-- FengyunPan2
-- flaper87
 - hogepodge
 - jichenjc
 - lingxiankong
-- mrhillsman
 - ramineni
 - ricolin
-- rootfs
 - zetaab


### PR DESCRIPTION
As requested https://github.com/kubernetes/cloud-provider-openstack/pull/969#pullrequestreview-397067830 , many of the contributors are not active in the project anymore over a year. Removing them from the reviewers list to avoid automatic assignment of PRs

Happy to add them if they are active in project again :) 
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
