### PR TITLE
[k8s-keystone-auth] Set the runAsUser: nobody security context.

### DIFF
--- a/examples/webhook/keystone-deployment.yaml
+++ b/examples/webhook/keystone-deployment.yaml
@@ -35,6 +35,8 @@ spec:
               readOnly: true
           ports:
             - containerPort: 8443
+          securityContext:
+            runAsUser: 65534
       volumes:
       - name: certs
         secret:


### PR DESCRIPTION
In order to allow PSP policies, add security context to the example deployment.

Reference: #1322 

Signed-off-by: Jorge Niedbalski <jorge.niedbalski@canonical.com>