### PR TITLE
[cinder-csi-plugin]update chart cacert location to /etc/caert

### DIFF
--- a/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -101,12 +101,12 @@ spec:
             - name: socket-dir
               mountPath: /csi
             - name: cacert
-              mountPath: /etc/kubernetes
+              mountPath: /etc/cacert
               readOnly: true
       volumes:
         - name: cacert
           hostPath:
-            path: /etc/kubernetes
+            path: /etc/cacert
             type: Directory
         - name: socket-dir
           emptyDir:

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -74,12 +74,12 @@ spec:
               mountPath: /dev
               mountPropagation: "HostToContainer"
             - name: cacert
-              mountPath: /etc/kubernetes
+              mountPath: /etc/cacert
               readOnly: true
       volumes:
         - name: cacert
           hostPath:
-            path: /etc/kubernetes
+            path: /etc/cacert
             type: Directory
         - name: socket-dir
           hostPath:


### PR DESCRIPTION
per doc for chart and our previous manifest, cacert is located
at /etc/cacert

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
