### PR TITLE
[cinder-csi-driver]Add flag to control enable topology or not

### DIFF
--- a/cmd/cinder-csi-plugin/main.go
+++ b/cmd/cinder-csi-plugin/main.go
@@ -32,10 +32,11 @@ import (
 )
 
 var (
-	endpoint    string
-	nodeID      string
-	cloudconfig string
-	cluster     string
+	withTopology bool
+	endpoint     string
+	nodeID       string
+	cloudconfig  string
+	cluster      string
 )
 
 func init() {
@@ -85,6 +86,9 @@ func main() {
 
 	cmd.PersistentFlags().StringVar(&cluster, "cluster", "", "The identifier of the cluster that the plugin is running in.")
 
+	// default topology is enabled
+	cmd.PersistentFlags().BoolVar(&withTopology, "with-topology", true, "cluster is topology-aware")
+
 	openstack.AddExtraFlags(pflag.CommandLine)
 
 	logs.InitLogs()
@@ -100,7 +104,7 @@ func main() {
 
 func handle() {
 
-	d := cinder.NewDriver(nodeID, endpoint, cluster)
+	d := cinder.NewDriver(nodeID, endpoint, cluster, withTopology)
 	// Initiliaze cloud
 	openstack.InitOpenStackProvider(cloudconfig)
 	cloud, err := openstack.GetOpenStackProvider()

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -66,7 +66,8 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	volType := req.GetParameters()["type"]
 
 	var volAvailability string
-	if req.GetAccessibilityRequirements() != nil {
+	// only check volume topo when it's enabled
+	if cs.Driver.withTypology && req.GetAccessibilityRequirements() != nil {
 		volAvailability = getAZFromTopology(req.GetAccessibilityRequirements())
 	}
 

--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -34,7 +34,7 @@ func init() {
 		osmock = new(openstack.OpenStackMock)
 		openstack.OsInstance = osmock
 
-		d := NewDriver(FakeNodeID, FakeEndpoint, FakeCluster)
+		d := NewDriver(FakeNodeID, FakeEndpoint, FakeCluster, true)
 
 		fakeCs = NewControllerServer(d, openstack.OsInstance)
 	}

--- a/pkg/csi/cinder/driver.go
+++ b/pkg/csi/cinder/driver.go
@@ -41,12 +41,13 @@ var (
 )
 
 type CinderDriver struct {
-	name        string
-	nodeID      string
-	fqVersion   string //Fully qualified version in format {Version}@{CPO version}
-	endpoint    string
-	cloudconfig string
-	cluster     string
+	name         string
+	nodeID       string
+	fqVersion    string //Fully qualified version in format {Version}@{CPO version}
+	endpoint     string
+	cloudconfig  string
+	cluster      string
+	withTypology bool
 
 	ids *identityServer
 	cs  *controllerServer
@@ -57,7 +58,7 @@ type CinderDriver struct {
 	nscap []*csi.NodeServiceCapability
 }
 
-func NewDriver(nodeID, endpoint, cluster string) *CinderDriver {
+func NewDriver(nodeID, endpoint, cluster string, withTypo bool) *CinderDriver {
 
 	d := &CinderDriver{}
 	d.name = driverName
@@ -65,6 +66,7 @@ func NewDriver(nodeID, endpoint, cluster string) *CinderDriver {
 	d.fqVersion = fmt.Sprintf("%s@%s", Version, version.Version)
 	d.endpoint = endpoint
 	d.cluster = cluster
+	d.withTypology = withTypo
 
 	klog.Info("Driver: ", d.name)
 	klog.Info("Driver version: ", d.fqVersion)

--- a/pkg/csi/cinder/driver_test.go
+++ b/pkg/csi/cinder/driver_test.go
@@ -33,7 +33,7 @@ var (
 
 func NewFakeDriver() *CinderDriver {
 
-	driver := NewDriver(FakeNodeID, FakeEndpoint, FakeCluster)
+	driver := NewDriver(FakeNodeID, FakeEndpoint, FakeCluster, true)
 
 	return driver
 }

--- a/pkg/csi/cinder/identityserver_test.go
+++ b/pkg/csi/cinder/identityserver_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestGetPluginInfo(t *testing.T) {
-	d := NewDriver(FakeNodeID, FakeEndpoint, FakeCluster)
+	d := NewDriver(FakeNodeID, FakeEndpoint, FakeCluster, true)
 
 	ids := NewIdentityServer(d)
 

--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -39,7 +39,7 @@ var omock *openstack.OpenStackMock
 func init() {
 	if fakeNs == nil {
 
-		d := NewDriver(FakeNodeID, FakeEndpoint, FakeCluster)
+		d := NewDriver(FakeNodeID, FakeEndpoint, FakeCluster, true)
 
 		// mock MountMock
 		mmock = new(mount.MountMock)
@@ -141,7 +141,7 @@ func TestNodePublishVolumeEphermeral(t *testing.T) {
 	metadata.MetadataService = metamock
 	openstack.OsInstance = omock
 
-	d := NewDriver(FakeNodeID, FakeEndpoint, FakeCluster)
+	d := NewDriver(FakeNodeID, FakeEndpoint, FakeCluster, true)
 	fakeNse := NewNodeServer(d, mount.MInstance, metadata.MetadataService, openstack.OsInstance)
 
 	// Init assert
@@ -292,7 +292,7 @@ func TestNodeUnpublishVolumeEphermeral(t *testing.T) {
 	omock.On("WaitDiskDetached", FakeNodeID, FakeVolID).Return(nil)
 	omock.On("DeleteVolume", FakeVolID).Return(nil)
 
-	d := NewDriver(FakeNodeID, FakeEndpoint, FakeCluster)
+	d := NewDriver(FakeNodeID, FakeEndpoint, FakeCluster, true)
 	fakeNse := NewNodeServer(d, mount.MInstance, metadata.MetadataService, openstack.OsInstance)
 
 	// Init assert

--- a/tests/sanity/cinder/sanity_test.go
+++ b/tests/sanity/cinder/sanity_test.go
@@ -25,7 +25,7 @@ func TestDriver(t *testing.T) {
 	cluster := "kubernetes"
 	nodeID := "fake-node"
 
-	d := cinder.NewDriver(nodeID, endpoint, cluster)
+	d := cinder.NewDriver(nodeID, endpoint, cluster, true)
 	fakecloudprovider := getfakecloud()
 	openstack.OsInstance = fakecloudprovider
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
related to #1300

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
