### PR TITLE
[cinder-csi-plugin] Run tests when Dockerfile is updated

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -56,6 +56,7 @@
       jobs:
         - cloud-provider-openstack-acceptance-test-csi-cinder:
             files:
+              - cluster/images/cinder-csi-plugin/.*
               - cmd/cinder-csi-plugin/.*
               - manifests/cinder-csi-plugin/.*
               - pkg/csi/cinder/.*
@@ -76,6 +77,7 @@
       jobs:
         - cloud-provider-openstack-e2e-test-csi-cinder:
             files:
+              - cluster/images/cinder-csi-plugin/.*
               - cmd/cinder-csi-plugin/.*
               - manifests/cinder-csi-plugin/.* 
               - pkg/csi/cinder/.*
@@ -109,6 +111,7 @@
       jobs:
         - cloud-provider-openstack-multinode-csi-migration-test:
             files:
+              - cluster/images/cinder-csi-plugin/.*
               - cmd/cinder-csi-plugin/.*
               - manifests/cinder-csi-plugin/.*
               - pkg/csi/cinder/.*

--- a/cluster/images/cinder-csi-plugin/Dockerfile
+++ b/cluster/images/cinder-csi-plugin/Dockerfile
@@ -24,7 +24,7 @@ LABEL name="cinder-csi-plugin" \
       description="Cinder CSI Plugin" \
       architecture=$ARCH \
       distribution-scope="public" \
-      summary="Cinder CSI Plugin" \
+      summary="Cinder CSI Plugin " \
       help="none"
 
 ADD rootfs.tar /


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
