### PR TITLE
[cinder-csi-plugin][manila-csi-plugin] Disable chart install job on Github actions workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,30 +1,9 @@
-name: Lint and Test Charts
+name: Lint Charts
 
 on: pull_request
 
 jobs:
-  changes:
-    outputs:
-      charts: ${{ steps.filter.outputs.charts }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - id: filter
-        uses: dorny/paths-filter@v2.2.0
-        with:
-          filters: |
-            charts:
-              - 'charts/**/Chart.yaml'
-              - 'charts/**/*'
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-  helm-lint-test:
-    if: ${{ needs.changes.outputs.charts == 'true' }}
-    name: Helm chart
-    needs:
-      - changes
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -38,13 +17,3 @@ jobs:
         uses: helm/chart-testing-action@v1.0.0
         with:
           command: lint
-
-      # Only build a kind cluster if there are chart changes to test.
-      - if: steps.lint.outputs.changed == 'true'
-        name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
-
-      - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v1.0.0
-        with:
-          command: install


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
For the chart install to work, the Kubernetes cluster needs to be able
to talk to an OpenStack cloud which cannot be done in the Github Actions CI. Therefore,
only perform the lint test and disable install.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
