### PR TITLE
[occm] don't error on unsupported octavia provider

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,6 +1,9 @@
 name: Lint Charts
 
-on: pull_request
+on:
+  pull_request:
+    branches:
+      - master
 
 jobs:
   lint:

--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -176,7 +176,7 @@ Although the openstack-cloud-controller-manager was initially implemented with N
   The load balancing algorithm used to create the load balancer pool. The value can be `ROUND_ROBIN`, `LEAST_CONNECTIONS`, or `SOURCE_IP`. Default: `ROUND_ROBIN`
 
 * `lb-provider`
-  Optional. Used to specify the provider of the load balancer, e.g. "amphora" or "octavia".
+  Optional. Used to specify the provider of the load balancer, e.g. "amphora" or "octavia". Only "amphora" or "octavia" provider are officially tested, other provider will cause a warning log.
 
 * `lb-version`
   Optional. If specified, only "v2" is supported.

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -416,7 +416,7 @@ func ReadConfig(config io.Reader) (Config, error) {
 	}
 
 	if !util.Contains(supportedLBProvider, cfg.LoadBalancer.LBProvider) {
-		return Config{}, fmt.Errorf("Unsupported LoadBalancer Provider: %s", cfg.LoadBalancer.LBProvider)
+		klog.Warningf("Unsupported LoadBalancer Provider: %s", cfg.LoadBalancer.LBProvider)
 	}
 
 	return cfg, err


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Cherry picked from https://github.com/kubernetes/cloud-provider-openstack/pull/1357

**Which issue this PR fixes(if applicable)**:
fixes #1356

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] Allow load balancer providers other than 'amphora' and 'octavia'.
```
