### PR TITLE
[cinder-csi-plugin] explicitly set cinder CSI sidecar timeouts to 3m

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 1.2.3
+version: 1.2.4
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -31,7 +31,7 @@ spec:
           imagePullPolicy: {{ .Values.csi.attacher.image.pullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
-            - "--timeout=3m"
+            - "--timeout={{ .Values.timeout }}"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -43,7 +43,7 @@ spec:
           imagePullPolicy: {{ .Values.csi.provisioner.image.pullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
-            - "--timeout=3m"
+            - "--timeout={{ .Values.timeout }}"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -55,6 +55,7 @@ spec:
           imagePullPolicy: {{ .Values.csi.snapshotter.image.pullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
+            - "--timeout={{ .Values.timeout }}"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -66,6 +67,7 @@ spec:
           imagePullPolicy: {{ .Values.csi.resizer.image.pullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
+            - "--csiTimeout={{ .Values.timeout }}"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -1,5 +1,6 @@
 nameOverride: ""
 fullnameOverride: ""
+timeout: 3m
 
 csi:
   attacher:

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -62,6 +62,7 @@ spec:
           image: quay.io/k8scsi/csi-snapshotter:v2.1.1
           args:
             - "--csi-address=$(ADDRESS)"
+            - "--timeout=3m"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -73,6 +74,7 @@ spec:
           image: quay.io/k8scsi/csi-resizer:v0.4.0
           args:
             - "--csi-address=$(ADDRESS)"
+            - "--timeout=3m"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -74,7 +74,7 @@ spec:
           image: quay.io/k8scsi/csi-resizer:v0.4.0
           args:
             - "--csi-address=$(ADDRESS)"
-            - "--timeout=3m"
+            - "--csiTimeout=3m"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Default CSI resizer timeout is [10 seconds](https://github.com/kubernetes-csi/external-resizer/blob/ae8826a2ac345af7a9bf4a6c5103441ec9940476/cmd/csi-resizer/main.go#L49), usually this is not enough. This PR explicitly sets 3m timeout in a CSI manifest sidecar containers.

**Which issue this PR fixes(if applicable)**:
fixes #1265

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

cc @rfranzke
