### PR TITLE
[occm] lookup flavor name if only id is provided

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -281,8 +281,9 @@ func srvInstanceType(client *gophercloud.ServiceClient, srv *servers.Server) (st
 			flavor, ok := val.(string)
 			if ok {
 				if key == "id" {
+					mc := metrics.NewMetricContext("flavor", "get")
 					f, err := flavors.Get(client, flavor).Extract()
-					if err == nil {
+					if mc.ObserveRequest(err) == nil {
 						return f.Name, nil
 					}
 				}

--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -274,7 +274,7 @@ func (i *Instances) InstanceType(ctx context.Context, name types.NodeName) (stri
 }
 
 func srvInstanceType(client *gophercloud.ServiceClient, srv *servers.Server) (string, error) {
-	keys := []string{"name", "id", "original_name"}
+	keys := []string{"original_name", "id"}
 	for _, key := range keys {
 		val, found := srv.Flavor[key]
 		if found {
@@ -282,10 +282,9 @@ func srvInstanceType(client *gophercloud.ServiceClient, srv *servers.Server) (st
 			if ok {
 				if key == "id" {
 					f, err := flavors.Get(client, flavor).Extract()
-					if err != nil {
-						return "", err
+					if err == nil {
+						return f.Name, nil
 					}
-					return f.Name, nil
 				}
 				return flavor, nil
 			}

--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"k8s.io/klog/v2"
 
@@ -194,7 +195,7 @@ func (i *Instances) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloud
 		return nil, err
 	}
 
-	instanceType, err := srvInstanceType(srv)
+	instanceType, err := srvInstanceType(i.compute, srv)
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +259,7 @@ func (i *Instances) InstanceTypeByProviderID(ctx context.Context, providerID str
 		return "", err
 	}
 
-	return srvInstanceType(server)
+	return srvInstanceType(i.compute, server)
 }
 
 // InstanceType returns the type of the specified instance.
@@ -269,16 +270,23 @@ func (i *Instances) InstanceType(ctx context.Context, name types.NodeName) (stri
 		return "", err
 	}
 
-	return srvInstanceType(&srv.Server)
+	return srvInstanceType(i.compute, &srv.Server)
 }
 
-func srvInstanceType(srv *servers.Server) (string, error) {
+func srvInstanceType(client *gophercloud.ServiceClient, srv *servers.Server) (string, error) {
 	keys := []string{"name", "id", "original_name"}
 	for _, key := range keys {
 		val, found := srv.Flavor[key]
 		if found {
 			flavor, ok := val.(string)
 			if ok {
+				if key == "id" {
+					f, err := flavors.Get(client, flavor).Extract()
+					if err != nil {
+						return "", err
+					}
+					return f.Name, nil
+				}
 				return flavor, nil
 			}
 		}


### PR DESCRIPTION

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
-->

**What this PR does / why we need it**:
This calls the API for a flavor name, if only the id is used to lookup the flavor. This provides a more meaningful return value.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] Always use flavor name for the Node label `node.kubernetes.io/instance-type`.
```
<sub>Sean Schneeweiss <sean.schneeweiss@daimler.com>, Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sub>