### PR TITLE
[occm] Add handling for supported LBProvider

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -86,6 +86,9 @@ var ErrIPv6SupportDisabled = errors.New("IPv6 support is disabled")
 // userAgentData is used to add extra information to the gophercloud user-agent
 var userAgentData []string
 
+// supportedLBProvider map is used to define LoadBalancer providers that we support
+var supportedLBProvider = []string{"amphora", "octavia"}
+
 // AddExtraFlags is called by the main package to add component specific command line flags
 func AddExtraFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVar(&userAgentData, "user-agent", nil, "Extra data to add to gophercloud user-agent. Use multiple times to add more than one component.")
@@ -410,6 +413,10 @@ func ReadConfig(config io.Reader) (Config, error) {
 	// Set the default values for search order if not set
 	if cfg.Metadata.SearchOrder == "" {
 		cfg.Metadata.SearchOrder = fmt.Sprintf("%s,%s", metadata.ConfigDriveID, metadata.MetadataID)
+	}
+
+	if !util.Contains(supportedLBProvider, cfg.LoadBalancer.LBProvider) {
+		return Config{}, fmt.Errorf("Unsupported LoadBalancer Provider: %s", cfg.LoadBalancer.LBProvider)
 	}
 
 	return cfg, err


### PR DESCRIPTION
Currently, when provided with a unsupported lb-provider,
occm will accept providers that we can't support at this stage.
Rather than accept it, we will parse the provided value, compare
with our new supportedLBProvider map and fail for unsupported
providers.

This change introduces supportedLBProvider map, and a small section
during ReadConfig() to ensure the provided value can be supported.


[occm] Check for supported LBProvider type

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)


**What this PR does / why we need it**:
This PR will add a map of supported LoadBalancer providers, and fail if the user specifies an unsupported Provider.

**Which issue this PR fixes(if applicable)**:
fixes #1332 1332

**Special notes for reviewers**:


**Release note**:
```release-note
[openstack-cloud-controller-manager] Added a check that only "amphora" and "octavia" are supported for the config `lb-provider`.
```
