### PR TITLE
[occm] Fix the test case test_update_port

### DIFF
--- a/tests/e2e/cloudprovider/test-lb-service.sh
+++ b/tests/e2e/cloudprovider/test-lb-service.sh
@@ -326,7 +326,7 @@ EOF
     printf "\n>>>>>>> Expected: NodePorts ${member_ports} before updating service.\n"
 
     printf "\n>>>>>>> Removing port2 and update NodePort of port1.\n"
-    kubectl patch svc $service --type json -p '[{"op": "remove","path": "/spec/ports/1"},{"op": "remove","path": "/spec/ports/0/nodePort"}]'
+    kubectl -n $NAMESPACE patch svc $service --type json -p '[{"op": "remove","path": "/spec/ports/1"},{"op": "remove","path": "/spec/ports/0/nodePort"}]'
 
     printf "\n>>>>>>> Waiting for load balancer $lbid ACTIVE.\n"
     wait_for_loadbalancer $lbid


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Fix the error in the test case test_update_port:

```
2020-12-11 11:02:23.710091 | ubuntu-bionic | >>>>>>> Removing port2 and update NodePort of port1.
2020-12-11 11:02:24.750672 | ubuntu-bionic | Error from server (NotFound): services "test-update-port" not found
```

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
