### PR TITLE
[manila-csi-plugin] Fix volume in nodeplugin

### DIFF
--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.9"
 description: A Helm chart for Kubernetes
 name: openstack-manila-csi
-version: 0.1.0
+version: 0.1.1

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -110,7 +110,7 @@ spec:
         - name: {{ .protocolSelector | lower }}-fwd-plugin-dir
           hostPath:
             path: {{ .fwdNodePluginEndpoint.dir }}
-            type: Directory
+            type: DirectoryOrCreate
         {{- end }}
     {{- if .Values.nodeplugin.affinity -}}
       affinity:

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -96,5 +96,5 @@ spec:
         - name: fwd-plugin-dir
           hostPath:
             path: /var/lib/kubelet/plugins/FWD-NODEPLUGIN
-            type: Directory
+            type: DirectoryOrCreate
 


### PR DESCRIPTION
Make hostpath volumes DirectoOrCreate instead of Directory
for a more resilient installation.

```release-note
manila-csi-plugin chart v0.1.1 Change to DirectoryOrCreate for nodeplugin volume.
```
