### PR TITLE
[cinder-csi-plugin] Fix pagination support for ListVolumes/ListSnapshots

### DIFF
--- a/pkg/csi/cinder/openstack/openstack_snapshots.go
+++ b/pkg/csi/cinder/openstack/openstack_snapshots.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
+	"github.com/gophercloud/gophercloud/pagination"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 )
@@ -81,10 +82,11 @@ func (os *OpenStack) CreateSnapshot(name, volID string, tags *map[string]string)
 // In addition the filters argument provides a mechanism for passing in valid filter strings to the list
 // operation.  Valid filter keys are:  Name, Status, VolumeID, Limit, Marker (TenantID has no effect)
 func (os *OpenStack) ListSnapshots(filters map[string]string) ([]snapshots.Snapshot, string, error) {
+	var nextPageToken string
+	var snaps []snapshots.Snapshot
+
 	// Build the Opts
 	opts := snapshots.ListOpts{}
-	nextPageToken := ""
-
 	for key, val := range filters {
 		switch key {
 		case "Status":
@@ -101,26 +103,34 @@ func (os *OpenStack) ListSnapshots(filters map[string]string) ([]snapshots.Snaps
 			klog.V(3).Infof("Not a valid filter key %s", key)
 		}
 	}
+	err := snapshots.List(os.blockstorage, opts).EachPage(func(page pagination.Page) (bool, error) {
+		var err error
 
-	pages, err := snapshots.List(os.blockstorage, opts).AllPages()
-	if err != nil {
-		klog.V(3).Infof("Failed to retrieve snapshots: %v", err)
-		return nil, nextPageToken, err
-	}
-	snaps, err := snapshots.ExtractSnapshots(pages)
-	if err != nil {
-		klog.V(3).Infof("Failed to extract snapshot pages: %v", err)
-		return nil, nextPageToken, err
-	}
+		snaps, err = snapshots.ExtractSnapshots(page)
+		if err != nil {
+			return false, err
+		}
 
-	nextPageURL, err := pages.NextPageURL()
-	if err != nil && nextPageURL != "" {
-		if queryParams, nerr := url.ParseQuery(nextPageURL); nerr != nil {
+		nextPageURL, err := page.NextPageURL()
+		if err != nil {
+			return false, err
+		}
+
+		if nextPageURL != "" {
+			queryParams, err := url.ParseQuery(nextPageURL)
+			if err != nil {
+				return false, err
+			}
 			nextPageToken = queryParams.Get("marker")
 		}
-	}
-	return snaps, nextPageToken, nil
 
+		return false, nil
+	})
+	if err != nil {
+		return nil, nextPageToken, err
+	}
+
+	return snaps, nextPageToken, nil
 }
 
 // DeleteSnapshot issues a request to delete the Snapshot with the specified ID from the Cinder backend


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

The #969 PR introduced the pagination support, however the pagination didn't make sense, since the `AllPages()` method was used, which automatically fetches all pages.
This PR uses a proper pagination and requests only one page, when the `MaxItems` limit is provided.

**Which issue this PR fixes(if applicable)**:
fixes #1383

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
