### PR TITLE
Only perform chart lint, remove install step (#1227)

### DIFF
--- a/.github/workflows/config/ct.yaml
+++ b/.github/workflows/config/ct.yaml
@@ -1,0 +1,1 @@
+target-branch: release-1.19

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,30 +1,9 @@
-name: Lint and Test Charts
+name: Lint Charts
 
 on: pull_request
 
 jobs:
-  changes:
-    outputs:
-      charts: ${{ steps.filter.outputs.charts }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - id: filter
-        uses: dorny/paths-filter@v2.2.0
-        with:
-          filters: |
-            charts:
-              - 'charts/**/Chart.yaml'
-              - 'charts/**/*'
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-  helm-lint-test:
-    if: ${{ needs.changes.outputs.charts == 'true' }}
-    name: Helm chart
-    needs:
-      - changes
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -38,13 +17,3 @@ jobs:
         uses: helm/chart-testing-action@v1.0.0
         with:
           command: lint
-
-      # Only build a kind cluster if there are chart changes to test.
-      - if: steps.lint.outputs.changed == 'true'
-        name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
-
-      - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v1.0.0
-        with:
-          command: install

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,3 +17,4 @@ jobs:
         uses: helm/chart-testing-action@v1.0.0
         with:
           command: lint
+          config: .github/workflows/config/ct.yaml

--- a/charts/cinder-csi-plugin/templates/controllerplugin-rbac.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-rbac.yaml
@@ -90,20 +90,15 @@ metadata:
   name: csi-snapshotter-role
 rules:
   - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
+  # Secret permission is optional.
+  # Enable it if your driver needs secret.
+  # For example, `csi.storage.k8s.io/snapshotter-secret-name` is set in VolumeSnapshotClass.
+  # See https://kubernetes-csi.github.io/docs/secrets-and-credentials.html for more details.
+  #  - apiGroups: [""]
+  #    resources: ["secrets"]
+  #    verbs: ["get", "list"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
@@ -111,15 +106,8 @@ rules:
     resources: ["volumesnapshotcontents"]
     verbs: ["create", "get", "list", "watch", "update", "delete"]
   - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshots"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshots/status"]
+    resources: ["volumesnapshotcontents/status"]
     verbs: ["update"]
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["create", "list", "watch", "delete"]
-
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
For the chart install to work, the Kubernetes cluster needs to be able
to talk to an OpenStack cloud which cannot be done in the CI. Therefore,
only perform the lint test and disable install.

(cherry picked from commit 534bf325c1412c62e753a8ac2e93d166066376e3)

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
