### PR TITLE
[cinder-csi-plugin] update topology feature docs

### DIFF
--- a/docs/cinder-csi-plugin/features.md
+++ b/docs/cinder-csi-plugin/features.md
@@ -29,7 +29,7 @@ This feature enables driver to consider the topology constraints while creating 
 
 * Supported topology keys:
   `topology.cinder.csi.openstack.org/zone` : Availability by Zone
-* `--feature-gates=Topology=true` needs to be enabled in external-provisioner. From the external-provisoner v1.6.0 , its enabled by default.
+* `--feature-gates=Topology=true` needs to be enabled in external-provisioner.
 * `allowedTopologies` can be specified in storage class to restrict the topology of provisioned volumes to specific zones and should be used as replacement of `availability` parameter.
 
 ## Block Volume


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
https://github.com/kubernetes-csi/external-provisioner/blob/v1.6.0/pkg/features/features.go#L38 , Topology feature doesnt seem to be enabled by default. So updating the docs.

xref: #1293
**Which issue this PR fixes(if applicable)**:
fixes #


**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
