### PR TITLE
[cinder-csi-plugin] handle a case when a volume was already resized

### DIFF
--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -431,8 +431,8 @@ func TestListSnapshots(t *testing.T) {
 
 func TestControllerExpandVolume(t *testing.T) {
 
-	// ExpandVolume(volumeID string, size int)
-	osmock.On("ExpandVolume", FakeVolName, 5).Return(nil)
+	// ExpandVolume(volumeID string, status string, size int)
+	osmock.On("ExpandVolume", FakeVolName, openstack.VolumeAvailableStatus, 5).Return(nil)
 
 	// Init assert
 	assert := assert.New(t)

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -58,7 +58,7 @@ type IOpenStack interface {
 	GetSnapshotByID(snapshotID string) (*snapshots.Snapshot, error)
 	WaitSnapshotReady(snapshotID string) error
 	GetInstanceByID(instanceID string) (*servers.Server, error)
-	ExpandVolume(volumeID string, size int) error
+	ExpandVolume(volumeID string, status string, size int) error
 	GetMaxVolLimit() int64
 	GetMetadataOpts() openstack_provider.MetadataOpts
 	GetBlockStorageOpts() BlockStorageOpts

--- a/pkg/csi/cinder/openstack/openstack_mock.go
+++ b/pkg/csi/cinder/openstack/openstack_mock.go
@@ -360,12 +360,12 @@ func (_m *OpenStackMock) GetInstanceByID(instanceID string) (*servers.Server, er
 }
 
 // ExpandVolume provides a mock function with given fields: instanceID, volumeID
-func (_m *OpenStackMock) ExpandVolume(volumeID string, size int) error {
-	ret := _m.Called(volumeID, size)
+func (_m *OpenStackMock) ExpandVolume(volumeID string, status string, size int) error {
+	ret := _m.Called(volumeID, status, size)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, int) error); ok {
-		r0 = rf(volumeID, size)
+	if rf, ok := ret.Get(0).(func(string, string, int) error); ok {
+		r0 = rf(volumeID, status, size)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/tests/sanity/cinder/fakecloud.go
+++ b/tests/sanity/cinder/fakecloud.go
@@ -254,7 +254,7 @@ func (cloud *cloud) GetInstanceByID(instanceID string) (*servers.Server, error) 
 	return inst, nil
 }
 
-func (cloud *cloud) ExpandVolume(volumeID string, size int) error {
+func (cloud *cloud) ExpandVolume(volumeID string, status string, size int) error {
 	return nil
 }
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Allows cinder csi plugi to handle a volume, which was already resized.

**Which issue this PR fixes(if applicable)**:
fixes #1265

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[cinder-csi-plugin] Added the size check for volume expansion.
```
