### PR TITLE
[occm] pattern based subnet detection for loadbalancers

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -203,10 +203,12 @@ floating-subnet-id="a374bed4-e920-4c40-b646-2d8927f7f67b"
 floating-subnet-id="b374bed4-e920-4c40-b646-2d8927f7f67b"
 ```
 
-Within a `LoadBalancerClass` one of `floating-subnet-id`, `floating-subnet-pattern` or `floating-subnet-tag` is mandatory.
+Within a `LoadBalancerClass` one of `floating-subnet-id`, `floating-subnet` or `floating-subnet-tags` is mandatory.
 `floating-subnet-id` takes precedence over the other ones with must all match if specified.
 If the pattern starts with a `!`, the match is negated. 
 The rest of the pattern can either be a direct name, a glob or a regular expression if it starts with a `~`.
+`floating-subnet-tags` can be a comma separated list of tags. By default it matches a subnet if at least one tag is present.
+If the list is preceded by a `&` all tags must be present. Again with a preceding `!` the condition be be negated.
 `floating-network-id` is optional can be defined in case it differs from the default `floating-network-id` in the `LoadBalancer` section.
 
 By using the `loadbalancer.openstack.org/class` annotation on the service object, you can now select which floating subnets the `LoadBalancer` should be using.

--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -96,8 +96,12 @@ Request Body:
 
 - `loadbalancer.openstack.org/floating-subnet-id`
 
-  This annotation is the ID of a subnet belonging to the floating network, if specified, it takes precedence over `loadbalancer.openstack.org/floating-subnet`.
+  This annotation is the ID of a subnet belonging to the floating network, if specified, it takes precedence over `loadbalancer.openstack.org/floating-subnet` or `loadbalancer.openstack.org/floating-tag`.
 
+- `loadbalancer.openstack.org/floating-subnet-tag`
+
+  This annotation is the tag of a subnet belonging to the floating network.
+  
 - `loadbalancer.openstack.org/class`
 
   The name of a preconfigured class in the config file. If provided, this config options included in the class section take precedence over the annotations of floating-subnet-id and floating-network-id. See the section below for how it works.
@@ -199,7 +203,11 @@ floating-subnet-id="a374bed4-e920-4c40-b646-2d8927f7f67b"
 floating-subnet-id="b374bed4-e920-4c40-b646-2d8927f7f67b"
 ```
 
-Within a `LoadBalancerClass` the `floating-subnet-id` is mandatory. `floating-network-id` is optional can be defined in case it differs from the default `floating-network-id` in the `LoadBalancer` section.
+Within a `LoadBalancerClass` one of `floating-subnet-id`, `floating-subnet-pattern` or `floating-subnet-tag` is mandatory.
+`floating-subnet-id` takes precedence over the other ones with must all match if specified.
+If the pattern starts with a `!`, the match is negated. 
+The rest of the pattern can either be a direct name, a glob or a regular expression if it starts with a `~`.
+`floating-network-id` is optional can be defined in case it differs from the default `floating-network-id` in the `LoadBalancer` section.
 
 By using the `loadbalancer.openstack.org/class` annotation on the service object, you can now select which floating subnets the `LoadBalancer` should be using.
 

--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -177,6 +177,9 @@ Although the openstack-cloud-controller-manager was initially implemented with N
 * `floating-subnet-id`
   Optional. The external network subnet used to create floating IP for the load balancer VIP. Can be overridden by the Service annotation `loadbalancer.openstack.org/floating-subnet-id`.
 
+* `floating-subnet-pattern`
+  Optional. A name pattern (glob) for the external network subnet used to create floating IP for the load balancer VIP. Can be overridden by the Service annotation `loadbalancer.openstack.org/floating-subnet`. If multiple subnets match the first one with still available IPs is used. 
+
 * `lb-method`
   The load balancing algorithm used to create the load balancer pool. The value can be `ROUND_ROBIN`, `LEAST_CONNECTIONS`, or `SOURCE_IP`. Default: `ROUND_ROBIN`
 
@@ -226,6 +229,7 @@ Although the openstack-cloud-controller-manager was initially implemented with N
 
   * floating-network-id. The same with `floating-network-id` option above.
   * floating-subnet-id. The same with `floating-subnet-id` option above.
