### PR TITLE
[cinder-csi-plugin] Update debian-base image

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -56,6 +56,7 @@
       jobs:
         - cloud-provider-openstack-acceptance-test-csi-cinder:
             files:
+              - cluster/images/cinder-csi-plugin/.*
               - cmd/cinder-csi-plugin/.*
               - manifests/cinder-csi-plugin/.*
               - pkg/csi/cinder/.*

--- a/cluster/images/cinder-csi-plugin/Dockerfile
+++ b/cluster/images/cinder-csi-plugin/Dockerfile
@@ -13,7 +13,7 @@
 ARG DEBIAN_ARCH=amd64
 # We not using scratch because we need to keep the basic image information
 # from parent image
-FROM k8s.gcr.io/debian-base-${DEBIAN_ARCH}:1.0.0
+FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base-${DEBIAN_ARCH}:v2.1.0
 
 ARG ARCH=amd64
 

--- a/cluster/images/cinder-csi-plugin/Dockerfile.build
+++ b/cluster/images/cinder-csi-plugin/Dockerfile.build
@@ -1,5 +1,5 @@
 ARG DEBIAN_ARCH=amd64
-FROM k8s.gcr.io/debian-base-${DEBIAN_ARCH}:1.0.0
+FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base-${DEBIAN_ARCH}:v2.1.0
 
 ARG ARCH=amd64
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
The PR updates the base image with us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:v2.1.0 as minimal base - ref https://github.com/kubernetes/kubernetes/tree/master/build/debian-base

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
