### PR TITLE
WIP: Add readOnly mode support for attachments.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -307,6 +307,7 @@ github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEo
 github.com/gophercloud/gophercloud v0.6.1-0.20191122030953-d8ac278c1c9d/go.mod h1:ozGNgr9KYOVATV5jsgHl/ceCDXGuguqOZAzoQ/2vcNM=
 github.com/gophercloud/gophercloud v0.12.1-0.20200922152735-900f5ba8c05b h1:dcAizxhbIBU4A7Iu9uARqZJz63uesA5MtXjHD1XSg3M=
 github.com/gophercloud/gophercloud v0.12.1-0.20200922152735-900f5ba8c05b/go.mod h1:VX0Ibx85B60B5XOrZr6kaNwrmPUzcmMpwxvQ1WQIIWM=
+github.com/gophercloud/gophercloud v0.15.0 h1:jQeAWj0s1p83+TrUXhJhEOK4oe2g6YcBcFwEyMNIjEk=
 github.com/gophercloud/utils v0.0.0-20200423144003-7c72efc7435d h1:fduaPzWwIfvOMLuHk2Al3GZH0XbUqG8MbElPop+Igzs=
 github.com/gophercloud/utils v0.0.0-20200423144003-7c72efc7435d/go.mod h1:ehWUbLQJPqS0Ep+CxeD559hsm9pthPXadJNKwZkp43w=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -165,10 +165,13 @@ func (cs *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 }
 
 func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
+	klog.V(4).Infof("ControllerPublishVolume: called with args %+v", *req)
 
 	// Volume Attach
 	instanceID := req.GetNodeId()
 	volumeID := req.GetVolumeId()
+	readOnly := req.GetReadonly()
+
 	volumeCapability := req.GetVolumeCapability()
 
 	if len(volumeID) == 0 {
@@ -197,7 +200,7 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 		return nil, status.Error(codes.Internal, fmt.Sprintf("[ControllerPublishVolume] GetInstanceByID failed with error %v", err))
 	}
 
-	_, err = cs.Cloud.AttachVolume(instanceID, volumeID)
+	_, err = cs.Cloud.AttachVolume(instanceID, volumeID, readOnly)
 	if err != nil {
 		klog.V(3).Infof("Failed to AttachVolume: %v", err)
 		return nil, status.Error(codes.Internal, fmt.Sprintf("[ControllerPublishVolume] Attach Volume failed with error %v", err))

--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -247,7 +247,7 @@ func TestDeleteVolume(t *testing.T) {
 func TestControllerPublishVolume(t *testing.T) {
 
 	// AttachVolume(instanceID, volumeID string) (string, error)
-	osmock.On("AttachVolume", FakeNodeID, FakeVolID).Return(FakeVolID, nil)
+	osmock.On("AttachVolume", FakeNodeID, FakeVolID, false).Return(FakeVolID, nil)
 	// WaitDiskAttached(instanceID string, volumeID string) error
 	osmock.On("WaitDiskAttached", FakeNodeID, FakeVolID).Return(nil)
 	// GetAttachmentDiskPath(instanceID, volumeID string) (string, error)

--- a/pkg/csi/cinder/driver.go
+++ b/pkg/csi/cinder/driver.go
@@ -80,6 +80,7 @@ func NewDriver(nodeID, endpoint, cluster string) *CinderDriver {
 			csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 			csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
 			csi.ControllerServiceCapability_RPC_LIST_VOLUMES_PUBLISHED_NODES,
+			csi.ControllerServiceCapability_RPC_PUBLISH_READONLY,
 		})
 	d.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER})
 

