### PR TITLE
[occm] Added Octavia Availability Zones support for LoadBalancers

### DIFF
--- a/docs/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/expose-applications-using-loadbalancer-type-service.md
@@ -158,6 +158,10 @@ Request Body:
 
   The id of the flavor that is used for creating the loadbalancer.
 
+- `loadbalancer.openstack.org/availability-zone`
+
+  The name of the loadbalancer availability zone to use.
+
 ### Switching between Floating Subnets by using preconfigured Classes
 
 If you have multiple `FloatingIPPools` and/or `FloatingIPSubnets` it might be desirable to offer the user logical meanings for `LoadBalancers` like `internetFacing` or `DMZ` instead of requiring the user to select a dedicated network or subnet ID at the service object level as an annotation.

--- a/docs/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/expose-applications-using-loadbalancer-type-service.md
@@ -160,7 +160,7 @@ Request Body:
 
 - `loadbalancer.openstack.org/availability-zone`
 
-  The name of the loadbalancer availability zone to use.
+  The name of the loadbalancer availability zone to use. It is ignored if the Octavia version doesn't support availability zones yet.
 
 ### Switching between Floating Subnets by using preconfigured Classes
 

--- a/docs/using-openstack-cloud-controller-manager.md
+++ b/docs/using-openstack-cloud-controller-manager.md
@@ -205,7 +205,7 @@ Although the openstack-cloud-controller-manager was initially implemented with N
   The id of the loadbalancer flavor to use. Uses octavia default if not set.
 
 * `availability-zone`
-  The name of the loadbalancer availability zone to use. Applicable if use-octavia is set to True and requires Octavia API version 2.14 or later (Ussuri release). The Octavia availability zone capabilities will not be used if the parameter is not set.
+  The name of the loadbalancer availability zone to use. It is applicable if use-octavia is set to True and requires Octavia API version 2.14 or later (Ussuri release). The Octavia availability zone capabilities will not be used if it is not set. The parameter will be ignored if the Octavia version doesn't support availability zones yet.
 
 * `LoadBalancerClass "ClassName"`
   This is a config section including a set of config options. User can choose the `ClassName` by specifying the Service annotation `loadbalancer.openstack.org/class`. The following options are supported:

--- a/docs/using-openstack-cloud-controller-manager.md
+++ b/docs/using-openstack-cloud-controller-manager.md
@@ -204,6 +204,9 @@ Although the openstack-cloud-controller-manager was initially implemented with N
 * `flavor-id`
   The id of the loadbalancer flavor to use. Uses octavia default if not set.
 
+* `availability-zone`
+  The name of the loadbalancer availability zone to use. Applicable if use-octavia is set to True and requires Octavia API version 2.14 or later (Ussuri release). The Octavia availability zone capabilities will not be used if the parameter is not set.
+
 * `LoadBalancerClass "ClassName"`
   This is a config section including a set of config options. User can choose the `ClassName` by specifying the Service annotation `loadbalancer.openstack.org/class`. The following options are supported:
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20190620071333-e64a0ec8b42a // indirect
 	github.com/emicklei/go-restful v2.9.6+incompatible // indirect
 	github.com/golang/protobuf v1.4.2
-	github.com/gophercloud/gophercloud v0.11.1-0.20200518183226-7aec46f32c19
+	github.com/gophercloud/gophercloud v0.12.1-0.20200922152735-900f5ba8c05b
 	github.com/gophercloud/utils v0.0.0-20200423144003-7c72efc7435d
 	github.com/gorilla/mux v1.7.3
 	github.com/hashicorp/go-version v1.2.0
