### PR TITLE
[manila-csi-plugin] Added runtime config with export location filter for NFS

### DIFF
--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.9"
 description: A Helm chart for Kubernetes
 name: openstack-manila-csi
-version: 0.1.1
+version: 0.1.2

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -74,6 +74,9 @@ spec:
             --with-topology
             --nodeaz={{ $.Values.csimanila.nodeAZ }}
             {{- end }}
+            {{- if $.Values.csimanila.runtimeConfig.enabled }}
+            --runtime-config-file=/runtimeconfig/runtimeconfig.json
+            {{- end }}
             --endpoint=$(CSI_ENDPOINT)
             --drivername=$(DRIVER_NAME)
             --share-protocol-selector=$(MANILA_SHARE_PROTO)
@@ -104,6 +107,11 @@ spec:
             - name: pod-mounts
               mountPath: /var/lib/kubelet/pods
               mountPropagation: Bidirectional
+            {{- if $.Values.csimanila.runtimeConfig.enabled }}
+            - name: {{ .protocolSelector | lower }}-runtime-config-dir
+              mountPath: /runtimeconfig
+              readOnly: true
+            {{- end }}
           resources:
 {{ toYaml $.Values.controllerplugin.nodeplugin.resources | indent 12 }}
         {{- end }}
@@ -117,6 +125,11 @@ spec:
           hostPath:
             path: {{ .fwdNodePluginEndpoint.dir }}
             type: Directory
+        {{- if $.Values.csimanila.runtimeConfig.enabled }}
+        - name: {{ .protocolSelector | lower }}-runtime-config-dir
+          configMap:
+            name: manila-csi-runtimeconf-cm
+        {{- end }}
         {{- end }}
         - name: pod-mounts
           hostPath:

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -66,6 +66,9 @@ spec:
             '/bin/manila-csi-plugin
             --v=5
             --nodeid=$(NODE_ID)
+            {{- if $.Values.csimanila.runtimeConfig.enabled }}
+            --runtime-config-file=/runtimeconfig/runtimeconfig.json
+            {{- end }}
             {{- if $.Values.csimanila.topologyAwarenessEnabled }}
             --with-topology
             --nodeaz={{ $.Values.csimanila.nodeAZ }}
@@ -94,6 +97,11 @@ spec:
               mountPath: /var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}
             - name: {{ .protocolSelector | lower }}-fwd-plugin-dir
               mountPath: {{ .fwdNodePluginEndpoint.dir }}
+            {{- if $.Values.csimanila.runtimeConfig.enabled }}
+            - name: {{ .protocolSelector | lower }}-runtime-config-dir
+              mountPath: /runtimeconfig
+              readOnly: true
+            {{- end }}
           resources:
 {{ toYaml $.Values.nodeplugin.nodeplugin.resources | indent 12 }}
         {{- end }}
@@ -111,6 +119,11 @@ spec:
           hostPath:
             path: {{ .fwdNodePluginEndpoint.dir }}
             type: DirectoryOrCreate
+        {{- if $.Values.csimanila.runtimeConfig.enabled }}
+        - name: {{ .protocolSelector | lower }}-runtime-config-dir
+          configMap:
+            name: manila-csi-runtimeconf-cm
+        {{- end }}
         {{- end }}
     {{- if .Values.nodeplugin.affinity -}}
       affinity:

--- a/charts/manila-csi-plugin/templates/runtimeconfig-cm.yaml
+++ b/charts/manila-csi-plugin/templates/runtimeconfig-cm.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.csimanila.runtimeConfig.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: manila-csi-runtimeconf-cm
+data:
+  runtimeconfig.json: |-
+{{ .Values.csimanila.runtimeConfig.jsonData | indent 4 }}
+{{- end }}

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -16,6 +16,15 @@ shareProtocols:
 csimanila:
   # Set topologyAwarenessEnabled to true to enable topology awareness
   topologyAwarenessEnabled: false
+  # Runtime configuration
+  runtimeConfig:
+    enabled: false
+    jsonData: |-
+      {
+        "nfs": {
+          "matchExportLocationAddress": "172.168.122.0/24"
+        }
+      }
   # Availability zone for each node. topologyAwarenessEnabled must be set to true for this option to have any effect.
   # If your Kubernetes cluster runs atop of Nova and want to use Nova AZs as AZs for the nodes of the cluster, uncomment the line below:
   # nodeAZ: "$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq -r .availability_zone)"

