### PR TITLE
[k8s-keystone-auth] Fix authorization error

### DIFF
--- a/pkg/identity/keystone/authorizer.go
+++ b/pkg/identity/keystone/authorizer.go
@@ -124,6 +124,11 @@ func resourcePermissionAllowed(permissionSpec map[string][]string, attr authoriz
 		nsDef := strings.ToLower(strings.TrimSpace(keyList[0]))
 		resDef := strings.ToLower(strings.TrimSpace(keyList[1]))
 
+		// When request without namespace, only policy which nsDef is equal to "*" could be executed.
+		if nsDef != "*" && ns == "" {
+			continue
+		}
+
 		allowedNamespaces, err := getAllowed(nsDef, ns)
 		if err != nil {
 			continue
@@ -317,6 +322,11 @@ func (a *Authorizer) Authorize(attributes authorizer.Attributes) (authorized aut
 		for _, role := range val {
 			userRoles.Insert(role)
 		}
+	}
+
+	// When the user.Extra does not exist, it means that the keytone user authentication has failed, and the authorization verification should not pass.
+	if user.GetExtra() == nil {
+		return authorizer.DecisionDeny, "No auth info found.", nil
 	}
 
 	// We support both project name and project ID.

--- a/pkg/identity/keystone/authorizer_test_policy_version2.json
+++ b/pkg/identity/keystone/authorizer_test_policy_version2.json
@@ -6,7 +6,8 @@
     },
     "resource_permissions": {
       "!kube-system/!['namespaces', 'clusterrolebindings', 'clusterroles', 'podsecuritypolicies', 'rolebindings', 'roles', 'podSecurityPolicies']": ["*"],
-      "!kube-system/['namespaces', 'clusterrolebindings', 'clusterroles', 'podsecuritypolicies', 'rolebindings', 'roles', 'podSecurityPolicies']": ["get", "list"]
+      "!kube-system/['namespaces', 'clusterrolebindings', 'clusterroles', 'podsecuritypolicies', 'rolebindings', 'roles', 'podSecurityPolicies']": ["get", "list"],
+      "*/['namespaces', 'clusterrolebindings', 'clusterroles', 'podsecuritypolicies', 'podSecurityPolicies']": ["get", "list"]
     }
   },
   {
@@ -28,6 +29,16 @@
     },
     "nonresource_permissions": {
       "/healthz": ["get", "post"]
+    }
+  },
+  {
+    "users": {
+      "roles": ["testuser"],
+      "projects": ["demo"]
+    },
+    "resource_permissions": {
+      "*/['namespaces', 'clusterroles']": ["get", "list"],
+      "default/['pods', 'deployments']": ["get", "list"]
     }
   }
 ]


### PR DESCRIPTION
Signed-off-by: bevisy <binbin36520@gmail.com>

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
1. Add user authorization information existence judgment
2. Repair request authorization error without namespace

**Which issue this PR fixes(if applicable)**:
fixes #1308 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[k8s-keystone-auth] Fix authorization error
```
