### PR TITLE
Update cloud-controller-manager flags

### DIFF
--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -43,7 +43,7 @@ spec:
             - --cloud-config=$(CLOUD_CONFIG)
             - --cloud-provider=openstack
             - --use-service-account-credentials=true
-            - --address=127.0.0.1
+            - --bind-address=127.0.0.1
           volumeMounts:
             - mountPath: /etc/kubernetes/pki
               name: k8s-certs

--- a/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
@@ -18,7 +18,7 @@ spec:
         - --cloud-config=$(CLOUD_CONFIG)
         - --cloud-provider=openstack
         - --use-service-account-credentials=true
-        - --address=127.0.0.1
+        - --bind-address=127.0.0.1
       volumeMounts:
         - mountPath: /etc/kubernetes/pki
           name: k8s-certs


### PR DESCRIPTION
This commit updates the CLI flags used to launch the controller manager.
The usage of `address` is deprecated. Hence, this commit updates the
flags to `bind-address` #1258.

**What this PR does / why we need it**:
As explained in the linked issue the current manifests use deprecated flags. 

**Which issue this PR fixes(if applicable)**:
fixes #1258
