### PR TITLE
Allow to specify container engine in the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@
 
 GIT_HOST = k8s.io
 
+CONTAINER_ENGINE ?= docker
+
 PWD := $(shell pwd)
 BASE_DIR := $(shell basename $(PWD))
 # Keep an existing GOPATH, make a private one if it is undefined
@@ -127,7 +129,7 @@ ifeq ($(GOOS),linux)
 	cp -r cluster/images/openstack-cloud-controller-manager $(TEMP_DIR)
 	cp openstack-cloud-controller-manager-$(ARCH) $(TEMP_DIR)/openstack-cloud-controller-manager
 	cp $(TEMP_DIR)/openstack-cloud-controller-manager/Dockerfile.build $(TEMP_DIR)/openstack-cloud-controller-manager/Dockerfile
-	docker build -t $(REGISTRY)/openstack-cloud-controller-manager:$(VERSION) $(TEMP_DIR)/openstack-cloud-controller-manager
+	$(CONTAINER_ENGINE) build -t $(REGISTRY)/openstack-cloud-controller-manager:$(VERSION) $(TEMP_DIR)/openstack-cloud-controller-manager
 	rm -rf $(TEMP_DIR)/openstack-cloud-controller-manager
 else
 	$(error Please set GOOS=linux for building the image)
@@ -238,9 +240,9 @@ shell:
 	$(SHELL) -i
 
 push-manifest-%:
-	docker manifest create --amend $(REGISTRY)/$*:$(VERSION) $(shell echo $(ARCHS) | sed -e "s~[^ ]*~$(REGISTRY)/$*\-&:$(VERSION)~g")
-	@for arch in $(ARCHS); do docker manifest annotate --os $(IMAGE_OS) --arch $${arch} $(REGISTRY)/$*:${VERSION} $(REGISTRY)/$*-$${arch}:${VERSION}; done
-	docker manifest push --purge $(REGISTRY)/$*:${VERSION}
+	$(CONTAINER_ENGINE) manifest create --amend $(REGISTRY)/$*:$(VERSION) $(shell echo $(ARCHS) | sed -e "s~[^ ]*~$(REGISTRY)/$*\-&:$(VERSION)~g")
+	@for arch in $(ARCHS); do $(CONTAINER_ENGINE) manifest annotate --os $(IMAGE_OS) --arch $${arch} $(REGISTRY)/$*:${VERSION} $(REGISTRY)/$*-$${arch}:${VERSION}; done
+	$(CONTAINER_ENGINE) manifest push --purge $(REGISTRY)/$*:${VERSION}
 
 push-all-manifest: $(addprefix push-manifest-,$(IMAGE_NAMES))
 
@@ -254,7 +256,7 @@ ifeq ($(GOOS),linux)
 	cp -r cluster/images/$* $(TEMP_DIR)
 
 ifneq ($(ARCH),amd64)
-	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+	$(CONTAINER_ENGINE) run --rm --privileged multiarch/qemu-user-static --reset -p yes
 	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)/$*
 	@# Ensure we don't get surprised by umask settings
 	chmod 0755 $(TEMP_DIR)/$*/qemu-$(QEMUARCH)-static
@@ -263,16 +265,16 @@ ifneq ($(ARCH),amd64)
 endif
 
 	cp $*-$(ARCH) $(TEMP_DIR)/$*
-	docker build --build-arg ALPINE_ARCH=$(ALPINE_ARCH) --build-arg ARCH=$(ARCH) --build-arg DEBIAN_ARCH=$(DEBIAN_ARCH) --pull -t build-$*-$(ARCH) -f $(TEMP_DIR)/$*/Dockerfile.build $(TEMP_DIR)/$*
-	docker create --name build-$*-$(ARCH) build-$*-$(ARCH)
-	docker export build-$*-$(ARCH) > $(TEMP_DIR)/$*/$(TAR_FILE)
+	$(CONTAINER_ENGINE) build --build-arg ALPINE_ARCH=$(ALPINE_ARCH) --build-arg ARCH=$(ARCH) --build-arg DEBIAN_ARCH=$(DEBIAN_ARCH) --pull -t build-$*-$(ARCH) -f $(TEMP_DIR)/$*/Dockerfile.build $(TEMP_DIR)/$*
+	$(CONTAINER_ENGINE) create --name build-$*-$(ARCH) build-$*-$(ARCH)
+	$(CONTAINER_ENGINE) export build-$*-$(ARCH) > $(TEMP_DIR)/$*/$(TAR_FILE)
 
 	@echo "build image $(REGISTRY)/$*-$(ARCH)"
-	docker build --build-arg ALPINE_ARCH=$(ALPINE_ARCH) --build-arg ARCH=$(ARCH) --build-arg DEBIAN_ARCH=$(DEBIAN_ARCH) --pull -t $(REGISTRY)/$*-$(ARCH):$(VERSION) $(TEMP_DIR)/$*
+	$(CONTAINER_ENGINE) build --build-arg ALPINE_ARCH=$(ALPINE_ARCH) --build-arg ARCH=$(ARCH) --build-arg DEBIAN_ARCH=$(DEBIAN_ARCH) --pull -t $(REGISTRY)/$*-$(ARCH):$(VERSION) $(TEMP_DIR)/$*
 
 	rm -rf $(TEMP_DIR)/$*
-	docker rm build-$*-$(ARCH)
-	docker rmi build-$*-$(ARCH)
+	$(CONTAINER_ENGINE) rm build-$*-$(ARCH)
+	$(CONTAINER_ENGINE) rmi build-$*-$(ARCH)
 else
 	$(error Please set GOOS=linux for building the image)
 endif
@@ -280,9 +282,9 @@ endif
 push-image-%:
 	@echo "push image $*-$(ARCH) to $(REGISTRY)"
 ifneq ($(and $(DOCKER_USERNAME),$(DOCKER_PASSWORD)),)
-	@docker login -u="$(DOCKER_USERNAME)" -p="$(DOCKER_PASSWORD)"
+	@$(CONTAINER_ENGINE) login -u="$(DOCKER_USERNAME)" -p="$(DOCKER_PASSWORD)"
 endif
-	docker push $(REGISTRY)/$*-$(ARCH):$(VERSION)
+	$(CONTAINER_ENGINE) push $(REGISTRY)/$*-$(ARCH):$(VERSION)
 
 images: $(addprefix build-arch-image-,$(ARCH))
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Now we always use docker, but sometimes it's required to use alternative container engines like `podman`.

This patch allows users to specify the desired container engine via CONTAINER_ENGINE env variable.
By default container engine is set to "docker" for backward compatibility.

**Release note**:
```release-note
NONE
```
