### PR TITLE
[cinder-csi-plugin] Add test changes into zuul file

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -81,7 +81,7 @@
               - manifests/cinder-csi-plugin/.* 
               - pkg/csi/cinder/.*
               - pkg/util/.*
-              - test/.*
+              - tests/e2e/csi/cinder/.*
               - cmd/tests/.*
               - go.mod$
               - go.sum$
@@ -98,6 +98,7 @@
               - cmd/cinder-csi-plugin/.*
               - pkg/csi/cinder/.*
               - pkg/util/.*
+              - tests/sanity/cinder/.*
               - go.mod$
               - go.sum$
               - Makefile$


### PR DESCRIPTION

**What this PR does / why we need it**:
the changes in `tests` folder will not trigger CSI e2e and sanity check
update zuul file on this
**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
