### PR TITLE
ManageSecurityGroups for octavia

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -1477,6 +1477,13 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 		Ingress: []corev1.LoadBalancerIngress{{IP: addr}},
 	}
 
+	if lbaas.opts.ManageSecurityGroups {
+		err := lbaas.ensureSecurityGroup(clusterName, service, nodes, loadbalancer)
+		if err != nil {
+			return status, fmt.Errorf("failed when reconciling security groups for LB service %v/%v: %v", service.Namespace, service.Name, err)
+		}
+	}
+
 	return status, nil
 }
 
@@ -2410,6 +2417,13 @@ func (lbaas *LbaasV2) updateOctaviaLoadBalancer(ctx context.Context, clusterName
 		_, err := lbaas.ensureOctaviaPool(loadbalancer.ID, &listener, service, port, nodes, svcConf)
 		if err != nil {
 			return err
+		}
+	}
+
+	if lbaas.opts.ManageSecurityGroups {
+		err := lbaas.updateSecurityGroup(clusterName, service, nodes, loadbalancer)
+		if err != nil {
+			return fmt.Errorf("failed to update Security Group for loadbalancer service %s: %v", serviceName, err)
 		}
 	}
 


### PR DESCRIPTION


**What this PR does / why we need it**: Currently it is not possible to use `ManageSecurityGroups` with octavia. The code does not execute managesecgroup stuff at all.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
