### PR TITLE
[occm] Add error handling for reading config

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -289,6 +289,7 @@ func init() {
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
 		cfg, err := ReadConfig(config)
 		if err != nil {
+			klog.Warningf("failed to read config: %v", err)
 			return nil, err
 		}
 		cloud, err := NewOpenStack(cfg)
@@ -381,6 +382,9 @@ func ReadConfig(config io.Reader) (Config, error) {
 	cfg.LoadBalancer.CascadeDelete = true
 
 	err := gcfg.FatalOnly(gcfg.ReadInto(&cfg, config))
+	if err != nil {
+		return Config{}, err
+	}
 
 	klog.V(5).Infof("Config, loaded from the config file:")
 	LogCfg(cfg)


### PR DESCRIPTION
**What this PR does / why we need it**:

As seeing this PR, there was lack of error handling.
So this adds it for investigating issues easily.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
