### PR TITLE
[cinder-csi-plugin] chart: better optional cloud-config secret handling

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 1.2.10
+version: 1.2.11
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -125,4 +125,12 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir:
+        - name: cloud-config
+        {{- if .Values.secret.use }}
+          secret:
+            secretName: {{ .Values.secret.name }}
+        {{- else }}
+          hostPath:
+            path: /etc/kubernetes
+        {{- end }}
         {{ .Values.csi.plugin.volumes | toYaml | trimSuffix "\n" | nindent 8 }}

--- a/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -126,7 +126,7 @@ spec:
         - name: socket-dir
           emptyDir:
         - name: cloud-config
-        {{- if .Values.secret.use }}
+        {{- if .Values.secret.enabled }}
           secret:
             secretName: {{ .Values.secret.name }}
         {{- else }}

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -118,4 +118,12 @@ spec:
           hostPath:
             path: /dev
             type: Directory
+        - name: cloud-config
+        {{- if .Values.secret.use }}
+          secret:
+            secretName: {{ .Values.secret.name }}
+        {{- else }}
+          hostPath:
+            path: /etc/kubernetes
+        {{- end }}
         {{ .Values.csi.plugin.volumes | toYaml | trimSuffix "\n" | nindent 8 }}

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -119,7 +119,7 @@ spec:
             path: /dev
             type: Directory
         - name: cloud-config
-        {{- if .Values.secret.use }}
+        {{- if .Values.secret.enabled }}
           secret:
             secretName: {{ .Values.secret.name }}
         {{- else }}

--- a/charts/cinder-csi-plugin/templates/secret.yaml
+++ b/charts/cinder-csi-plugin/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.secret }}
+{{- if .Values.secret.create }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -51,7 +51,7 @@ csi:
         readOnly: true
 
 secret:
-  use: false
+  enabled: false
   create: false
 #  name: cinder-csi-cloud-config
 #  data:

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -42,11 +42,6 @@ csi:
       - name: cacert
         hostPath:
           path: /etc/cacert
-      - name: cloud-config
-        hostPath:
-          path: /etc/kubernetes
-        # secret:
-        #   secretName: cinder-csi-cloud-config
     volumeMounts:
       - name: cacert
         mountPath: /etc/cacert
@@ -56,6 +51,8 @@ csi:
         readOnly: true
 
 secret:
+  use: false
+  create: false
 #  name: cinder-csi-cloud-config
 #  data:
 #    cloud-config: |-

--- a/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
+++ b/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
@@ -141,7 +141,7 @@ cinder.csi.openstack.org   2019-07-29T09:02:40Z
 You can specify a K8S Secret for `cloud-config` :
 ```
 secret:
-  use: true
+  enabled: true
   name: yousecretname
 ```
 
@@ -149,7 +149,7 @@ You can also tell Helm to create the K8S Secret :
 
 ```
 secret:
-  use: true
+  enabled: true
   name: cinder-csi-cloud-config
   data:
     cloud-config: |-

--- a/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
+++ b/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
@@ -95,9 +95,9 @@ Configuration file specified in `$CLOUD_CONFIG` is passed to cinder CSI driver v
 
 To create a secret:
 
-* Encode your ```$CLOUD_CONFIG``` file content using base64.
+* Encode your `$CLOUD_CONFIG` file content using base64.
 
-```$ base64 -w 0 $CLOUD_CONFIG```
+`$ base64 -w 0 $CLOUD_CONFIG`
 
 * Update ```cloud.conf``` configuration in ```manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml``` file
 by using the result of the above command.
@@ -136,7 +136,26 @@ cinder.csi.openstack.org   2019-07-29T09:02:40Z
 
 ### Using the Helm chart
 
-> NOTE: This chart assumes that the `cloud-config` is found on the host under `/etc/kubernetes/` and that your OpenStack cloud has cert under `/etc/cacert`.
+> NOTE: With default values, this chart assumes that the `cloud-config` is found on the host under `/etc/kubernetes/` and that your OpenStack cloud has cert under `/etc/cacert`.
+
+You can specify a K8S Secret for `cloud-config` :
+```
+secret:
+  use: true
+  name: yousecretname
+```
+
+You can also tell Helm to create the K8S Secret :
+
+```
+secret:
+  use: true
+  name: cinder-csi-cloud-config
+  data:
+    cloud-config: |-
+      ...
+```
+
 
 To install the chart, use the following command:
 ```


### PR DESCRIPTION
This PR offers better secret handling for `cloud-config` : 

* use an existing secret : 
```yaml
secret:
  use: true
  name: cinder-csi-cloud-config
```

* create a new secret for `cloud-config` :
```yaml
secret:
  use: true
  name: cinder-csi-cloud-config
  data:
    cloud-config: |-
      ...
```
