### PR TITLE
[cinder-csi-plugin] validate volume capabilities before creation

### DIFF
--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -55,6 +55,12 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, status.Error(codes.InvalidArgument, "[CreateVolume] missing Volume capability")
 	}
 
+	for _, cap := range volCapabilities {
+		if cap.GetAccessMode().GetMode() != cs.Driver.vcap[0].Mode {
+			return nil, status.Errorf(codes.InvalidArgument, "[CreateVolume] requested Volume capabilty not supported: %s", cap.GetAccessMode().GetMode())
+		}
+	}
+
 	// Volume Size - Default is 1 GiB
 	volSizeBytes := int64(1 * 1024 * 1024 * 1024)
 	if req.GetCapacityRange() != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
To comply with in-tree cinder plugin, we need to prevent PVCs with ROX/RWX access modes.

**Which issue this PR fixes(if applicable)**:
fixes #1367 

**Release note**:
```release-note
NONE
```
