### PR TITLE
[occm] fix bug for network-id annotation

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -476,7 +476,7 @@ func (lbaas *LbaasV2) createOctaviaLoadBalancer(service *corev1.Service, name, c
 
 		if lbClass != nil && lbClass.NetworkID != "" {
 			createOpts.VipNetworkID = lbClass.NetworkID
-		} else if lbaas.opts.NetworkID != "" {
+		} else if svcConf.lbNetworkID != "" {
 			createOpts.VipNetworkID = svcConf.lbNetworkID
 		} else {
 			klog.V(4).Infof("network-id parameter not passed, it will be inferred from subnet-id")


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This bug was introduced in PR: https://github.com/kubernetes/cloud-provider-openstack/pull/1144

How to reproduce?
Set `loadbalancer.openstack.org/network-id` annotation in service template. Cloud provider will not consume the value mentioned in the annotation!

**Release note**:
```release-note
NONE
```
