### PR TITLE
[occm] fix nil pointer dereference in create loadbalancer func

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -476,15 +476,15 @@ func (lbaas *LbaasV2) createLoadBalancer(service *corev1.Service, name, clusterN
 	}
 
 	loadbalancer, err := loadbalancers.Create(lbaas.lb, createOpts).Extract()
+	if err != nil {
+		return nil, fmt.Errorf("error creating loadbalancer %v: %v", createOpts, err)
+	}
 
 	// when NetworkID is specified, subnet will be selected by the backend for allocating virtual IP
 	if (lbClass != nil && lbClass.NetworkID != "") || lbaas.opts.NetworkID != "" {
 		lbaas.opts.SubnetID = loadbalancer.VipSubnetID
 	}
 
-	if err != nil {
-		return nil, fmt.Errorf("error creating loadbalancer %v: %v", createOpts, err)
-	}
 	return loadbalancer, nil
 }
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Fixes nil pointer dereference error in create load balancer func. 
If the load balancer creation fails then error should be returned instead of accessing VipSubnetID from nil
**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
