### PR TITLE
[magnum-auto-healer] Uses OpenStack instance ID from Node ProviderID

### DIFF
--- a/pkg/autohealing/cloudprovider/openstack/provider.go
+++ b/pkg/autohealing/cloudprovider/openstack/provider.go
@@ -253,15 +253,14 @@ func (provider OpenStackCloudProvider) Repair(nodes []healthcheck.NodeInfo) erro
 	if isWorkerNode {
 		for _, n := range nodes {
 			nodesToReplace := sets.NewString()
-			machineID := uuid.Parse(n.KubeNode.Status.NodeInfo.MachineID)
-			if machineID == nil {
+			serverID := strings.TrimPrefix(n.KubeNode.Spec.ProviderID, "openstack:///")
+			if serverID == "" {
 				log.Warningf("Failed to get the correct server ID for server %s", n.KubeNode.Name)
 				continue
 			}
-			serverID := machineID.String()
 
 			if err := provider.waitForServerDetachVolumes(serverID, 30*time.Second); err != nil {
-				log.Warningf("Failed to detach volumes from server %s, error: %v", serverID, err)
+				log.Warningf("Failed to shutdown the server %s, error: %v, continue handling...", serverID, err)
 			}
 
 			if err := provider.waitForServerPoweredOff(serverID, 30*time.Second); err != nil {
@@ -308,12 +307,11 @@ func (provider OpenStackCloudProvider) Repair(nodes []healthcheck.NodeInfo) erro
 		}
 
 		for _, n := range nodes {
-			id := uuid.Parse(n.KubeNode.Status.NodeInfo.MachineID)
-			if id == nil {
+			serverID := strings.TrimPrefix(n.KubeNode.Spec.ProviderID, "openstack:///")
+			if serverID == "" {
 				log.Warningf("Failed to get the correct server ID for server %s", n.KubeNode.Name)
 				continue
 			}
-			serverID := id.String()
 
 			if err := provider.waitForServerPoweredOff(serverID, 30*time.Second); err != nil {
 				log.Warningf("Failed to shutdown the server %s, error: %v", serverID, err)


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Currently, the magnum auto-healer works with the assumption that the node's MachineID == Openstack Instance UUID. However, that is not always the case, not all hypervisors pass the ``instance.uuid`` to the VM's SMBIOS as libvirt does, and not all OSes rely on the MachineID / ``/etc/machine-id`` (e.g.: Windows VMs).

The OpenStack instance UUID can also be found in the Node's ProviderID with the format:

    openstack:///openstack-uuid

We can use that instead. Additionally, OCCM already uses the ProviderID for the same reason, so this will make it more consistent.


**Which issue this PR fixes(if applicable)**:
fixes #1278

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
