### PR TITLE
[cinder-csi-plugin] Do not ignore use-cloud config option

### DIFF
--- a/pkg/csi/cinder/openstack/fixtures/clouds.yaml
+++ b/pkg/csi/cinder/openstack/fixtures/clouds.yaml
@@ -1,0 +1,12 @@
+clouds:
+    openstack:
+      auth:
+        auth_url: "https://169.254.169.254/identity/v3"
+        username: "user"
+        password: "pass"
+        project_id: "c869168a828847f39f7f06edd7305637"
+        domain_id: "2a73b8f597c04551a0fdc8e95544be8a"
+      region_name: "RegionOne"
+      cacert: "fake-ca.crt"
+      interface: "public"
+      identity_api_version: 3

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -103,6 +103,18 @@ func GetConfigFromFile(configFilePath string) (Config, error) {
 		return cfg, err
 	}
 
+	// Update the config with data from clouds.yaml if UseClouds is enabled
+	if cfg.Global.UseClouds {
+		if cfg.Global.CloudsFile != "" {
+			os.Setenv("OS_CLIENT_CONFIG_FILE", cfg.Global.CloudsFile)
+		}
+		err = openstack_provider.ReadClouds(&cfg.Config)
+		if err != nil {
+			return cfg, err
+		}
+		klog.V(5).Infof("Credentials are loaded from %s:", cfg.Global.CloudsFile)
+	}
+
 	return cfg, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Now use-cloud option is ignored in the driver's config.

This commit fixes this issue and allows the driver to read credentials from the given clouds.yaml file.

**Which issue this PR fixes(if applicable)**:
fixes #1260

**Release note**:
```release-note
NONE
```