--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -123,6 +123,7 @@ func nodePublishEphermeral(req *csi.NodePublishVolumeRequest, ns *nodeServer) (*
 	var err error
 
 	volID := req.GetVolumeId()
+	readOnly := req.GetReadonly()
 	volName := fmt.Sprintf("ephemeral-%s", volID)
 	properties := map[string]string{"cinder.csi.openstack.org/cluster": ns.Driver.cluster}
 	capacity, ok := req.GetVolumeContext()["capacity"]
@@ -165,7 +166,7 @@ func nodePublishEphermeral(req *csi.NodePublishVolumeRequest, ns *nodeServer) (*
 		return nil, status.Error(codes.Internal, fmt.Sprintf("Ephermal Volume Attach: Failed to get Instance ID: %v", err))
 	}
 
-	_, err = ns.Cloud.AttachVolume(nodeID, evol.ID)
+	_, err = ns.Cloud.AttachVolume(nodeID, evol.ID, readOnly)
 	if err != nil {
 		klog.V(3).Infof("Ephermal Volume Attach: %v", err)
 		return nil, status.Error(codes.Internal, fmt.Sprintf("Ephermal Volume Attach: Failed to Attach Volume: %v", err))

--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -131,7 +131,7 @@ func TestNodePublishVolumeEphermeral(t *testing.T) {
 
 	omock.On("CreateVolume", fvolName, 2, "test", "nova", "", "", &properties).Return(&FakeVol, nil)
 
-	omock.On("AttachVolume", FakeNodeID, FakeVolID).Return(FakeVolID, nil)
+	omock.On("AttachVolume", FakeNodeID, FakeVolID, false).Return(FakeVolID, nil)
 	omock.On("WaitDiskAttached", FakeNodeID, FakeVolID).Return(nil)
 	mmock.On("GetDevicePath", FakeVolID).Return(FakeDevicePath, nil)
 	mmock.On("IsLikelyNotMountPointAttach", FakeTargetPath).Return(true, nil)

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -44,7 +44,7 @@ type IOpenStack interface {
 	CheckBlockStorageAPI() error
 	CreateVolume(name string, size int, vtype, availability string, snapshotID string, sourcevolID string, tags *map[string]string) (*volumes.Volume, error)
 	DeleteVolume(volumeID string) error
-	AttachVolume(instanceID, volumeID string) (string, error)
+	AttachVolume(instanceID, volumeID string, readOnly bool) (string, error)
 	ListVolumes(limit int, startingToken string) ([]volumes.Volume, string, error)
 	WaitDiskAttached(instanceID string, volumeID string) error
 	DetachVolume(instanceID, volumeID string) error

--- a/pkg/csi/cinder/openstack/openstack_mock.go
+++ b/pkg/csi/cinder/openstack/openstack_mock.go
@@ -56,19 +56,19 @@ type OpenStackMock struct {
 }
 
 // AttachVolume provides a mock function with given fields: instanceID, volumeID
-func (_m *OpenStackMock) AttachVolume(instanceID string, volumeID string) (string, error) {
-	ret := _m.Called(instanceID, volumeID)
+func (_m *OpenStackMock) AttachVolume(instanceID string, volumeID string, readOnly bool) (string, error) {
+	ret := _m.Called(instanceID, volumeID, readOnly)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(string, string) string); ok {
-		r0 = rf(instanceID, volumeID)
+	if rf, ok := ret.Get(0).(func(string, string, bool) string); ok {
+		r0 = rf(instanceID, volumeID, readOnly)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(instanceID, volumeID)
+	if rf, ok := ret.Get(1).(func(string, string, bool) error); ok {
+		r1 = rf(instanceID, volumeID, readOnly)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/tests/sanity/cinder/fakecloud.go
+++ b/tests/sanity/cinder/fakecloud.go
@@ -61,7 +61,7 @@ func (cloud *cloud) CheckBlockStorageAPI() error {
 	return nil
 }
 
-func (cloud *cloud) AttachVolume(instanceID, volumeID string) (string, error) {
+func (cloud *cloud) AttachVolume(instanceID, volumeID string, readOnly bool) (string, error) {
 	// update the volume with attachement
 
 	vol, ok := cloud.volumes[volumeID]


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #1169

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
