### PR TITLE
Update docs

### DIFF
--- a/docs/barbican-kms-plugin/using-barbican-kms-plugin.md
+++ b/docs/barbican-kms-plugin/using-barbican-kms-plugin.md
@@ -3,7 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [OpenStack Barbican KMS Plugin](#openstack-barbican-kms-plugin)
-  - [Installation Steps:](#installation-steps)
+  - [Installation Steps](#installation-steps)
     - [Verify](#verify)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -17,7 +17,7 @@ It is recommended to read following kubernetes documents
 * [Encrypting Secret Data at Rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#verifying-that-data-is-encrypted)  
 * [Using a KMS provider for data encryption](https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/)
 
-## Installation Steps:
+## Installation Steps
 The following installation steps assumes that you have a Kubernetes cluster(v1.10+) running on OpenStack Cloud.
 
 1. Create 256bit(32 byte) cbc key and store in barbican

--- a/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
+++ b/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
@@ -208,4 +208,4 @@ Starting from Kubernetes 1.18, CSI migration is supported as beta feature. If yo
 * The CSI Migration feature for Cinder, when enabled, shims all plugin operations from the existing in-tree plugin to the `cinder.csi.openstack.org` CSI Driver. 
 * In order to use this feature, the Openstack Cinder CSI Driver must be installed on the cluster.
 * To turn on the migration, set `CSIMigration` and `CSIMigrationOpenstack` feature gates to true for kube-controller-manager and kubelet.
-* For more info, please refer [Migrate to CCM with CSI Migration](../migrate-to-ccm-with-csimigration.md#migrate-from-in-tree-cloud-provider-to-openstack-cloud-controller-manager-and-enable-csimigration) guide
+* For more info, please refer [Migrate to CCM with CSI Migration](../openstack-cloud-controller-manager/migrate-to-ccm-with-csimigration.md#migrate-from-in-tree-cloud-provider-to-openstack-cloud-controller-manager-and-enable-csimigration) guide

--- a/docs/manila-csi-plugin/using-manila-csi-plugin.md
+++ b/docs/manila-csi-plugin/using-manila-csi-plugin.md
@@ -3,7 +3,6 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [CSI Manila driver](#csi-manila-driver)
-          - [Table of contents](#table-of-contents)
   - [Configuration](#configuration)
     - [Command line arguments](#command-line-arguments)
     - [Controller Service volume parameters](#controller-service-volume-parameters)


### PR DESCRIPTION
This PR fix the links that are broken due to refactoring.

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
