### PR TITLE
Remove index.yaml and add README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Cloud Provider OpenStack Helm Chart Repository
+
+## Add repo
+
+    helm repo add cpo https://kubernetes.github.io/cloud-provider-openstack
+    helm repo update
+
+## Install Cinder CSI chart
+
+    helm install cinder-csi cpo/openstack-cinder-csi
+
+## Install Manila CSI chart
+
+    helm install manila-csi cpo/openstack-manila-csi

--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<!--Converted via md-to-html-->
+<html>
+ <head>
+ </head>
+ <body>
+  <h1>
+   Cloud Provider OpenStack Helm Chart Repository
+  </h1>
+  <h2>
+   Add repo
+  </h2>
+  <pre><code>helm repo add cpo https://kubernetes.github.io/cloud-provider-openstack
+</code></pre>
+  <pre><code>helm repo update
+</code></pre>
+  <h2>
+   Install Cinder CSI chart
+  </h2>
+  <pre><code>helm install cinder-csi cpo/openstack-cinder-csi
+</code></pre>
+  <h2>
+   Install Manila CSI chart
+  </h2>
+  <pre><code>helm install manila-csi cpo/openstack-manila-csi
+</code></pre>
+ </body>
+</html>


### PR DESCRIPTION
GH action fails when there is an empty index.yaml file.  It is better to
have none at all so that it can create a valid index.yaml file for us.

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
