### PR TITLE
[occm] refactor keepClientIP and useProxyProtocol

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -893,12 +893,29 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 		}
 	}
 
+	var keepClientIP bool
+	var useProxyProtocol bool
 	if !lbaas.opts.UseOctavia {
 		// Check for TCP protocol on each port
 		for _, port := range ports {
 			if port.Protocol != corev1.ProtocolTCP {
 				return nil, fmt.Errorf("only TCP LoadBalancer is supported for openstack load balancers")
 			}
+		}
+	} else {
+		//setting http headers and proxy protocol is only supported by Octavia
+		keepClientIP, err = getBoolFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerXForwardedFor, false)
+		if err != nil {
+			return nil, err
+		}
+
+		useProxyProtocol, err = getBoolFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerProxyEnabled, false)
+		if err != nil {
+			return nil, err
+		}
+
+		if useProxyProtocol && keepClientIP {
+			return nil, fmt.Errorf("annotation %s and %s cannot be used together", ServiceAnnotationLoadBalancerProxyEnabled, ServiceAnnotationLoadBalancerXForwardedFor)
 		}
 	}
 
@@ -968,17 +985,8 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 			connLimit = tmp
 		}
 
-		keepClientIP := false
 		if listener == nil {
 			listenerProtocol := listeners.Protocol(port.Protocol)
-			keepClientIP, err = getBoolFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerXForwardedFor, false)
-			if err != nil {
-				return nil, err
-			}
-			if keepClientIP {
-				listenerProtocol = listeners.ProtocolHTTP
-			}
-
 			listenerCreateOpt := listeners.CreateOpts{
 				Name:           cutString(fmt.Sprintf("listener_%d_%s", portIndex, name)),
 				Protocol:       listenerProtocol,
@@ -988,6 +996,15 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 			}
 
 			if lbaas.opts.UseOctavia {
+				if keepClientIP {
+					if listenerCreateOpt.Protocol != listeners.ProtocolHTTP {
+						klog.V(4).Infof("Forcing to use %q protocol for listener because %q "+
+							"annotation is set", listeners.ProtocolHTTP, ServiceAnnotationLoadBalancerXForwardedFor)
+						listenerCreateOpt.Protocol = listeners.ProtocolHTTP
+					}
+					listenerCreateOpt.InsertHeaders = map[string]string{"X-Forwarded-For": "true"}
+				}
+
 				if timeoutClientData, ok := getIntFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerTimeoutClientData); ok {
 					listenerCreateOpt.TimeoutClientData = &timeoutClientData
 				}
@@ -999,9 +1016,6 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 				}
 				if timeoutTCPInspect, ok := getIntFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerTimeoutTCPInspect); ok {
 					listenerCreateOpt.TimeoutTCPInspect = &timeoutTCPInspect
-				}
-				if keepClientIP {
-					listenerCreateOpt.InsertHeaders = map[string]string{"X-Forwarded-For": "true"}
 				}
 				if len(listenerAllowedCIDRs) > 0 {
 					listenerCreateOpt.AllowedCIDRs = listenerAllowedCIDRs
@@ -1054,17 +1068,14 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 			// Use the protocol of the listerner
 			poolProto := v2pools.Protocol(listener.Protocol)
 
-			useProxyProtocol, err := getBoolFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerProxyEnabled, false)
-			if err != nil {
-				return nil, err
-			}
-			if useProxyProtocol && keepClientIP {
-				return nil, fmt.Errorf("annotation %s and %s cannot be used together", ServiceAnnotationLoadBalancerProxyEnabled, ServiceAnnotationLoadBalancerXForwardedFor)
-			}
-			if useProxyProtocol {
-				poolProto = v2pools.ProtocolPROXY
-			} else if keepClientIP {
-				poolProto = v2pools.ProtocolHTTP
+			if lbaas.opts.UseOctavia {
+				if useProxyProtocol {
+					poolProto = v2pools.ProtocolPROXY
+				} else if keepClientIP && poolProto != v2pools.ProtocolHTTP {
+					klog.V(4).Infof("Forcing to use %q protocol for pool because %q "+
+						"annotation is set", v2pools.ProtocolHTTP, ServiceAnnotationLoadBalancerXForwardedFor)
+					poolProto = v2pools.ProtocolHTTP
+				}
 			}
 
 			lbmethod := v2pools.LBMethod(lbaas.opts.LBMethod)


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Refactor/Improve processing of **loadbalancer.openstack.org/x-forwarded-for** and **loadbalancer.openstack.org/proxy-protocol** annotations

**Which issue this PR fixes(if applicable)**:
keepClientIP and useProxyProtocol options are only supported by Octavia. This PR fixes the following issues:
* For neutron lbaas, listener protocol should only be TCP [ref](https://github.com/kubernetes/cloud-provider-openstack/blob/a7e33e5a83027f87c9781cb2cb21ab423fad99a4/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go#L900), however when **loadbalancer.openstack.org/x-forwarded-for** annotation is specified, regardless of Octavia or neutron LBaaS, occm sets listener protocol to HTTP [ref](https://github.com/kubernetes/cloud-provider-openstack/blob/a7e33e5a83027f87c9781cb2cb21ab423fad99a4/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go#L978).
* Proxy Protocol is not supported by Neutron LBaaS, occm sets pool protocol to proxy, even for neutron LBaaS [ref](https://github.com/kubernetes/cloud-provider-openstack/blob/a7e33e5a83027f87c9781cb2cb21ab423fad99a4/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go#L1065).
* OCCM throws an error when both **loadbalancer.openstack.org/x-forwarded-for** and **loadbalancer.openstack.org/proxy-protocol** annotations are specified together [ref](https://github.com/kubernetes/cloud-provider-openstack/blob/a7e33e5a83027f87c9781cb2cb21ab423fad99a4/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go#L1061). This check is made after creating loadbalancer and listener resources. Ideally, such checks should be made before creating any resources.

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] The annotations loadbalancer.openstack.org/x-forwarded-for and loadbalancer.openstack.org/proxy-protocol are only supported when Octavia is deployed.
```