--- a/cmd/manila-csi-plugin/main.go
+++ b/cmd/manila-csi-plugin/main.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila/csiclient"
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila/manilaclient"
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila/options"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/runtimeconfig"
 	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
 )
@@ -37,6 +38,7 @@ var (
 	driverName            string
 	nodeID                string
 	nodeAZ                string
+	runtimeConfigFile     string
 	withTopology          bool
 	protoSelector         string
 	fwdEndpoint           string
@@ -145,6 +147,8 @@ func main() {
 				klog.Fatalf("driver initialization failed: %v", err)
 			}
 
+			runtimeconfig.RuntimeConfigFilename = runtimeConfigFile
+
 			d.Run()
 		},
 	}
@@ -159,6 +163,8 @@ func main() {
 	cmd.MarkPersistentFlagRequired("nodeid")
 
 	cmd.PersistentFlags().StringVar(&nodeAZ, "nodeaz", "", "this node's availability zone")
+
+	cmd.PersistentFlags().StringVar(&runtimeConfigFile, "runtime-config-file", "", "path to the runtime configuration file")
 
 	cmd.PersistentFlags().BoolVar(&withTopology, "with-topology", false, "cluster is topology-aware")
 

--- a/docs/using-manila-csi-plugin.md
+++ b/docs/using-manila-csi-plugin.md
@@ -10,6 +10,7 @@
     - [Node Service volume context](#node-service-volume-context)
     - [Secrets, authentication](#secrets-authentication)
     - [Topology-aware dynamic provisioning](#topology-aware-dynamic-provisioning)
+    - [Runtime configuration file](#runtime-configuration-file)
   - [Deployment](#deployment)
     - [Kubernetes 1.15+](#kubernetes-115)
       - [Verifying the deployment](#verifying-the-deployment)
@@ -33,6 +34,7 @@ Option | Default value | Description
 `--drivername` | `manila.csi.openstack.org` | Name of this driver
 `--nodeid` | _none_ | ID of this node
 `--nodeaz` | _none_ | Availability zone of this node
+`--runtime-config-file` | _none_ | Path to the [runtime configuration file](#runtime-configuration-file)
 `--with-topology` | _none_ | CSI Manila is topology-aware. See [Topology-aware dynamic provisioning](#topology-aware-dynamic-provisioning) for more info
 `--share-protocol-selector` | _none_ | Specifies which Manila share protocol to use for this instance of the driver. See [supported protocols](#share-protocol-support-matrix) for valid values.
 `--fwdendpoint` | _none_ | [CSI Node Plugin](https://github.com/container-storage-interface/spec/blob/master/spec.md#rpc-interface) endpoint to which all Node Service RPCs are forwarded. Must be able to handle the file-system specified in `share-protocol-selector`. Check out the [Deployment](#deployment) section to see why this is necessary.
@@ -119,6 +121,23 @@ Storage AZ does not influence
 ```
 
 [Enabling topology awareness in Kubernetes](#enabling-topology-awareness)
+
+### Runtime configuration file
+
+CSI Manila's runtime configuration file is a JSON document for modifying behavior of the driver at runtime.
+
+Schema:
+
+* Root object:
+  Attribute | Type | Description
+  ----------|------|------------
+  `nfs` | `NfsConfig` | Configuration for NFS shares. Optional.
+* `NfsConfig`:
+  Attribute | Type | Description
+  ----------|------|------------
+  `matchExportLocationAddress` | `string` | When mounting an NFS share, select an export location with matching IP address. No match between this address and at least a single export location for this share will result in an error. Expects a CIDR-formatted address. If prefix is not provided, /32 or /128 prefix is assumed for IPv4 and IPv6 respectively. Optional.
+
+In Kubernetes, you may store this configuration in a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) and expose it to CSI Manila pods as a [volume](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#add-configmap-data-to-a-volume). Then enter the path to the file populated by the ConfigMap into `--runtime-config-file`. Demo ConfigMap is located in `examples/manila-csi-plugin/runtimeconfig-cm.yaml`. If you're deploying CSI Manila with Helm, setting `csimanila.runtimeConfig.enabled` to `true` will take care of the setup.
 
 ## Deployment
 
@@ -214,3 +233,4 @@ Manila share protocol | CSI Node Plugin
 ## For developers
 
 If you'd like to contribute to CSI Manila, check out `docs/developers-csi-manila.md` to get you started.
+

--- a/examples/manila-csi-plugin/runtimeconfig-cm.yaml
+++ b/examples/manila-csi-plugin/runtimeconfig-cm.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: manila-csi-runtimeconf-cm
+data:
+  runtimeconfig.json: |
+    {
+      "nfs": {
+        # When mounting an NFS share, select an export location with
+        # this IP address. No match between this address and
+        # at least a single export location for this share will
+        # result in an error.
+        # Expects a CIDR-formatted address. If prefix is not provided,
+        # /32 or /128 prefix is assumed for IPv4 and IPv6 respectively.
+        "matchExportLocationAddress": "172.168.122.0/24"
+      }
+    }

--- a/pkg/csi/manila/runtimeconfig/nfsconfig.go
+++ b/pkg/csi/manila/runtimeconfig/nfsconfig.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtimeconfig
+
+type NfsConfig struct {
+	// When mounting an NFS share, select an export location with matching IP address.
+	// No match between this address and at least a single export location for this share
+	// will result in an error.
+	// Expects a CIDR-formatted address. If prefix is not provided,
+	// /32 or /128 prefix is assumed for IPv4 and IPv6 respectively.
+	MatchExportLocationAddress string `json:"matchExportLocationAddress,omitempty"`
+}

--- a/pkg/csi/manila/runtimeconfig/runtimeconfig.go
+++ b/pkg/csi/manila/runtimeconfig/runtimeconfig.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtimeconfig
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+)
+
+var (
+	// Path to the runtime config file
+	RuntimeConfigFilename string
+)
+
+type RuntimeConfig struct {
+	Nfs *NfsConfig `json:"nfs,omitempty"`
+}
+
+func Get() (*RuntimeConfig, error) {
+	// File contents are deliberately not cached
+	// as they may change over time.
+	data, err := ioutil.ReadFile(RuntimeConfigFilename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	var cfg *RuntimeConfig
+	if err = json.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}

--- a/pkg/csi/manila/shareadapters/cephfs.go
+++ b/pkg/csi/manila/shareadapters/cephfs.go
@@ -110,7 +110,7 @@ func (Cephfs) BuildVolumeContext(args *VolumeContextArgs) (volumeContext map[str
 		return nil, fmt.Errorf("failed to choose an export location: %v", err)
 	}
 
-	monitors, rootPath, err := splitExportLocation(&args.Locations[chosenExportLocationIdx])
+	monitors, rootPath, err := splitExportLocationPath(args.Locations[chosenExportLocationIdx].Path)
 
 	return map[string]string{
 		"monitors":        monitors,

--- a/pkg/csi/manila/shareadapters/nfs.go
+++ b/pkg/csi/manila/shareadapters/nfs.go
@@ -18,9 +18,12 @@ package shareadapters
 
 import (
 	"fmt"
+	"net"
+	"strings"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
+	"k8s.io/cloud-provider-openstack/pkg/csi/manila/runtimeconfig"
 	manilautil "k8s.io/cloud-provider-openstack/pkg/csi/manila/util"
 	"k8s.io/klog/v2"
 )
@@ -58,12 +61,12 @@ func (NFS) GetOrGrantAccess(args *GrantAccessArgs) (*shares.AccessRight, error) 
 }
 
 func (NFS) BuildVolumeContext(args *VolumeContextArgs) (volumeContext map[string]string, err error) {
-	chosenExportLocationIdx, err := manilautil.FindExportLocation(args.Locations, manilautil.AnyExportLocation)
+	chosenExportLocationIdx, err := nfsChooseExportLocation(args.Locations)
 	if err != nil {
 		return nil, fmt.Errorf("failed to choose an export location: %v", err)
 	}
 
-	server, share, err := splitExportLocation(&args.Locations[chosenExportLocationIdx])
+	server, share, err := splitExportLocationPath(args.Locations[chosenExportLocationIdx].Path)
 
 	return map[string]string{
 		"server": server,
@@ -77,4 +80,86 @@ func (NFS) BuildNodeStageSecret(args *SecretArgs) (secret map[string]string, err
 
 func (NFS) BuildNodePublishSecret(args *SecretArgs) (secret map[string]string, err error) {
 	return nil, nil
+}
+
+// Tries to choose a suitable export location from the given list.
+// Returns index into `locs`.
+// Runtime config for NFS is probed first to see if it contains any export location filters.
+// Those are then used for selecting the location. If none are defined, the function
+// falls back to using manilautil.AnyExportLocation filter.
+func nfsChooseExportLocation(locs []shares.ExportLocation) (chosenExportLocationIdx int, err error) {
+	var conf *runtimeconfig.RuntimeConfig
+
+	if conf, err = runtimeconfig.Get(); err != nil {
+		return -1, fmt.Errorf("failed to read runtime config file %s: %v", runtimeconfig.RuntimeConfigFilename, err)
+	}
+
+	if conf != nil {
+		if chosenExportLocationIdx, err = nfsMatchExportLocationFromConfig(locs, conf); err != nil {
+			return -1, err
+		}
+
+		if chosenExportLocationIdx != -1 {
+			return chosenExportLocationIdx, err
+		}
+
+		// If we got here, it either means there's no NFS config,
+		// or it doesn't contain any configuration for export locations.
+		// Fall through and choose any suitable location.
+	}
+
+	return manilautil.FindExportLocation(locs, manilautil.AnyExportLocation)
+}
+
+func nfsMatchExportLocationFromConfig(locs []shares.ExportLocation, conf *runtimeconfig.RuntimeConfig) (idx int, err error) {
+	if conf.Nfs != nil {
+		if conf.Nfs.MatchExportLocationAddress != "" {
+			return nfsMatchExportLocationAddress(locs, conf.Nfs.MatchExportLocationAddress)
+		}
+	}
+
+	// No NFS export location filters specified
+	return -1, nil
+}
+
+// Selects an export location with a matching address
+func nfsMatchExportLocationAddress(locs []shares.ExportLocation, matchAddress string) (idx int, err error) {
+	if ip := net.ParseIP(matchAddress); ip != nil {
+		// `matchAddress` is a valid IP, but does not have a prefix.
+		// This means we're looking for an exact match in export location addresses.
+
+		// Heuristic to check whether this is an IPv4 or IPv6 address
+		if strings.Contains(matchAddress, ".") {
+			// IPv4
+			matchAddress += "/32"
+		} else {
+			// IPv6
+			matchAddress += "/128"
+		}
+	}
+
+	_, netIP, err := net.ParseCIDR(matchAddress)
+	if err != nil {
+		return -1, fmt.Errorf("matchExportLocationAddress filter '%s' is not a CIDR-formatted IP address", matchAddress)
+	}
+
+	idx, err = manilautil.FindExportLocation(locs, func(i int) (bool, error) {
+		addr, _, err := splitExportLocationPath(locs[i].Path)
+		if err != nil {
+			return false, err
+		}
+
+		hostIP := net.ParseIP(addr)
+		if hostIP == nil {
+			return false, fmt.Errorf("IP '%s' in export location path %s is invalid", addr, locs[i].Path)
+		}
+
+		return netIP.Contains(hostIP), nil
+	})
+
+	if err != nil {
+		return -1, fmt.Errorf("matchExportLocationAddress filter '%s': %v", matchAddress, err)
+	}
+
+	return idx, nil
 }

--- a/pkg/csi/manila/shareadapters/util.go
+++ b/pkg/csi/manila/shareadapters/util.go
@@ -19,19 +19,17 @@ package shareadapters
 import (
 	"fmt"
 	"strings"
-
-	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
 )
 
-func splitExportLocation(loc *shares.ExportLocation) (address, location string, err error) {
-	delimPos := strings.LastIndexByte(loc.Path, ':')
+func splitExportLocationPath(exportLocationPath string) (address, location string, err error) {
+	delimPos := strings.LastIndexByte(exportLocationPath, ':')
 	if delimPos <= 0 {
-		err = fmt.Errorf("failed to parse address and location from export location '%s'", loc.Path)
+		err = fmt.Errorf("failed to parse address and location from export location '%s'", exportLocationPath)
 		return
 	}
 
-	address = loc.Path[:delimPos]
-	location = loc.Path[delimPos+1:]
+	address = exportLocationPath[:delimPos]
+	location = exportLocationPath[delimPos+1:]
 
 	return
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The main point of this PR is to give users the ability to filter out export location for NFS shares. Here is the use-case: https://github.com/kubernetes/cloud-provider-openstack/issues/1136

This is achieved by having a runtime JSON config file (represented as a ConfigMap in k8s) where users may enter a single IP address in CIDR format. This address is then used to choose an export location that matches this address. No match results in `NodePublishVolume` returning error with code `INVALID_ARGUMENT`.

**Which issue this PR fixes(if applicable)**:
fixes https://github.com/kubernetes/cloud-provider-openstack/issues/1136

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
manila-csi-plugin: added runtime configuration file, --runtime-config-file cmd argument
manila-csi-plugin: added the ability to filter out export locations for NFS shares using a CIDR address configurable via runtime config
```
