### PR TITLE
[occm] Check octavia version for timeout params when creating listener

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -1117,14 +1117,17 @@ func (lbaas *LbaasV2) ensureOctaviaListener(lbID string, oldListeners []listener
 	if !ok {
 		listenerProtocol := listeners.Protocol(port.Protocol)
 		listenerCreateOpt := listeners.CreateOpts{
-			Protocol:             listenerProtocol,
-			ProtocolPort:         int(port.Port),
-			ConnLimit:            &svcConf.connLimit,
-			LoadbalancerID:       lbID,
-			TimeoutClientData:    &svcConf.timeoutClientData,
-			TimeoutMemberConnect: &svcConf.timeoutMemberConnect,
-			TimeoutMemberData:    &svcConf.timeoutMemberData,
-			TimeoutTCPInspect:    &svcConf.timeoutTCPInspect,
+			Protocol:       listenerProtocol,
+			ProtocolPort:   int(port.Port),
+			ConnLimit:      &svcConf.connLimit,
+			LoadbalancerID: lbID,
+		}
+
+		if openstackutil.IsOctaviaFeatureSupported(lbaas.lb, openstackutil.OctaviaFeatureTimeout) {
+			listenerCreateOpt.TimeoutClientData = &svcConf.timeoutClientData
+			listenerCreateOpt.TimeoutMemberConnect = &svcConf.timeoutMemberConnect
+			listenerCreateOpt.TimeoutMemberData = &svcConf.timeoutMemberData
+			listenerCreateOpt.TimeoutTCPInspect = &svcConf.timeoutTCPInspect
 		}
 
 		if svcConf.keepClientIP {
@@ -1166,21 +1169,23 @@ func (lbaas *LbaasV2) ensureOctaviaListener(lbID string, oldListeners []listener
 			}
 			listenerChanged = true
 		}
-		if svcConf.timeoutClientData != listener.TimeoutClientData {
-			updateOpts.TimeoutClientData = &svcConf.timeoutClientData
-			listenerChanged = true
-		}
-		if svcConf.timeoutMemberConnect != listener.TimeoutMemberConnect {
-			updateOpts.TimeoutMemberConnect = &svcConf.timeoutMemberConnect
-			listenerChanged = true
-		}
-		if svcConf.timeoutMemberData != listener.TimeoutMemberData {
-			updateOpts.TimeoutMemberData = &svcConf.timeoutMemberData
-			listenerChanged = true
-		}
-		if svcConf.timeoutTCPInspect != listener.TimeoutTCPInspect {
-			updateOpts.TimeoutTCPInspect = &svcConf.timeoutTCPInspect
-			listenerChanged = true
+		if openstackutil.IsOctaviaFeatureSupported(lbaas.lb, openstackutil.OctaviaFeatureTimeout) {
+			if svcConf.timeoutClientData != listener.TimeoutClientData {
+				updateOpts.TimeoutClientData = &svcConf.timeoutClientData
+				listenerChanged = true
+			}
+			if svcConf.timeoutMemberConnect != listener.TimeoutMemberConnect {
+				updateOpts.TimeoutMemberConnect = &svcConf.timeoutMemberConnect
+				listenerChanged = true
+			}
+			if svcConf.timeoutMemberData != listener.TimeoutMemberData {
+				updateOpts.TimeoutMemberData = &svcConf.timeoutMemberData
+				listenerChanged = true
+			}
+			if svcConf.timeoutTCPInspect != listener.TimeoutTCPInspect {
+				updateOpts.TimeoutTCPInspect = &svcConf.timeoutTCPInspect
+				listenerChanged = true
+			}
 		}
 		if openstackutil.IsOctaviaFeatureSupported(lbaas.lb, openstackutil.OctaviaFeatureVIPACL) {
 			if !cpoutil.StringListEqual(svcConf.allowedCIDR, listener.AllowedCIDRs) {
@@ -1326,10 +1331,12 @@ func (lbaas *LbaasV2) checkService(service *corev1.Service, nodes []*corev1.Node
 	svcConf.keepClientIP = keepClientIP
 	svcConf.enableProxyProtocol = useProxyProtocol
 
-	svcConf.timeoutClientData = getIntFromServiceAnnotation(service, ServiceAnnotationLoadBalancerTimeoutClientData, 50000)
-	svcConf.timeoutMemberConnect = getIntFromServiceAnnotation(service, ServiceAnnotationLoadBalancerTimeoutMemberConnect, 5000)
-	svcConf.timeoutMemberData = getIntFromServiceAnnotation(service, ServiceAnnotationLoadBalancerTimeoutMemberData, 50000)
-	svcConf.timeoutTCPInspect = getIntFromServiceAnnotation(service, ServiceAnnotationLoadBalancerTimeoutTCPInspect, 0)
+	if openstackutil.IsOctaviaFeatureSupported(lbaas.lb, openstackutil.OctaviaFeatureTimeout) {
+		svcConf.timeoutClientData = getIntFromServiceAnnotation(service, ServiceAnnotationLoadBalancerTimeoutClientData, 50000)
+		svcConf.timeoutMemberConnect = getIntFromServiceAnnotation(service, ServiceAnnotationLoadBalancerTimeoutMemberConnect, 5000)
+		svcConf.timeoutMemberData = getIntFromServiceAnnotation(service, ServiceAnnotationLoadBalancerTimeoutMemberData, 50000)
+		svcConf.timeoutTCPInspect = getIntFromServiceAnnotation(service, ServiceAnnotationLoadBalancerTimeoutTCPInspect, 0)
+	}
 
 	var listenerAllowedCIDRs []string
 	sourceRanges, err := GetLoadBalancerSourceRanges(service)

--- a/pkg/util/openstack/loadbalancer.go
+++ b/pkg/util/openstack/loadbalancer.go
@@ -38,6 +38,7 @@ const (
 	OctaviaFeatureTags    = 0
 	OctaviaFeatureVIPACL  = 1
 	OctaviaFeatureFlavors = 2
+	OctaviaFeatureTimeout = 3
 
 	loadbalancerActiveInitDelay = 1 * time.Second
 	loadbalancerActiveFactor    = 1.2
@@ -108,6 +109,11 @@ func IsOctaviaFeatureSupported(client *gophercloud.ServiceClient, feature int) b
 		}
 	case OctaviaFeatureFlavors:
 		verFlavors, _ := version.NewVersion("v2.6")
+		if currentVer.GreaterThanOrEqual(verFlavors) {
+			return true
+		}
+	case OctaviaFeatureTimeout:
+		verFlavors, _ := version.NewVersion("v2.1")
 		if currentVer.GreaterThanOrEqual(verFlavors) {
 			return true
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry Picked from #1228

**Which issue this PR fixes(if applicable)**:
fixes #1196

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] Added Octavia service version check when creating listeners with timeout parameters.
```
