### PR TITLE
[occm] Check is timeout parameters for Octavia listener supported

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -1665,12 +1665,10 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 					listenerCreateOpt.InsertHeaders = map[string]string{"X-Forwarded-For": "true"}
 				}
 
-				if openstackutil.IsOctaviaFeatureSupported(lbaas.lb, openstackutil.OctaviaFeatureTimeout) {
-					listenerCreateOpt.TimeoutClientData = &timeoutClientData
-					listenerCreateOpt.TimeoutMemberData = &timeoutMemberData
-					listenerCreateOpt.TimeoutMemberConnect = &timeoutMemberConnect
-					listenerCreateOpt.TimeoutTCPInspect = &timeoutTCPInspect
-				}
+				listenerCreateOpt.TimeoutClientData = &timeoutClientData
+				listenerCreateOpt.TimeoutMemberData = &timeoutMemberData
+				listenerCreateOpt.TimeoutMemberConnect = &timeoutMemberConnect
+				listenerCreateOpt.TimeoutTCPInspect = &timeoutTCPInspect
 
 				if len(listenerAllowedCIDRs) > 0 {
 					listenerCreateOpt.AllowedCIDRs = listenerAllowedCIDRs

--- a/pkg/util/openstack/loadbalancer.go
+++ b/pkg/util/openstack/loadbalancer.go
@@ -38,6 +38,7 @@ const (
 	OctaviaFeatureTags    = 0
 	OctaviaFeatureVIPACL  = 1
 	OctaviaFeatureFlavors = 2
+	OctaviaFeatureTimeout = 3
 
 	loadbalancerActiveInitDelay = 1 * time.Second
 	loadbalancerActiveFactor    = 1.2
@@ -108,6 +109,11 @@ func IsOctaviaFeatureSupported(client *gophercloud.ServiceClient, feature int) b
 		}
 	case OctaviaFeatureFlavors:
 		verFlavors, _ := version.NewVersion("v2.6")
+		if currentVer.GreaterThanOrEqual(verFlavors) {
+			return true
+		}
+	case OctaviaFeatureTimeout:
+		verFlavors, _ := version.NewVersion("v2.1")
 		if currentVer.GreaterThanOrEqual(verFlavors) {
 			return true
 		}


### PR DESCRIPTION
**What this PR does / why we need it**: Newest 1.19 ccm uses timeout parameters that are not supported in octavia 2.0 API, we need check is these supported

**Which issue this PR fixes(if applicable)**:
fixes #1196

```release-note
[openstack-cloud-controller-manager] Added Octavia service version check to the timeout parameters when creating listeners.
```