### PR TITLE
[octavia-ingress-controller] Check if TLS field in Ingress spec is set

### DIFF
--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -515,7 +515,7 @@ func (c *Controller) deleteIngress(ing *nwv1beta1.Ingress) error {
 	lbName := utils.GetResourceName(ing.Namespace, ing.Name, c.config.ClusterName)
 
 	// Delete Barbican secrets
-	if c.osClient.Barbican != nil {
+	if c.osClient.Barbican != nil && ing.Spec.TLS != nil {
 		nameFilter := fmt.Sprintf("kube_ingress_%s_%s_%s", c.config.ClusterName, ing.Namespace, ing.Name)
 		if err := openstackutil.DeleteSecrets(c.osClient.Barbican, nameFilter); err != nil {
 			return fmt.Errorf("failed to remove Barbican secrets: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
At the moment the OIC connects to the Barbican API on every delete event since the if-statement checking if Barbican client is not `nil` will always be true.

This PR adds another condition to that if-statement, in this case to see if the `TLS` field of the `Ingress` spec is not `nil`. 

With that said there's two other ways to approach this when it comes to the if-statement:

1. As in the `ensureIngress` method check the `len()` of `ing.spec.TLS`.
2. Remove the current if-statement in the `deleteIngress` method and replace it with either a `len()` check or `!= nil` check as i've proposed in this PR.

I've tested this locally and it seems to work as i would expect but i need some more eyes on this.

**Which issue this PR fixes(if applicable)**:
Proposed fix to #1230

**Special notes for reviewers**:

**Release note**:
```release-note
NONE
```
