### PR TITLE
[cinder-csi-plugin] Removed CI Job cloud-provider-openstack-acceptance-test-csi-cinder

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -51,27 +51,6 @@
               - ^OWNERS$
               - ^SECURITY_CONTACTS$
               - ^.gitignore$
-    cloud-provider-openstack-acceptance-test-csi-cinder:
-      jobs:
-        - cloud-provider-openstack-acceptance-test-csi-cinder:
-            files:
-              - cluster/images/cinder-csi-plugin/.*
-              - cmd/cinder-csi-plugin/.*
-              - manifests/cinder-csi-plugin/.*
-              - pkg/csi/cinder/.*
-              - pkg/util/.*
-              - pkg/cloudprovider/providers/openstack/.*
-              - test/.*
-              - cmd/tests/.*
-              - go.mod$
-              - go.sum$
-              - Makefile$
-            irrelevant-files:
-              - ^docs/.*$
-              - ^.*\.md$
-              - ^OWNERS$
-              - ^SECURITY_CONTACTS$
-              - ^.gitignore$
     cloud-provider-openstack-e2e-test-csi-cinder:
       jobs:
         - cloud-provider-openstack-e2e-test-csi-cinder:


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

We run
* cloud-provider-openstack-e2e-test-csi-cinder
* cloud-provider-openstack-multinode-csi-migration-test

in the same cases, we don't get any benefit out of
cloud-provider-openstack-acceptance-test-csi-cinder, but we must compile
the binaries multiple times, as well as creating another kubernetes for
only a single testcase. This exact testcase is covered by the mentioned
ones.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
