### PR TITLE
[cinder-csi-plugin] update plugin to v1.18.0

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "v1.1.0"
+appVersion: "v1.18.0"
 description: Cinder CSI Plugin for OpenStack
 name: openstack-cinder-csi
-version: 1.1.0
+version: 1.1.1

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -5,7 +5,7 @@ csi:
   attacher:
     image:
       repository: quay.io/k8scsi/csi-attacher
-      tag: v2.0.0
+      tag: v2.1.1
       pullPolicy: IfNotPresent
   provisioner:
     image:
@@ -20,17 +20,17 @@ csi:
   resizer:
     image:
       repository: quay.io/k8scsi/csi-resizer
-      tag: v0.3.0
+      tag: v0.4.0
       pullPolicy: IfNotPresent
   nodeDriverRegistrar:
     image:
       repository: quay.io/k8scsi/csi-node-driver-registrar
-      tag: v1.1.0
+      tag: v1.2.0
       pullPolicy: IfNotPresent
   plugin:
     image:
       repository: docker.io/k8scloudprovider/cinder-csi-plugin
-      tag: v1.17.0
+      tag: v1.18.0
       pullPolicy: IfNotPresent
 
 storageClass:


### PR DESCRIPTION
Use the latest version of the cinder-csi-plugin and related sidecars.

https://github.com/kubernetes/cloud-provider-openstack/releases/tag/v1.18.0
    
csi-attacher:v2.1.1
https://github.com/kubernetes/cloud-provider-openstack/blob/release-1.18/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml#L38

csi-provisioner:v1.4.0
https://github.com/kubernetes/cloud-provider-openstack/blob/release-1.18/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml#L50

csi-snapshotter:v1.2.2
https://github.com/kubernetes/cloud-provider-openstack/blob/release-1.18/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml#L62

csi-resizer:v0.4.0
https://github.com/kubernetes/cloud-provider-openstack/blob/release-1.18/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml#L73

cinder-csi-pluginv1.18.0
https://github.com/kubernetes/cloud-provider-openstack/blob/release-1.18/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml#L84

csi-node-driver-registrar:v1.2.0
https://github.com/kubernetes/cloud-provider-openstack/blob/release-1.18/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml#L22


```release-note
[cinder-csi-plugin] update plugin to v1.18.0 and related sidecars to version compatible to 1.18 chart-version: 1.1.1
```
