### PR TITLE
Remove trailing whitespace

### DIFF
--- a/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -69,7 +69,7 @@ spec:
         - name: cinder-csi-plugin
           image: "{{ .Values.csi.plugin.image.repository }}:{{ .Values.csi.plugin.image.tag }}"
           imagePullPolicy: {{ .Values.csi.plugin.image.pullPolicy }}
-          args :
+          args:
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -49,7 +49,7 @@ spec:
             allowPrivilegeEscalation: true
           image: "{{ .Values.csi.plugin.image.repository }}:{{ .Values.csi.plugin.image.tag }}"
           imagePullPolicy: {{ .Values.csi.plugin.image.pullPolicy }}
-          args :
+          args:
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/docs/using-cinder-csi-plugin.md
+++ b/docs/using-cinder-csi-plugin.md
@@ -32,7 +32,7 @@ Check [kubernetes CSI Docs](https://kubernetes-csi.github.io/docs/) for flag det
 
 ### Deploy
 
-You can either use the manifests under `manifests/cinder-csi-plugin` or the Helm chart `charts/cinder-csi-plugin`. 
+You can either use the manifests under `manifests/cinder-csi-plugin` or the Helm chart `charts/cinder-csi-plugin`.
 
 #### Using the Helm chart
 
@@ -85,7 +85,7 @@ csi-cinder-controllerplugin         4/4     Running   0          29h
 csi-cinder-nodeplugin               2/2     Running   0          46h
 ```
 
-you can get information about CSI Drivers running in a cluster, using **CSIDriver** object    
+you can get information about CSI Drivers running in a cluster, using **CSIDriver** object
 
 ```
 $ kubectl get csidrivers.storage.k8s.io
@@ -109,7 +109,7 @@ Spec:
   Pod Info On Mount:  false
 Events:               <none>
 ```
- 
+
 ### Example Nginx application usage
 
 After performing above steps, you can try to create StorageClass, PersistentVolumeClaim and pod to consume it.
@@ -117,7 +117,7 @@ Try following command by using [examples](https://github.com/kubernetes/cloud-pr
 
 ```kubectl -f examples/cinder-csi-plugin/nginx.yaml create```
 
-You will get pvc which claims one volume from cinder 
+You will get pvc which claims one volume from cinder
 
 ```
 $ kubectl get pvc
@@ -214,7 +214,7 @@ Supported parameters for VolumeSnapshotClass:
 * `force-create`: Support creating snapshot for a volume in in-use status.
 
 For Snapshot Creation and Volume Restore, please follow below steps:
-* Create Storage Class, Snapshot Class and PVC    
+* Create Storage Class, Snapshot Class and PVC
 ```
 $ kubectl -f examples/cinder-csi-plugin/snapshot/example.yaml create
 storageclass.storage.k8s.io/csi-sc-cinderplugin created
@@ -223,19 +223,19 @@ persistentvolumeclaim/pvc-snapshot-demo created
 ```
 
 * Verify that pvc is bounded
-``` 
+```
 $ kubectl get pvc --all-namespaces
 NAMESPACE   NAME                STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS          AGE
 default     pvc-snapshot-demo   Bound    pvc-4699fa78-4149-4772-b900-9536891fe200   1Gi        RWO 
-```   
-* Create Snapshot of the PVC    
+```
+* Create Snapshot of the PVC
 ```
 $ kubectl -f examples/cinder-csi-plugin/snapshot/snapshotcreate.yaml create
 volumesnapshot.snapshot.storage.k8s.io/new-snapshot-demo created
 ```
-* Verify that snapshot is created    
+* Verify that snapshot is created
 ```
-$ kubectl get volumesnapshot 
+$ kubectl get volumesnapshot
 NAME                AGE
 new-snapshot-demo   2m54s
 $ openstack snapshot list
@@ -244,13 +244,13 @@ $ openstack snapshot list
 +--------------------------------------+-----------------------------------------------+-------------+-----------+------+
 | 1b673af2-3a69-4cc6-8dd0-9ac62e29df9e | snapshot-332a8a7e-c5f2-4df9-b6a0-cf52e18e72b1 | None        | available |    1 |
 +--------------------------------------+-----------------------------------------------+-------------+-----------+------+
-```   
-* Restore volume from snapshot    
+```
+* Restore volume from snapshot
 ```
 $ kubectl -f examples/cinder-csi-plugin/snapshot/snapshotrestore.yaml create
 persistentvolumeclaim/snapshot-demo-restore created
 ```
-* Verify that volume from snapshot is created    
+* Verify that volume from snapshot is created
 ```
 $ kubectl get pvc
 NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS          AGE
@@ -263,7 +263,7 @@ $ openstack volume list
 +--------------------------------------+------------------------------------------+-----------+------+-------------------------------------------------+
 | 07522a3b-95db-4bfa-847c-ffa179d08c39 | pvc-400b1ca8-8786-435f-a6cc-f684afddbbea | available |    1 |                                                 |
 | bf8f9ae9-87b4-42bb-b74c-ba4645634be6 | pvc-4699fa78-4149-4772-b900-9536891fe200 | available |    1 |                                                 |
-``` 
+```
 ### Example: Raw Block Volume
 
 For consuming a cinder volume as a raw block device
@@ -351,20 +351,20 @@ Not all hypervizors have a `/sys/class/block/XXX/device/rescan` location, theref
 
 ### Inline Volumes
 
-This feature allows CSI volumes to be directly embedded in the Pod specification instead of a PersistentVolume. Volumes specified in this way are ephemeral and do not persist across Pod restarts. As of Kubernetes v1.16 this feature is beta so enabled by default. To enable this feature for CSI Driver, `volumeLifecycleModes` needs to be specified in [CSIDriver](https://github.com/kubernetes/cloud-provider-openstack/blob/master/manifests/cinder-csi-plugin/csi-cinder-driver.yaml) object. The driver can run in `Persistent` mode, `Ephemeral` or in both modes. `podInfoOnMount` must be `true` to use this feature. 
+This feature allows CSI volumes to be directly embedded in the Pod specification instead of a PersistentVolume. Volumes specified in this way are ephemeral and do not persist across Pod restarts. As of Kubernetes v1.16 this feature is beta so enabled by default. To enable this feature for CSI Driver, `volumeLifecycleModes` needs to be specified in [CSIDriver](https://github.com/kubernetes/cloud-provider-openstack/blob/master/manifests/cinder-csi-plugin/csi-cinder-driver.yaml) object. The driver can run in `Persistent` mode, `Ephemeral` or in both modes. `podInfoOnMount` must be `true` to use this feature.
 
 Example:
-1. Deploy CSI Driver, in default yamls both modes are enabled. 
+1. Deploy CSI Driver, in default yamls both modes are enabled.
 ```
 $ kubectl create -f manifests/cinder-csi-plugin/
 ```
 2. Create a pod with inline volume
 ```
-$ kubectl create -f examples/cinder-csi-plugin/inline/inline-example.yaml 
+$ kubectl create -f examples/cinder-csi-plugin/inline/inline-example.yaml
 ```
 3. Get the pod description, verify created volume in Volumes section.
 ```
-$ kubectl describe pod 
+$ kubectl describe pod
 
 Volumes:
   my-csi-volume:

--- a/docs/using-openstack-cloud-controller-manager.md
+++ b/docs/using-openstack-cloud-controller-manager.md
@@ -21,7 +21,7 @@ For more information about cloud-controller-manager, please see:
 - <https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager>
 - <https://kubernetes.io/docs/tasks/administer-cluster/developing-cloud-controller-manager/>
 
-**NOTE: Now, the openstack-cloud-controller-manager implementation is based on OpenStack Octavia, Neutron-LBaaS has been deprecated in OpenStack since Queens release and no longer maintained in openstack-cloud-controller-manager. So make sure to use Octavia if upgrade to the latest openstack-cloud-controller-manager docker image.** 
+**NOTE: Now, the openstack-cloud-controller-manager implementation is based on OpenStack Octavia, Neutron-LBaaS has been deprecated in OpenStack since Queens release and no longer maintained in openstack-cloud-controller-manager. So make sure to use Octavia if upgrade to the latest openstack-cloud-controller-manager docker image.**
 
 ## Deploy a Kubernetes cluster with openstack-cloud-controller-manager using kubeadm
 
@@ -98,7 +98,7 @@ The options in `Global` section are used for openstack-cloud-controller-manager 
 * `domain-name`
   Keystone user domain name, not required if `domain-id` is set.
 * `tenant-id`
-  Keystone project ID. When using Keystone V3 - which changed the identifier `tenant` to `project` - the `tenant-id` value is automatically mapped to the project construct in the API. 
+  Keystone project ID. When using Keystone V3 - which changed the identifier `tenant` to `project` - the `tenant-id` value is automatically mapped to the project construct in the API.
 
   `tenant-id` is not needed when using `trust-id` or [Keystone application credential](https://docs.openstack.org/keystone/latest/user/application_credentials.html)
 * `tenant-name`
@@ -107,7 +107,7 @@ The options in `Global` section are used for openstack-cloud-controller-manager 
   Keystone project domain ID.
 * `tenant-domain-name`
   Keystone project domain name.
-* `user-domain-id`: 
+* `user-domain-id`
   Keystone user domain ID.
 * `user-domain-name`
   Keystone user domain name.
@@ -183,7 +183,7 @@ Although the openstack-cloud-controller-manager was initially implemented with N
   * `metadataService` - Only retrieve instance metadata from the metadata service.
   * `metadataService,configDrive` - Retrieve instance metadata from the metadata service first if available, then the configuration drive.
 
-  Not all OpenStack clouds provide both configuration drive and metadata service though and only one or the other may be available which is why the default is to check both. Especially, the metadata on the config drive may grow stale over time, whereas the metadata service always provides the most up to date data. 
+  Not all OpenStack clouds provide both configuration drive and metadata service though and only one or the other may be available which is why the default is to check both. Especially, the metadata on the config drive may grow stale over time, whereas the metadata service always provides the most up to date data.
 
 ## Exposing applications using services of LoadBalancer type
 

--- a/examples/cinder-csi-plugin/inline/inline-example.yaml
+++ b/examples/cinder-csi-plugin/inline/inline-example.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Pod
-metadata: 
+metadata:
   name: inline-pod
 spec:
   containers:
@@ -18,4 +18,3 @@ spec:
         capacity: 1Gi # default is 1Gi
       readOnly: false  # default is false
       fsType: ext4 # default is ext4
-

--- a/examples/cinder-csi-plugin/nginx.yaml
+++ b/examples/cinder-csi-plugin/nginx.yaml
@@ -24,7 +24,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: nginx 
+  name: nginx
 spec:
   containers:
   - image: nginx
@@ -35,7 +35,7 @@ spec:
       protocol: TCP
     volumeMounts:
       - mountPath: /var/lib/www/html
-        name: csi-data-cinderplugin 
+        name: csi-data-cinderplugin
   volumes:
   - name: csi-data-cinderplugin
     persistentVolumeClaim:

--- a/examples/cinder-csi-plugin/resize/example.yaml
+++ b/examples/cinder-csi-plugin/resize/example.yaml
@@ -25,7 +25,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: nginx 
+  name: nginx
 spec:
   containers:
   - image: nginx
@@ -36,7 +36,7 @@ spec:
       protocol: TCP
     volumeMounts:
       - mountPath: /var/lib/www/html
-        name: csi-data-cinderplugin 
+        name: csi-data-cinderplugin
   volumes:
   - name: csi-data-cinderplugin
     persistentVolumeClaim:

--- a/examples/cinder-csi-plugin/snapshot/snapshotrestore.yaml
+++ b/examples/cinder-csi-plugin/snapshot/snapshotrestore.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   storageClassName: csi-sc-cinderplugin
   dataSource:
-    name: new-snapshot-demo 
+    name: new-snapshot-demo
     kind: VolumeSnapshot
     apiGroup: snapshot.storage.k8s.io
   accessModes:

--- a/examples/loadbalancers/README.MD
+++ b/examples/loadbalancers/README.MD
@@ -38,7 +38,7 @@ metadata:
   name: external-http-nginx-service
   annotations:
     service.beta.kubernetes.io/openstack-internal-load-balancer: "false"
-    loadbalancer.openstack.org/floating-network-id: "9be23551-38e2-4d27-b5ea-ea2ea1321bd6"  
+    loadbalancer.openstack.org/floating-network-id: "9be23551-38e2-4d27-b5ea-ea2ea1321bd6"
 spec:
   selector:
     app: nginx
@@ -111,7 +111,7 @@ apiVersion: v1
 metadata:
   name: internal-http-nginx-service
   annotations:
-    service.beta.kubernetes.io/openstack-internal-load-balancer: "true"  
+    service.beta.kubernetes.io/openstack-internal-load-balancer: "true"
 spec:
   selector:
     app: nginx

--- a/examples/manila-csi-plugin/README.md
+++ b/examples/manila-csi-plugin/README.md
@@ -3,7 +3,7 @@
 1. Make sure you've completed all the steps in `docs/using-manila-csi-plugin.md`: e.g. you've deployed CSI NFS and CSI Manila plugins and CSI Manila is running with `--share-protocol-selector=NFS` and `--fwdendpoint=unix:///csi/csi-nfsplugin/csi.sock` (or similar, based on your environment)
 2. Modify `secrets.yaml` to suite your OpenStack cloud environment. Refer to the _"Secrets, authentication"_ section of CSI Manila docs. You may also use helper scripts from `examples/manila-provisioner` to generate the Secrets manifest.
 3. The same steps apply to all supported Manila share protocols
-4. `exec-bash.sh`, `logs.sh` are convenience scripts for debugging CSI Manila 
+4. `exec-bash.sh`, `logs.sh` are convenience scripts for debugging CSI Manila
 
 ## Example CSI Manila usage with NFS shares
 
@@ -32,7 +32,7 @@ Files marked with `--> ... <--` may need to be customized.
 
 * `dynamic-provisioning/` : creates a new Manila NFS share and mounts it in a Pod.
 * `static-provisioning/` : fetches an existing Manila NFS share and mounts it in a Pod
-* `snapshot/` : takes a snapshot from a PVC source, restores it into a new share and mounts it in a Pod. Deploy manifests in `dynamic-provisioning/` first 
+* `snapshot/` : takes a snapshot from a PVC source, restores it into a new share and mounts it in a Pod. Deploy manifests in `dynamic-provisioning/` first
 * `topology-aware/` : topology-aware dynamic provisioning
 
 Make sure the `provisioner` field in `storageclass.yaml` and `snapshotclass.yaml` matches the driver name in your deployment!

--- a/examples/manila-csi-plugin/helm-deployment/templates/nodeplugin-clusterrolebinding.yaml
+++ b/examples/manila-csi-plugin/helm-deployment/templates/nodeplugin-clusterrolebinding.yaml
@@ -15,4 +15,4 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: {{ include "openstack-manila-csi.nodeplugin.fullname" . }}
-  apiGroup: rbac.authorization.k8s.io          
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/manila-csi-plugin/nfs/dynamic-provisioning/storageclass.yaml
+++ b/examples/manila-csi-plugin/nfs/dynamic-provisioning/storageclass.yaml
@@ -6,7 +6,7 @@ provisioner: nfs.manila.csi.openstack.org
 parameters:
   # Manila share type
   type: default
-  
+
   csi.storage.k8s.io/provisioner-secret-name: csi-manila-secrets
   csi.storage.k8s.io/provisioner-secret-namespace: default
   csi.storage.k8s.io/node-stage-secret-name: csi-manila-secrets

--- a/examples/manila-csi-plugin/nfs/topology-aware/storageclass.yaml
+++ b/examples/manila-csi-plugin/nfs/topology-aware/storageclass.yaml
@@ -17,7 +17,7 @@ provisioner: nfs.manila.csi.openstack.org
 parameters:
   type: default
   availability: manila-zone-1
-  
+
   csi.storage.k8s.io/provisioner-secret-name: csi-manila-secrets
   csi.storage.k8s.io/provisioner-secret-namespace: default
   csi.storage.k8s.io/node-stage-secret-name: csi-manila-secrets

--- a/examples/mysql-cinder-pd/mysql.yaml
+++ b/examples/mysql-cinder-pd/mysql.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - resources:
-        limits :
+        limits:
           cpu: 0.5
       image: mysql
       name: mysql

--- a/manifests/barbican-kms/encryption-config.yaml
+++ b/manifests/barbican-kms/encryption-config.yaml
@@ -5,7 +5,7 @@ resources:
     - secrets
     providers:
     - kms:
-        name : barbican
+        name: barbican
         endpoint: unix:///var/lib/kms/kms.sock
         cachesize: 20
     - identity: {}

--- a/manifests/barbican-kms/pod.yaml
+++ b/manifests/barbican-kms/pod.yaml
@@ -1,10 +1,10 @@
-apiVersion: v1 
-kind: Pod 
-metadata: 
+apiVersion: v1
+kind: Pod
+metadata:
  name: barbican-kms
-spec: 
-  containers: 
-    - name: barbican-kms 
+spec:
+  containers:
+    - name: barbican-kms
       image: docker.io/k8scloudprovider/barbican-kms-plugin:latest
       args:
         - "--socketpath=/kms/kms.sock"

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin-rbac.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin-rbac.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: kube-system
 
 ---
-# external attacher 
+# external attacher
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -82,7 +82,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: cinder-csi-plugin
           image: docker.io/k8scloudprovider/cinder-csi-plugin:latest
-          args :
+          args:
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -49,7 +49,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: docker.io/k8scloudprovider/cinder-csi-plugin:latest
-          args :
+          args:
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/manifests/manila-csi-plugin/csi-nodeplugin-rbac.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin-rbac.yaml
@@ -55,4 +55,4 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: openstack-manila-csi-nodeplugin
-  apiGroup: rbac.authorization.k8s.io          
+  apiGroup: rbac.authorization.k8s.io

--- a/release-procedure.md
+++ b/release-procedure.md
@@ -1,6 +1,6 @@
 # Release Procedure
 
-Cloud Provider OpenStack Release is done in sync with kubernetes/kubernetes, Minor versions can be released intermittently for critical bug fixes. 
+Cloud Provider OpenStack Release is done in sync with kubernetes/kubernetes, Minor versions can be released intermittently for critical bug fixes.
 
 ## Before Release
 
@@ -8,7 +8,7 @@ Update cloud-provider-openstack to kubernetes/kubernetes latest release. Make Su
 
 ## Making a Release
 
-1. Checkout the release branch 
+1. Checkout the release branch
 
 ```
 $ git fetch upstream


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Remove trailing whitespace.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
