### PR TITLE
[occm] validate flavor name, fallback on flavor id (release-1.20)

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -29,6 +29,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/cloud-provider-openstack/pkg/cloudprovider/providers/openstack/metrics"
 	"k8s.io/cloud-provider-openstack/pkg/util/errors"
@@ -280,21 +281,38 @@ func srvInstanceType(client *gophercloud.ServiceClient, srv *servers.Server) (st
 	keys := []string{"original_name", "id"}
 	for _, key := range keys {
 		val, found := srv.Flavor[key]
-		if found {
-			flavor, ok := val.(string)
-			if ok {
-				if key == "id" {
-					mc := metrics.NewMetricContext("flavor", "get")
-					f, err := flavors.Get(client, flavor).Extract()
-					if mc.ObserveRequest(err) == nil {
-						return f.Name, nil
-					}
-				}
-				return flavor, nil
+		if !found {
+			continue
+		}
+
+		flavor, ok := val.(string)
+		if !ok {
+			continue
+		}
+
+		if key == "original_name" && isValidLabelValue(flavor) {
+			return flavor, nil
+		}
+
+		// get flavor name by id
+		mc := metrics.NewMetricContext("flavor", "get")
+		f, err := flavors.Get(client, flavor).Extract()
+		if mc.ObserveRequest(err) == nil {
+			if isValidLabelValue(f.Name) {
+				return f.Name, nil
 			}
+			// fallback on flavor id
+			return f.ID, nil
 		}
 	}
-	return "", fmt.Errorf("flavor name/id not found")
+	return "", fmt.Errorf("flavor original_name/id not found")
+}
+
+func isValidLabelValue(v string) bool {
+	if errs := validation.IsValidLabelValue(v); len(errs) != 0 {
+		return false
+	}
+	return true
 }
 
 // If Instances.InstanceID or cloudprovider.GetInstanceProviderID is changed, the regexp should be changed too.


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Cherry picked from #1364 

**Which issue this PR fixes(if applicable)**:


**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
<sub>Sean Schneeweiss <sean.schneeweiss@daimler.com>, Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sub>