### PR TITLE
Fix `conversion from int to string yields a string of one rune` issues

### DIFF
--- a/pkg/ingress/controller/openstack/neutron.go
+++ b/pkg/ingress/controller/openstack/neutron.go
@@ -213,7 +213,7 @@ func (os *OpenStack) EnsureSecurityGroupRules(sgID string, sourceIP string, dstP
 	// Because the security group is supposed to be managed by octavia-ingress-controller, we assume the `port_range_min`
 	// equals to `port_range_max`.
 	for _, rule := range allRules {
-		if !dstPortsSet.Has(string(rule.PortRangeMin)) {
+		if !dstPortsSet.Has(strconv.Itoa(rule.PortRangeMin)) {
 			// Delete the rule
 			if err := rules.Delete(os.neutron, rule.ID).ExtractErr(); err != nil {
 				return err


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #1139

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
