### PR TITLE
[occm] WIP add support for TLS terminated loadbalancers

### DIFF
--- a/docs/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/expose-applications-using-loadbalancer-type-service.md
@@ -158,6 +158,11 @@ Request Body:
 
   The id of the flavor that is used for creating the loadbalancer.
 
+- `loadbalancer.openstack.org/default-tls-container-ref`
+
+  Reference to tls container. This option works with Octavia, when this option is set then a TLS Terminated loadbalancer will be created by cloud provider.
+  Format for tls container ref: `https://{keymanager_host}/v1/containers/{uuid}`
+
 ### Switching between Floating Subnets by using preconfigured Classes
 
 If you have multiple `FloatingIPPools` and/or `FloatingIPSubnets` it might be desirable to offer the user logical meanings for `LoadBalancers` like `internetFacing` or `DMZ` instead of requiring the user to select a dedicated network or subnet ID at the service object level as an annotation.

--- a/docs/using-openstack-cloud-controller-manager.md
+++ b/docs/using-openstack-cloud-controller-manager.md
@@ -208,6 +208,11 @@ Although the openstack-cloud-controller-manager was initially implemented with N
   * network-id. The same with `network-id` option above.
   * subnet-id. The same with `subnet-id` option above.
 
+* `default-tls-container-ref`
+  Reference to tls container. This option works with Octavia, when this option is set then a TLS Terminated loadbalancer will be created by cloud provider.
+
+  Format for tls container ref: `https://{keymanager_host}/v1/containers/{uuid}`
+
 ### Metadata
 
 * `search-order`

--- a/pkg/cloudprovider/providers/openstack/openstack_client.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_client.go
@@ -74,3 +74,14 @@ func (os *OpenStack) NewLoadBalancerV2() (*gophercloud.ServiceClient, error) {
 	}
 	return lb, nil
 }
+
+// NewKeyManagerV1 creates a ServiceClient that can be used with KeyManager v1 API
+func (os *OpenStack) NewKeyManagerV1() (*gophercloud.ServiceClient, error) {
+	secret, err := openstack.NewKeyManagerV1(os.provider, gophercloud.EndpointOpts{
+		Region: os.region,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to initialize keymanager client for region %s: %v", os.region, err)
+	}
+	return secret, nil
+}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This PR brings support for creating TLS Terminated loadbalancers. User can specify tls container ref either in cloud-config file using `default-tls-container-ref` option or pass tls container ref in service spec using annotation `loadbalancer.openstack.org/default-tls-container-ref`. Cloud provider will create a listener with protocol **TERMINATED_HTTPS** and a pool with protocol **HTTP**.

This feature is supported only for Octavia.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
support for TLS terminated loadbalancers
```
