### PR TITLE
trivial: Correct casing of OpenStack

### DIFF
--- a/docs/cinder-csi-plugin/features.md
+++ b/docs/cinder-csi-plugin/features.md
@@ -46,7 +46,7 @@ For usage, refer [sample app](./examples.md#using-block-volume)
 ## Volume Expansion
 
 Driver supports both `Offline` and `Online` resize of cinder volumes. Cinder online resize support is available since cinder 3.42 microversion. 
-The same should be supported by underlying Openstack Cloud to avail the feature.
+The same should be supported by underlying OpenStack Cloud to avail the feature.
 
 * As of kubernetes v1.16, Volume Expansion is a beta feature and enabled by default.
 * Make sure to set `allowVolumeExpansion` to `true` in Storage class spec.

--- a/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
+++ b/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
@@ -26,7 +26,7 @@
 
 # CSI Cinder driver
 
-The Cinder CSI Driver is a CSI Specification compliant driver used by Container Orchestrators to manage the lifecycle of Openstack Cinder Volumes.
+The Cinder CSI Driver is a CSI Specification compliant driver used by Container Orchestrators to manage the lifecycle of OpenStack Cinder Volumes.
 
 ## CSI Compatibility
 
@@ -58,7 +58,7 @@ For Driver configuration, parameters must be passed via configuration file speci
 The following sections are supported in configuration file.
 
 ### Global 
-For Cinder CSI Plugin to authenticate with Openstack Keystone, required parameters needs to be passed in `[Global]` section of the file. For all supported parameters, please refer [Global](../openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#global) section.
+For Cinder CSI Plugin to authenticate with OpenStack Keystone, required parameters needs to be passed in `[Global]` section of the file. For all supported parameters, please refer [Global](../openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#global) section.
 
 ### Block Storage
 These configuration options pertain to block storage and should appear in the `[BlockStorage]` section of the `$CLOUD_CONFIG` file.
@@ -207,6 +207,6 @@ Optionally, to test the driver csc tool could be used. please refer, [usage guid
 Starting from Kubernetes 1.18, CSI migration is supported as beta feature. If you have persistence volumes that are created with in-tree `kubernetes.io/cinder` plugin, you could migrate to use `cinder.csi.openstack.org` Container Storage Interface (CSI) Driver. 
 
 * The CSI Migration feature for Cinder, when enabled, shims all plugin operations from the existing in-tree plugin to the `cinder.csi.openstack.org` CSI Driver. 
-* In order to use this feature, the Openstack Cinder CSI Driver must be installed on the cluster.
+* In order to use this feature, the OpenStack Cinder CSI Driver must be installed on the cluster.
 * To turn on the migration, set `CSIMigration` and `CSIMigrationOpenstack` feature gates to true for kube-controller-manager and kubelet.
 * For more info, please refer [Migrate to CCM with CSI Migration](../openstack-cloud-controller-manager/migrate-to-ccm-with-csimigration.md#migrate-from-in-tree-cloud-provider-to-openstack-cloud-controller-manager-and-enable-csimigration) guide

--- a/docs/keystone-auth/using-client-keystone-auth.md
+++ b/docs/keystone-auth/using-client-keystone-auth.md
@@ -27,7 +27,7 @@ provided by [k8s-keystone-auth binary](./using-keystone-webhook-authenticator-an
 
 ## Example use case
 
-In a hypothetical use case, an organization would run an external service that exchanges Openstack Keystone
+In a hypothetical use case, an organization would run an external service that exchanges OpenStack Keystone
 credentials for user specific, signed tokens. The service would also be capable of responding to [webhook token
 authenticator](https://kubernetes.io/docs/admin/authentication/#webhook-token-authentication) requests to
 validate the tokens. Users would be required to install a credential plugin on their workstation.

--- a/pkg/csi/cinder/identityserver.go
+++ b/pkg/csi/cinder/identityserver.go
@@ -55,7 +55,7 @@ func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*c
 	}
 	if err := oProvider.CheckBlockStorageAPI(); err != nil {
 		klog.Errorf("Failed to query blockstorage API: %v", err)
-		return nil, status.Error(codes.FailedPrecondition, "Failed to communicate with Openstack BlockStorage API")
+		return nil, status.Error(codes.FailedPrecondition, "Failed to communicate with OpenStack BlockStorage API")
 	}
 	return &csi.ProbeResponse{}, nil
 }


### PR DESCRIPTION

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This fixes a few instances where OpenStack was not correctly cased.
There are other instances in code, but that would be more disruptive to
change.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
