### PR TITLE
[cinder-csi-plugin][doc] update doc to link to internal doc instead of external links

### DIFF
--- a/docs/cinder-csi-plugin/examples.md
+++ b/docs/cinder-csi-plugin/examples.md
@@ -18,7 +18,7 @@ All following examples need to be used inside instance(s) provisoned by openstac
 ## Dynamic Volume Provisioning
 
 For dynamic provisoning , create StorageClass, PersistentVolumeClaim and pod to consume it. 
-Checkout [sample app](https://github.com/kubernetes/cloud-provider-openstack/blob/master/examples/cinder-csi-plugin/nginx.yaml) definition fore reference.
+Checkout [sample app](../../examples/cinder-csi-plugin/nginx.yaml) definition fore reference.
 
 ```kubectl -f examples/cinder-csi-plugin/nginx.yaml create```
 
@@ -101,10 +101,10 @@ index.html  lost+found
 
 ## Deploy app using Inline volumes
 
-Sample App definition on using Inline volumes can be found at [here](https://github.com/kubernetes/cloud-provider-openstack/blob/master/examples/cinder-csi-plugin/inline/inline-example.yaml)
+Sample App definition on using Inline volumes can be found at [here](../../examples/cinder-csi-plugin/inline/inline-example.yaml)
 
 Prerequisites:
-* Deploy CSI Driver, with both volumeLifecycleModes enabled as specified [here](https://github.com/kubernetes/cloud-provider-openstack/blob/master/manifests/cinder-csi-plugin/csi-cinder-driver.yaml)
+* Deploy CSI Driver, with both volumeLifecycleModes enabled as specified [here](../../manifests/cinder-csi-plugin/csi-cinder-driver.yaml)
 
 Create a pod with inline volume
 ```
@@ -130,7 +130,7 @@ Volumes:
 
 ## Volume Expansion Example
 
-Sample App definition for volume resize could be found [here](https://github.com/kubernetes/cloud-provider-openstack/blob/master/examples/cinder-csi-plugin/resize/example.yaml)
+Sample App definition for volume resize could be found [here](../../examples/cinder-csi-plugin/resize/example.yaml)
 
 Deploy the sample app 
 ```
@@ -181,7 +181,7 @@ Filesystem      Size  Used Avail Use% Mounted on
 
 ## Using Block Volume 
 
-Sample App definition of pod consuming block volume can be found [here](https://github.com/kubernetes/cloud-provider-openstack/blob/master/examples/cinder-csi-plugin/block/block.yaml)
+Sample App definition of pod consuming block volume can be found [here](../../examples/cinder-csi-plugin/block/block.yaml)
 
 Deploy the same app  
 ```
@@ -202,7 +202,7 @@ brw-rw----    1 root     disk      202, 23296 Mar 12 04:23 /dev/xvda
 
 ## Snapshot Create and Restore
 
-Sample App definition using snapshots can be found [here](https://github.com/kubernetes/cloud-provider-openstack/tree/master/examples/cinder-csi-plugin/snapshot)
+Sample App definition using snapshots can be found [here](../../examples/cinder-csi-plugin/snapshot)
 
 Deploy app , Create Storage Class, Snapshot Class and PVC
 ```

--- a/docs/cinder-csi-plugin/features.md
+++ b/docs/cinder-csi-plugin/features.md
@@ -67,10 +67,10 @@ This feature enables creating volume snapshots and restore volume from snapshot.
 
 ## Inline Volumes
 
-This feature allows CSI volumes to be directly embedded in the Pod specification instead of a PersistentVolume. Volumes specified in this way are ephemeral and do not persist across Pod restarts. 
+This feature allows CSI volumes to be directly embedded in the Pod specification instead of a PersistentVolume. Volumes specified in this way are ephemeral and do not persist across Pod restarts.
 
 * As of Kubernetes v1.16 this feature is beta so enabled by default. 
-* To enable this feature for CSI Driver, `volumeLifecycleModes` needs to be specified in [CSIDriver](https://github.com/kubernetes/cloud-provider-openstack/blob/master/manifests/cinder-csi-plugin/csi-cinder-driver.yaml) object. The driver can run in `Persistent` mode, `Ephemeral` or in both modes. 
+* To enable this feature for CSI Driver, `volumeLifecycleModes` needs to be specified in [CSIDriver](../../manifests/cinder-csi-plugin/csi-cinder-driver.yaml) object. The driver can run in `Persistent` mode, `Ephemeral` or in both modes.
 * `podInfoOnMount` must be `true` to use this feature.
 * For usage, refer [sample app](./examples.md#deploy-app-using-inline-volumes)
 
@@ -83,7 +83,7 @@ Prerequisites:
 * source and destination PVCs must be in the same namespace.
 * Cloning is only supported within the same Storage Class. Destination volume must be the same storage class as the source
 
-For example, refer [sample app](https://github.com/kubernetes/cloud-provider-openstack/tree/master/examples/cinder-csi-plugin/clone)
+For example, refer [sample app](../../examples/cinder-csi-plugin/clone)
 
 ## Multi-Attach Volumes
 

--- a/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
+++ b/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
@@ -58,7 +58,7 @@ For Driver configuration, parameters must be passed via configuration file speci
 The following sections are supported in configuration file.
 
 ### Global 
-For Cinder CSI Plugin to authenticate with Openstack Keystone, required parameters needs to be passed in `[Global]` section of the file. For all supported parameters, please refer [Global](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#global) section.
+For Cinder CSI Plugin to authenticate with Openstack Keystone, required parameters needs to be passed in `[Global]` section of the file. For all supported parameters, please refer [Global](../openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#global) section.
 
 ### Block Storage
 These configuration options pertain to block storage and should appear in the `[BlockStorage]` section of the `$CLOUD_CONFIG` file.
@@ -153,6 +153,7 @@ helm install --namespace kube-system --name cinder-csi ./charts/cinder-csi-plugi
 * [Volume Snapshots](./features.md#volume-snapshots)
 * [Inline Volumes](./features.md#inline-volumes)
 * [Multiattach Volumes](./features.md#multi-attach-volumes)
+* [Liveness probe](./features.md#liveness-probe)
 
 ## Supported Parameters
 

--- a/docs/keystone-auth/using-client-keystone-auth.md
+++ b/docs/keystone-auth/using-client-keystone-auth.md
@@ -23,7 +23,7 @@ not natively supported by `k8s.io/client-go`. The plugin implements the protocol
 then returns opaque credentials to use. This credential plugin use cases require a server side
 component with support for the [webhook token authenticator](https://kubernetes.io/docs/admin/authentication/#webhook-token-authentication)
 to interpret the credential format produced by the client plugin. The webhook authenticator is
-provided by [k8s-keystone-auth binary](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/keystone-auth/using-keystone-webhook-authenticator-and-authorizer.md)
+provided by [k8s-keystone-auth binary](./using-keystone-webhook-authenticator-and-authorizer.md)
 
 ## Example use case
 

--- a/docs/openstack-cloud-controller-manager/migrate-to-ccm-with-csimigration.md
+++ b/docs/openstack-cloud-controller-manager/migrate-to-ccm-with-csimigration.md
@@ -91,7 +91,7 @@ W1117 19:59:34.094187       1 controllermanager.go:513] "route" is disabled
 W1117 19:59:44.988353       1 controllermanager.go:513] "cloud-node-lifecycle" is disabled
 ```
 
-You can now deploy `openstack-cloud-controller-manager` using [RBAC](https://github.com/kubernetes/cloud-provider-openstack/tree/master/cluster/addons/rbac) and the [CCM manifest](https://github.com/kubernetes/cloud-provider-openstack/blob/master/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml). But disable the controller `cloud-node` by adding the argument `--controllers=*,-cloud-node`. This will be done by the `kubelets` up until the entire migration is done. Note: You must create a secret `cloud-config` with a valid `cloud.conf` for the CCM. E.g.
+You can now deploy `openstack-cloud-controller-manager` using [RBAC](../../cluster/addons/rbac) and the [CCM manifest](../../manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml). But disable the controller `cloud-node` by adding the argument `--controllers=*,-cloud-node`. This will be done by the `kubelets` up until the entire migration is done. Note: You must create a secret `cloud-config` with a valid `cloud.conf` for the CCM. E.g.
 
 ```bash
 kubectl -n kube-system create secret generic cloud-config --from-file=cloud.conf=/etc/kubernetes/cloud.conf
@@ -101,7 +101,7 @@ Note: Because you still want to use the in-tree volume API, you **must** keep th
 
 At this point, the cluster should work as before. LoadBalancers can be created and `StatefulSets` create and use persistent volumes. Note: The logs of `openstack-cloud-controller-manager` in namespace `kube-system` reveal, that this now takes care of creating LoadBalancers. All further management of existing LoadBalancers is taken over by `openstack-cloud-controller-manager` as well. There is no need to recreate any LoadBalancer.
 
-At this point, you should also deploy [Cinder CSI Plugin](./cinder-csi-plugin/using-cinder-csi-plugin.md). As mentioned above, this can be deployed alogside the in-tree provider. We would recommend to create a separate `StorageClass` for Cinder CSI Plugin, and make it the default. (see https://github.com/kubernetes/cloud-provider-openstack/tree/master/examples/cinder-csi-plugin for examples)
+At this point, you should also deploy [Cinder CSI Plugin](./cinder-csi-plugin/using-cinder-csi-plugin.md). As mentioned above, this can be deployed alogside the in-tree provider. We would recommend to create a separate `StorageClass` for Cinder CSI Plugin, and make it the default. (refer [example](../../examples/cinder-csi-plugin))
 
 ## Enable CSIMigration
 

--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -41,7 +41,7 @@ The following guide has been tested to install Kubernetes v1.17 on Ubuntu 18.04.
 
 ### Steps
 
-- Create the kubeadm config file according to [`manifests/controller-manager/kubeadm.conf`](https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/manifests/controller-manager/kubeadm.conf)
+- Create the kubeadm config file according to [`manifests/controller-manager/kubeadm.conf`](../../manifests/controller-manager/kubeadm.conf)
 
 - Bootstrap the cluster, make sure to install the [CNI network plugin](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#pod-network) as well.
 
@@ -51,7 +51,7 @@ The following guide has been tested to install Kubernetes v1.17 on Ubuntu 18.04.
 
 - Bootstrap worker nodes. You need to set `--cloud-provider=external` for kubelet service before running `kubeadm join`.
 
-- Create a secret containing the cloud configuration. You can find an example config file in [`manifests/controller-manager/cloud-config`](https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/manifests/controller-manager/cloud-config). If you have certs you need put the cert file into folder `/etc/ssl/certs/` and update `ca-file` in the configuration file, refer to `ca-file` option [here](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#global) for further information. After that, Save the configuration to a file named *cloud.conf*, then:
+- Create a secret containing the cloud configuration. You can find an example config file in [`manifests/controller-manager/cloud-config`](../../manifests/controller-manager/cloud-config). If you have certs you need put the cert file into folder `/etc/ssl/certs/` and update `ca-file` in the configuration file, refer to `ca-file` option [here](./using-openstack-cloud-controller-manager.md#global) for further information. After that, Save the configuration to a file named *cloud.conf*, then:
 
     ```shell
     kubectl create secret -n kube-system generic cloud-config --from-file=cloud.conf


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
