### PR TITLE
[occm] add octavia loadbalancer flavor option

### DIFF
--- a/docs/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/expose-applications-using-loadbalancer-type-service.md
@@ -153,6 +153,10 @@ Request Body:
 - `loadbalancer.openstack.org/enable-health-monitor`
 
   Defines whether or not to create health monitor for the load balancer pool, if not specified, use `create-monitor` config. The health monitor can be created or deleted dynamically.
+  
+- `loadbalancer.openstack.org/flavor-id`
+
+  The id of the flavor that is used for creating the loadbalancer.
 
 ### Switching between Floating Subnets by using preconfigured Classes
 

--- a/docs/using-openstack-cloud-controller-manager.md
+++ b/docs/using-openstack-cloud-controller-manager.md
@@ -196,6 +196,9 @@ Although the openstack-cloud-controller-manager was initially implemented with N
 
 * `cascade-delete`
   Determines whether or not to perform cascade deletion of load balancers. Default: true.
+  
+* `flavor-id`
+  The id of the loadbalancer flavor to use. Uses octavia default if not set.
 
 * `LoadBalancerClass "ClassName"`
   This is a config section including a set of config options. User can choose the `ClassName` by specifying the Service annotation `loadbalancer.openstack.org/class`. The following options are supported:

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -132,6 +132,7 @@ type LoadBalancerOpts struct {
 	NodeSecurityGroupIDs []string            // Do not specify, get it automatically when enable manage-security-groups. TODO(FengyunPan): move it into cache
 	InternalLB           bool                `gcfg:"internal-lb"`    // default false
 	CascadeDelete        bool                `gcfg:"cascade-delete"` // applicable only if use-octavia is set to True
+	FlavorID             string              `gcfg:"flavor-id"`
 }
 
 // LBClass defines the corresponding floating network, floating subnet or internal subnet ID

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -95,6 +95,7 @@ const (
 	ServiceAnnotationLoadBalancerTimeoutMemberData    = "loadbalancer.openstack.org/timeout-member-data"
 	ServiceAnnotationLoadBalancerTimeoutTCPInspect    = "loadbalancer.openstack.org/timeout-tcp-inspect"
 	ServiceAnnotationLoadBalancerXForwardedFor        = "loadbalancer.openstack.org/x-forwarded-for"
+	ServiceAnnotationLoadBalancerFlavorID             = "loadbalancer.openstack.org/flavor-id"
 	// ServiceAnnotationLoadBalancerEnableHealthMonitor defines whether or not to create health monitor for the load balancer
 	// pool, if not specified, use 'create-monitor' config. The health monitor can be created or deleted dynamically.
 	ServiceAnnotationLoadBalancerEnableHealthMonitor = "loadbalancer.openstack.org/enable-health-monitor"
@@ -118,6 +119,7 @@ type serviceConfig struct {
 	enableProxyProtocol bool
 	allowedCIDR         []string
 	enableMonitor       bool
+	flavorID            string
 }
 
 type listenerKey struct {
@@ -460,6 +462,7 @@ func (lbaas *LbaasV2) createOctaviaLoadBalancer(service *corev1.Service, name, c
 		Name:        name,
 		Description: fmt.Sprintf("Kubernetes external service %s/%s from cluster %s", service.Namespace, service.Name, clusterName),
 		Provider:    lbaas.opts.LBProvider,
+		FlavorID:    svcConf.flavorID,
 	}
 
 	vipPort := getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerPortID, "")
@@ -1197,6 +1200,7 @@ func (lbaas *LbaasV2) checkService(service *corev1.Service, nodes []*corev1.Node
 
 	svcConf.lbNetworkID = getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerNetworkID, lbaas.opts.NetworkID)
 	svcConf.lbSubnetID = getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerSubnetID, lbaas.opts.SubnetID)
+	svcConf.flavorID = getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerFlavorID, lbaas.opts.FlavorID)
 	if lbaas.opts.SubnetID != "" {
 		svcConf.lbMemberSubnetID = lbaas.opts.SubnetID
 	} else {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This pr adds an option to specify the flavor-id used for the octavia loadbalancer.
The flavor-id can be set in the config or via annotation.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->
Flavors were being introduced in octavia version 4.0.0 if I am not mistaken.
I haven't found a way to check the octavia version from within the occm so if a check is needed here I would appreciate if someone can point me in the right direction here.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] Add support to set octavia loadbalancer flavor-id.
```
