### PR TITLE
[cinder-csi-plugin] Add error handling for list fucntions before creating

### DIFF
--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -81,6 +81,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	volumes, err := cloud.GetVolumesByName(volName)
 	if err != nil {
 		klog.V(3).Infof("Failed to query for existing Volume during CreateVolume: %v", err)
+		return nil, status.Error(codes.Internal, "Failed to check existing Volume")
 	}
 
 	if len(volumes) == 1 {
@@ -324,6 +325,7 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 	snapshots, _, err := cs.Cloud.ListSnapshots(filters)
 	if err != nil {
 		klog.V(3).Infof("Failed to query for existing Snapshot during CreateSnapshot: %v", err)
+		return nil, status.Error(codes.Internal, "Failed to check existing Snapshot")
 	}
 	var snap *ossnapshots.Snapshot
 

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -81,7 +81,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	volumes, err := cloud.GetVolumesByName(volName)
 	if err != nil {
 		klog.V(3).Infof("Failed to query for existing Volume during CreateVolume: %v", err)
-		return nil, status.Error(codes.Internal, "Failed to check existing Volume")
+		return nil, status.Error(codes.Internal, "Failed to get volumes")
 	}
 
 	if len(volumes) == 1 {
@@ -325,7 +325,7 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 	snapshots, _, err := cs.Cloud.ListSnapshots(filters)
 	if err != nil {
 		klog.V(3).Infof("Failed to query for existing Snapshot during CreateSnapshot: %v", err)
-		return nil, status.Error(codes.Internal, "Failed to check existing Snapshot")
+		return nil, status.Error(codes.Internal, "Failed to get snapshots")
 	}
 	var snap *ossnapshots.Snapshot
 


### PR DESCRIPTION
**What this PR does / why we need it**:
current implementation checks existing volumes before creating.
but if somehow list request is failed (due to temporal API fails or something), next mechanism is not handle correctly.
we should just return error when list operation is failed 
**Which issue this PR fixes(if applicable)**:
no-issue

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
