### PR TITLE
make batch member update configurable

### DIFF
--- a/docs/using-openstack-cloud-controller-manager.md
+++ b/docs/using-openstack-cloud-controller-manager.md
@@ -201,7 +201,10 @@ Although the openstack-cloud-controller-manager was initially implemented with N
 
 * `cascade-delete`
   Determines whether or not to perform cascade deletion of load balancers. Default: true.
-  
+
+* `batch-member-update`
+  Determines whether or not to perform batch update of pool members. Default: true.
+
 * `flavor-id`
   The id of the loadbalancer flavor to use. Uses octavia default if not set.
 

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -135,6 +135,7 @@ type LoadBalancerOpts struct {
 	CascadeDelete        bool                `gcfg:"cascade-delete"` // applicable only if use-octavia is set to True
 	FlavorID             string              `gcfg:"flavor-id"`
 	AvailabilityZone     string              `gcfg:"availability-zone"`
+	BatchMemberUpdate    bool                `gcfg:"batch-member-update"` // applicable for octavia
 }
 
 // LBClass defines the corresponding floating network, floating subnet or internal subnet ID
@@ -388,6 +389,7 @@ func ReadConfig(config io.Reader) (Config, error) {
 	cfg.LoadBalancer.MonitorTimeout = MyDuration{3 * time.Second}
 	cfg.LoadBalancer.MonitorMaxRetries = 1
 	cfg.LoadBalancer.CascadeDelete = true
+	cfg.LoadBalancer.BatchMemberUpdate = true
 
 	err := gcfg.FatalOnly(gcfg.ReadInto(&cfg, config))
 	if err != nil {

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -1033,32 +1033,8 @@ func (lbaas *LbaasV2) ensureOctaviaHealthMonitor(lbID string, pool *v2pools.Pool
 	return nil
 }
 
-// Make sure the pool is created for the Service, nodes are added as pool members.
+// Make sure the pool is created for the Service
 func (lbaas *LbaasV2) ensureOctaviaPool(lbID string, listener *listeners.Listener, service *corev1.Service, port corev1.ServicePort, nodes []*corev1.Node, svcConf *serviceConfig) (*v2pools.Pool, error) {
-	var members []v2pools.BatchUpdateMemberOpts
-	newMembers := sets.NewString()
-
-	for _, node := range nodes {
-		addr, err := nodeAddressForLB(node)
-		if err != nil {
-			if err == ErrNotFound {
-				// Node failure, do not create member
-				klog.Warningf("Failed to get the address of node %s for creating member: %v", node.Name, err)
-				continue
-			} else {
-				return nil, fmt.Errorf("error getting address of node %s: %v", node.Name, err)
-			}
-		}
-
-		member := v2pools.BatchUpdateMemberOpts{
-			Address:      addr,
-			ProtocolPort: int(port.NodePort),
-			Name:         &node.Name,
-			SubnetID:     &svcConf.lbMemberSubnetID,
-		}
-		members = append(members, member)
-		newMembers.Insert(fmt.Sprintf("%s-%d", addr, member.ProtocolPort))
-	}
 
 	pool, err := openstackutil.GetPoolByListener(lbaas.lb, lbID, listener.ID)
 	if err != nil && err != openstackutil.ErrNotFound {
@@ -1108,24 +1084,67 @@ func (lbaas *LbaasV2) ensureOctaviaPool(lbID string, listener *listeners.Listene
 
 	klog.V(2).Infof("Pool %s created for listener %s", pool.ID, listener.ID)
 
-	curMembers := sets.NewString()
+	return pool, nil
+}
+
+// Make sure nodes are added as pool members
+func (lbaas *LbaasV2) ensureOctaviaPoolMembers(loadbalancer *loadbalancers.LoadBalancer, nodes []*corev1.Node, nodePort int, pool *v2pools.Pool, svcConf *serviceConfig) error {
+
 	poolMembers, err := openstackutil.GetMembersbyPool(lbaas.lb, pool.ID)
 	if err != nil {
 		klog.Errorf("failed to get members in the pool %s: %v", pool.ID, err)
 	}
+
+	// Compose Set of member (addresses) that _should_ exist
+	addrs := make(map[string]*corev1.Node)
+	for _, node := range nodes {
+		addr, err := nodeAddressForLB(node)
+		if err != nil {
+			if err == ErrNotFound {
+				// Node failure, do not create member
+				klog.Warningf("Failed to get the address of node %s for creating member: %v", node.Name, err)
+				continue
+			} else {
+				return fmt.Errorf("error getting address of node %s: %v", node.Name, err)
+			}
+		}
+		addrs[addr] = node
+	}
+
+	if !lbaas.opts.BatchMemberUpdate {
+		return lbaas.ensurePoolMembers(poolMembers, addrs, nodePort, *pool, loadbalancer)
+	}
+
+	var members []v2pools.BatchUpdateMemberOpts
+	newMembers := sets.NewString()
+
+	// Add any new members for this port
+	for addr, node := range addrs {
+		member := v2pools.BatchUpdateMemberOpts{
+			Address:      addr,
+			ProtocolPort: nodePort,
+			Name:         &node.Name,
+			SubnetID:     &svcConf.lbMemberSubnetID,
+		}
+		members = append(members, member)
+		newMembers.Insert(fmt.Sprintf("%s-%d", addr, member.ProtocolPort))
+
+	}
+
+	curMembers := sets.NewString()
 	for _, m := range poolMembers {
 		curMembers.Insert(fmt.Sprintf("%s-%d", m.Address, m.ProtocolPort))
 	}
 
 	if !curMembers.Equal(newMembers) {
 		klog.V(2).Infof("Updating %d members for pool %s", len(members), pool.ID)
-		if err := openstackutil.BatchUpdatePoolMembers(lbaas.lb, lbID, pool.ID, members); err != nil {
-			return nil, err
+		if err := openstackutil.BatchUpdatePoolMembers(lbaas.lb, loadbalancer.ID, pool.ID, members); err != nil {
+			return err
 		}
 		klog.V(2).Infof("Successfully updated %d members for pool %s", len(members), pool.ID)
 	}
 
-	return pool, nil
+	return nil
 }
 
 // Make sure the listener is created for Service
@@ -1456,6 +1475,10 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 
 		pool, err := lbaas.ensureOctaviaPool(loadbalancer.ID, listener, service, port, nodes, svcConf)
 		if err != nil {
+			return nil, err
+		}
+
+		if err := lbaas.ensureOctaviaPoolMembers(loadbalancer, nodes, int(port.NodePort), pool, svcConf); err != nil {
 			return nil, err
 		}
 
@@ -1826,7 +1849,7 @@ func (lbaas *LbaasV2) ensureLoadBalancer(ctx context.Context, clusterName string
 				klog.V(4).Infof("Creating member for pool %s", pool.ID)
 				mc := metrics.NewMetricContext("loadbalancer_member", "create")
 				_, err := v2pools.CreateMember(lbaas.lb, pool.ID, v2pools.CreateMemberOpts{
-					Name:         cutString(fmt.Sprintf("member_%d_%s_%s", portIndex, node.Name, name)),
+					Name:         node.Name,
 					ProtocolPort: int(port.NodePort),
 					Address:      addr,
 					SubnetID:     lbaas.opts.SubnetID,
@@ -2407,7 +2430,12 @@ func (lbaas *LbaasV2) updateOctaviaLoadBalancer(ctx context.Context, clusterName
 			return fmt.Errorf("loadbalancer %s does not contain required listener for port %d and protocol %s", loadbalancer.ID, port.Port, port.Protocol)
 		}
 
-		_, err := lbaas.ensureOctaviaPool(loadbalancer.ID, &listener, service, port, nodes, svcConf)
+		pool, err := lbaas.ensureOctaviaPool(loadbalancer.ID, &listener, service, port, nodes, svcConf)
+		if err != nil {
+			return err
+		}
+
+		err = lbaas.ensureOctaviaPoolMembers(loadbalancer, nodes, int(port.NodePort), pool, svcConf)
 		if err != nil {
 			return err
 		}
@@ -2421,6 +2449,56 @@ func (lbaas *LbaasV2) UpdateLoadBalancer(ctx context.Context, clusterName string
 	mc := metrics.NewMetricContext("loadbalancer", "update")
 	err := lbaas.updateLoadBalancer(ctx, clusterName, service, nodes)
 	return mc.ObserveReconcile(err)
+}
+
+func (lbaas *LbaasV2) ensurePoolMembers(currentMembers []v2pools.Member, addrs map[string]*corev1.Node, nodePort int, pool v2pools.Pool, loadbalancer *loadbalancers.LoadBalancer) error {
+
+	members := make(map[string]v2pools.Member)
+	for _, member := range currentMembers {
+		members[member.Address] = member
+	}
+
+	// Add any new members for this port
+	for addr, node := range addrs {
+		if _, ok := members[addr]; ok && members[addr].ProtocolPort == nodePort {
+			// Already exists, do not create member
+			continue
+		}
+		mc := metrics.NewMetricContext("loadbalancer_member", "create")
+		_, err := v2pools.CreateMember(lbaas.lb, pool.ID, v2pools.CreateMemberOpts{
+			Name:         node.Name,
+			Address:      addr,
+			ProtocolPort: nodePort,
+			SubnetID:     lbaas.opts.SubnetID,
+		}).Extract()
+		if mc.ObserveRequest(err) != nil {
+			return err
+		}
+		provisioningStatus, err := waitLoadbalancerActiveProvisioningStatus(lbaas.lb, loadbalancer.ID)
+		if err != nil {
+			return fmt.Errorf("timeout when waiting for loadbalancer to be ACTIVE after creating member, current provisioning status %s", provisioningStatus)
+		}
+	}
+
+	// Remove any old members for this port
+	for _, member := range members {
+		if _, ok := addrs[member.Address]; ok && member.ProtocolPort == nodePort {
+			// Still present, do not delete member
+			continue
+		}
+		mc := metrics.NewMetricContext("loadbalancer_member", "delete")
+		err := v2pools.DeleteMember(lbaas.lb, pool.ID, member.ID).ExtractErr()
+		if err != nil && !cpoerrors.IsNotFound(err) {
+			return mc.ObserveRequest(err)
+		}
+		mc.ObserveRequest(nil)
+		provisioningStatus, err := waitLoadbalancerActiveProvisioningStatus(lbaas.lb, loadbalancer.ID)
+		if err != nil {
+			return fmt.Errorf("timeout when waiting for loadbalancer to be ACTIVE after deleting member, current provisioning status %s", provisioningStatus)
+		}
+	}
+
+	return nil
 }
 
 func (lbaas *LbaasV2) updateLoadBalancer(ctx context.Context, clusterName string, service *corev1.Service, nodes []*corev1.Node) error {
@@ -2500,7 +2578,7 @@ func (lbaas *LbaasV2) updateLoadBalancer(ctx context.Context, clusterName string
 	}
 
 	// Check for adding/removing members associated with each port
-	for portIndex, port := range ports {
+	for _, port := range ports {
 		// Get listener associated with this port
 		listener, ok := lbListeners[portKey{
 			Protocol: toListenersProtocol(port.Protocol),
@@ -2521,49 +2599,11 @@ func (lbaas *LbaasV2) updateLoadBalancer(ctx context.Context, clusterName string
 		if err != nil {
 			return fmt.Errorf("error getting pool members %s: %v", pool.ID, err)
 		}
-		members := make(map[string]v2pools.Member)
-		for _, member := range getMembers {
-			members[member.Address] = member
-		}
 
-		// Add any new members for this port
-		for addr, node := range addrs {
-			if _, ok := members[addr]; ok && members[addr].ProtocolPort == int(port.NodePort) {
-				// Already exists, do not create member
-				continue
-			}
-			mc := metrics.NewMetricContext("loadbalancer_member", "create")
-			_, err := v2pools.CreateMember(lbaas.lb, pool.ID, v2pools.CreateMemberOpts{
-				Name:         cutString(fmt.Sprintf("member_%d_%s_%s_", portIndex, node.Name, loadbalancer.Name)),
-				Address:      addr,
-				ProtocolPort: int(port.NodePort),
-				SubnetID:     lbaas.opts.SubnetID,
-			}).Extract()
-			if mc.ObserveRequest(err) != nil {
-				return err
-			}
-			provisioningStatus, err := waitLoadbalancerActiveProvisioningStatus(lbaas.lb, loadbalancer.ID)
-			if err != nil {
-				return fmt.Errorf("timeout when waiting for loadbalancer to be ACTIVE after creating member, current provisioning status %s", provisioningStatus)
-			}
-		}
-
-		// Remove any old members for this port
-		for _, member := range members {
-			if _, ok := addrs[member.Address]; ok && member.ProtocolPort == int(port.NodePort) {
-				// Still present, do not delete member
-				continue
-			}
-			mc := metrics.NewMetricContext("loadbalancer_member", "delete")
-			err = v2pools.DeleteMember(lbaas.lb, pool.ID, member.ID).ExtractErr()
-			if err != nil && !cpoerrors.IsNotFound(err) {
-				return mc.ObserveRequest(err)
-			}
-			mc.ObserveRequest(nil)
-			provisioningStatus, err := waitLoadbalancerActiveProvisioningStatus(lbaas.lb, loadbalancer.ID)
-			if err != nil {
-				return fmt.Errorf("timeout when waiting for loadbalancer to be ACTIVE after deleting member, current provisioning status %s", provisioningStatus)
-			}
+		//ensure members
+		err = lbaas.ensurePoolMembers(getMembers, addrs, int(port.NodePort), pool, loadbalancer)
+		if err != nil {
+			return fmt.Errorf("error ensuring pool members %s: %v", pool.ID, err)
 		}
 	}
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
make batch member update configurable

Octavia supports batch member updates, however some provider drivers for Octavia do not support batch update of pool members. In that case, the pool members are added/removed by occm. 

`batch-member-update` can be set in cloud-config file.

**Special notes for reviewers**:

Batch member update is enabled by default for Octavia.

<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
