### PR TITLE
[occm] changing connection-limit annotation not limited to Octavia

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -1058,11 +1058,12 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 			listenerChanged := false
 			updateOpts := listeners.UpdateOpts{}
 
+			if connLimit != listener.ConnLimit {
+				updateOpts.ConnLimit = &connLimit
+				listenerChanged = true
+			}
+
 			if lbaas.opts.UseOctavia {
-				if connLimit != listener.ConnLimit {
-					updateOpts.ConnLimit = &connLimit
-					listenerChanged = true
-				}
 				if openstackutil.IsOctaviaFeatureSupported(lbaas.lb, openstackutil.OctaviaFeatureVIPACL) {
 					if !cpoutil.StringListEqual(listenerAllowedCIDRs, listener.AllowedCIDRs) {
 						updateOpts.AllowedCIDRs = &listenerAllowedCIDRs


### PR DESCRIPTION
**What this PR does / why we need it**:
In [PR](https://github.com/kubernetes/cloud-provider-openstack/pull/837) the change of the `connection-limit` was
limited to Octavia but should be updated without this restriction.

**Which issue this PR fixes(if applicable)**:
fixes #1147 

**Special notes for reviewers**:
The intention of the mentioned [PR](https://github.com/kubernetes/cloud-provider-openstack/pull/837) was
to restrict `allowed_cidrs` to Octavia according to this [issue](https://github.com/kubernetes/cloud-provider-openstack/issues/829). Propably unintentional the `connection-limit` was included by the code change.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] Update Neutron loadbalancer if service annoation `loadbalancer.openstack.org/connection-limit` changes
```

<sub>Sean Schneeweiss <sean.schneeweiss@daimler.com>, Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sub>