### PR TITLE
[manila-csi-plugin] add OWNERS file

### DIFF
--- a/pkg/csi/manila/OWNERS
+++ b/pkg/csi/manila/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+- gman0
+- gouthampacha
+- tombarron
+reviewers:
+- gman0
+- gouthampacha
+- tombarron
+- Fedosin
+- tsmetana


### PR DESCRIPTION
Commit 313fc67b856b8e21bebe1b4a45a55ca25070207e intended to set
up an OWNERS file for the manila-csi driver, but it was set up
under the old non-csi pkg/share/manila path and was lost when
that legacy path was dropped with 1.18.

Set up the OWNERS file in the right path with appropriate current
membership.

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Adds an OWNERS file to delegate responsibility for the manila csi plugin.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
