### PR TITLE
[manila-csi-plugin] Export location resolution moved into individual share adapters

### DIFF
--- a/pkg/csi/manila/nodeserver.go
+++ b/pkg/csi/manila/nodeserver.go
@@ -28,7 +28,6 @@ import (
 	openstack_provider "k8s.io/cloud-provider-openstack/pkg/cloudprovider/providers/openstack"
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila/options"
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila/shareadapters"
-	manilautil "k8s.io/cloud-provider-openstack/pkg/csi/manila/util"
 	clouderrors "k8s.io/cloud-provider-openstack/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
@@ -97,13 +96,6 @@ func (ns *nodeServer) buildVolumeContext(volID volumeID, shareOpts *options.Node
 			volID, share.ID, share.Status)
 	}
 
-	// Choose an export location for this share
-
-	chosenExportLocation, err := manilautil.GetChosenExportLocation(share.ID, manilaClient)
-	if err != nil {
-		return nil, nil, status.Errorf(codes.Internal, "failed to resolve export location for volume %s: %v", volID, err)
-	}
-
 	// Get the access right for this share
 
 	accessRights, err := manilaClient.GetAccessRights(share.ID)
@@ -124,11 +116,19 @@ func (ns *nodeServer) buildVolumeContext(volID volumeID, shareOpts *options.Node
 			shareOpts.ShareAccessID, volID, share.ID)
 	}
 
+	// Retrieve list of all export locations for this share.
+	// Share adapter will try to choose the correct one for mounting.
+
+	availableExportLocations, err := manilaClient.GetExportLocations(share.ID)
+	if err != nil {
+		return nil, nil, status.Errorf(codes.Internal, "failed to list export locations for volume %s: %v", volID, err)
+	}
+
 	// Build volume context for fwd plugin
 
 	sa := getShareAdapter(ns.d.shareProto)
 
-	volumeContext, err = sa.BuildVolumeContext(&shareadapters.VolumeContextArgs{Location: chosenExportLocation, Options: shareOpts})
+	volumeContext, err = sa.BuildVolumeContext(&shareadapters.VolumeContextArgs{Locations: availableExportLocations, Options: shareOpts})
 	if err != nil {
 		return nil, nil, status.Errorf(codes.InvalidArgument, "failed to build volume context for volume %s: %v", volID, err)
 	}

--- a/pkg/csi/manila/shareadapters/cephfs.go
+++ b/pkg/csi/manila/shareadapters/cephfs.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
 	"k8s.io/apimachinery/pkg/util/wait"
+	manilautil "k8s.io/cloud-provider-openstack/pkg/csi/manila/util"
 	"k8s.io/klog/v2"
 )
 
@@ -104,7 +105,12 @@ func (Cephfs) GetOrGrantAccess(args *GrantAccessArgs) (accessRight *shares.Acces
 }
 
 func (Cephfs) BuildVolumeContext(args *VolumeContextArgs) (volumeContext map[string]string, err error) {
-	monitors, rootPath, err := splitExportLocation(args.Location)
+	chosenExportLocation, err := manilautil.ChooseExportLocation(args.Locations)
+	if err != nil {
+		return nil, fmt.Errorf("failed to choose an export location: %v", err)
+	}
+
+	monitors, rootPath, err := splitExportLocation(chosenExportLocation)
 
 	return map[string]string{
 		"monitors":        monitors,

--- a/pkg/csi/manila/shareadapters/nfs.go
+++ b/pkg/csi/manila/shareadapters/nfs.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
+	manilautil "k8s.io/cloud-provider-openstack/pkg/csi/manila/util"
 	"k8s.io/klog/v2"
 )
 
@@ -57,7 +58,12 @@ func (NFS) GetOrGrantAccess(args *GrantAccessArgs) (*shares.AccessRight, error) 
 }
 
 func (NFS) BuildVolumeContext(args *VolumeContextArgs) (volumeContext map[string]string, err error) {
-	server, share, err := splitExportLocation(args.Location)
+	chosenExportLocation, err := manilautil.ChooseExportLocation(args.Locations)
+	if err != nil {
+		return nil, fmt.Errorf("failed to choose an export location: %v", err)
+	}
+
+	server, share, err := splitExportLocation(chosenExportLocation)
 
 	return map[string]string{
 		"server": server,

--- a/pkg/csi/manila/shareadapters/shareadapter.go
+++ b/pkg/csi/manila/shareadapters/shareadapter.go
@@ -29,8 +29,11 @@ type GrantAccessArgs struct {
 }
 
 type VolumeContextArgs struct {
-	Location *shares.ExportLocation
-	Options  *options.NodeVolumeContext
+	// Share adapters are responsible for choosing
+	// an export location when building a volume context.
+	Locations []shares.ExportLocation
+
+	Options *options.NodeVolumeContext
 }
 
 type SecretArgs struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR refactors the export location resolution code and moves it into individual share adapters. This is to prepare share adapters to employ their own logic into choosing an appropriate export location.

xref https://github.com/kubernetes/cloud-provider-openstack/issues/1136

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
