### PR TITLE
WIP: Upgrade klog to v2.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	k8s.io/code-generator v0.18.1 // indirect
 	k8s.io/component-base v0.18.0
 	k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac // indirect
-	k8s.io/klog/v2 v2.0.0
+	k8s.io/klog/v2 v2.1.0
 	k8s.io/kubernetes v1.18.0
 	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
 	software.sslmate.com/src/go-pkcs12 v0.0.0-20190209200317-47dd539968c4


### PR DESCRIPTION
**What this PR does / why we need it**:

We are facing CI issue as https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/cloud-provider-openstack/1099/pull-cloud-provider-openstack-check/1271460686282625025/build-log.txt
This is for fixing the issue:
```
W0612 15:17:02.939] # k8s.io/klog/v2
W0612 15:17:02.939] /go/pkg/mod/k8s.io/klog/v2@v2.1.0/klog.go:690:45: undefined: logr.InfoLogger
W0612 15:17:02.939] /go/pkg/mod/k8s.io/klog/v2@v2.1.0/klog.go:702:43: undefined: logr.InfoLogger
W0612 15:17:02.940] /go/pkg/mod/k8s.io/klog/v2@v2.1.0/klog.go:706:48: undefined: logr.InfoLogger
W0612 15:17:02.940] /go/pkg/mod/k8s.io/klog/v2@v2.1.0/klog.go:721:44: undefined: logr.InfoLogger
W0612 15:17:02.941] /go/pkg/mod/k8s.io/klog/v2@v2.1.0/klog.go:739:55: undefined: logr.InfoLogger
W0612 15:17:02.941] /go/pkg/mod/k8s.io/klog/v2@v2.1.0/klog.go:764:32: undefined: logr.InfoLogger
W0612 15:17:02.941] /go/pkg/mod/k8s.io/klog/v2@v2.1.0/klog.go:881:43: undefined: logr.InfoLogger
W0612 15:17:02.941] /go/pkg/mod/k8s.io/klog/v2@v2.1.0/klog.go:1234:10: undefined: logr.InfoLogger
```

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