@@ -36,7 +36,7 @@ require (
 	google.golang.org/grpc v1.27.0
 	gopkg.in/gcfg.v1 v1.2.3
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.2.8
+	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.19.0
 	k8s.io/apimachinery v0.19.0
 	k8s.io/apiserver v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -289,6 +289,8 @@ github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEo
 github.com/gophercloud/gophercloud v0.6.1-0.20191122030953-d8ac278c1c9d/go.mod h1:ozGNgr9KYOVATV5jsgHl/ceCDXGuguqOZAzoQ/2vcNM=
 github.com/gophercloud/gophercloud v0.11.1-0.20200518183226-7aec46f32c19 h1:Amaxs7PsvtzbahUHadno+OZI0IrMqwbPhoGUVLdM1NA=
 github.com/gophercloud/gophercloud v0.11.1-0.20200518183226-7aec46f32c19/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
+github.com/gophercloud/gophercloud v0.12.1-0.20200922152735-900f5ba8c05b h1:dcAizxhbIBU4A7Iu9uARqZJz63uesA5MtXjHD1XSg3M=
+github.com/gophercloud/gophercloud v0.12.1-0.20200922152735-900f5ba8c05b/go.mod h1:VX0Ibx85B60B5XOrZr6kaNwrmPUzcmMpwxvQ1WQIIWM=
 github.com/gophercloud/utils v0.0.0-20200423144003-7c72efc7435d h1:fduaPzWwIfvOMLuHk2Al3GZH0XbUqG8MbElPop+Igzs=
 github.com/gophercloud/utils v0.0.0-20200423144003-7c72efc7435d/go.mod h1:ehWUbLQJPqS0Ep+CxeD559hsm9pthPXadJNKwZkp43w=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -357,6 +359,7 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
@@ -824,6 +827,7 @@ gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -133,6 +133,7 @@ type LoadBalancerOpts struct {
 	InternalLB           bool                `gcfg:"internal-lb"`    // default false
 	CascadeDelete        bool                `gcfg:"cascade-delete"` // applicable only if use-octavia is set to True
 	FlavorID             string              `gcfg:"flavor-id"`
+	AvailabilityZone     string              `gcfg:"availability-zone"`
 }
 
 // LBClass defines the corresponding floating network, floating subnet or internal subnet ID

--- a/pkg/util/openstack/loadbalancer.go
+++ b/pkg/util/openstack/loadbalancer.go
@@ -35,10 +35,11 @@ import (
 )
 
 const (
-	OctaviaFeatureTags    = 0
-	OctaviaFeatureVIPACL  = 1
-	OctaviaFeatureFlavors = 2
-	OctaviaFeatureTimeout = 3
+	OctaviaFeatureTags              = 0
+	OctaviaFeatureVIPACL            = 1
+	OctaviaFeatureFlavors           = 2
+	OctaviaFeatureTimeout           = 3
+	OctaviaFeatureAvailabilityZones = 4
 
 	loadbalancerActiveInitDelay = 1 * time.Second
 	loadbalancerActiveFactor    = 1.2
@@ -115,6 +116,11 @@ func IsOctaviaFeatureSupported(client *gophercloud.ServiceClient, feature int) b
 	case OctaviaFeatureTimeout:
 		verFlavors, _ := version.NewVersion("v2.1")
 		if currentVer.GreaterThanOrEqual(verFlavors) {
+			return true
+		}
+	case OctaviaFeatureAvailabilityZones:
+		verAvailabilityZones, _ := version.NewVersion("v2.14")
+		if currentVer.GreaterThanOrEqual(verAvailabilityZones) {
 			return true
 		}
 	default:


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
The Ussuri release of Octavia now supports the availability zone feature where operators can specify some useful capabilities such as the compute availability zone for the amphora instances. 

A POST request to create LB:
https://github.com/openstack/octavia/blob/master/octavia/api/v2/types/load_balancer.py#L109-L126

Added in the 2.14 Octavia version:
https://github.com/openstack/octavia/blob/master/octavia/api/root_controller.py#L109

Such support in gophercloud: https://github.com/gophercloud/gophercloud/pull/2026
**Which issue this PR fixes(if applicable)**:
fixes #1223

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

The code to check the availability of the Octavia feature will inform operators through the warning if Octavia doesn't support AZ yet, but the operator requests it (in the cloud config or service annotation):

```
I0924 08:41:21.765794       1 controller.go:368] Ensuring load balancer for service kube-system/prometheus-operator-grafana-lb
W0924 08:41:21.766243       1 openstack_loadbalancer.go:1368] LoadBalancer Availability Zones isn't supported. Upgrade Octavia API to version 2.14 (Ussuri release) or later to use them
I0924 08:41:21.768166       1 event.go:291] "Event occurred" object="kube-system/prometheus-operator-grafana-lb" kind="Service" apiVersion="v1" type="Normal" reason="EnsuringLoadBalancer" message="Ensuring load balancer"
```

```release-note
[openstack-cloud-controller-manager] Added Octavia Availability Zones support for LoadBalancers.
```