### PR TITLE
[occm] Support for adding members to an existing pool

### DIFF
--- a/docs/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/expose-applications-using-loadbalancer-type-service.md
@@ -147,6 +147,10 @@ Request Body:
 
   Defines whether or not to create health monitor for the load balancer pool, if not specified, use `create-monitor` config. The health monitor can be created or deleted dynamically.
 
+- `loadbalancer.openstack.org/unmanaged-pool-id`
+
+  Cloud provider will simply add or remove members from the pool. Creation and deletion of pool, listener, healthmonitor and loadbalancer will not be performed by cloudprovider---user is expected to create these resources beforehand using openstack CLI. With this feature services running on different k8s clusters can be served from the same loadbalancer.
+  
 ### Switching between Floating Subnets by using preconfigured Classes
 
 If you have multiple `FloatingIPPools` and/or `FloatingIPSubnets` it might be desirable to offer the user logical meanings for `LoadBalancers` like `internetFacing` or `DMZ` instead of requiring the user to select a dedicated network or subnet ID at the service object level as an annotation.

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -220,7 +220,7 @@ func getListenerForPort(existingListeners []listeners.Listener, port corev1.Serv
 	return nil
 }
 
-// Get listener for a pool. A pool is always assosiated with a single listener
+// Get listener for a pool. A pool is always associated with a single listener
 func getListenerByPoolID(client *gophercloud.ServiceClient, poolID string) (*listeners.Listener, error) {
 	pool, err := v2pools.Get(client, poolID).Extract()
 	if err != nil {
@@ -241,7 +241,7 @@ func getListenerByPoolID(client *gophercloud.ServiceClient, poolID string) (*lis
 	return listener, nil
 }
 
-// Get loadbalancer assosiated with a pool.
+// Get loadbalancer associated with a pool.
 func getLoadBalancerByPoolID(client *gophercloud.ServiceClient, poolID string) (*loadbalancers.LoadBalancer, error) {
 	pool, err := v2pools.Get(client, poolID).Extract()
 	if err != nil {
@@ -249,7 +249,7 @@ func getLoadBalancerByPoolID(client *gophercloud.ServiceClient, poolID string) (
 	}
 
 	if len(pool.Loadbalancers) == 0 {
-		return nil, fmt.Errorf("No Loadbalancer is assosiated with pool %q", poolID)
+		return nil, fmt.Errorf("No Loadbalancer is associated with pool %q", poolID)
 	}
 
 	loadbalancerID := pool.Loadbalancers[0].ID


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes # [932](https://github.com/kubernetes/cloud-provider-openstack/issues/932)
fixes #933

**Special notes for reviewers**:
This PR brings support for adding members to an existing pool. When `loadbalancer.openstack.org/unmanaged-pool-id` annotation is set, then cloud provider will simply add or remove members from the given pool. Following requirements should be met:
* User has to make sure that the port number specified in service spec matches with the port number of listener attached to the pool.
* User is expected to create loadbalancer, listener, pool and healthmonitor resources beforehand using openstack CLI. 
* Only one port could be specified in service spec because a single pool is referenced in `loadbalancer.openstack.org/unmanaged-pool-id` annotation and a pool is attached to a single listener. 

Some other stuff:
* When a service with annotation `loadbalancer.openstack.org/unmanaged-pool-id` is deleted then cloud provider will only delete the members.
* When nodes are added or removed from the k8s cluster, then cloud provider will automatically add or remove members from the pool respectively.
* **Only new functionality has been added. Existing features of cloud provider will continue working as before**

With this PR, occm will be able to support the following usecases:

* Using a single loadbalancer to expose services running on multiple k8s clusters
* Using a single loadbalancer to expose multiple services running on the same k8s cluster
* Using a single loadbalancer to serve traffic on a combination of VMs and k8s services
* Minimize blast radius of applications running on k8s:
  For HA purposes, multiple instances of application can be deployed in different K8s clusters (running in different availability zones). With this feature, a user can expose multiple instances of application using the same loadbalancer. If one k8s cluster goes down (let's say from power outage) then users will experience a reduced capacity instead of a complete downtime for application.  
* Save cost associated with public IP addresses by exposing multiple services behind a single loadbalancer. 

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
support for adding members to an existing pool
```
