### PR TITLE
[DNM] Check CI

### DIFF
--- a/cmd/k8s-keystone-auth/main.go
+++ b/cmd/k8s-keystone-auth/main.go
@@ -30,7 +30,7 @@ func main() {
 	// Glog requires this otherwise it complains.
 	flag.CommandLine.Parse(nil)
 	// This is a temporary hack to enable proper logging until upstream dependencies
-	// are migrated to fully utilize klog instead of glog.
+	// are migrated to fully utilize klog instead of glog .
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(klogFlags)
 

--- a/cmd/openstack-cloud-controller-manager/main.go
+++ b/cmd/openstack-cloud-controller-manager/main.go
@@ -80,7 +80,7 @@ the cloud specific control loops shipped with Kubernetes.`,
 			goflag.CommandLine.Parse(nil)
 
 			// This is a temporary hack to enable proper logging until upstream dependencies
-			// are migrated to fully utilize klog instead of glog.
+			// are migrated to fully utilize klog instead of glog
 			klogFlags := goflag.NewFlagSet("klog", goflag.ExitOnError)
 			klog.InitFlags(klogFlags)
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