+  * floating-subnet-pattern. The same with `floating-subnet-pattern` option above.
   * network-id. The same with `network-id` option above.
   * subnet-id. The same with `subnet-id` option above.
 

--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -177,11 +177,11 @@ Although the openstack-cloud-controller-manager was initially implemented with N
 * `floating-subnet-id`
   Optional. The external network subnet used to create floating IP for the load balancer VIP. Can be overridden by the Service annotation `loadbalancer.openstack.org/floating-subnet-id`.
 
-* `floating-subnet-pattern`
+* `floating-subnet`
   Optional. A name pattern (glob or regexp if starting with `~`) for the external network subnet used to create floating IP for the load balancer VIP. Can be overridden by the Service annotation `loadbalancer.openstack.org/floating-subnet`. If multiple subnets match the first one with still available IPs is used. 
 
-* `floating-subnet-tag`
-  Optional. A tag for the external network subnet used to create floating IP for the load balancer VIP. Can be overridden by the Service annotation `loadbalancer.openstack.org/floating-subnet-tag`. If multiple subnets match the first one with still available IPs is used. 
+* `floating-subnet-tags`
+  Optional. Tags for the external network subnet used to create floating IP for the load balancer VIP. Can be overridden by the Service annotation `loadbalancer.openstack.org/floating-subnet-tags`. If multiple subnets match the first one with still available IPs is used. 
 
 * `lb-method`
   The load balancing algorithm used to create the load balancer pool. The value can be `ROUND_ROBIN`, `LEAST_CONNECTIONS`, or `SOURCE_IP`. Default: `ROUND_ROBIN`
@@ -232,8 +232,8 @@ Although the openstack-cloud-controller-manager was initially implemented with N
 
   * floating-network-id. The same with `floating-network-id` option above.
   * floating-subnet-id. The same with `floating-subnet-id` option above.
-  * floating-subnet-pattern. The same with `floating-subnet-pattern` option above.
-  * floating-subnet-tag. The same with `floating-subnet-tag` option above.
+  * floating-subnet. The same with `floating-subnet` option above.
+  * floating-subnet-tags. The same with `floating-subnet-tags` option above.
   * network-id. The same with `network-id` option above.
   * subnet-id. The same with `subnet-id` option above.
 

--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -178,7 +178,10 @@ Although the openstack-cloud-controller-manager was initially implemented with N
   Optional. The external network subnet used to create floating IP for the load balancer VIP. Can be overridden by the Service annotation `loadbalancer.openstack.org/floating-subnet-id`.
 
 * `floating-subnet-pattern`
-  Optional. A name pattern (glob) for the external network subnet used to create floating IP for the load balancer VIP. Can be overridden by the Service annotation `loadbalancer.openstack.org/floating-subnet`. If multiple subnets match the first one with still available IPs is used. 
+  Optional. A name pattern (glob or regexp if starting with `~`) for the external network subnet used to create floating IP for the load balancer VIP. Can be overridden by the Service annotation `loadbalancer.openstack.org/floating-subnet`. If multiple subnets match the first one with still available IPs is used. 
+
+* `floating-subnet-tag`
+  Optional. A tag for the external network subnet used to create floating IP for the load balancer VIP. Can be overridden by the Service annotation `loadbalancer.openstack.org/floating-subnet-tag`. If multiple subnets match the first one with still available IPs is used. 
 
 * `lb-method`
   The load balancing algorithm used to create the load balancer pool. The value can be `ROUND_ROBIN`, `LEAST_CONNECTIONS`, or `SOURCE_IP`. Default: `ROUND_ROBIN`
@@ -230,6 +233,7 @@ Although the openstack-cloud-controller-manager was initially implemented with N
   * floating-network-id. The same with `floating-network-id` option above.
   * floating-subnet-id. The same with `floating-subnet-id` option above.
   * floating-subnet-pattern. The same with `floating-subnet-pattern` option above.
