### PR TITLE
[occm] Split Octavia related functions

### DIFF
--- a/docs/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/expose-applications-using-loadbalancer-type-service.md
@@ -96,11 +96,11 @@ Request Body:
 
 - `loadbalancer.openstack.org/floating-subnet-id`
 
-  This annotation is the ID of a subnet belonging to the floating network. This annotation is optional.
+  This annotation is the ID of a subnet belonging to the floating network, if specified, it takes precedence over `loadbalancer.openstack.org/floating-subnet`.
 
 - `loadbalancer.openstack.org/class`
 
-  The name of a preconfigured class in the config file. The annotation of floating-subnet-id and floating-network-id won't work if you use class annotation. See the section below for how it works.
+  The name of a preconfigured class in the config file. If provided, this config options included in the class section take precedence over the annotations of floating-subnet-id and floating-network-id. See the section below for how it works.
 
 - `loadbalancer.openstack.org/subnet-id`
 
@@ -116,7 +116,7 @@ Request Body:
 
 - `loadbalancer.openstack.org/connection-limit`
 
-  The maximum number of connections per second allowed for the listener. Positive integer or -1 for unlimited (default).
+  The maximum number of connections per second allowed for the listener. Positive integer or -1 for unlimited (default). This annotation supports update operation.
 
 - `loadbalancer.openstack.org/keep-floatingip`
 
@@ -148,7 +148,7 @@ Request Body:
 
 - `service.beta.kubernetes.io/openstack-internal-load-balancer`
 
-  If 'true', the loadbalancer VIP won't be associated with a floating IP. Default is 'false'.
+  If 'true', the loadbalancer VIP won't be associated with a floating IP. Default is 'false'. This annotation is ignored if only internal Service is allowed to create in the cluster.
 
 - `loadbalancer.openstack.org/enable-health-monitor`
 
