### PR TITLE
[cinder-csi-plugin] Bump driver version to 1.2.1

### DIFF
--- a/pkg/csi/cinder/driver.go
+++ b/pkg/csi/cinder/driver.go
@@ -37,7 +37,7 @@ const (
 var (
 	specVersion = "1.2.0"
 	// we used to use spec version as driver version, now separate them
-	Version = "1.2.0"
+	Version = "1.2.1"
 )
 
 type CinderDriver struct {

--- a/pkg/csi/cinder/driver_test.go
+++ b/pkg/csi/cinder/driver_test.go
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	vendorVersion = "1.2.0"
+	vendorVersion = "1.2.1"
 )
 
 func NewFakeDriver() *CinderDriver {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Bump cinder csi driver version to 1.2.1
**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[cinder-csi-plugin] Bump Cinder CSI Driver version to 1.2.1
```
