### PR TITLE
[occm] Fix loadbalancer.openstack.org/proxy-protocol docs

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -124,7 +124,7 @@ Request Body:
 
 - `loadbalancer.openstack.org/proxy-protocol`
 
-  If 'true', the protocol for listener will be set as `PROXY`. Default is 'false'.
+  If 'true', the loadbalancer pool protocol will be set as `PROXY`. Default is 'false'.
 
 - `loadbalancer.openstack.org/x-forwarded-for`
 


### PR DESCRIPTION
The loadbalancer.openstack.org/proxy-protocol actually controls the loadbalancer pool's protocol, and not the listener protocol.

See also the octavia documentation, there is no PROXY listener protocol: https://docs.openstack.org/api-ref/load-balancer/v2/#protocol-combinations-listener-pool

**What this PR does / why we need it**:

Correct the documentation of one of the openstack annotations

**Which issue this PR fixes(if applicable)**:
No github issue opened for minor fix

```release-note
NONE
```
