### PR TITLE
Backport #1399 and #1395 to release 1.20

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.20.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 1.2.13
+version: 1.2.14
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -111,13 +111,13 @@ spec:
               protocol: TCP
           # The probe
           livenessProbe:
-            failureThreshold: 5
+            failureThreshold: {{ .Values.csi.livenessprobe.failureThreshold }}
             httpGet:
               path: /healthz
               port: healthz
-            initialDelaySeconds: 10
-            timeoutSeconds: 3
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.csi.livenessprobe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.csi.livenessprobe.timeoutSeconds }}
+            periodSeconds: {{ .Values.csi.livenessprobe.periodSeconds }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -79,13 +79,13 @@ spec:
               protocol: TCP
           # The probe
           livenessProbe:
-            failureThreshold: 5
+            failureThreshold: {{ .Values.csi.livenessprobe.failureThreshold }}
             httpGet:
               path: /healthz
               port: healthz
-            initialDelaySeconds: 10
-            timeoutSeconds: 3
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.csi.livenessprobe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.csi.livenessprobe.timeoutSeconds }}
+            periodSeconds: {{ .Values.csi.livenessprobe.periodSeconds }}
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -28,6 +28,10 @@ csi:
       repository: k8s.gcr.io/sig-storage/livenessprobe
       tag: v2.1.0
       pullPolicy: IfNotPresent
+    failureThreshold: 5
+    initialDelaySeconds: 10
+    timeoutSeconds: 10
+    periodSeconds: 60
   nodeDriverRegistrar:
     image:
       repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -123,8 +123,8 @@ spec:
               path: /healthz
               port: healthz
             initialDelaySeconds: 10
-            timeoutSeconds: 3
-            periodSeconds: 10
+            timeoutSeconds: 10
+            periodSeconds: 60
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/pkg/csi/cinder/identityserver.go
+++ b/pkg/csi/cinder/identityserver.go
@@ -47,7 +47,6 @@ func (ids *identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPlugin
 }
 
 func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
-	klog.V(5).Infof("Probe() called with req %+v", req)
 	oProvider, err := openstack.GetOpenStackProvider()
 	if err != nil {
 		klog.Errorf("Failed to GetOpenStackProvider: %v", err)


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This PR backports fixes #1399 and #1395 to release-1.20

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