@@ -257,6 +257,8 @@ spec:
       port: 80
       targetPort: 8080
 ```
+
+`loadBalancerSourceRanges` field supports to be updated.
 
 ## Issues
 

--- a/docs/using-openstack-cloud-controller-manager.md
+++ b/docs/using-openstack-cloud-controller-manager.md
@@ -152,38 +152,59 @@ Although the openstack-cloud-controller-manager was initially implemented with N
 
 * `use-octavia`
   Whether or not to use Octavia for LoadBalancer type of Service implementation instead of using Neutron-LBaaS. Default: true
+  
 * `floating-network-id`
-  Optional. The external network used to create floating IP for the load balancer VIP.
+  Optional. The external network used to create floating IP for the load balancer VIP. If there are multiple external networks in the cloud, either this option must be set or user must specify `loadbalancer.openstack.org/floating-network-id` in the Service annotation.
+
 * `floating-subnet-id`
-  Optional. The subnet ID used to create floating IP for the load balancer's VIP. Floating subnet should belong to the floating network.
+  Optional. The external network subnet used to create floating IP for the load balancer VIP. Can be overridden by the Service annotation `loadbalancer.openstack.org/floating-subnet-id`.
+
 * `lb-method`
   The load balancing algorithm used to create the load balancer pool. The value can be `ROUND_ROBIN`, `LEAST_CONNECTIONS`, or `SOURCE_IP`. Default: `ROUND_ROBIN`
+
 * `lb-provider`
   Optional. Used to specify the provider of the load balancer, e.g. "amphora" or "octavia".
+
 * `lb-version`
   Optional. If specified, only "v2" is supported.
+
 * `subnet-id`
-  ID of the Neutron subnet on which to create load balancer VIP.
+  ID of the Neutron subnet on which to create load balancer VIP, this ID is also used to create pool members.
+
 * `network-id`
   ID of the Neutron network on which to create load balancer VIP, not needed if `subnet-id` is set.
+
 * `manage-security-groups`
   If the Neutron security groups should be managed separately. Default: false
 
-  This option is not needed when using Octavia. The worker nodes and the Octavia amphorae are usually in the same subnet, so it's sufficient to config the port security group rules manually for worker nodes, to allow the traffic coming from the the subnet IP range to the node port range(i.e. 30000-32767).
+  This option is not supported for Octavia. The worker nodes and the Octavia amphorae are usually in the same subnet, so it's sufficient to config the port security group rules manually for worker nodes, to allow the traffic coming from the the subnet IP range to the node port range(i.e. 30000-32767).
+
 * `create-monitor`
   Indicates whether or not to create a health monitor for the service load balancer. Default: false
+
 * `monitor-delay`
   The time, in seconds, between sending probes to members of the load balancer. Default: 5
+
 * `monitor-max-retries`
   The number of successful checks before changing the operating status of the load balancer member to ONLINE. A valid value is from 1 to 10. Default: 1
+
 * `monitor-timeout`
   The maximum time, in seconds, that a monitor waits to connect backend before it times out. Default: 3
-* `node-security-group`
-  Deprecated.
+
 * `internal-lb`
   Determines whether or not to create an internal load balancer (no floating IP) by default. Default: false.
+
 * `cascade-delete`
   Determines whether or not to perform cascade deletion of load balancers. Default: true.
+
+* `LoadBalancerClass "ClassName"`
+  This is a config section including a set of config options. User can choose the `ClassName` by specifying the Service annotation `loadbalancer.openstack.org/class`. The following options are supported:
+
+  * floating-network-id. The same with `floating-network-id` option above.
+  * floating-subnet-id. The same with `floating-subnet-id` option above.
+  * network-id. The same with `network-id` option above.
+  * subnet-id. The same with `subnet-id` option above.
+
 ### Metadata
 
 * `search-order`

--- a/pkg/util/openstack/loadbalancer.go
+++ b/pkg/util/openstack/loadbalancer.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 	version "github.com/hashicorp/go-version"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
 	cpoerrors "k8s.io/cloud-provider-openstack/pkg/util/errors"
 )
@@ -257,11 +257,78 @@ func GetPoolByName(client *gophercloud.ServiceClient, name string, lbID string) 
 	return &listenerPools[0], nil
 }
 
+// GetPoolsByListener finds pool for a listener. A listener always has exactly one pool.
+func GetPoolByListener(client *gophercloud.ServiceClient, lbID, listenerID string) (*pools.Pool, error) {
+	listenerPools := make([]pools.Pool, 0, 1)
+	err := pools.List(client, pools.ListOpts{LoadbalancerID: lbID}).EachPage(func(page pagination.Page) (bool, error) {
+		poolsList, err := pools.ExtractPools(page)
+		if err != nil {
+			return false, err
+		}
+		for _, p := range poolsList {
+			for _, l := range p.Listeners {
+				if l.ID == listenerID {
+					listenerPools = append(listenerPools, p)
+				}
+			}
+		}
+		if len(listenerPools) > 1 {
+			return false, ErrMultipleResults
+		}
+		return true, nil
+	})
+	if err != nil {
+		if cpoerrors.IsNotFound(err) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	if len(listenerPools) == 0 {
+		return nil, ErrNotFound
+	}
+
+	return &listenerPools[0], nil
+}
+
 // DeleteLoadbalancer deletes a loadbalancer with all its child objects.
 func DeleteLoadbalancer(client *gophercloud.ServiceClient, lbID string) error {
 	err := loadbalancers.Delete(client, lbID, loadbalancers.DeleteOpts{Cascade: true}).ExtractErr()
 	if err != nil && !cpoerrors.IsNotFound(err) {
 		return fmt.Errorf("error deleting loadbalancer %s: %v", lbID, err)
+	}
+
+	return nil
+}
+
+// GetMembersbyPool get all the members in the pool.
+func GetMembersbyPool(client *gophercloud.ServiceClient, poolID string) ([]pools.Member, error) {
+	var members []pools.Member
+
+	err := pools.ListMembers(client, poolID, pools.ListMembersOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		membersList, err := pools.ExtractMembers(page)
+		if err != nil {
+			return false, err
+		}
+		members = append(members, membersList...)
+
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return members, nil
+}
+
+func BatchUpdatePoolMembers(client *gophercloud.ServiceClient, lbID, poolID string, opts []pools.BatchUpdateMemberOpts) error {
+	err := pools.BatchUpdateMembers(client, poolID, opts).ExtractErr()
+	if err != nil {
+		return err
+	}
+
+	if err := waitLoadbalancerActive(client, lbID); err != nil {
+		return fmt.Errorf("failed to wait for load balancer ACTIVE after updating pool members for %s: %v", poolID, err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Refactor loadbalancer related functions, split the code when Octavia is enabled.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->
Now, `ensureOctaviaLoadBalancer()` and `updateOctaviaLoadBalancer()` should be the two functions we need to maintain. Legacy code should be removed at some point in the future.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
