### PR TITLE
Add serviceName to cinder-csi-plugin/templates/controllerplugin-statefulset.yaml

### DIFF
--- a/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -1,3 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cinder-csi.name" . }}-controllerplugin
+  labels:
+    {{- include "cinder-csi.controllerplugin.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+---    
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
@@ -5,7 +14,7 @@ metadata:
   labels:
     {{- include "cinder-csi.controllerplugin.labels" . | nindent 4 }}
 spec:
-  serviceName: csi-cinder-controller
+  serviceName: {{ include "cinder-csi.name" . }}-controllerplugin
   replicas: 1
   selector:
     matchLabels:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "cinder-csi.controllerplugin.labels" . | nindent 4 }}
 spec:
+  serviceName: csi-cinder-controller
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

It fixes the following error:

helm install cinder-csi cloud-provider-openstack/charts/cinder-csi-plugin
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(StatefulSet.spec): missing required field "serviceName" in io.k8s.api.apps.v1.StatefulSetSpec

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
