### PR TITLE
[cinder-csi-plugin] Support image-csi-plugin target in Makefile - release-1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,10 @@ cinder-csi-plugin: work $(SOURCES)
 		-o cinder-csi-plugin \
 		cmd/cinder-csi-plugin/main.go
 
+# This target is for supporting CI jobs of release-1.17 branch. We should delete this target once 1.17 support is dropped and change the cinder-csi-plugin related CI jobs to use target image-cinder-csi-plugin
+image-csi-plugin:
+	$(MAKE) image-cinder-csi-plugin
+
 manila-csi-plugin: work $(SOURCES)
 	CGO_ENABLED=0 GOOS=$(GOOS) go build \
 		-ldflags $(LDFLAGS) \


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This PR is a cherry-pick of #1045.

Add target `image-csi-plugin` in Makefile which is used by CI jobs against previous branches (e.g. release-1.17).

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
As a follow-up, I will change the openlab CI job to use `image-csi-plugin` so we don't break CI of previous branches.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
