### PR TITLE
[octavia-ingress-controller] Add node name to pool member during creation

### DIFF
--- a/pkg/ingress/controller/openstack/octavia.go
+++ b/pkg/ingress/controller/openstack/octavia.go
@@ -352,7 +352,9 @@ func (os *OpenStack) EnsurePoolMembers(deleted bool, poolName string, lbID strin
 			continue
 		}
 
+		nodeName := node.Name
 		member := pools.BatchUpdateMemberOpts{
+			Name:         &nodeName,
 			Address:      addr,
 			ProtocolPort: *nodePort,
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This small PR adds the Kubernetes node name to the pool member (during batch update). I've tested this with a patched version of OIC based on `v1.18.2`.

**Which issue this PR fixes(if applicable)**:
fixes #1324 

**Special notes for reviewers**:
N/A

**Release note**:
```release-note
NONE
```
