### PR TITLE
[manila-csi-plugin] Added appendShareMetadata volume parameter

### DIFF
--- a/docs/using-manila-csi-plugin.md
+++ b/docs/using-manila-csi-plugin.md
@@ -48,7 +48,7 @@ Parameter | Required | Description
 `type` | _yes_ | Manila [share type](https://wiki.openstack.org/wiki/Manila/Concepts#share_type)
 `shareNetworkID` | _no_ | Manila [share network ID](https://wiki.openstack.org/wiki/Manila/Concepts#share_network)
 `availability` | _no_ | Manila availability zone of the provisioned share. If none is provided, the default Manila zone will be used. Note that this parameter is opaque to the CO and does not influence placement of workloads that will consume this share, meaning they may be scheduled onto any node of the cluster. If the specified Manila AZ is not equally accessible from all compute nodes of the cluster, use [Topology-aware dynamic provisioning](#topology-aware-dynamic-provisioning).
-`appendShareMetadata` | _no_ | Append user-defined metadata to the provisioned share. Must be a string with a valid JSON object. The object must consist of key-value pairs of type string. Example: `"{..., \"key\": \"value\"}"`.
+`appendShareMetadata` | _no_ | Append user-defined metadata to the provisioned share. If not empty, this field must be a string with a valid JSON object. The object must consist of key-value pairs of type string. Example: `"{..., \"key\": \"value\"}"`.
 `cephfs-mounter` | _no_ | Relevant for CephFS Manila shares. Specifies which mounting method to use with the CSI CephFS driver. Available options are `kernel` and `fuse`, defaults to `fuse`. See [CSI CephFS docs](https://github.com/ceph/ceph-csi/blob/csi-v1.0/docs/deploy-cephfs.md#configuration) for further information.
 `nfs-shareClient` | _no_ | Relevant for NFS Manila shares. Specifies what address has access to the NFS share. Defaults to `0.0.0.0/0`, i.e. anyone. 
 

--- a/docs/using-manila-csi-plugin.md
+++ b/docs/using-manila-csi-plugin.md
@@ -48,6 +48,7 @@ Parameter | Required | Description
 `type` | _yes_ | Manila [share type](https://wiki.openstack.org/wiki/Manila/Concepts#share_type)
 `shareNetworkID` | _no_ | Manila [share network ID](https://wiki.openstack.org/wiki/Manila/Concepts#share_network)
 `availability` | _no_ | Manila availability zone of the provisioned share. If none is provided, the default Manila zone will be used. Note that this parameter is opaque to the CO and does not influence placement of workloads that will consume this share, meaning they may be scheduled onto any node of the cluster. If the specified Manila AZ is not equally accessible from all compute nodes of the cluster, use [Topology-aware dynamic provisioning](#topology-aware-dynamic-provisioning).
+`appendShareMetadata` | _no_ | Append user-defined metadata to the provisioned share. Must be a string with a valid JSON object. The object must consist of key-value pairs of type string. Example: `"{..., \"key\": \"value\"}"`.
 `cephfs-mounter` | _no_ | Relevant for CephFS Manila shares. Specifies which mounting method to use with the CSI CephFS driver. Available options are `kernel` and `fuse`, defaults to `fuse`. See [CSI CephFS docs](https://github.com/ceph/ceph-csi/blob/csi-v1.0/docs/deploy-cephfs.md#configuration) for further information.
 `nfs-shareClient` | _no_ | Relevant for NFS Manila shares. Specifies what address has access to the NFS share. Defaults to `0.0.0.0/0`, i.e. anyone. 
 

--- a/pkg/csi/manila/options/shareoptions.go
+++ b/pkg/csi/manila/options/shareoptions.go
@@ -21,10 +21,11 @@ import (
 )
 
 type ControllerVolumeContext struct {
-	Protocol         string `name:"protocol" matches:"^(?i)CEPHFS|NFS$"`
-	Type             string `name:"type" value:"default:default"`
-	ShareNetworkID   string `name:"shareNetworkID" value:"optional"`
-	AvailabilityZone string `name:"availability" value:"optional"`
+	Protocol            string `name:"protocol" matches:"^(?i)CEPHFS|NFS$"`
+	Type                string `name:"type" value:"default:default"`
+	ShareNetworkID      string `name:"shareNetworkID" value:"optional"`
+	AvailabilityZone    string `name:"availability" value:"optional"`
+	AppendShareMetadata string `name:"appendShareMetadata" value:"optional"`
 
 	// Adapter options
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the ability to set user-defined metadata on newly created shares.

**Which issue this PR fixes(if applicable)**:
fixes https://github.com/kubernetes/cloud-provider-openstack/issues/1280

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[manila-csi-plugin] Added appendShareMetadata volume parameter
```
