### PR TITLE
[cinder-csi-plugin] find device by path from lun address

### DIFF
--- a/pkg/util/metadata/metadata.go
+++ b/pkg/util/metadata/metadata.go
@@ -253,6 +253,21 @@ func GetDevicePath(volumeID string) string {
 				return diskPaths[0]
 			}
 
+			// Hyper-V gen1 can have same lun number on several disks
+			if len(diskPaths) > 1 {
+				// Remove root and metadata disks
+				gen1DiskPaths := []string{}
+				for _, diskPath := range diskPaths {
+					if !strings.Contains(diskPath, "00000000000088990000000000000000") &&
+						!strings.Contains(diskPath, "00000001000088990000000000000000") {
+						gen1DiskPaths = append(gen1DiskPaths, diskPath)
+					}
+				}
+				if len(gen1DiskPaths) == 1 {
+					return gen1DiskPaths[0]
+				}
+			}
+
 			klog.V(4).Infof("expecting to find one disk path for volumeID %q, found %d: %v",
 				volumeID, len(diskPaths), diskPaths)
 
@@ -261,6 +276,11 @@ func GetDevicePath(volumeID string) string {
 
 	klog.V(4).Infof("Could not retrieve device metadata for volumeID: %q", volumeID)
 	return ""
+}
+
+func removeBootAndMetadataDisks(diskPaths []string) []string {
+	newSlice := []string{}
+	return newSlice
 }
 
 // Get retrieves metadata from either config drive or metadata service.


### PR DESCRIPTION
Disks can appear with the pattern `/dev/disk/by-path/*lun-<id>` on Hyper-V.
Using the last value in the address as an id.

**What this PR does / why we need it**:
Makes it possible to detect disks on Hyper-V that appear with the pattern  `/dev/disk/by-path/*lun-<id>`.

**Which issue this PR fixes(if applicable)**:
fixes #1192

**Special notes for reviewers**:
To test this PR you need Openstack installed on top of Hyper-V and install kube and cinder-csi-plugin. Then create a matching storage class, a PVC using that storage class and a Pod that mounts the PVC. See the issue for more details.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[cinder-csi-plugin] Add support for detecting disks by-path for lun volumes on Hyper-V.
```
