### PR TITLE
[cinder-csi-plugin] Fix sanity failures 3/3

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -85,6 +85,26 @@
               - go.mod$
               - go.sum$
               - Makefile$
+            irrelevant-files:
+              - docs/.*$
+              - ^.*\.md$
+              - ^OWNERS$
+              - ^SECURITY_CONTACTS$
+    cloud-provider-openstack-sanity-test-csi-cinder:
+      jobs:
+        - cloud-provider-openstack-sanity-test-csi-cinder:
+            files:
+              - cmd/cinder-csi-plugin/.*
+              - pkg/csi/cinder/.*
+              - pkg/util/.*
+              - go.mod$
+              - go.sum$
+              - Makefile$
+            irrelevant-files:
+              - docs/.*$
+              - ^.*\.md$
+              - ^OWNERS$
+              - ^SECURITY_CONTACTS$
     cloud-provider-openstack-multinode-csi-migration-test:
       jobs:
         - cloud-provider-openstack-multinode-csi-migration-test:

--- a/pkg/csi/cinder/fake.go
+++ b/pkg/csi/cinder/fake.go
@@ -88,6 +88,7 @@ var FakeSnapshotRes = snapshots.Snapshot{
 	ID:       FakeSnapshotID,
 	Name:     "fake-snapshot",
 	VolumeID: FakeVolID,
+	Size:     1,
 }
 
 var FakeSnapshotsRes = []snapshots.Snapshot{FakeSnapshotRes}
@@ -95,6 +96,7 @@ var FakeSnapshotsRes = []snapshots.Snapshot{FakeSnapshotRes}
 var FakeVolListMultiple = []volumes.Volume{FakeVol1, FakeVol3}
 var FakeVolList = []volumes.Volume{FakeVol1}
 var FakeVolListEmpty = []volumes.Volume{}
+var FakeSnapshotListEmpty = []snapshots.Snapshot{}
 
 var FakeInstanceID = "321a8b81-3660-43e5-bab8-6470b65ee4e8"
 

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -53,9 +53,8 @@ type IOpenStack interface {
 	GetVolume(volumeID string) (*volumes.Volume, error)
 	GetVolumesByName(name string) ([]volumes.Volume, error)
 	CreateSnapshot(name, volID string, tags *map[string]string) (*snapshots.Snapshot, error)
-	ListSnapshots(limit, offset int, filters map[string]string) ([]snapshots.Snapshot, error)
+	ListSnapshots(filters map[string]string) ([]snapshots.Snapshot, string, error)
 	DeleteSnapshot(snapID string) error
-	GetSnapshotByNameAndVolumeID(n string, volumeId string) ([]snapshots.Snapshot, error)
 	GetSnapshotByID(snapshotID string) (*snapshots.Snapshot, error)
 	WaitSnapshotReady(snapshotID string) error
 	GetInstanceByID(instanceID string) (*servers.Server, error)

--- a/pkg/csi/cinder/openstack/openstack_mock.go
+++ b/pkg/csi/cinder/openstack/openstack_mock.go
@@ -209,26 +209,35 @@ func (_m *OpenStackMock) GetVolumesByName(name string) ([]volumes.Volume, error)
 }
 
 // ListSnapshots provides a mock function with given fields: limit, offset, filters
-func (_m *OpenStackMock) ListSnapshots(limit int, offset int, filters map[string]string) ([]snapshots.Snapshot, error) {
-	ret := _m.Called(limit, offset, filters)
+func (_m *OpenStackMock) ListSnapshots(filters map[string]string) ([]snapshots.Snapshot, string, error) {
+	ret := _m.Called(filters)
 
 	var r0 []snapshots.Snapshot
-	if rf, ok := ret.Get(0).(func(int, int, map[string]string) []snapshots.Snapshot); ok {
-		r0 = rf(limit, offset, filters)
+	if rf, ok := ret.Get(0).(func(map[string]string) []snapshots.Snapshot); ok {
+		r0 = rf(filters)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]snapshots.Snapshot)
 		}
 	}
+	var r1 string
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(int, int, map[string]string) error); ok {
-		r1 = rf(limit, offset, filters)
+	if rf, ok := ret.Get(1).(func(map[string]string) string); ok {
+		r1 = rf(filters)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(string)
+		}
 	}
 
-	return r0, r1
+	var r2 error
+	if rf, ok := ret.Get(2).(func(map[string]string) error); ok {
+		r2 = rf(filters)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // CreateSnapshot provides a mock function with given fields: name, volID, tags
@@ -299,12 +308,6 @@ func (_m *OpenStackMock) ListVolumes(limit int, marker string) ([]volumes.Volume
 	}
 
 	return r0, r1, r2
-}
-
-func (_m *OpenStackMock) GetSnapshotByNameAndVolumeID(n string, volumeId string) ([]snapshots.Snapshot, error) {
-	var slist []snapshots.Snapshot
-	slist = append(slist, fakeSnapshot)
-	return slist, nil
 }
 
 func (_m *OpenStackMock) GetAvailabilityZone() (string, error) {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This PR fixes the sanity test failures, adds the job to the pipeline
**Which issue this PR fixes(if applicable)**:
fixes #793

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
