### PR TITLE
[occm] Address detection logic fixes

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 
-	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/cloud-provider-openstack/pkg/util/errors"
@@ -112,7 +112,12 @@ func (i *Instances) NodeAddressesByProviderID(ctx context.Context, providerID st
 		return []v1.NodeAddress{}, err
 	}
 
-	addresses, err := nodeAddresses(server, interfaces, i.networkingOpts)
+	networkIdsToNameMapping, err := mapNetworkIdsToNames(i.compute)
+	if err != nil {
+		return nil, err
+	}
+
+	addresses, err := nodeAddresses(server, interfaces, networkIdsToNameMapping, i.networkingOpts)
 	if err != nil {
 		return []v1.NodeAddress{}, err
 	}

--- a/pkg/cloudprovider/providers/openstack/openstack_routes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_routes.go
@@ -66,7 +66,12 @@ func (r *Routes) ListRoutes(ctx context.Context, clusterName string) ([]*cloudpr
 			return false, err
 		}
 
-		addrs, err := nodeAddresses(srv, interfaces, r.networkingOpts)
+		networkIdsToNameMapping, err := mapNetworkIdsToNames(r.network)
+		if err != nil {
+			return false, err
+		}
+
+		addrs, err := nodeAddresses(srv, interfaces, networkIdsToNameMapping, r.networkingOpts)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -471,7 +471,7 @@ func TestNodeAddresses(t *testing.T) {
 		},
 	}
 
-	addrs, err := nodeAddresses(&srv, interfaces, networkingOpts)
+	addrs, err := nodeAddresses(&srv, interfaces, nil, networkingOpts)
 	if err != nil {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}
@@ -550,7 +550,7 @@ func TestNodeAddressesCustomPublicNetwork(t *testing.T) {
 		},
 	}
 
-	addrs, err := nodeAddresses(&srv, interfaces, networkingOpts)
+	addrs, err := nodeAddresses(&srv, interfaces, nil, networkingOpts)
 	if err != nil {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}
@@ -580,12 +580,6 @@ func TestNodeAddressesMultipleCustomInternalNetworks(t *testing.T) {
 		AccessIPv6: "2001:4800:790e:510:be76:4eff:fe04:82a8",
 		Addresses: map[string]interface{}{
 			"private": []interface{}{
-				map[string]interface{}{
-					"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:7c:1b:2b",
-					"version":                 float64(4),
-					"addr":                    "10.0.0.32",
-					"OS-EXT-IPS:type":         "fixed",
-				},
 				map[string]interface{}{
 					"version":         float64(4),
 					"addr":            "50.56.176.36",
@@ -632,10 +626,12 @@ func TestNodeAddressesMultipleCustomInternalNetworks(t *testing.T) {
 					IPAddress: "10.0.0.31",
 				},
 			},
+			NetID: "test",
 		},
 	}
 
-	addrs, err := nodeAddresses(&srv, interfaces, networkingOpts)
+	netIdsToNamesMapping := map[string]string{"test": "test"}
+	addrs, err := nodeAddresses(&srv, interfaces, netIdsToNamesMapping, networkingOpts)
 	if err != nil {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}
@@ -643,12 +639,11 @@ func TestNodeAddressesMultipleCustomInternalNetworks(t *testing.T) {
 	t.Logf("addresses are %v", addrs)
 
 	want := []v1.NodeAddress{
-		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
-		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
 		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
 		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
 		{Type: v1.NodeInternalIP, Address: "10.0.0.64"},
 		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
 	}
 
 	if !reflect.DeepEqual(want, addrs) {
@@ -713,7 +708,7 @@ func TestNodeAddressesIPv6Disabled(t *testing.T) {
 		},
 	}
 
-	addrs, err := nodeAddresses(&srv, interfaces, networkingOpts)
+	addrs, err := nodeAddresses(&srv, interfaces, nil, networkingOpts)
 	if err != nil {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
If the `internal-network-name` option is present, ignore FixedIPs from other networks.

**Which issue this PR fixes(if applicable)**:
fixes #1039

**Special notes for reviewers**:
Cherry-pick candidate for branch release-1.18

Similar to #1041, but is a tiny bit harder on the OpenStack API. Also fixes FixedIPs being added that are not specified in the config.

**Release note**:
```release-note
NONE
```