### PR TITLE
[cinder-csi-plugin] Add support for PSP and ability to set priority class in the helm chart

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 1.3.0
+version: 1.3.1
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-rbac.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-rbac.yaml
@@ -184,3 +184,35 @@ roleRef:
   kind: Role
   name: external-resizer-cfg
   apiGroup: rbac.authorization.k8s.io
+
+{{ if .Values.podSecurityPolicy.enabled }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-cinder-controller-psp
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - {{ .Values.podSecurityPolicy.existingPolicyName | default "csi-cinder" }}
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-cinder-controller-psp
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: csi-cinder-controller-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: csi-cinder-controller-psp
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -25,6 +25,9 @@ spec:
         {{- include "cinder-csi.controllerplugin.labels" . | nindent 8 }}
     spec:
       serviceAccount: csi-cinder-controller-sa
+{{- if .Values.priorityClassName.controllerPlugin }}
+      priorityClassName: {{ .Values.priorityClassName.controllerPlugin }}
+{{- end }}
       containers:
         - name: csi-attacher
           image: "{{ .Values.csi.attacher.image.repository }}:{{ .Values.csi.attacher.image.tag }}"

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -17,6 +17,9 @@ spec:
         - operator: Exists
       serviceAccount: csi-cinder-node-sa
       hostNetwork: true
+{{- if .Values.priorityClassName.nodePlugin }}
+      priorityClassName: {{ .Values.priorityClassName.nodePlugin }}
+{{- end }}
       containers:
         - name: node-driver-registrar
           image: "{{ .Values.csi.nodeDriverRegistrar.image.repository }}:{{ .Values.csi.nodeDriverRegistrar.image.tag }}"

--- a/charts/cinder-csi-plugin/templates/nodeplugin-rbac.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-rbac.yaml
@@ -26,3 +26,35 @@ roleRef:
   kind: ClusterRole
   name: csi-nodeplugin-role
   apiGroup: rbac.authorization.k8s.io
+
+{{ if .Values.podSecurityPolicy.enabled }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-cinder-node-psp
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - {{ .Values.podSecurityPolicy.existingPolicyName | default "csi-cinder" }}
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-cinder-node-psp
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: csi-cinder-node-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: csi-cinder-node-psp
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/charts/cinder-csi-plugin/templates/psp.yaml
+++ b/charts/cinder-csi-plugin/templates/psp.yaml
@@ -1,0 +1,29 @@
+{{ if and .Values.podSecurityPolicy.create .Values.podSecurityPolicy.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: csi-cinder
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  volumes:
+  - '*'
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+{{ end }}

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -72,3 +72,12 @@ storageClass:
   retain:
     isDefault: false
     allowVolumeExpansion: true
+
+priorityClassName:
+  controllerPlugin: ""
+  nodePlugin: ""
+
+podSecurityPolicy:
+  enabled: false
+  existingPolicyName: ""
+  create: false

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -78,6 +78,12 @@ priorityClassName:
   nodePlugin: ""
 
 podSecurityPolicy:
+  # Setting this to true will create a role and rolebinding granting the service accounts access to use the selected pod security policy
   enabled: false
+
+  # Leave empty if you want the helm chart to create a pod security policy for you (and set create to true)
+  # If not empty this should be the name of a pre-existing pod security policy resource deployed in the cluster (and set create to false)
   existingPolicyName: ""
+
+  # Whether the helm chart should create a pod security policy
   create: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes it possible to deploy the cinder-csi-plugin helm chart in Kubernetes clusters that has the Pod Security Policy admission controller enabled. Also allows the user to specify priority class for the statefulset and daemonset pods.

**Which issue this PR fixes(if applicable)**:
N/A

**Special notes for reviewers**:
The provided pod security policy was inspired by the full access policy example from K8S docs:  https://kubernetes.io/docs/concepts/policy/pod-security-policy/#example-policies but this might be possible to restrict further?

**Release note**:
```release-note
NONE
```
