### PR TITLE
[cinder-csi-plugin] Backward compatible to cinder api v2

### DIFF
--- a/docs/using-cinder-csi-plugin.md
+++ b/docs/using-cinder-csi-plugin.md
@@ -106,7 +106,7 @@ search-order = configDrive,metadataService
 
 ```
 [BlockStorage]
-bs-version=v3
+bs-version=v2
 ```
 
 > NOTE: if your openstack cloud has cert (which means you already has [ca-file](provider-configuration.md#global-optional-parameters) definition in cloud-config), please make sure that you also updated the volumes list of `cinder-csi-controllerplugin.yaml` and `cinder-csi-nodeplugin.yaml` to include the cacert. e.g following sample then mount the volume to the pod as well.

--- a/docs/using-cinder-csi-plugin.md
+++ b/docs/using-cinder-csi-plugin.md
@@ -101,6 +101,14 @@ by using the result of the above command.
 search-order = configDrive,metadataService
 ```
 
+> NOTE: If you are using OpenStack cloud with old version cinder api (v2),
+> considering use `bs-version=v2` to enable backward compatible ability.
+
+```
+[BlockStorage]
+bs-version=v3
+```
+
 > NOTE: if your openstack cloud has cert (which means you already has [ca-file](provider-configuration.md#global-optional-parameters) definition in cloud-config), please make sure that you also updated the volumes list of `cinder-csi-controllerplugin.yaml` and `cinder-csi-nodeplugin.yaml` to include the cacert. e.g following sample then mount the volume to the pod as well.
 
 ```

--- a/pkg/csi/cinder/etc/cloud.conf
+++ b/pkg/csi/cinder/etc/cloud.conf
@@ -4,3 +4,6 @@ password=pass
 auth-url=https://<keystone_ip>/identity/v3
 tenant-id=c869168a828847f39f7f06edd7305637
 domain-id=2a73b8f597c04551a0fdc8e95544be8a
+
+[BlockStorage]
+bs-version=v3


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

add backward compatible to Cinder API v2
Cinder API v2 is deprecated in official support,
but upgrade to v3 is hard work for old cloud platforms (We start at OS Mitaka version).

**Which issue this PR fixes(if applicable)**:
fixes #751 #1059 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
