### PR TITLE
[occm] don't error on unsupported octavia provider

### DIFF
--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -176,7 +176,7 @@ Although the openstack-cloud-controller-manager was initially implemented with N
   The load balancing algorithm used to create the load balancer pool. The value can be `ROUND_ROBIN`, `LEAST_CONNECTIONS`, or `SOURCE_IP`. Default: `ROUND_ROBIN`
 
 * `lb-provider`
-  Optional. Used to specify the provider of the load balancer, e.g. "amphora" or "octavia".
+  Optional. Used to specify the provider of the load balancer, e.g. "amphora" or "octavia". Only "amphora" or "octavia" provider are officially tested, other provider will cause a warning log.
 
 * `lb-version`
   Optional. If specified, only "v2" is supported.

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -416,7 +416,7 @@ func ReadConfig(config io.Reader) (Config, error) {
 	}
 
 	if !util.Contains(supportedLBProvider, cfg.LoadBalancer.LBProvider) {
-		return Config{}, fmt.Errorf("Unsupported LoadBalancer Provider: %s", cfg.LoadBalancer.LBProvider)
+		klog.Warningf("Unsupported LoadBalancer Provider: %s", cfg.LoadBalancer.LBProvider)
 	}
 
 	return cfg, err


### PR DESCRIPTION
**What this PR does / why we need it**:
Emit's a warning instead of initialisation failure if an unsupported octavia provider plugin is used.

**Which issue this PR fixes(if applicable)**:
fixes #1356

**Special notes for reviewers**:


**Release note**:
```release-note
[openstack-cloud-controller-manager] Allow load balancer providers other than 'amphora' and 'octavia'.
```
