### PR TITLE
[cinder-csi-plugin][manila-csi-plugin] Add chart releaser script

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,9 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      # TODO (brtknr): Use a release tag when the change in the commit is
+      # released under a tag greater than v1.0.0.
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.0.0
+        uses: helm/chart-releaser-action@06d81fa7f63ab865cf0ed2045bde38529c392845
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* cinder-csi-plugin
* manila-csi-plugin
-->

**What this PR does / why we need it**:

The chart-releaser-action assumes that master branch is used for release. I believe this is a bug because the chart-releaser incorrectly tags the HEAD of `master` branch rather than `release-1.19` branch (See https://github.com/kubernetes/cloud-provider-openstack/tags and notice that the openstack-* tags do not correspond to the correct commits but rather the current tip of the master branch). This does not work with our model as we want our charts to be based on `release-*` branches and explicitly not master which uses the `latest` images. This PR copies script from chart-releaser-action repo and make the necessary modification to facilitate chart publishing from release branches. Once the chart-releaser-action fixes this issue, we can revert this change.

**Which issue this PR fixes(if applicable)**:
fixes #1202

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

For provenance, most of the script is direct copy of https://github.com/helm/chart-releaser-action/blob/master/cr.sh and https://github.com/helm/chart-releaser-action/blob/master/main.sh with a small modification.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
