### PR TITLE
[manila-csi-plugin] Switch CSI sidecar image repository to gcr

### DIFF
--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 1.0.1
+version: 1.0.2
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -47,8 +47,8 @@ nodeplugin:
   # csi-node-driver-registrar
   registrar:
     image:
-      repository: quay.io/k8scsi/csi-node-driver-registrar
-      tag: v1.1.0
+      repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+      tag: v1.3.0
       pullPolicy: IfNotPresent
     resources: {}
   nodeSelector: {}
@@ -66,14 +66,14 @@ controllerplugin:
   # CSI external-provisioner container spec
   provisioner:
     image:
-      repository: quay.io/k8scsi/csi-provisioner
+      repository: k8s.gcr.io/sig-storage/csi-provisioner
       tag: v2.0.2
       pullPolicy: IfNotPresent
     resources: {}
   # CSI external-snapshotter container spec
   snapshotter:
     image:
-      repository: quay.io/k8scsi/csi-snapshotter
+      repository: k8s.gcr.io/sig-storage/csi-snapshotter
       tag: v2.1.1
       pullPolicy: IfNotPresent
     resources: {}

--- a/manifests/manila-csi-plugin/csi-controllerplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-controllerplugin.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: openstack-manila-csi-controllerplugin
       containers:
         - name: provisioner
-          image: "quay.io/k8scsi/csi-provisioner:v2.0.2"
+          image: "k8s.gcr.io/sig-storage/csi-provisioner:v2.0.2"
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -50,7 +50,7 @@ spec:
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
         - name: snapshotter
-          image: "quay.io/k8scsi/csi-snapshotter:v2.1.1"
+          image: "k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.1"
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -21,7 +21,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: registrar
-          image: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0"
+          image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0"
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"


### PR DESCRIPTION
**What this PR does / why we need it**:
Ref kubernetes-csi/csi-release-tools#86
Along the way the `csi-node-driver-registrar` was updated from v1.1.0 to v1.3.0 (as the v1.1.0 tag is not available in gcr).

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[manila-csi-plugin] use GCR images of the CSI sidecar containers.
```