+  * floating-subnet-tag. The same with `floating-subnet-tag` option above.
   * network-id. The same with `network-id` option above.
   * subnet-id. The same with `subnet-id` option above.
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module k8s.io/cloud-provider-openstack
 go 1.15
 
 require (
+	github.com/MichaelTJones/walk v0.0.0-20161122175330-4748e29d5718 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/container-storage-interface/spec v1.2.0
 	github.com/coreos/go-systemd v0.0.0-20190620071333-e64a0ec8b42a // indirect
@@ -17,6 +18,7 @@ require (
 	github.com/kubernetes-csi/csi-lib-utils v0.6.1
 	github.com/kubernetes-csi/csi-test v2.2.0+incompatible
 	github.com/kubernetes-csi/csi-test/v3 v3.1.0
+	github.com/mgutz/str v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/onsi/ginkgo v1.12.0
@@ -33,6 +35,7 @@ require (
 	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
 	google.golang.org/grpc v1.27.1
 	gopkg.in/gcfg.v1 v1.2.3
+	gopkg.in/godo.v2 v2.0.9
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317/go.mod h1:DF8FZRxMHMGv/vP2lQP6h+dYzzjpuRn24VeRiYn3qjQ=
 github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
+github.com/MichaelTJones/walk v0.0.0-20161122175330-4748e29d5718 h1:FSsoaa1q4jAaeiAUxf9H0PgFP7eA/UL6c3PdJH+nMN4=
+github.com/MichaelTJones/walk v0.0.0-20161122175330-4748e29d5718/go.mod h1:VVwKsx9Dc8rNG55BWqogoJzGubjKnRoXdUvpGbWqeCc=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
 github.com/Microsoft/go-winio v0.4.15/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
 github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990/go.mod h1:ay/0dTb7NsG8QMDfsRfLHgZo/6xAJShLe1+ePPflihk=
@@ -431,6 +433,8 @@ github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mgutz/str v1.2.0 h1:4IzWSdIz9qPQWLfKZ0rJcV0jcUDpxvP4JVZ4GXQyvSw=
+github.com/mgutz/str v1.2.0/go.mod h1:w1v0ofgLaJdoD0HpQ3fycxKD1WtxpjSo151pK/31q6w=
 github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2/go.mod h1:g4cOPxcjV0oFq3qwpjSA30LReKD8AoIfwAY9VvG35NY=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.3/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -916,6 +920,8 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/gcfg.v1 v1.2.0/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/gcfg.v1 v1.2.3 h1:m8OOJ4ccYHnx2f4gQwpno8nAX5OGOh7RLaaz0pj3Ogs=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
+gopkg.in/godo.v2 v2.0.9 h1:jnbznTzXVk0JDKOxN3/LJLDPYJzIl0734y+Z0cEJb4A=
+gopkg.in/godo.v2 v2.0.9/go.mod h1:wgvPPKLsWN0hPIJ4JyxvFGGbIW3fJMSrXhdvSuZ1z/8=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.0 h1:AQvPpx3LzTDM0AjnIRlVFwFFGC+npRopjZxLJj6gdno=

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -3184,6 +3184,9 @@ func PreserveGopherError(rawError error) error {
 	if rawError == nil {
 		return nil
 	}
+	if v, ok := rawError.(gophercloud.ErrErrorAfterReauthentication); ok {
+		rawError = v.ErrOriginal
+	}
 	var details []byte
 	switch e := rawError.(type) {
 	case gophercloud.ErrDefault400:
@@ -3196,6 +3199,7 @@ func PreserveGopherError(rawError error) error {
 		details = e.Body
 	case gophercloud.ErrDefault408:
 		details = e.Body
+	case gophercloud.ErrDefault409:
 	case gophercloud.ErrDefault429:
 		details = e.Body
 	case gophercloud.ErrDefault500:

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -92,33 +92,35 @@ type LoadBalancer struct {
 
 // LoadBalancerOpts have the options to talk to Neutron LBaaSV2 or Octavia
 type LoadBalancerOpts struct {
-	LBVersion            string              `gcfg:"lb-version"`          // overrides autodetection. Only support v2.
-	UseOctavia           bool                `gcfg:"use-octavia"`         // uses Octavia V2 service catalog endpoint
-	SubnetID             string              `gcfg:"subnet-id"`           // overrides autodetection.
-	NetworkID            string              `gcfg:"network-id"`          // If specified, will create virtual ip from a subnet in network which has available IP addresses
-	FloatingNetworkID    string              `gcfg:"floating-network-id"` // If specified, will create floating ip for loadbalancer, or do not create floating ip.
-	FloatingSubnetID     string              `gcfg:"floating-subnet-id"`  // If specified, will create floating ip for loadbalancer in this particular floating pool subnetwork.
-	LBClasses            map[string]*LBClass // Predefined named Floating networks and subnets
-	LBMethod             string              `gcfg:"lb-method"` // default to ROUND_ROBIN.
-	LBProvider           string              `gcfg:"lb-provider"`
-	CreateMonitor        bool                `gcfg:"create-monitor"`
-	MonitorDelay         util.MyDuration     `gcfg:"monitor-delay"`
-	MonitorTimeout       util.MyDuration     `gcfg:"monitor-timeout"`
-	MonitorMaxRetries    uint                `gcfg:"monitor-max-retries"`
-	ManageSecurityGroups bool                `gcfg:"manage-security-groups"`
-	NodeSecurityGroupIDs []string            // Do not specify, get it automatically when enable manage-security-groups. TODO(FengyunPan): move it into cache
-	InternalLB           bool                `gcfg:"internal-lb"`    // default false
-	CascadeDelete        bool                `gcfg:"cascade-delete"` // applicable only if use-octavia is set to True
-	FlavorID             string              `gcfg:"flavor-id"`
-	AvailabilityZone     string              `gcfg:"availability-zone"`
+	LBVersion             string              `gcfg:"lb-version"`              // overrides autodetection. Only support v2.
+	UseOctavia            bool                `gcfg:"use-octavia"`             // uses Octavia V2 service catalog endpoint
+	SubnetID              string              `gcfg:"subnet-id"`               // overrides autodetection.
+	NetworkID             string              `gcfg:"network-id"`              // If specified, will create virtual ip from a subnet in network which has available IP addresses
+	FloatingNetworkID     string              `gcfg:"floating-network-id"`     // If specified, will create floating ip for loadbalancer, or do not create floating ip.
+	FloatingSubnetID      string              `gcfg:"floating-subnet-id"`      // If specified, will create floating ip for loadbalancer in this particular floating pool subnetwork.
+	FloatingSubnetPattern string              `gcfg:"floating-subnet-pattern"` // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
+	LBClasses             map[string]*LBClass // Predefined named Floating networks and subnets
+	LBMethod              string              `gcfg:"lb-method"` // default to ROUND_ROBIN.
+	LBProvider            string              `gcfg:"lb-provider"`
+	CreateMonitor         bool                `gcfg:"create-monitor"`
+	MonitorDelay          util.MyDuration     `gcfg:"monitor-delay"`
+	MonitorTimeout        util.MyDuration     `gcfg:"monitor-timeout"`
+	MonitorMaxRetries     uint                `gcfg:"monitor-max-retries"`
+	ManageSecurityGroups  bool                `gcfg:"manage-security-groups"`
+	NodeSecurityGroupIDs  []string            // Do not specify, get it automatically when enable manage-security-groups. TODO(FengyunPan): move it into cache
+	InternalLB            bool                `gcfg:"internal-lb"`    // default false
+	CascadeDelete         bool                `gcfg:"cascade-delete"` // applicable only if use-octavia is set to True
+	FlavorID              string              `gcfg:"flavor-id"`
+	AvailabilityZone      string              `gcfg:"availability-zone"`
 }
 
 // LBClass defines the corresponding floating network, floating subnet or internal subnet ID
 type LBClass struct {
-	FloatingNetworkID string `gcfg:"floating-network-id,omitempty"`
-	FloatingSubnetID  string `gcfg:"floating-subnet-id,omitempty"`
-	SubnetID          string `gcfg:"subnet-id,omitempty"`
-	NetworkID         string `gcfg:"network-id,omitempty"`
+	FloatingNetworkID     string `gcfg:"floating-network-id,omitempty"`
+	FloatingSubnetID      string `gcfg:"floating-subnet-id,omitempty"`
+	FloatingSubnetPattern string `gcfg:"floating-subnet-pattern,omitempty"`
+	SubnetID              string `gcfg:"subnet-id,omitempty"`
+	NetworkID             string `gcfg:"network-id,omitempty"`
 }
 
 // BlockStorageOpts is used to talk to Cinder service

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -92,35 +92,37 @@ type LoadBalancer struct {
 
 // LoadBalancerOpts have the options to talk to Neutron LBaaSV2 or Octavia
 type LoadBalancerOpts struct {
-	LBVersion             string              `gcfg:"lb-version"`              // overrides autodetection. Only support v2.
-	UseOctavia            bool                `gcfg:"use-octavia"`             // uses Octavia V2 service catalog endpoint
-	SubnetID              string              `gcfg:"subnet-id"`               // overrides autodetection.
-	NetworkID             string              `gcfg:"network-id"`              // If specified, will create virtual ip from a subnet in network which has available IP addresses
-	FloatingNetworkID     string              `gcfg:"floating-network-id"`     // If specified, will create floating ip for loadbalancer, or do not create floating ip.
-	FloatingSubnetID      string              `gcfg:"floating-subnet-id"`      // If specified, will create floating ip for loadbalancer in this particular floating pool subnetwork.
-	FloatingSubnetPattern string              `gcfg:"floating-subnet-pattern"` // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
-	LBClasses             map[string]*LBClass // Predefined named Floating networks and subnets
-	LBMethod              string              `gcfg:"lb-method"` // default to ROUND_ROBIN.
-	LBProvider            string              `gcfg:"lb-provider"`
-	CreateMonitor         bool                `gcfg:"create-monitor"`
-	MonitorDelay          util.MyDuration     `gcfg:"monitor-delay"`
-	MonitorTimeout        util.MyDuration     `gcfg:"monitor-timeout"`
-	MonitorMaxRetries     uint                `gcfg:"monitor-max-retries"`
-	ManageSecurityGroups  bool                `gcfg:"manage-security-groups"`
-	NodeSecurityGroupIDs  []string            // Do not specify, get it automatically when enable manage-security-groups. TODO(FengyunPan): move it into cache
-	InternalLB            bool                `gcfg:"internal-lb"`    // default false
-	CascadeDelete         bool                `gcfg:"cascade-delete"` // applicable only if use-octavia is set to True
-	FlavorID              string              `gcfg:"flavor-id"`
-	AvailabilityZone      string              `gcfg:"availability-zone"`
+	LBVersion            string              `gcfg:"lb-version"`          // overrides autodetection. Only support v2.
+	UseOctavia           bool                `gcfg:"use-octavia"`         // uses Octavia V2 service catalog endpoint
+	SubnetID             string              `gcfg:"subnet-id"`           // overrides autodetection.
+	NetworkID            string              `gcfg:"network-id"`          // If specified, will create virtual ip from a subnet in network which has available IP addresses
+	FloatingNetworkID    string              `gcfg:"floating-network-id"` // If specified, will create floating ip for loadbalancer, or do not create floating ip.
+	FloatingSubnetID     string              `gcfg:"floating-subnet-id"`  // If specified, will create floating ip for loadbalancer in this particular floating pool subnetwork.
+	FloatingSubnet       string              `gcfg:"floating-subnet"`     // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
+	FloatingSubnetTag    string              `gcfg:"floating-subnet-tag"` // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
+	LBClasses            map[string]*LBClass // Predefined named Floating networks and subnets
+	LBMethod             string              `gcfg:"lb-method"` // default to ROUND_ROBIN.
+	LBProvider           string              `gcfg:"lb-provider"`
+	CreateMonitor        bool                `gcfg:"create-monitor"`
+	MonitorDelay         util.MyDuration     `gcfg:"monitor-delay"`
+	MonitorTimeout       util.MyDuration     `gcfg:"monitor-timeout"`
+	MonitorMaxRetries    uint                `gcfg:"monitor-max-retries"`
+	ManageSecurityGroups bool                `gcfg:"manage-security-groups"`
+	NodeSecurityGroupIDs []string            // Do not specify, get it automatically when enable manage-security-groups. TODO(FengyunPan): move it into cache
+	InternalLB           bool                `gcfg:"internal-lb"`    // default false
+	CascadeDelete        bool                `gcfg:"cascade-delete"` // applicable only if use-octavia is set to True
+	FlavorID             string              `gcfg:"flavor-id"`
+	AvailabilityZone     string              `gcfg:"availability-zone"`
 }
 
 // LBClass defines the corresponding floating network, floating subnet or internal subnet ID
 type LBClass struct {
-	FloatingNetworkID     string `gcfg:"floating-network-id,omitempty"`
-	FloatingSubnetID      string `gcfg:"floating-subnet-id,omitempty"`
-	FloatingSubnetPattern string `gcfg:"floating-subnet-pattern,omitempty"`
-	SubnetID              string `gcfg:"subnet-id,omitempty"`
-	NetworkID             string `gcfg:"network-id,omitempty"`
+	FloatingNetworkID string `gcfg:"floating-network-id,omitempty"`
+	FloatingSubnetID  string `gcfg:"floating-subnet-id,omitempty"`
+	FloatingSubnet    string `gcfg:"floating-subnet,omitempty"`
+	FloatingSubnetTag string `gcfg:"floating-subnet-tag"`
+	NetworkID         string `gcfg:"network-id,omitempty"`
+	SubnetID          string `gcfg:"sunet-id,omitempty"`
 }
 
 // BlockStorageOpts is used to talk to Cinder service

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -92,14 +92,14 @@ type LoadBalancer struct {
 
 // LoadBalancerOpts have the options to talk to Neutron LBaaSV2 or Octavia
 type LoadBalancerOpts struct {
-	LBVersion            string              `gcfg:"lb-version"`          // overrides autodetection. Only support v2.
-	UseOctavia           bool                `gcfg:"use-octavia"`         // uses Octavia V2 service catalog endpoint
-	SubnetID             string              `gcfg:"subnet-id"`           // overrides autodetection.
-	NetworkID            string              `gcfg:"network-id"`          // If specified, will create virtual ip from a subnet in network which has available IP addresses
-	FloatingNetworkID    string              `gcfg:"floating-network-id"` // If specified, will create floating ip for loadbalancer, or do not create floating ip.
-	FloatingSubnetID     string              `gcfg:"floating-subnet-id"`  // If specified, will create floating ip for loadbalancer in this particular floating pool subnetwork.
-	FloatingSubnet       string              `gcfg:"floating-subnet"`     // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
-	FloatingSubnetTag    string              `gcfg:"floating-subnet-tag"` // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
+	LBVersion            string              `gcfg:"lb-version"`           // overrides autodetection. Only support v2.
+	UseOctavia           bool                `gcfg:"use-octavia"`          // uses Octavia V2 service catalog endpoint
+	SubnetID             string              `gcfg:"subnet-id"`            // overrides autodetection.
+	NetworkID            string              `gcfg:"network-id"`           // If specified, will create virtual ip from a subnet in network which has available IP addresses
+	FloatingNetworkID    string              `gcfg:"floating-network-id"`  // If specified, will create floating ip for loadbalancer, or do not create floating ip.
+	FloatingSubnetID     string              `gcfg:"floating-subnet-id"`   // If specified, will create floating ip for loadbalancer in this particular floating pool subnetwork.
+	FloatingSubnet       string              `gcfg:"floating-subnet"`      // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
+	FloatingSubnetTags   string              `gcfg:"floating-subnet-tags"` // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
 	LBClasses            map[string]*LBClass // Predefined named Floating networks and subnets
 	LBMethod             string              `gcfg:"lb-method"` // default to ROUND_ROBIN.
 	LBProvider           string              `gcfg:"lb-provider"`

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -117,12 +117,12 @@ type LoadBalancerOpts struct {
 
 // LBClass defines the corresponding floating network, floating subnet or internal subnet ID
 type LBClass struct {
-	FloatingNetworkID string `gcfg:"floating-network-id,omitempty"`
-	FloatingSubnetID  string `gcfg:"floating-subnet-id,omitempty"`
-	FloatingSubnet    string `gcfg:"floating-subnet,omitempty"`
-	FloatingSubnetTag string `gcfg:"floating-subnet-tag"`
-	NetworkID         string `gcfg:"network-id,omitempty"`
-	SubnetID          string `gcfg:"sunet-id,omitempty"`
+	FloatingNetworkID  string `gcfg:"floating-network-id,omitempty"`
+	FloatingSubnetID   string `gcfg:"floating-subnet-id,omitempty"`
+	FloatingSubnet     string `gcfg:"floating-subnet,omitempty"`
+	FloatingSubnetTags string `gcfg:"floating-subnet-tags,omitempty"`
+	NetworkID          string `gcfg:"network-id,omitempty"`
+	SubnetID           string `gcfg:"subnet-id,omitempty"`
 }
 
 // BlockStorageOpts is used to talk to Cinder service

--- a/pkg/openstack/openstack_loadbalancer_subnet_match_test.go
+++ b/pkg/openstack/openstack_loadbalancer_subnet_match_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchSubnet(t *testing.T) {
+
+	subnet := subnets.Subnet{
+		Name: "test-123",
+		Tags: []string{
+			"other=other",
+			"tag=value",
+		},
+	}
+
+	glob := floatingSubnetSpec{
+		subnet: "test-*",
+	}
+	rexp := floatingSubnetSpec{
+		subnet: "~test-.*",
+	}
+	tag := floatingSubnetSpec{
+		subnetTag: "tag=value",
+	}
+	tagname := floatingSubnetSpec{
+		subnet:    "test-*",
+		subnetTag: "tag=value",
+	}
+
+	runName(t, &subnet, glob, true)
+	runName(t, &subnet, rexp, true)
+	runName(t, &subnet, tagname, true)
+
+	runTag(t, &subnet, tag, true)
+	runTag(t, &subnet, tagname, true)
+}
+
+func runName(t *testing.T, subnet *subnets.Subnet, spec floatingSubnetSpec, expected bool) {
+	runNameNeg(t, subnet, spec, expected)
+	spec.subnet = "other*"
+	runNameNeg(t, subnet, spec, !expected)
+	spec.subnet = "~other.*"
+	runNameNeg(t, subnet, spec, !expected)
+	spec.subnet = "*"
+	runNameNeg(t, subnet, spec, true)
+	spec.subnet = "~.*"
+	runNameNeg(t, subnet, spec, true)
+}
+
+func runNameNeg(t *testing.T, subnet *subnets.Subnet, spec floatingSubnetSpec, expected bool) {
+	runMatch(t, subnet, spec, expected)
+	spec.subnet = "!" + spec.subnet
+	runMatch(t, subnet, spec, !expected)
+}
+
+func runTag(t *testing.T, subnet *subnets.Subnet, spec floatingSubnetSpec, expected bool) {
+	runMatch(t, subnet, spec, expected)
+
+	spec.subnetTag = "!" + spec.subnetTag
+	runMatch(t, subnet, spec, !expected)
+
+	spec.subnetTag = "tag=other"
+	runMatch(t, subnet, spec, !expected)
+
+	spec.subnetTag = "!" + spec.subnetTag
+	runMatch(t, subnet, spec, expected)
+}
+
+func runMatch(t *testing.T, subnet *subnets.Subnet, spec floatingSubnetSpec, expected bool) {
+	m, err := spec.Matcher()
+	assert.NoError(t, err)
+	assert.Equal(t, m(subnet), expected)
+}


### PR DESCRIPTION
**Which issue this PR fixes(if applicable)**:
fixes #1328

**What this PR does / why we need it**:

A floating IP for a loadbalancer is created on a subnet of a floating pool (specified by a network id of the provider network).
Such a subnet has a dedicated IP range (CIDR). Therefore it might happen, that the subnet runs out of IP addresses. To not disrupt the existing FIP users in such a case a new subnet can be added to the provider network. This one will potentially automatically be selected for new FIP creation if the creator does not explicitly specify the subnet id.

But this automated subnet selection makes only sense if all subnets configured for a provider network provide the same kind
of routing. In Openstack it is possible to configure subnets for the same provider network that feature different kinds of routing (for example public internet or company network). In such a scenario so far a dedicated subnet must be specified for the FIP creation of a loadbalancer. If this setting is not done via service annotation, but as configuration of the cloud controller manager it is not possible to transparently add new matching subnets to the provider network by an administrator which is then used for further FIP creation.

This PR provides support for a new configuration possibility to overcome this problem. Instead of a dedicated subnet id it is possible now to optionally configure a subnet name pattern (supporting the standard glob mechanism) or tags. For this configuration option all matching subnets of a provider network are tried to create a new FIP. The first one where the FIP creation succeeds is used. 
This allows configuring subnets with similar names according to name patterns specific for the routing environment, so that FIPs can transparently be created for loadbalancers just by adding a subnet with a name matching the dedicated name pattern.

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] Added support to use subnet name pattern and tag filtering for creating floating IP for the load balancer.
```
