### PR TITLE
[cinder-csi-plugin] Add http endpoint of CSI container

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/onsi/gomega v1.9.0
 	github.com/pborman/uuid v1.2.0
 	github.com/pelletier/go-toml v1.4.0 // indirect
+	github.com/prometheus/client_golang v1.7.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -103,7 +103,6 @@ github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313/go.mod h1:P1w
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa h1:OaNxuTZr7kxeODyLWsRMC+OD03aFUH+mW6r2d+MWa5Y=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
-github.com/container-storage-interface/spec v1.2.0 h1:bD9KIVgaVKKkQ/UbVUY9kCaH/CJbhNxe0eeB4JeJV2s=
 github.com/container-storage-interface/spec v1.2.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
 github.com/container-storage-interface/spec v1.3.0 h1:wMH4UIoWnK/TXYw8mbcIHgZmB6kHOeIsYsiaTJwa6bc=
 github.com/container-storage-interface/spec v1.3.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
@@ -309,8 +308,6 @@ github.com/googleapis/gnostic v0.4.1 h1:DLJCy1n/vrD4HPjOvYcT8aYQXpPIzoRZONaYwyyc
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gophercloud/gophercloud v0.6.1-0.20191122030953-d8ac278c1c9d/go.mod h1:ozGNgr9KYOVATV5jsgHl/ceCDXGuguqOZAzoQ/2vcNM=
-github.com/gophercloud/gophercloud v0.12.1-0.20200922152735-900f5ba8c05b h1:dcAizxhbIBU4A7Iu9uARqZJz63uesA5MtXjHD1XSg3M=
-github.com/gophercloud/gophercloud v0.12.1-0.20200922152735-900f5ba8c05b/go.mod h1:VX0Ibx85B60B5XOrZr6kaNwrmPUzcmMpwxvQ1WQIIWM=
 github.com/gophercloud/gophercloud v0.15.1-0.20210105012856-e34a44dc6580 h1:EWFhxn19tw6t3LjFe95Kli30sBI02+fPYBqMvXmCvtU=
 github.com/gophercloud/gophercloud v0.15.1-0.20210105012856-e34a44dc6580/go.mod h1:VX0Ibx85B60B5XOrZr6kaNwrmPUzcmMpwxvQ1WQIIWM=
 github.com/gophercloud/utils v0.0.0-20200423144003-7c72efc7435d h1:fduaPzWwIfvOMLuHk2Al3GZH0XbUqG8MbElPop+Igzs=

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -104,6 +104,7 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--cloud-config=$(CLOUD_CONFIG)"
             - "--cluster=$(CLUSTER_NAME)"
+            - "--http-endpoint=$(HTTP_ENDPOINT)"
           env:
             - name: NODE_ID
               valueFrom:
@@ -115,6 +116,8 @@ spec:
               value: /etc/config/cloud.conf
             - name: CLUSTER_NAME
               value: kubernetes
+            - name: HTTP_ENDPOINT
+              value: :8080
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 9808

--- a/pkg/metrics/metrics_prometheus.go
+++ b/pkg/metrics/metrics_prometheus.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type OpenstackPrometheusMetrics struct {
+	Duration *prometheus.HistogramVec
+	Total    *prometheus.CounterVec
+	Errors   *prometheus.CounterVec
+}
+
+// MetricContext indicates the context for OpenStack metrics.
+type MetricPrometheusContext struct {
+	Start      time.Time
+	Attributes []string
+	Metrics    *OpenstackPrometheusMetrics
+}
+
+// NewMetricContext creates a new MetricContext.
+func NewMetricPrometheusContext(resource string, request string) *MetricPrometheusContext {
+	return &MetricPrometheusContext{
+		Start:      time.Now(),
+		Attributes: []string{resource + "_" + request},
+	}
+}
+
+// ObserveRequest records the request latency and counts the errors.
+func (mc *MetricPrometheusContext) ObserveRequest(err error) error {
+	return mc.Observe(APIRequestPrometheusMetrics, err)
+}
+
+// ObserveRequest records the request latency and counts the errors.
+func (mc *MetricPrometheusContext) Observe(om *OpenstackPrometheusMetrics, err error) error {
+	if om == nil {
+		// mc.RequestMetrics not set, ignore this request
+		return nil
+	}
+
+	om.Duration.WithLabelValues(mc.Attributes...).Observe(
+		time.Since(mc.Start).Seconds())
+	om.Total.WithLabelValues(mc.Attributes...).Inc()
+	if err != nil {
+		om.Errors.WithLabelValues(mc.Attributes...).Inc()
+	}
+	return err
+}
+
+var (
+	APIRequestPrometheusMetrics = &OpenstackPrometheusMetrics{
+		Duration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: "cinder_csi",
+				Name:      "openstack_api_request_duration_seconds",
+				Help:      "Latency of an OpenStack API call",
+			}, []string{"request"}),
+		Total: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "cinder_csi",
+				Name:      "openstack_api_requests_total",
+				Help:      "Total number of OpenStack API calls",
+			}, []string{"request"}),
+		Errors: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "cinder_csi",
+				Name:      "openstack_api_request_errors_total",
+				Help:      "Total number of errors for an OpenStack API call",
+			}, []string{"request"}),
+	}
+)
+
+var registerAPIPrometheusMetrics sync.Once
+
+func RegisterAPIPrometheusMetrics() {
+	registerAPIPrometheusMetrics.Do(func() {
+		prometheus.MustRegister(APIRequestPrometheusMetrics.Duration)
+		prometheus.MustRegister(APIRequestPrometheusMetrics.Total)
+		prometheus.MustRegister(APIRequestPrometheusMetrics.Errors)
+	})
+}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Add http endpoint of CSI container , it will be used for metris later

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
