### PR TITLE
[manila-csi-plugin] Fix whitespaces and invalid dot

### DIFF
--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 1.0.0
+version: 1.0.1
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -135,15 +135,12 @@ spec:
           hostPath:
             path: /var/lib/kubelet/pods
             type: Directory
-{{ if .Values.controllerplugin.affinity }}
-      affinity:
-{{ toYaml .Values.controllerplugin.affinity | indent 8 }}
-{{ end }}
-{{ if .Values.controllerplugin.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.controllerplugin.nodeSelector | indent 8 }}
-{{ end }}
-{{ if .Values.controllerplugin.tolerations }}
-      tolerations:
-{{ toYaml .Values.controllerplugin.tolerations | indent 8 }}
-{{ end }}
+    {{- if .Values.controllerplugin.affinity }}
+      affinity: {{ toYaml .Values.controllerplugin.affinity | nindent 8 }}
+    {{- end }}
+    {{- if .Values.controllerplugin.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.controllerplugin.nodeSelector | nindent 8 }}
+    {{- end }}
+    {{- if .Values.controllerplugin.tolerations }}
+      tolerations: {{ toYaml .Values.controllerplugin.tolerations | nindent 8 }}
+    {{- end }}

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -135,15 +135,15 @@ spec:
           hostPath:
             path: /var/lib/kubelet/pods
             type: Directory
-    {{- if .Values.controllerplugin.affinity -}}
+{{ if .Values.controllerplugin.affinity }}
       affinity:
-{{ toYaml .Values.controllerplugin.affinity . | indent 8 }}
-    {{- end -}}
-    {{- if .Values.controllerplugin.nodeSelector -}}
+{{ toYaml .Values.controllerplugin.affinity | indent 8 }}
+{{ end }}
+{{ if .Values.controllerplugin.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.controllerplugin.nodeSelector | indent 8 }}
-    {{- end -}}
-    {{- if .Values.controllerplugin.tolerations -}}
+{{ end }}
+{{ if .Values.controllerplugin.tolerations }}
       tolerations:
 {{ toYaml .Values.controllerplugin.tolerations | indent 8 }}
-    {{- end -}}
+{{ end }}

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -125,15 +125,12 @@ spec:
             name: manila-csi-runtimeconf-cm
         {{- end }}
         {{- end }}
-{{ if .Values.nodeplugin.affinity }}
-      affinity:
-{{ toYaml .Values.nodeplugin.affinity | indent 8 }}
-{{ end }}
-{{ if .Values.nodeplugin.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeplugin.nodeSelector | indent 8 }}
-{{ end }}
-{{ if .Values.nodeplugin.tolerations }}
-      tolerations:
-{{ toYaml .Values.nodeplugin.tolerations | indent 8 }}
-{{ end }}
+    {{- if .Values.nodeplugin.affinity }}
+      affinity: {{ toYaml .Values.nodeplugin.affinity | nindent 8 }}
+    {{- end }}
+    {{- if .Values.nodeplugin.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.nodeplugin.nodeSelector | nindent 8 }}
+    {{- end }}
+    {{- if .Values.nodeplugin.tolerations }}
+      tolerations: {{ toYaml .Values.nodeplugin.tolerations | nindent 8 }}
+    {{- end }}

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -125,15 +125,15 @@ spec:
             name: manila-csi-runtimeconf-cm
         {{- end }}
         {{- end }}
-    {{- if .Values.nodeplugin.affinity -}}
+{{ if .Values.nodeplugin.affinity }}
       affinity:
-{{ toYaml .Values.nodeplugin.affinity . | indent 8 }}
-    {{- end -}}
-    {{- if .Values.nodeplugin.nodeSelector -}}
+{{ toYaml .Values.nodeplugin.affinity | indent 8 }}
+{{ end }}
+{{ if .Values.nodeplugin.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeplugin.nodeSelector | indent 8 }}
-    {{- end -}}
-    {{- if .Values.nodeplugin.tolerations -}}
+{{ end }}
+{{ if .Values.nodeplugin.tolerations }}
       tolerations:
 {{ toYaml .Values.nodeplugin.tolerations | indent 8 }}
-    {{- end -}}
+{{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Chart removes whitespace too aggressively in 
https://github.com/kubernetes/cloud-provider-openstack/blob/master/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml#L138-L149

and 

https://github.com/kubernetes/cloud-provider-openstack/blob/master/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml#L128-L139

I saw this when trying to set `.Values.controllerplugin.nodeSelector` or `.Values.nodeplugin.nodeSelector`

**Which issue this PR fixes(if applicable)**:
fixes #1284

**Special notes for reviewers**:
Impossible to set `.Values.controllerplugin.nodeSelector` or `.Values.nodeplugin.nodeSelector`

**Release note**:
```
Fix possibility to set `.Values.controllerplugin.nodeSelector` or `.Values.nodeplugin.nodeSelector`
```
