### PR TITLE
WIP ONLY FOR TESTING PURPOSES: testing latest ci changes

### DIFF
--- a/cmd/cinder-csi-plugin/main.go
+++ b/cmd/cinder-csi-plugin/main.go
@@ -44,6 +44,7 @@ func init() {
 
 func main() {
 	fmt.Println("Hello World. This is only for testing purposes")
+	fmt.Println("Hello World. This is only for testing purposes")
 
 	flag.CommandLine.Parse([]string{})
 

--- a/cmd/cinder-csi-plugin/main.go
+++ b/cmd/cinder-csi-plugin/main.go
@@ -43,6 +43,7 @@ func init() {
 }
 
 func main() {
+	fmt.Println("Hello World. This is only for testing purposes")
 
 	flag.CommandLine.Parse([]string{})
 


### PR DESCRIPTION
DONT'T TOUCH ONLY FOR TESTING PURPOSES!!!! 
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
