### PR TITLE
[octavia-ingress-controller] Improve Ingress reconciliation

### DIFF
--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -23,12 +23,15 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	log "github.com/sirupsen/logrus"
 	apiv1 "k8s.io/api/core/v1"
@@ -222,6 +225,21 @@ func getNodeConditionPredicate() NodeConditionPredicate {
 		}
 		return true
 	}
+}
+
+func getNodeAddressForLB(node *apiv1.Node) (string, error) {
+	addrs := node.Status.Addresses
+	if len(addrs) == 0 {
+		return "", errors.New("no address found for host")
+	}
+
+	for _, addr := range addrs {
+		if addr.Type == apiv1.NodeInternalIP {
+			return addr.Address, nil
+		}
+	}
+
+	return addrs[0].Address, nil
 }
 
 // NewController creates a new OpenStack Ingress controller.
@@ -476,10 +494,11 @@ func (c *Controller) processNextItem() bool {
 func (c *Controller) processItem(event Event) error {
 	ing := event.Obj.(*nwv1.Ingress)
 	key := fmt.Sprintf("%s/%s", ing.Namespace, ing.Name)
+	logger := log.WithFields(log.Fields{"ingress": key})
 
 	switch event.Type {
 	case CreateEvent:
-		log.WithFields(log.Fields{"ingress": key}).Info("ingress created, will create openstack resources")
+		logger.Info("creating ingress")
 
 		if err := c.ensureIngress(ing); err != nil {
 			utilruntime.HandleError(fmt.Errorf("failed to create openstack resources for ingress %s: %v", key, err))
@@ -488,7 +507,7 @@ func (c *Controller) processItem(event Event) error {
 			c.recorder.Event(ing, apiv1.EventTypeNormal, "Created", fmt.Sprintf("Ingress %s", key))
 		}
 	case UpdateEvent:
-		log.WithFields(log.Fields{"ingress": key}).Info("ingress updated, will update openstack resources")
+		logger.Info("updating ingress")
 
 		if err := c.ensureIngress(ing); err != nil {
 			utilruntime.HandleError(fmt.Errorf("failed to update openstack resources for ingress %s: %v", key, err))
@@ -497,7 +516,7 @@ func (c *Controller) processItem(event Event) error {
 			c.recorder.Event(ing, apiv1.EventTypeNormal, "Updated", fmt.Sprintf("Ingress %s", key))
 		}
 	case DeleteEvent:
-		log.WithFields(log.Fields{"ingress": key}).Info("ingress has been deleted, will delete openstack resources")
+		logger.Info("deleting ingress")
 
 		if err := c.deleteIngress(ing); err != nil {
 			utilruntime.HandleError(fmt.Errorf("failed to delete openstack resources for ingress %s: %v", key, err))
@@ -513,6 +532,7 @@ func (c *Controller) processItem(event Event) error {
 func (c *Controller) deleteIngress(ing *nwv1.Ingress) error {
 	key := fmt.Sprintf("%s/%s", ing.Namespace, ing.Name)
 	lbName := utils.GetResourceName(ing.Namespace, ing.Name, c.config.ClusterName)
+	logger := log.WithFields(log.Fields{"ingress": key})
 
 	// Delete Barbican secrets
 	if c.osClient.Barbican != nil && ing.Spec.TLS != nil {
@@ -521,7 +541,7 @@ func (c *Controller) deleteIngress(ing *nwv1.Ingress) error {
 			return fmt.Errorf("failed to remove Barbican secrets: %v", err)
 		}
 
-		log.WithFields(log.Fields{"ingress": key}).Info("Barbican secrets deleted")
+		logger.Info("Barbican secrets deleted")
 	}
 
 	// If load balancer doesn't exist, assume it's already deleted.
@@ -531,19 +551,19 @@ func (c *Controller) deleteIngress(ing *nwv1.Ingress) error {
 			return fmt.Errorf("error getting loadbalancer %s: %v", ing.Name, err)
 		}
 
-		log.WithFields(log.Fields{"lbName": lbName, "ingressName": ing.Name, "namespace": ing.Namespace}).Info("loadbalancer for ingress deleted")
+		logger.WithFields(log.Fields{"lbName": lbName}).Info("loadbalancer for ingress deleted")
 		return nil
 	}
 
 	// Delete the floating IP for the load balancer VIP. We don't check if the Ingress is internal or not, just delete
 	// any floating IPs associated with the load balancer VIP port.
-	log.WithFields(log.Fields{"ingress": key}).Debug("deleting floating IP")
+	logger.Debug("deleting floating IP")
 
 	if _, err = c.osClient.EnsureFloatingIP(true, loadbalancer.VipPortID, "", ""); err != nil {
 		return fmt.Errorf("failed to delete floating IP: %v", err)
 	}
 
-	log.WithFields(log.Fields{"ingress": key}).Info("floating IP deleted")
+	logger.Info("floating IP deleted")
 
 	// Delete security group managed for the Ingress backend service
 	if c.config.Octavia.ManageSecurityGroups {
@@ -569,11 +589,11 @@ func (c *Controller) deleteIngress(ing *nwv1.Ingress) error {
 			}
 		}
 
-		log.WithFields(log.Fields{"ingress": key}).Info("security group deleted")
+		logger.Info("security group deleted")
 	}
 
 	err = openstackutil.DeleteLoadbalancer(c.osClient.Octavia, loadbalancer.ID)
-	log.WithFields(log.Fields{"lbID": loadbalancer.ID}).Info("loadbalancer deleted")
+	logger.WithFields(log.Fields{"lbID": loadbalancer.ID}).Info("loadbalancer deleted")
 
 	return err
 }
@@ -621,20 +641,22 @@ func (c *Controller) ensureIngress(ing *nwv1.Ingress) error {
 	ingNamespace := ing.ObjectMeta.Namespace
 	clusterName := c.config.ClusterName
 
-	key := fmt.Sprintf("%s/%s", ingNamespace, ingName)
-	name := utils.GetResourceName(ingNamespace, ingName, clusterName)
+	ingfullName := fmt.Sprintf("%s/%s", ingNamespace, ingName)
+	resName := utils.GetResourceName(ingNamespace, ingName, clusterName)
 
 	if len(ing.Spec.TLS) > 0 && c.osClient.Barbican == nil {
 		return fmt.Errorf("TLS Ingress not supported because of Key Manager service unavailable")
 	}
 
-	lb, err := c.osClient.EnsureLoadBalancer(name, c.config.Octavia.SubnetID, ingNamespace, ingName, clusterName)
+	lb, err := c.osClient.EnsureLoadBalancer(resName, c.config.Octavia.SubnetID, ingNamespace, ingName, clusterName)
 	if err != nil {
 		return err
 	}
 
+	logger := log.WithFields(log.Fields{"ingress": ingfullName, "lbID": lb.ID})
+
 	if strings.Contains(lb.Description, ing.ResourceVersion) {
-		log.WithFields(log.Fields{"ingress": key}).Info("ingress not changed")
+		logger.Info("ingress not changed")
 		return nil
 	}
 
@@ -642,16 +664,16 @@ func (c *Controller) ensureIngress(ing *nwv1.Ingress) error {
 	var sgID string
 
 	if c.config.Octavia.ManageSecurityGroups {
-		log.WithFields(log.Fields{"ingress": key}).Info("ensuring security group")
+		logger.Info("ensuring security group")
 
-		sgDescription := fmt.Sprintf("Security group created for Ingress %s from cluster %s", key, clusterName)
+		sgDescription := fmt.Sprintf("Security group created for Ingress %s from cluster %s", ingfullName, clusterName)
 		sgTags := []string{IngressControllerTag, fmt.Sprintf("%s_%s", ingNamespace, ingName)}
-		sgID, err = c.osClient.EnsureSecurityGroup(false, name, sgDescription, sgTags)
+		sgID, err = c.osClient.EnsureSecurityGroup(false, resName, sgDescription, sgTags)
 		if err != nil {
-			return fmt.Errorf("failed to prepare the security group for the ingress %s: %v", key, err)
+			return fmt.Errorf("failed to prepare the security group for the ingress %s: %v", ingfullName, err)
 		}
 
-		log.WithFields(log.Fields{"sgID": sgID, "ingress": key}).Info("ensured security group")
+		logger.WithFields(log.Fields{"sgID": sgID}).Info("ensured security group")
 	}
 
 	// Convert kubernetes secrets to barbican ones
@@ -663,7 +685,7 @@ func (c *Controller) ensureIngress(ing *nwv1.Ingress) error {
 			return fmt.Errorf("failed to create Barbican secret: %v", err)
 		}
 
-		log.WithFields(log.Fields{"secretName": secretName, "secretRef": secretRef, "ingress": key}).Info("secret created in Barbican")
+		logger.WithFields(log.Fields{"secretName": secretName, "secretRef": secretRef}).Info("secret created in Barbican")
 
 		secretRefs = append(secretRefs, secretRef)
 	}
@@ -673,109 +695,165 @@ func (c *Controller) ensureIngress(ing *nwv1.Ingress) error {
 	}
 
 	// Create listener
-	listener, err := c.osClient.EnsureListener(name, lb.ID, secretRefs)
+	listener, err := c.osClient.EnsureListener(resName, lb.ID, secretRefs)
 	if err != nil {
 		return err
 	}
 
-	// get nodes information
+	// get nodes information and prepare update member params.
 	nodeObjs, err := listWithPredicate(c.nodeLister, getNodeConditionPredicate())
 	if err != nil {
 		return err
 	}
+	var updateMemberOpts []pools.BatchUpdateMemberOpts
+	for _, node := range nodeObjs {
+		addr, err := getNodeAddressForLB(node)
+		if err != nil {
+			// Node failure, do not create member
+			logger.WithFields(log.Fields{"node": node.Name, "error": err}).Warn("failed to get node address")
+			continue
+		}
+		nodeName := node.Name
+		member := pools.BatchUpdateMemberOpts{
+			Name:    &nodeName,
+			Address: addr,
+		}
+		updateMemberOpts = append(updateMemberOpts, member)
+	}
+	// only allow >= 1 members or it will lead to openstack octavia issue
+	if len(updateMemberOpts) == 0 {
+		return fmt.Errorf("no available nodes")
+	}
+
+	// Get all the existing pools and l7 policies
+	var newPools []openstack.IngPool
+	var newPolicies []openstack.IngPolicy
+	var oldPolicies []openstack.ExistingPolicy
+
+	existingPolicies, err := openstackutil.GetL7policies(c.osClient.Octavia, listener.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get l7 policies for listener %s", listener.ID)
+	}
+	for _, policy := range existingPolicies {
+		rules, err := openstackutil.GetL7Rules(c.osClient.Octavia, policy.ID)
+		if err != nil {
+			return fmt.Errorf("failed to get l7 rules for policy %s", policy.ID)
+		}
+		oldPolicies = append(oldPolicies, openstack.ExistingPolicy{
+			Policy: policy,
+			Rules:  rules,
+		})
+	}
+
+	existingPools, err := openstackutil.GetPools(c.osClient.Octavia, lb.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get pools from load balancer %s, error: %v", lb.ID, err)
+	}
 
 	// Add default pool for the listener if 'backend' is defined
 	if ing.Spec.DefaultBackend != nil {
+		poolName := utils.Hash(fmt.Sprintf("%s+%s", ing.Spec.DefaultBackend.Service.Name, ing.Spec.DefaultBackend.Service.Port.String()))
+
 		serviceName := fmt.Sprintf("%s/%s", ingNamespace, ing.Spec.DefaultBackend.Service.Name)
-
-		var portInfo intstr.IntOrString
-		if ing.Spec.DefaultBackend.Service.Port.Name != "" {
-			portInfo.Type = intstr.String
-			portInfo.StrVal = ing.Spec.DefaultBackend.Service.Port.Name
-		} else {
-			portInfo.Type = intstr.Int
-			portInfo.IntVal = ing.Spec.DefaultBackend.Service.Port.Number
-		}
-
-		nodePort, err := c.getServiceNodePort(serviceName, portInfo)
+		nodePort, err := c.getServiceNodePort(serviceName, ing.Spec.DefaultBackend.Service)
 		if err != nil {
 			return err
 		}
-
 		nodePorts = append(nodePorts, nodePort)
 
-		if _, err = c.osClient.EnsurePoolMembers(false, name, lb.ID, listener.ID, &nodePort, nodeObjs); err != nil {
-			return err
+		var members = make([]pools.BatchUpdateMemberOpts, len(updateMemberOpts))
+		copy(members, updateMemberOpts)
+		for index := range members {
+			members[index].ProtocolPort = nodePort
 		}
-	} else {
-		// Delete default pool and its members
-		if _, err = c.osClient.EnsurePoolMembers(true, name, lb.ID, "", nil, nil); err != nil {
-			return err
-		}
+
+		// This pool is the default pool of the listener.
+		newPools = append(newPools, openstack.IngPool{
+			Name: poolName,
+			Opts: pools.CreateOpts{
+				Name:        poolName,
+				Protocol:    "HTTP",
+				LBMethod:    pools.LBMethodRoundRobin,
+				ListenerID:  listener.ID,
+				Persistence: nil,
+			},
+			PoolMembers: members,
+		})
 	}
 
-	// Delete all existing policies
-	existingPolicies, err := c.osClient.GetL7policies(listener.ID)
-	if err != nil {
-		return err
-	}
-	for _, p := range existingPolicies {
-		err = c.osClient.DeleteL7policy(p.ID, lb.ID)
-		if err != nil {
-			log.WithFields(log.Fields{"policyID": p.ID, "lbID": lb.ID}).Errorf("could not delete L7 policy: %v", err)
-		}
-	}
-
-	// Delete all existing shared pools
-	existingSharedPools, err := c.osClient.GetPools(lb.ID, true)
-	if err != nil {
-		return err
-	}
-	for _, sp := range existingSharedPools {
-		err = c.osClient.DeletePool(sp.ID, lb.ID)
-		if err != nil {
-			log.WithFields(log.Fields{"poolID": sp.ID, "lbID": lb.ID}).Errorf("could not delete shared pool: %v", err)
-		}
-	}
-
-	// Add l7 load balancing rules. Each host and path combination is mapped to a l7 policy in octavia,
+	// Add l7 load balancing rules. Each host and path pair is mapped to a l7 policy in octavia,
 	// which contains two rules(with type 'HOST_NAME' and 'PATH' respectively)
 	for _, rule := range ing.Spec.Rules {
 		host := rule.Host
 
 		for _, path := range rule.HTTP.Paths {
+			var policyRules []l7policies.CreateRuleOpts
+
+			if host != "" {
+				policyRules = append(policyRules, l7policies.CreateRuleOpts{
+					RuleType:    l7policies.TypeHostName,
+					CompareType: l7policies.CompareTypeRegex,
+					Value:       fmt.Sprintf("^%s(:%d)?$", strings.ReplaceAll(host, ".", "\\."), port)})
+			}
+
 			// make the pool name unique in the load balancer
 			poolName := utils.Hash(fmt.Sprintf("%s+%s", path.Backend.Service.Name, path.Backend.Service.Port.String()))
 
 			serviceName := fmt.Sprintf("%s/%s", ingNamespace, path.Backend.Service.Name)
-			var portInfo intstr.IntOrString
-			if path.Backend.Service.Port.Name != "" {
-				portInfo.Type = intstr.String
-				portInfo.StrVal = path.Backend.Service.Port.Name
-			} else {
-				portInfo.Type = intstr.Int
-				portInfo.IntVal = path.Backend.Service.Port.Number
-			}
-			nodePort, err := c.getServiceNodePort(serviceName, portInfo)
+			nodePort, err := c.getServiceNodePort(serviceName, path.Backend.Service)
 			if err != nil {
 				return err
 			}
-
 			nodePorts = append(nodePorts, nodePort)
 
-			poolID, err := c.osClient.EnsurePoolMembers(false, poolName, lb.ID, "", &nodePort, nodeObjs)
-			if err != nil {
-				return err
+			var members = make([]pools.BatchUpdateMemberOpts, len(updateMemberOpts))
+			copy(members, updateMemberOpts)
+			for index := range members {
+				members[index].ProtocolPort = nodePort
 			}
 
-			if err = c.osClient.CreatePolicyRules(lb.ID, listener.ID, *poolID, host, path.Path, port); err != nil {
-				return err
-			}
+			// The pool is a shared pool in a load balancer.
+			newPools = append(newPools, openstack.IngPool{
+				Name: poolName,
+				Opts: pools.CreateOpts{
+					Name:           poolName,
+					Protocol:       "HTTP",
+					LBMethod:       pools.LBMethodRoundRobin,
+					LoadbalancerID: lb.ID,
+					Persistence:    nil,
+				},
+				PoolMembers: members,
+			})
+
+			policyRules = append(policyRules, l7policies.CreateRuleOpts{
+				RuleType:    l7policies.TypePath,
+				CompareType: l7policies.CompareTypeStartWith,
+				Value:       path.Path,
+			})
+
+			newPolicies = append(newPolicies, openstack.IngPolicy{
+				RedirectPoolName: poolName,
+				Opts: l7policies.CreateOpts{
+					ListenerID:  listener.ID,
+					Action:      l7policies.ActionRedirectToPool,
+					Description: "Created by kubernetes ingress",
+				},
+				RulesOpts: policyRules,
+			})
 		}
 	}
 
+	// Reconsile octavia resources.
+	rt := openstack.NewResourceTracker(ingfullName, c.osClient.Octavia, lb.ID, listener.ID, newPools, newPolicies, existingPools, oldPolicies)
+	if err := rt.CreateResources(); err != nil {
+		return err
+	}
+	if err := rt.CleanupResources(); err != nil {
+		return err
+	}
+
 	if c.config.Octavia.ManageSecurityGroups {
-		log.WithFields(log.Fields{"ingress": key, "sgID": sgID}).Info("ensuring security group rules")
+		logger.WithFields(log.Fields{"sgID": sgID}).Info("ensuring security group rules")
 
 		if err := c.osClient.EnsureSecurityGroupRules(sgID, c.subnetCIDR, nodePorts); err != nil {
 			return fmt.Errorf("failed to ensure security group rules for Ingress %s: %v", ingName, err)
@@ -785,7 +863,7 @@ func (c *Controller) ensureIngress(ing *nwv1.Ingress) error {
 			return fmt.Errorf("failed to operate port security group for Ingress %s: %v", ingName, err)
 		}
 
-		log.WithFields(log.Fields{"ingress": key, "sgID": sgID}).Info("ensured security group rules")
+		logger.WithFields(log.Fields{"sgID": sgID}).Info("ensured security group rules")
 	}
 
 	internalSetting := getStringFromIngressAnnotation(ing, IngressAnnotationInternal, "true")
@@ -797,7 +875,7 @@ func (c *Controller) ensureIngress(ing *nwv1.Ingress) error {
 	address := lb.VipAddress
 	// Allocate floating ip for loadbalancer vip if the external network is configured and the Ingress is not internal.
 	if !isInternal && c.config.Octavia.FloatingIPNetwork != "" {
-		log.WithFields(log.Fields{"ingress": key}).Info("creating floating IP")
+		logger.Info("creating floating IP")
 
 		description := fmt.Sprintf("Floating IP for Kubernetes ingress %s in namespace %s from cluster %s", ingName, ingNamespace, clusterName)
 		address, err = c.osClient.EnsureFloatingIP(false, lb.VipPortID, c.config.Octavia.FloatingIPNetwork, description)
@@ -805,7 +883,7 @@ func (c *Controller) ensureIngress(ing *nwv1.Ingress) error {
 			return fmt.Errorf("failed to create floating IP: %v", err)
 		}
 
-		log.WithFields(log.Fields{"ingress": key, "fip": address}).Info("floating IP created")
+		logger.WithFields(log.Fields{"fip": address}).Info("floating IP created")
 	}
 
 	// Update ingress status
@@ -813,7 +891,7 @@ func (c *Controller) ensureIngress(ing *nwv1.Ingress) error {
 	if err != nil {
 		return err
 	}
-	c.recorder.Event(ing, apiv1.EventTypeNormal, "Updated", fmt.Sprintf("Successfully associated IP address %s to ingress %s", address, key))
+	c.recorder.Event(ing, apiv1.EventTypeNormal, "Updated", fmt.Sprintf("Successfully associated IP address %s to ingress %s", address, ingfullName))
 
 	// Add ingress resource version to the load balancer description
 	newDes := fmt.Sprintf("Kubernetes Ingress %s in namespace %s from cluster %s, version: %s", ingName, ingNamespace, clusterName, newIng.ResourceVersion)
@@ -821,7 +899,7 @@ func (c *Controller) ensureIngress(ing *nwv1.Ingress) error {
 		return err
 	}
 
-	log.WithFields(log.Fields{"ingress": key, "lbID": lb.ID}).Info("openstack resources for ingress created")
+	logger.Info("openstack resources for ingress created")
 
 	return nil
 }
@@ -854,8 +932,19 @@ func (c *Controller) getService(key string) (*apiv1.Service, error) {
 	return service, nil
 }
 
-func (c *Controller) getServiceNodePort(name string, port intstr.IntOrString) (int, error) {
-	log.WithFields(log.Fields{"service": name, "port": port.String()}).Debug("getting service nodeport")
+func (c *Controller) getServiceNodePort(name string, serviceBackend *nwv1.IngressServiceBackend) (int, error) {
+	var portInfo intstr.IntOrString
+	if serviceBackend.Port.Name != "" {
+		portInfo.Type = intstr.String
+		portInfo.StrVal = serviceBackend.Port.Name
+	} else {
+		portInfo.Type = intstr.Int
+		portInfo.IntVal = serviceBackend.Port.Number
+	}
+
+	logger := log.WithFields(log.Fields{"service": name, "port": portInfo.String()})
+
+	logger.Debug("getting service nodeport")
 
 	svc, err := c.getService(name)
 	if err != nil {
@@ -865,11 +954,11 @@ func (c *Controller) getServiceNodePort(name string, port intstr.IntOrString) (i
 	var nodePort int
 	ports := svc.Spec.Ports
 	for _, p := range ports {
-		if port.Type == intstr.Int && int(p.Port) == port.IntValue() {
+		if portInfo.Type == intstr.Int && int(p.Port) == portInfo.IntValue() {
 			nodePort = int(p.NodePort)
 			break
 		}
-		if port.Type == intstr.String && p.Name == port.StrVal {
+		if portInfo.Type == intstr.String && p.Name == portInfo.StrVal {
 			nodePort = int(p.NodePort)
 			break
 		}
@@ -878,6 +967,8 @@ func (c *Controller) getServiceNodePort(name string, port intstr.IntOrString) (i
 	if nodePort == 0 {
 		return 0, fmt.Errorf("failed to find nodeport for service %s", name)
 	}
+
+	logger.Debug("found service nodeport")
 
 	return nodePort, nil
 }
@@ -899,7 +990,7 @@ func privateKeyFromPEM(pemData []byte) (crypto.PrivateKey, error) {
 	for {
 		result, rest = pem.Decode(rest)
 		if result == nil {
-			return nil, fmt.Errorf("Cannot decode supplied PEM data")
+			return nil, fmt.Errorf("cannot decode supplied PEM data")
 		}
 
 		switch result.Type {

--- a/pkg/ingress/controller/openstack/octavia.go
+++ b/pkg/ingress/controller/openstack/octavia.go
@@ -22,15 +22,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
-	"github.com/gophercloud/gophercloud/pagination"
 	log "github.com/sirupsen/logrus"
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	"k8s.io/cloud-provider-openstack/pkg/ingress/utils"
 	cpoerrors "k8s.io/cloud-provider-openstack/pkg/util/errors"
 	openstackutil "k8s.io/cloud-provider-openstack/pkg/util/openstack"
 )
@@ -57,6 +59,195 @@ func getNodeAddressForLB(node *apiv1.Node) (string, error) {
 	}
 
 	return addrs[0].Address, nil
+}
+
+type IngPolicy struct {
+	RedirectPoolName string
+	Opts             l7policies.CreateOpts
+	RulesOpts        []l7policies.CreateRuleOpts
+}
+
+type ExistingPolicy struct {
+	Policy l7policies.L7Policy
+	Rules  []l7policies.Rule
+}
+
+type IngPool struct {
+	Name        string
+	Opts        pools.CreateOptsBuilder
+	PoolMembers []pools.BatchUpdateMemberOpts
+}
+
+// ResourceTracker tracks the resources created for Ingress.
+type ResourceTracker struct {
+	client *gophercloud.ServiceClient
+	logger *log.Entry
+
+	lbID       string
+	listenerID string
+
+	newPoolNames sets.String
+	newPools     []IngPool
+	newPolicies  []IngPolicy
+	// A map from rule hash key to pool ID.
+	newPolicyRuleMapping map[string]string
+
+	// A map from pool name to pool ID
+	oldPoolMapping map[string]string
+	oldPools       []pools.Pool
+	// A map from rule hash key to policy.
+	oldPolicyMapping map[string]ExistingPolicy
+}
+
+func NewResourceTracker(ingressName string, client *gophercloud.ServiceClient, lbID string, listenerID string, newPools []IngPool, newPolicies []IngPolicy, oldPools []pools.Pool, oldPolicies []ExistingPolicy) *ResourceTracker {
+	newPoolNames := sets.NewString()
+	oldPoolMapping := make(map[string]string)
+	for _, pool := range newPools {
+		newPoolNames.Insert(pool.Name)
+	}
+	for _, pool := range oldPools {
+		oldPoolMapping[pool.Name] = pool.ID
+	}
+
+	oldPolicyMapping := make(map[string]ExistingPolicy)
+	for _, policy := range oldPolicies {
+		ruleIden := sets.NewString()
+		for _, rule := range policy.Rules {
+			ruleIden.Insert(rule.RuleType, rule.CompareType, rule.Value)
+		}
+		rulesKey := utils.Hash(strings.Join(ruleIden.List(), ","))
+		oldPolicyMapping[rulesKey] = policy
+	}
+
+	logger := log.WithFields(log.Fields{"ingress": ingressName, "lbID": lbID})
+
+	var oldPoolIDs []string
+	for _, poolID := range oldPoolMapping {
+		oldPoolIDs = append(oldPoolIDs, poolID)
+	}
+	logger.Debugf("Existing pools: %v", oldPoolIDs)
+
+	oldPoliciesTmp := make(map[string]string)
+	for key, policy := range oldPolicyMapping {
+		oldPoliciesTmp[key] = policy.Policy.RedirectPoolID
+	}
+	logger.Debugf("Existing l7 policies: %v", oldPoliciesTmp)
+
+	rt := &ResourceTracker{
+		client:               client,
+		logger:               logger,
+		lbID:                 lbID,
+		listenerID:           listenerID,
+		newPoolNames:         newPoolNames,
+		newPools:             newPools,
+		newPolicies:          newPolicies,
+		newPolicyRuleMapping: make(map[string]string),
+		oldPools:             oldPools,
+		oldPoolMapping:       oldPoolMapping,
+		oldPolicyMapping:     oldPolicyMapping,
+	}
+
+	return rt
+}
+
+// createResources only creates resources when necessary.
+func (rt *ResourceTracker) CreateResources() error {
+	poolMapping := make(map[string]string)
+	for _, pool := range rt.newPools {
+		// Different ingress paths may configure the same service, but we only need to create one pool.
+		if _, isPresent := poolMapping[pool.Name]; isPresent {
+			continue
+		}
+
+		poolID, isPresent := rt.oldPoolMapping[pool.Name]
+		if !isPresent {
+			rt.logger.WithFields(log.Fields{"poolName": pool.Name}).Info("creating pool")
+			newPool, err := openstackutil.CreatePool(rt.client, pool.Opts, rt.lbID)
+			if err != nil {
+				return fmt.Errorf("failed to create pool %s, error: %v", pool.Name, err)
+			}
+
+			poolID = newPool.ID
+			rt.logger.WithFields(log.Fields{"poolName": pool.Name, "poolID": poolID}).Info("pool created")
+		}
+
+		poolMapping[pool.Name] = poolID
+
+		rt.logger.WithFields(log.Fields{"poolName": pool.Name, "poolID": poolID}).Info("updating pool members")
+		if err := openstackutil.BatchUpdatePoolMembers(rt.client, rt.lbID, poolID, pool.PoolMembers); err != nil {
+			return fmt.Errorf("failed to update pool members, error: %v", err)
+		}
+		rt.logger.WithFields(log.Fields{"poolName": pool.Name, "poolID": poolID}).Info("pool members updated ")
+	}
+
+	var curPoolIDs []string
+	for _, id := range poolMapping {
+		curPoolIDs = append(curPoolIDs, id)
+	}
+	rt.logger.Debugf("Current pools: %v", curPoolIDs)
+
+	for _, policy := range rt.newPolicies {
+		newRuleIden := sets.NewString()
+		for _, opt := range policy.RulesOpts {
+			newRuleIden.Insert(string(opt.RuleType), string(opt.CompareType), opt.Value)
+		}
+		rulesKey := utils.Hash(strings.Join(newRuleIden.List(), ","))
+
+		poolID := poolMapping[policy.RedirectPoolName]
+
+		oldPolicy, isPresent := rt.oldPolicyMapping[rulesKey]
+		if !isPresent || oldPolicy.Policy.RedirectPoolID != poolID {
+			// Create new policy with rules
+			rt.logger.WithFields(log.Fields{"listenerID": rt.listenerID, "poolID": poolID}).Info("creating l7 policy")
+			policy.Opts.RedirectPoolID = poolID
+			newPolicy, err := openstackutil.CreateL7Policy(rt.client, policy.Opts, rt.lbID)
+			if err != nil {
+				return fmt.Errorf("failed to create l7policy, error: %v", err)
+			}
+			rt.logger.WithFields(log.Fields{"listenerID": rt.listenerID, "poolID": poolID}).Info("l7 policy created")
+
+			rt.logger.WithFields(log.Fields{"listenerID": rt.listenerID, "policyID": newPolicy.ID}).Info("creating l7 rules")
+			for _, opt := range policy.RulesOpts {
+				if err := openstackutil.CreateL7Rule(rt.client, newPolicy.ID, opt, rt.lbID); err != nil {
+					return fmt.Errorf("failed to create l7 rules for policy %s, error: %v", newPolicy.ID, err)
+				}
+			}
+			rt.logger.WithFields(log.Fields{"listenerID": rt.listenerID, "policyID": newPolicy.ID}).Info("l7 rules created")
+		}
+
+		rt.newPolicyRuleMapping[rulesKey] = poolID
+	}
+
+	rt.logger.Debugf("Current l7 policies: %v", rt.newPolicyRuleMapping)
+
+	return nil
+}
+
+func (rt *ResourceTracker) CleanupResources() error {
+	for key, oldPolicy := range rt.oldPolicyMapping {
+		poolID, isPresent := rt.newPolicyRuleMapping[key]
+		if !isPresent || poolID != oldPolicy.Policy.RedirectPoolID {
+			// Delete invalid policy
+			rt.logger.WithFields(log.Fields{"policyID": oldPolicy.Policy.ID}).Info("deleting policy")
+			if err := openstackutil.DeleteL7policy(rt.client, oldPolicy.Policy.ID, rt.lbID); err != nil {
+				return fmt.Errorf("failed to delete l7 policy %s, error: %v", oldPolicy.Policy.ID, err)
+			}
+			rt.logger.WithFields(log.Fields{"policyID": oldPolicy.Policy.ID}).Info("policy deleted")
+		}
+	}
+
+	for _, pool := range rt.oldPools {
+		if !rt.newPoolNames.Has(pool.Name) {
+			// Delete unused pool
+			rt.logger.WithFields(log.Fields{"poolID": pool.ID}).Info("deleting pool")
+			if err := openstackutil.DeletePool(rt.client, pool.ID, rt.lbID); err != nil {
+				return fmt.Errorf("failed to delete pool %s, error: %v", pool.ID, err)
+			}
+			rt.logger.WithFields(log.Fields{"poolID": pool.ID}).Info("pool deleted")
+		}
+	}
+
+	return nil
 }
 
 func (os *OpenStack) waitLoadbalancerActiveProvisioningStatus(loadbalancerID string) (string, error) {
@@ -89,105 +280,10 @@ func (os *OpenStack) waitLoadbalancerActiveProvisioningStatus(loadbalancerID str
 	return provisioningStatus, err
 }
 
-// GetPools retrives the pools belong to the loadbalancer. If shared is true, only return the shared pools.
-func (os *OpenStack) GetPools(lbID string, shared bool) ([]pools.Pool, error) {
-	var lbPools []pools.Pool
-
-	opts := pools.ListOpts{
-		LoadbalancerID: lbID,
-	}
-	err := pools.List(os.Octavia, opts).EachPage(func(page pagination.Page) (bool, error) {
-		v, err := pools.ExtractPools(page)
-		if err != nil {
-			return false, err
-		}
-		for _, p := range v {
-			if shared && len(p.Listeners) != 0 {
-				continue
-			}
-			lbPools = append(lbPools, p)
-		}
-
-		return true, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return lbPools, nil
-}
-
-// GetMembers retrieve all the members of the specified pool
-func (os *OpenStack) GetMembers(poolID string) ([]pools.Member, error) {
-	var members []pools.Member
-
-	opts := pools.ListMembersOpts{}
-	err := pools.ListMembers(os.Octavia, poolID, opts).EachPage(func(page pagination.Page) (bool, error) {
-		v, err := pools.ExtractMembers(page)
-		if err != nil {
-			return false, err
-		}
-		members = append(members, v...)
-		return true, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return members, nil
-}
-
-// DeletePool deletes a pool
-func (os *OpenStack) DeletePool(poolID string, lbID string) error {
-	if err := pools.Delete(os.Octavia, poolID).ExtractErr(); err != nil {
-		return fmt.Errorf("failed to delete pool %s: %v", poolID, err)
-	}
-
-	_, err := os.waitLoadbalancerActiveProvisioningStatus(lbID)
-	if err != nil {
-		return fmt.Errorf("failed to wait for loadbalancer to be active: %v", err)
-	}
-
-	return nil
-}
-
-// GetL7policies retrieves all l7 policies for the given listener.
-func (os *OpenStack) GetL7policies(listenerID string) ([]l7policies.L7Policy, error) {
-	var policies []l7policies.L7Policy
-	opts := l7policies.ListOpts{
-		ListenerID: listenerID,
-	}
-	err := l7policies.List(os.Octavia, opts).EachPage(func(page pagination.Page) (bool, error) {
-		v, err := l7policies.ExtractL7Policies(page)
-		if err != nil {
-			return false, err
-		}
-		policies = append(policies, v...)
-		return true, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return policies, nil
-}
-
-// DeleteL7policy deletes a l7 policy
-func (os *OpenStack) DeleteL7policy(policyID string, lbID string) error {
-	if err := l7policies.Delete(os.Octavia, policyID).ExtractErr(); err != nil {
-		return fmt.Errorf("failed to delete l7 policy: %v", err)
-	}
-
-	_, err := os.waitLoadbalancerActiveProvisioningStatus(lbID)
-	if err != nil {
-		return fmt.Errorf("failed to wait for loadbalancer to be active: %v", err)
-	}
-
-	return nil
-}
-
 // EnsureLoadBalancer creates a loadbalancer in octavia if it does not exist, wait for the loadbalancer to be ACTIVE.
 func (os *OpenStack) EnsureLoadBalancer(name string, subnetID string, ingNamespace string, ingName string, clusterName string) (*loadbalancers.LoadBalancer, error) {
+	logger := log.WithFields(log.Fields{"ingress": fmt.Sprintf("%s/%s", ingNamespace, ingName)})
+
 	loadbalancer, err := openstackutil.GetLoadbalancerByName(os.Octavia, name)
 	if err != nil {
 		if err != openstackutil.ErrNotFound {
@@ -212,14 +308,14 @@ func (os *OpenStack) EnsureLoadBalancer(name string, subnetID string, ingNamespa
 			return nil, fmt.Errorf("error creating loadbalancer %v: %v", createOpts, err)
 		}
 
-		log.WithFields(log.Fields{"name": name, "ID": loadbalancer.ID}).Info("creating loadbalancer")
+		logger.WithFields(log.Fields{"lbName": name, "lbID": loadbalancer.ID}).Info("creating loadbalancer")
 	} else {
-		log.WithFields(log.Fields{"name": name}).Debug("loadbalancer exists")
+		logger.WithFields(log.Fields{"lbName": name, "lbID": loadbalancer.ID}).Debug("loadbalancer exists")
 	}
 
 	_, err = os.waitLoadbalancerActiveProvisioningStatus(loadbalancer.ID)
 	if err != nil {
-		return nil, fmt.Errorf("error creating loadbalancer: %v", err)
+		return nil, fmt.Errorf("loadbalancer %s not in ACTIVE status, error: %v", loadbalancer.ID, err)
 	}
 
 	return loadbalancer, nil
@@ -234,7 +330,7 @@ func (os *OpenStack) UpdateLoadBalancerDescription(lbID string, newDescription s
 		return fmt.Errorf("failed to update loadbalancer description: %v", err)
 	}
 
-	log.WithFields(log.Fields{"lb": lbID}).Debug("loadbalancer description updated")
+	log.WithFields(log.Fields{"lbID": lbID}).Debug("loadbalancer description updated")
 	return nil
 }
 
@@ -246,7 +342,7 @@ func (os *OpenStack) EnsureListener(name string, lbID string, secretRefs []strin
 			return nil, fmt.Errorf("error getting listener %s: %v", name, err)
 		}
 
-		log.WithFields(log.Fields{"lb": lbID, "listenerName": name}).Debug("creating listener")
+		log.WithFields(log.Fields{"lbID": lbID, "listenerName": name}).Info("creating listener")
 
 		opts := listeners.CreateOpts{
 			Name:           name,
@@ -265,12 +361,12 @@ func (os *OpenStack) EnsureListener(name string, lbID string, secretRefs []strin
 			return nil, fmt.Errorf("error creating listener: %v", err)
 		}
 
-		log.WithFields(log.Fields{"lb": lbID, "listenerName": name}).Info("listener created")
+		log.WithFields(log.Fields{"lbID": lbID, "listenerName": name}).Info("listener created")
 	}
 
 	_, err = os.waitLoadbalancerActiveProvisioningStatus(lbID)
 	if err != nil {
-		return nil, fmt.Errorf("error creating listener: %v", err)
+		return nil, fmt.Errorf("loadbalancer %s not in ACTIVE status after creating listener, error: %v", lbID, err)
 	}
 
 	return listener, nil
@@ -278,6 +374,8 @@ func (os *OpenStack) EnsureListener(name string, lbID string, secretRefs []strin
 
 // EnsurePoolMembers ensure the pool and its members exist if deleted flag is not set, delete the pool and all its members otherwise.
 func (os *OpenStack) EnsurePoolMembers(deleted bool, poolName string, lbID string, listenerID string, nodePort *int, nodes []*apiv1.Node) (*string, error) {
+	logger := log.WithFields(log.Fields{"lbID": lbID, "listenerID": listenerID, "poolName": poolName})
+
 	if deleted {
 		pool, err := openstackutil.GetPoolByName(os.Octavia, poolName, lbID)
 		if err != nil {
@@ -307,7 +405,7 @@ func (os *OpenStack) EnsurePoolMembers(deleted bool, poolName string, lbID strin
 			return nil, fmt.Errorf("error getting pool %s: %v", poolName, err)
 		}
 
-		log.WithFields(log.Fields{"lb": lbID, "listenerID": listenerID, "poolName": poolName}).Debug("creating pool")
+		logger.Info("creating pool")
 
 		// Create new pool
 		var opts pools.CreateOptsBuilder
@@ -333,7 +431,7 @@ func (os *OpenStack) EnsurePoolMembers(deleted bool, poolName string, lbID strin
 			return nil, fmt.Errorf("error creating pool: %v", err)
 		}
 
-		log.WithFields(log.Fields{"lb": lbID, "listenerID": listenerID, "poolName": poolName, "pooID": pool.ID}).Info("pool created")
+		logger.Info("pool created")
 
 	}
 
@@ -348,7 +446,7 @@ func (os *OpenStack) EnsurePoolMembers(deleted bool, poolName string, lbID strin
 		addr, err := getNodeAddressForLB(node)
 		if err != nil {
 			// Node failure, do not create member
-			log.WithFields(log.Fields{"node": node.Name, "poolName": poolName, "pooID": pool.ID, "error": err}).Warn("failed to create LB pool member for node")
+			logger.WithFields(log.Fields{"nodeName": node.Name, "error": err}).Warn("failed to create LB pool member for node")
 			continue
 		}
 
@@ -373,80 +471,14 @@ func (os *OpenStack) EnsurePoolMembers(deleted bool, poolName string, lbID strin
 		return nil, fmt.Errorf("error waiting for loadbalancer %s to be active: %v", lbID, err)
 	}
 
-	log.WithFields(log.Fields{"lb": lbID, "listenerID": listenerID, "poolName": poolName, "pooID": pool.ID}).Info("pool members updated")
+	logger.Info("pool members updated")
 
 	return &pool.ID, nil
 }
 
-// CreatePolicyRules creates l7 policy and its rules for the listener
-func (os *OpenStack) CreatePolicyRules(lbID, listenerID, poolID, host, path string, port int) error {
-	log.WithFields(log.Fields{"lb": lbID, "listenerID": listenerID}).Debug("creating policy")
-
-	policy, err := l7policies.Create(os.Octavia, l7policies.CreateOpts{
-		ListenerID:     listenerID,
-		Action:         l7policies.ActionRedirectToPool,
-		Description:    "Created by kubernetes ingress",
-		RedirectPoolID: poolID,
-	}).Extract()
-	if err != nil {
-		return fmt.Errorf("error creating l7policy: %v", err)
-	}
-
-	_, err = os.waitLoadbalancerActiveProvisioningStatus(lbID)
-	if err != nil {
-		return fmt.Errorf("error waiting for loadbalancer %s to be active: %v", lbID, err)
-	}
-
-	log.WithFields(log.Fields{"lb": lbID, "listenerID": listenerID, "policyID": policy.ID}).Info("policy created")
-
-	if host != "" {
-		log.WithFields(log.Fields{"type": l7policies.TypeHostName, "host": host, "policyID": policy.ID, "listenerID": listenerID}).Debug("creating policy rule")
-
-		// Create HOST_NAME type rule. Use REGEX type rule to support both host and host:port
-		_, err = l7policies.CreateRule(os.Octavia, policy.ID, l7policies.CreateRuleOpts{
-			RuleType:    l7policies.TypeHostName,
-			CompareType: l7policies.CompareTypeRegex,
-			Value:       fmt.Sprintf("^%s(:%d)?$", strings.ReplaceAll(host, ".", "\\."), port),
-		}).Extract()
-		if err != nil {
-			return fmt.Errorf("error creating l7 rule: %v", err)
-		}
-
-		_, err = os.waitLoadbalancerActiveProvisioningStatus(lbID)
-		if err != nil {
-			return fmt.Errorf("error waiting for loadbalancer %s to be active: %v", lbID, err)
-		}
-
-		log.WithFields(log.Fields{"type": l7policies.TypeHostName, "host": host, "policyID": policy.ID, "listenerID": listenerID}).Info("policy rule created")
-	}
-
-	if path != "" {
-		log.WithFields(log.Fields{"type": l7policies.TypePath, "path": path, "policyID": policy.ID, "listenerID": listenerID}).Debug("creating policy rule")
-
-		// Create PATH type rule
-		_, err = l7policies.CreateRule(os.Octavia, policy.ID, l7policies.CreateRuleOpts{
-			RuleType:    l7policies.TypePath,
-			CompareType: l7policies.CompareTypeStartWith,
-			Value:       path,
-		}).Extract()
-		if err != nil {
-			return fmt.Errorf("error creating l7 rule: %v", err)
-		}
-
-		_, err = os.waitLoadbalancerActiveProvisioningStatus(lbID)
-		if err != nil {
-			return fmt.Errorf("error waiting for loadbalancer %s to be active: %v", lbID, err)
-		}
-
-		log.WithFields(log.Fields{"type": l7policies.TypePath, "path": path, "policyID": policy.ID, "listenerID": listenerID}).Info("policy rule created")
-	}
-
-	return nil
-}
-
 // UpdateLoadbalancerMembers update members for all the pools in the specified load balancer.
 func (os *OpenStack) UpdateLoadbalancerMembers(lbID string, nodes []*apiv1.Node) error {
-	lbPools, err := os.GetPools(lbID, false)
+	lbPools, err := openstackutil.GetPools(os.Octavia, lbID)
 	if err != nil {
 		return err
 	}
@@ -454,7 +486,7 @@ func (os *OpenStack) UpdateLoadbalancerMembers(lbID string, nodes []*apiv1.Node)
 	for _, pool := range lbPools {
 		log.WithFields(log.Fields{"poolID": pool.ID}).Debug("Starting to update pool members")
 
-		members, err := os.GetMembers(pool.ID)
+		members, err := openstackutil.GetMembersbyPool(os.Octavia, pool.ID)
 		if err != nil {
 			log.WithFields(log.Fields{"poolID": pool.ID}).Errorf("Failed to get pool members: %v", err)
 			continue

--- a/pkg/util/openstack/loadbalancer.go
+++ b/pkg/util/openstack/loadbalancer.go
@@ -23,15 +23,16 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/apiversions"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
 	"github.com/gophercloud/gophercloud/pagination"
-	"github.com/hashicorp/go-version"
+	version "github.com/hashicorp/go-version"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/cloud-provider-openstack/pkg/metrics"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
+	"k8s.io/cloud-provider-openstack/pkg/metrics"
 	cpoerrors "k8s.io/cloud-provider-openstack/pkg/util/errors"
 )
 
@@ -158,6 +159,43 @@ func waitLoadbalancerActive(client *gophercloud.ServiceClient, loadbalancerID st
 	return err
 }
 
+// GetLoadbalancerByName retrieves loadbalancer object
+func GetLoadbalancerByName(client *gophercloud.ServiceClient, name string) (*loadbalancers.LoadBalancer, error) {
+	opts := loadbalancers.ListOpts{
+		Name: name,
+	}
+	mc := metrics.NewMetricContext("loadbalancer", "list")
+	allPages, err := loadbalancers.List(client, opts).AllPages()
+	if mc.ObserveRequest(err) != nil {
+		return nil, err
+	}
+	loadbalancerList, err := loadbalancers.ExtractLoadBalancers(allPages)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(loadbalancerList) > 1 {
+		return nil, ErrMultipleResults
+	}
+	if len(loadbalancerList) == 0 {
+		return nil, ErrNotFound
+	}
+
+	return &loadbalancerList[0], nil
+}
+
+// DeleteLoadbalancer deletes a loadbalancer with all its child objects.
+func DeleteLoadbalancer(client *gophercloud.ServiceClient, lbID string) error {
+	mc := metrics.NewMetricContext("loadbalancer", "delete")
+	err := loadbalancers.Delete(client, lbID, loadbalancers.DeleteOpts{Cascade: true}).ExtractErr()
+	if err != nil && !cpoerrors.IsNotFound(err) {
+		_ = mc.ObserveRequest(err)
+		return fmt.Errorf("error deleting loadbalancer %s: %v", lbID, err)
+	}
+
+	return mc.ObserveRequest(nil)
+}
+
 // UpdateListener updates a listener and wait for the lb active
 func UpdateListener(client *gophercloud.ServiceClient, lbID string, listenerID string, opts listeners.UpdateOpts) error {
 	mc := metrics.NewMetricContext("loadbalancer_listener", "update")
@@ -186,31 +224,6 @@ func CreateListener(client *gophercloud.ServiceClient, lbID string, opts listene
 	}
 
 	return listener, nil
-}
-
-// GetLoadbalancerByName retrieves loadbalancer object
-func GetLoadbalancerByName(client *gophercloud.ServiceClient, name string) (*loadbalancers.LoadBalancer, error) {
-	opts := loadbalancers.ListOpts{
-		Name: name,
-	}
-	mc := metrics.NewMetricContext("loadbalancer", "list")
-	allPages, err := loadbalancers.List(client, opts).AllPages()
-	if mc.ObserveRequest(err) != nil {
-		return nil, err
-	}
-	loadbalancerList, err := loadbalancers.ExtractLoadBalancers(allPages)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(loadbalancerList) > 1 {
-		return nil, ErrMultipleResults
-	}
-	if len(loadbalancerList) == 0 {
-		return nil, ErrNotFound
-	}
-
-	return &loadbalancerList[0], nil
 }
 
 // GetListenerByName gets a listener by its name, raise error if not found or get multiple ones.
@@ -246,6 +259,21 @@ func GetListenerByName(client *gophercloud.ServiceClient, name string, lbID stri
 	}
 
 	return &listenerList[0], nil
+}
+
+// CreatePool creates a new pool.
+func CreatePool(client *gophercloud.ServiceClient, opts pools.CreateOptsBuilder, lbID string) (*pools.Pool, error) {
+	mc := metrics.NewMetricContext("loadbalancer_pool", "create")
+	pool, err := pools.Create(client, opts).Extract()
+	if mc.ObserveRequest(err) != nil {
+		return nil, err
+	}
+
+	if err = waitLoadbalancerActive(client, lbID); err != nil {
+		return nil, fmt.Errorf("failed to wait for load balancer ACTIVE after creating pool: %v", err)
+	}
+
+	return pool, nil
 }
 
 // GetPoolByName gets a pool by its name, raise error if not found or get multiple ones.
@@ -319,16 +347,24 @@ func GetPoolByListener(client *gophercloud.ServiceClient, lbID, listenerID strin
 	return &listenerPools[0], nil
 }
 
-// DeleteLoadbalancer deletes a loadbalancer with all its child objects.
-func DeleteLoadbalancer(client *gophercloud.ServiceClient, lbID string) error {
-	mc := metrics.NewMetricContext("loadbalancer", "delete")
-	err := loadbalancers.Delete(client, lbID, loadbalancers.DeleteOpts{Cascade: true}).ExtractErr()
-	if err != nil && !cpoerrors.IsNotFound(err) {
-		_ = mc.ObserveRequest(err)
-		return fmt.Errorf("error deleting loadbalancer %s: %v", lbID, err)
+// GetPools retrives the pools belong to the loadbalancer.
+func GetPools(client *gophercloud.ServiceClient, lbID string) ([]pools.Pool, error) {
+	var lbPools []pools.Pool
+
+	opts := pools.ListOpts{
+		LoadbalancerID: lbID,
+	}
+	allPages, err := pools.List(client, opts).AllPages()
+	if err != nil {
+		return nil, err
 	}
 
-	return mc.ObserveRequest(nil)
+	lbPools, err = pools.ExtractPools(allPages)
+	if err != nil {
+		return nil, err
+	}
+
+	return lbPools, nil
 }
 
 // GetMembersbyPool get all the members in the pool.
@@ -352,14 +388,110 @@ func GetMembersbyPool(client *gophercloud.ServiceClient, poolID string) ([]pools
 	return members, nil
 }
 
-func BatchUpdatePoolMembers(client *gophercloud.ServiceClient, lbID, poolID string, opts []pools.BatchUpdateMemberOpts) error {
+// DeletePool deletes a pool.
+func DeletePool(client *gophercloud.ServiceClient, poolID string, lbID string) error {
+	mc := metrics.NewMetricContext("loadbalancer_pool", "delete")
+	if err := pools.Delete(client, poolID).ExtractErr(); mc.ObserveRequest(err) != nil {
+		return err
+	}
+
+	if err := waitLoadbalancerActive(client, lbID); err != nil {
+		return fmt.Errorf("failed to wait for load balancer ACTIVE after deleting pool: %v", err)
+	}
+
+	return nil
+}
+
+// BatchUpdatePoolMembers updates pool members in batch.
+func BatchUpdatePoolMembers(client *gophercloud.ServiceClient, lbID string, poolID string, opts []pools.BatchUpdateMemberOpts) error {
+	mc := metrics.NewMetricContext("loadbalancer_members", "update")
 	err := pools.BatchUpdateMembers(client, poolID, opts).ExtractErr()
-	if err != nil {
+	if mc.ObserveRequest(err) != nil {
 		return err
 	}
 
 	if err := waitLoadbalancerActive(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer ACTIVE after updating pool members for %s: %v", poolID, err)
+	}
+
+	return nil
+}
+
+// GetL7policies retrieves all l7 policies for the given listener.
+func GetL7policies(client *gophercloud.ServiceClient, listenerID string) ([]l7policies.L7Policy, error) {
+	var policies []l7policies.L7Policy
+	opts := l7policies.ListOpts{
+		ListenerID: listenerID,
+	}
+	err := l7policies.List(client, opts).EachPage(func(page pagination.Page) (bool, error) {
+		v, err := l7policies.ExtractL7Policies(page)
+		if err != nil {
+			return false, err
+		}
+		policies = append(policies, v...)
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return policies, nil
+}
+
+// CreateL7Policy creates a l7 policy.
+func CreateL7Policy(client *gophercloud.ServiceClient, opts l7policies.CreateOpts, lbID string) (*l7policies.L7Policy, error) {
+	mc := metrics.NewMetricContext("loadbalancer_l7policy", "create")
+	policy, err := l7policies.Create(client, opts).Extract()
+	if mc.ObserveRequest(err) != nil {
+		return nil, err
+	}
+
+	if err = waitLoadbalancerActive(client, lbID); err != nil {
+		return nil, fmt.Errorf("failed to wait for load balancer ACTIVE after creating l7policy: %v", err)
+	}
+
+	return policy, nil
+}
+
+// DeleteL7policy deletes a l7 policy.
+func DeleteL7policy(client *gophercloud.ServiceClient, policyID string, lbID string) error {
+	mc := metrics.NewMetricContext("loadbalancer_l7policy", "delete")
+	if err := l7policies.Delete(client, policyID).ExtractErr(); mc.ObserveRequest(err) != nil {
+		return err
+	}
+
+	if err := waitLoadbalancerActive(client, lbID); err != nil {
+		return fmt.Errorf("failed to wait for load balancer ACTIVE after deleting l7policy: %v", err)
+	}
+
+	return nil
+}
+
+// GetL7Rules gets all the rules for a l7 policy
+func GetL7Rules(client *gophercloud.ServiceClient, policyID string) ([]l7policies.Rule, error) {
+	listOpts := l7policies.ListRulesOpts{}
+	allPages, err := l7policies.ListRules(client, policyID, listOpts).AllPages()
+	if err != nil {
+		return nil, err
+	}
+	allRules, err := l7policies.ExtractRules(allPages)
+	if err != nil {
+		return nil, err
+	}
+
+	return allRules, nil
+}
+
+// CreateL7Rule creates a l7 rule.
+func CreateL7Rule(client *gophercloud.ServiceClient, policyID string, opts l7policies.CreateRuleOpts, lbID string) error {
+	mc := metrics.NewMetricContext("loadbalancer_l7rule", "create")
+	_, err := l7policies.CreateRule(client, policyID, opts).Extract()
+	if mc.ObserveRequest(err) != nil {
+		return err
+	}
+
+	if err = waitLoadbalancerActive(client, lbID); err != nil {
+		return fmt.Errorf("failed to wait for load balancer ACTIVE after creating l7policy rule: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
* Refactored how the ingress controller reconciles resources in Octavia. Changed the way that all the pools and l7 policies were removed before creating new resources, which brings downtime of the Ingress service.
* Improved log.
* Moved octavia related utility functions to `pkg/util/openstack/loadbalancer.go`

**Which issue this PR fixes(if applicable)**:
fixes #1417

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[octavia-ingress-controller] Fixed the issue that pools and l7 policies are removed no matter how the Ingress is changed.
```
