### PR TITLE
[occm] Add OVN to supported Octavia providers.

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -130,27 +130,39 @@ Request Body:
 
   If 'true', the loadbalancer pool protocol will be set as `PROXY`. Default is 'false'.
 
+  Not supported when `lb-provider=ovn` is configured in openstack-cloud-controller-manager.
+
 - `loadbalancer.openstack.org/x-forwarded-for`
 
   If 'true', `X-Forwarded-For` is inserted into the HTTP headers which contains the original client IP address so that the backend HTTP service is able to get the real source IP of the request. Please note that the cloud provider will force the creation of an Octavia listener of type `HTTP` if this option is set. Only applies when using Octavia.
 
   This annotation also works in conjunction with the `loadbalancer.openstack.org/default-tls-container-ref` annotation. In this case the cloud provider will create an Octavia listener of type `TERMINATED_HTTPS` instead of an `HTTP` listener.
 
+  Not supported when `lb-provider=ovn` is configured in openstack-cloud-controller-manager.
+
 - `loadbalancer.openstack.org/timeout-client-data`
 
   Frontend client inactivity timeout in milliseconds for the load balancer.
+
+  Not supported when `lb-provider=ovn` is configured in openstack-cloud-controller-manager.
 
 - `loadbalancer.openstack.org/timeout-member-connect`
 
   Backend member connection timeout in milliseconds for the load balancer.
 
+  Not supported when `lb-provider=ovn` is configured in openstack-cloud-controller-manager.
+
 - `loadbalancer.openstack.org/timeout-member-data`
 
   Backend member inactivity timeout in milliseconds for the load balancer.
 
+  Not supported when `lb-provider=ovn` is configured in openstack-cloud-controller-manager.
+
 - `loadbalancer.openstack.org/timeout-tcp-inspect`
 
   Time to wait for additional TCP packets for content inspection in milliseconds for the load balancer.
+
+  Not supported when `lb-provider=ovn` is configured in openstack-cloud-controller-manager.
 
 - `service.beta.kubernetes.io/openstack-internal-load-balancer`
 
@@ -159,19 +171,27 @@ Request Body:
 - `loadbalancer.openstack.org/enable-health-monitor`
 
   Defines whether or not to create health monitor for the load balancer pool, if not specified, use `create-monitor` config. The health monitor can be created or deleted dynamically.
+
+  Not supported when `lb-provider=ovn` is configured in openstack-cloud-controller-manager.
   
 - `loadbalancer.openstack.org/flavor-id`
 
   The id of the flavor that is used for creating the loadbalancer.
 
+  Not supported when `lb-provider=ovn` is configured in openstack-cloud-controller-manager.
+
 - `loadbalancer.openstack.org/availability-zone`
 
   The name of the loadbalancer availability zone to use. It is ignored if the Octavia version doesn't support availability zones yet.
+
+  Not supported when `lb-provider=ovn` is configured in openstack-cloud-controller-manager.
 
 - `loadbalancer.openstack.org/default-tls-container-ref`
 
   Reference to a tls container. This option works with Octavia, when this option is set then the cloud provider will create an Octavia Listener of type `TERMINATED_HTTPS` for a TLS Terminated loadbalancer.
   Format for tls container ref: `https://{keymanager_host}/v1/containers/{uuid}`
+
+  Not supported when `lb-provider=ovn` is configured in openstack-cloud-controller-manager.
 
 ### Switching between Floating Subnets by using preconfigured Classes
 

--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -253,6 +253,10 @@ Although the openstack-cloud-controller-manager was initially implemented with N
 
   Format for tls container ref: `https://{keymanager_host}/v1/containers/{uuid}`
 
+NOTE:
+
+* When using `ovn` provider service has limited scope - `create_monitor` is not supported and only supported `lb-method` is `SOURCE_IP`.
+
 ### Metadata
 
 * `search-order`

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -75,7 +75,7 @@ var ErrIPv6SupportDisabled = errors.New("IPv6 support is disabled")
 var userAgentData []string
 
 // supportedLBProvider map is used to define LoadBalancer providers that we support
-var supportedLBProvider = []string{"amphora", "octavia"}
+var supportedLBProvider = []string{"amphora", "octavia", "ovn"}
 
 // AddExtraFlags is called by the main package to add component specific command line flags
 func AddExtraFlags(fs *pflag.FlagSet) {

--- a/pkg/util/openstack/loadbalancer.go
+++ b/pkg/util/openstack/loadbalancer.go
@@ -91,7 +91,7 @@ func getOctaviaVersion(client *gophercloud.ServiceClient) (string, error) {
 }
 
 // IsOctaviaFeatureSupported returns true if the given feature is supported in the deployed Octavia version.
-func IsOctaviaFeatureSupported(client *gophercloud.ServiceClient, feature int) bool {
+func IsOctaviaFeatureSupported(client *gophercloud.ServiceClient, feature int, lbProvider string) bool {
 	octaviaVer, err := getOctaviaVersion(client)
 	if err != nil {
 		klog.Warningf("Failed to get current Octavia API version: %v", err)
@@ -102,6 +102,9 @@ func IsOctaviaFeatureSupported(client *gophercloud.ServiceClient, feature int) b
 
 	switch feature {
 	case OctaviaFeatureVIPACL:
+		if lbProvider == "ovn" {
+			return false
+		}
 		verACL, _ := version.NewVersion("v2.12")
 		if currentVer.GreaterThanOrEqual(verACL) {
 			return true
@@ -112,16 +115,25 @@ func IsOctaviaFeatureSupported(client *gophercloud.ServiceClient, feature int) b
 			return true
 		}
 	case OctaviaFeatureFlavors:
+		if lbProvider == "ovn" {
+			return false
+		}
 		verFlavors, _ := version.NewVersion("v2.6")
 		if currentVer.GreaterThanOrEqual(verFlavors) {
 			return true
 		}
 	case OctaviaFeatureTimeout:
+		if lbProvider == "ovn" {
+			return false
+		}
 		verFlavors, _ := version.NewVersion("v2.1")
 		if currentVer.GreaterThanOrEqual(verFlavors) {
 			return true
 		}
 	case OctaviaFeatureAvailabilityZones:
+		if lbProvider == "ovn" {
+			return false
+		}
 		verAvailabilityZones, _ := version.NewVersion("v2.14")
 		if currentVer.GreaterThanOrEqual(verAvailabilityZones) {
 			return true


### PR DESCRIPTION
Closes #1350

Signed-off-by: Michał Nasiadka <mnasiadka@gmail.com>

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This PR adds support for using OVN Octavia provider driver (in addition to Amphora - the default one)

**Which issue this PR fixes(if applicable)**:
fixes #1350

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
