### PR TITLE
[cinder-csi-driver] bump container version

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 1.2.5
+version: 1.2.6
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -6,27 +6,27 @@ csi:
   attacher:
     image:
       repository: quay.io/k8scsi/csi-attacher
-      tag: v2.2.0
+      tag: v2.2.1
       pullPolicy: IfNotPresent
   provisioner:
     image:
       repository: quay.io/k8scsi/csi-provisioner
-      tag: v1.6.0
+      tag: v1.6.1
       pullPolicy: IfNotPresent
   snapshotter:
     image:
       repository: quay.io/k8scsi/csi-snapshotter
-      tag: v2.1.1
+      tag: v2.1.2
       pullPolicy: IfNotPresent
   resizer:
     image:
       repository: quay.io/k8scsi/csi-resizer
-      tag: v0.4.0
+      tag: v0.5.1
       pullPolicy: IfNotPresent
   nodeDriverRegistrar:
     image:
       repository: quay.io/k8scsi/csi-node-driver-registrar
-      tag: v1.2.0
+      tag: v1.3.0
       pullPolicy: IfNotPresent
   plugin:
     image:

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccount: csi-cinder-controller-sa
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v2.2.0
+          image: quay.io/k8scsi/csi-attacher:v2.2.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -47,7 +47,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.6.0
+          image: quay.io/k8scsi/csi-provisioner:v1.6.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -59,7 +59,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v2.1.1
+          image: quay.io/k8scsi/csi-snapshotter:v2.1.2
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -71,7 +71,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.4.0
+          image: quay.io/k8scsi/csi-resizer:v0.5.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--csiTimeout=3m"

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -21,7 +21,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

bump CSI side car containers to latest one

NOTE: originally the PR plan to bump version to node-driver-registrar to latest (2.0.1)
but due to CI issue, this PR only update it to 1.3.0 along with other update of container 
versions for CSI and a follow up PR will handle node-driver-registrar to 2.0.1

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
