### PR TITLE
[Doc] Add description for os-TLSInsecure

### DIFF
--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -143,6 +143,8 @@ The options in `Global` section are used for openstack-cloud-controller-manager 
   The name of an application credential to authenticate with. If `application-credential-id` is not set, the user name and domain need to be set.
 * `application-credential-secret`
   The secret of an application credential to authenticate with.
+* `os-TLSInsecure`
+  If set to `true`, then the server’s certificate will not be verified. Default is `false`.
 
 ###  Networking
 

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -209,7 +209,6 @@ type AuthOpts struct {
 	CertFile string `gcfg:"cert-file" mapstructure:"cert-file" name:"os-clientCertPath" value:"optional" dependsOn:"os-clientKeyPath"`
 	KeyFile  string `gcfg:"key-file" mapstructure:"key-file" name:"os-clientKeyPath" value:"optional" dependsOn:"os-clientCertPath"`
 
-	// Manila only options
 	TLSInsecure string `name:"os-TLSInsecure" value:"optional" matches:"^true|false$"`
 	// backward compatibility with the manila-csi-plugin
 	CAFileContents  string `name:"os-certAuthority" value:"optional"`


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #1306 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
