### PR TITLE
[occm] make floating subnet optional

### DIFF
--- a/docs/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/expose-applications-using-loadbalancer-type-service.md
@@ -85,11 +85,11 @@ Request Body:
 
 - `loadbalancer.openstack.org/floating-subnet`
 
-  A public network can have several subnets. This annotation is one of subnets' name.
+  A public network can have several subnets. This annotation is the name of subnet belonging to the floating network. This annotation is optional.
 
 - `loadbalancer.openstack.org/floating-subnet-id`
 
-  This annotation is one of subnets' id in a public network.
+  This annotation is the ID of a subnet belonging to the floating network. This annotation is optional.
 
 - `loadbalancer.openstack.org/class`
 

--- a/docs/using-openstack-cloud-controller-manager.md
+++ b/docs/using-openstack-cloud-controller-manager.md
@@ -147,6 +147,8 @@ Although the openstack-cloud-controller-manager was initially implemented with N
   Whether or not to use Octavia for LoadBalancer type of Service implementation instead of using Neutron-LBaaS. Default: true
 * `floating-network-id`
   Optional. The external network used to create floating IP for the load balancer VIP.
+* `floating-subnet-id`
+  Optional. The subnet ID used to create floating IP for the load balancer's VIP. Floating subnet should belong to the floating network.
 * `lb-method`
   The load balancing algorithm used to create the load balancer pool. The value can be `ROUND_ROBIN`, `LEAST_CONNECTIONS`, or `SOURCE_IP`. Default: `ROUND_ROBIN`
 * `lb-provider`

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -1323,13 +1323,16 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 
 		// third attempt: create a new floating IP
 		if floatIP == nil {
-			if floatingNetworkID != "" && floatingSubnetID != "" {
+			if floatingNetworkID != "" {
 				klog.V(4).Infof("Creating floating IP %s for loadbalancer %s", loadBalancerIP, loadbalancer.ID)
 				floatIPOpts := floatingips.CreateOpts{
 					FloatingNetworkID: floatingNetworkID,
-					SubnetID:          floatingSubnetID,
 					PortID:            portID,
 					Description:       fmt.Sprintf("Floating IP for Kubernetes external service %s from cluster %s", serviceName, clusterName),
+				}
+
+				if floatingSubnetID != "" {
+					floatIPOpts.SubnetID = floatingSubnetID
 				}
 
 				if loadBalancerIP != "" {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
In [PR ](https://github.com/kubernetes/cloud-provider-openstack/pull/1102) floating subnet was made mandatory, for backward compatibility we should make it optional again. I have also added docs to clearly specify that floating-subnet is an optional argument. 

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
