### PR TITLE
[magnum-auto-healer] Fix autohealer nil pointer bug

### DIFF
--- a/pkg/autohealing/cloudprovider/openstack/provider.go
+++ b/pkg/autohealing/cloudprovider/openstack/provider.go
@@ -172,10 +172,10 @@ func (provider OpenStackCloudProvider) waitForClusterComplete(clusterID string, 
 	err := wait.Poll(3*time.Second, timeout,
 		func() (bool, error) {
 			cluster, err := clusters.Get(provider.Magnum, clusterID).Extract()
-			log.V(5).Infof("Cluster %s in status %s", clusterID, cluster.Status)
 			if err != nil {
 				return false, err
 			}
+			log.V(5).Infof("Cluster %s in status %s", clusterID, cluster.Status)
 			if strings.HasSuffix(cluster.Status, "_COMPLETE") {
 				return true, nil
 			}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Cherry picked from https://github.com/kubernetes/cloud-provider-openstack/pull/1334

Before referencing the cluster status, it'd better to check if cluster
get action returns without error.

**Which issue this PR fixes(if applicable)**:
fixes #1333

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[magnum-auto-healer] Fixed a nil pointer bug due to getting cluster failure.
```
