### PR TITLE
WIP: update docker file

### DIFF
--- a/cluster/images/cinder-csi-plugin/Dockerfile.build
+++ b/cluster/images/cinder-csi-plugin/Dockerfile.build
@@ -1,9 +1,34 @@
-ARG DEBIAN_ARCH=amd64
-FROM k8s.gcr.io/build-image/debian-base-${DEBIAN_ARCH}:v2.1.3
+FROM golang:1.13.8 as builder
 
+# Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
+ARG goproxy=https://proxy.golang.org
+ENV GOPROXY=$goproxy
+WORKDIR /workspace
+
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY ./pkg ./pkg
+COPY ./cmd/ ./cmd
+
+# Cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Build
 ARG ARCH=amd64
+ARG LDFLAGS
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -ldflags "${LDFLAGS}" -o cinder-csi-plugin  ./cmd/cinder-csi-plugin/main.go
+
+
+
+FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:v2.1.0
+
+# Copy the controller-manager into a thin image
 
 # Install e4fsprogs for format
 RUN clean-install ca-certificates e2fsprogs mount xfsprogs udev
 
-ADD cinder-csi-plugin-${ARCH} /bin/cinder-csi-plugin
+COPY --from=builder /workspace/cinder-csi-plugin ./cinder-csi-plugin-adm64
+
+ADD cinder-csi-plugin-amd64 /bin/cinder-csi-plugin


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
