### PR TITLE
[cinder-csi-plugin] [doc] update doc about VolumeAttributes is optional

### DIFF
--- a/docs/using-cinder-csi-plugin.md
+++ b/docs/using-cinder-csi-plugin.md
@@ -405,6 +405,9 @@ $ kubectl create -f manifests/cinder-csi-plugin/
 ```
 $ kubectl create -f examples/cinder-csi-plugin/inline/inline-example.yaml
 ```
+
+> NOTE: specifying volume `capacity` is optional, if it's not provided, it will default to `1Gi`
+
 3. Get the pod description, verify created volume in Volumes section.
 ```
 $ kubectl describe pod


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

indicate `VolumeAttributes ` for ephemeral disk is optional and default to 1G

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
