### PR TITLE
[cinder-csi-plugin]add e2e test when cloudprovider changes

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -80,6 +80,7 @@
               - cmd/cinder-csi-plugin/.*
               - manifests/cinder-csi-plugin/.* 
               - pkg/csi/cinder/.*
+              - pkg/cloudprovider/.*
               - pkg/util/.*
               - tests/e2e/csi/cinder/.*
               - cmd/tests/.*


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

https://github.com/kubernetes/cloud-provider-openstack/blob/master/pkg/csi/cinder/openstack/openstack.go#L30
uses cloud provider, so better to run cinder e2e when anything changed in that folder
**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
