### PR TITLE
[cinder-csi-plugin] Add serviceName in statefulset

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v1.1.0"
 description: Cinder CSI Plugin for OpenStack
 name: openstack-cinder-csi
-version: 1.1.0
+version: 1.1.1

--- a/charts/cinder-csi-plugin/templates/controllerplugin-service.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-service.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ include "cinder-csi.name" . }}-controllerplugin
+  labels:
+    {{- include "cinder-csi.controllerplugin.matchLabels" . | nindent 4}}
+spec:
+  selector:
+    {{- include "cinder-csi.controllerplugin.matchLabels" . | nindent 4}}
+  ports:
+    - name: dummy
+      port: 12345

--- a/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "cinder-csi.controllerplugin.labels" . | nindent 4 }}
 spec:
+  serviceName: {{ include "cinder-csi.name" . }}-controllerplugin
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
serviceName is required for stateful sets
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#statefulset-v1-apps

Add a dummy service like in manila-csi so that serviceName points to something.

Since there a change in the chart, make a point release.

```release-note
[cinder-csi-plugin] Add serviceName in chart's statefulset chart version: 1.1.1  
```
