### PR TITLE
[octavia-ingress-controller] Improve Ingress reconciliation

### DIFF
--- a/pkg/ingress/cmd/root.go
+++ b/pkg/ingress/cmd/root.go
@@ -30,7 +30,7 @@ import (
 
 	"k8s.io/cloud-provider-openstack/pkg/ingress/config"
 	"k8s.io/cloud-provider-openstack/pkg/ingress/controller"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 )
 
 var (
@@ -67,6 +67,12 @@ func Execute() {
 
 func init() {
 	log.SetOutput(os.Stdout)
+	log.SetFormatter(&log.TextFormatter{
+		ForceColors:            true,
+		FullTimestamp:          true,
+		DisableLevelTruncation: true,
+		PadLevelText:           true,
+	})
 
 	cobra.OnInitialize(initConfig)
 

--- a/pkg/ingress/controller/openstack/octavia.go
+++ b/pkg/ingress/controller/openstack/octavia.go
@@ -22,15 +22,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/l7policies"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
-	"github.com/gophercloud/gophercloud/pagination"
 	log "github.com/sirupsen/logrus"
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	"k8s.io/cloud-provider-openstack/pkg/ingress/utils"
 	cpoerrors "k8s.io/cloud-provider-openstack/pkg/util/errors"
 	openstackutil "k8s.io/cloud-provider-openstack/pkg/util/openstack"
 )
@@ -57,6 +59,195 @@ func getNodeAddressForLB(node *apiv1.Node) (string, error) {
 	}
 
 	return addrs[0].Address, nil
+}
+
+type IngPolicy struct {
+	RedirectPoolName string
+	Opts             l7policies.CreateOpts
+	RulesOpts        []l7policies.CreateRuleOpts
+}
+
+type ExistingPolicy struct {
+	Policy l7policies.L7Policy
+	Rules  []l7policies.Rule
+}
+
+type IngPool struct {
+	Name        string
+	Opts        pools.CreateOptsBuilder
+	PoolMembers []pools.BatchUpdateMemberOpts
+}
+
+// ResourceTracker tracks the resources created for Ingress.
+type ResourceTracker struct {
+	client *gophercloud.ServiceClient
+	logger *log.Entry
+
+	lbID       string
+	listenerID string
+
+	newPoolNames sets.String
+	newPools     []IngPool
+	newPolicies  []IngPolicy
+	// A map from rule hash key to pool ID.
+	newPolicyRuleMapping map[string]string
+
+	// A map from pool name to pool ID
+	oldPoolMapping map[string]string
+	oldPools       []pools.Pool
+	// A map from rule hash key to policy.
+	oldPolicyMapping map[string]ExistingPolicy
+}
+
+func NewResourceTracker(ingressName string, client *gophercloud.ServiceClient, lbID string, listenerID string, newPools []IngPool, newPolicies []IngPolicy, oldPools []pools.Pool, oldPolicies []ExistingPolicy) *ResourceTracker {
+	newPoolNames := sets.NewString()
+	oldPoolMapping := make(map[string]string)
+	for _, pool := range newPools {
+		newPoolNames.Insert(pool.Name)
+	}
+	for _, pool := range oldPools {
+		oldPoolMapping[pool.Name] = pool.ID
+	}
+
+	oldPolicyMapping := make(map[string]ExistingPolicy)
+	for _, policy := range oldPolicies {
+		ruleIden := sets.NewString()
+		for _, rule := range policy.Rules {
+			ruleIden.Insert(rule.RuleType, rule.CompareType, rule.Value)
+		}
+		rulesKey := utils.Hash(strings.Join(ruleIden.List(), ","))
+		oldPolicyMapping[rulesKey] = policy
+	}
+
+	logger := log.WithFields(log.Fields{"ingress": ingressName, "lbID": lbID})
+
+	var oldPoolIDs []string
+	for _, poolID := range oldPoolMapping {
+		oldPoolIDs = append(oldPoolIDs, poolID)
+	}
+	logger.Debugf("Existing pools: %v", oldPoolIDs)
+
+	oldPoliciesTmp := make(map[string]string)
+	for key, policy := range oldPolicyMapping {
+		oldPoliciesTmp[key] = policy.Policy.RedirectPoolID
+	}
+	logger.Debugf("Existing l7 policies: %v", oldPoliciesTmp)
+
+	rt := &ResourceTracker{
+		client:               client,
+		logger:               logger,
+		lbID:                 lbID,
+		listenerID:           listenerID,
+		newPoolNames:         newPoolNames,
+		newPools:             newPools,
+		newPolicies:          newPolicies,
+		newPolicyRuleMapping: make(map[string]string),
+		oldPools:             oldPools,
+		oldPoolMapping:       oldPoolMapping,
+		oldPolicyMapping:     oldPolicyMapping,
+	}
+
+	return rt
+}
+
+// createResources only creates resources when necessary.
+func (rt *ResourceTracker) CreateResources() error {
+	poolMapping := make(map[string]string)
+	for _, pool := range rt.newPools {
+		// Different ingress paths may configure the same service, but we only need to create one pool.
+		if _, isPresent := poolMapping[pool.Name]; isPresent {
+			continue
+		}
+
+		poolID, isPresent := rt.oldPoolMapping[pool.Name]
+		if !isPresent {
+			rt.logger.WithFields(log.Fields{"poolName": pool.Name}).Info("creating pool")
+			newPool, err := openstackutil.CreatePool(rt.client, pool.Opts, rt.lbID)
+			if err != nil {
+				return fmt.Errorf("failed to create pool %s, error: %v", pool.Name, err)
+			}
+
+			poolID = newPool.ID
+			rt.logger.WithFields(log.Fields{"poolName": pool.Name, "poolID": poolID}).Info("pool created")
+		}
+
+		poolMapping[pool.Name] = poolID
+
+		rt.logger.WithFields(log.Fields{"poolName": pool.Name, "poolID": poolID}).Info("updating pool members")
+		if err := openstackutil.BatchUpdatePoolMembers(rt.client, rt.lbID, poolID, pool.PoolMembers); err != nil {
+			return fmt.Errorf("failed to update pool members, error: %v", err)
+		}
+		rt.logger.WithFields(log.Fields{"poolName": pool.Name, "poolID": poolID}).Info("pool members updated ")
+	}
+
+	var curPoolIDs []string
+	for _, id := range poolMapping {
+		curPoolIDs = append(curPoolIDs, id)
+	}
+	rt.logger.Debugf("Current pools: %v", curPoolIDs)
+
+	for _, policy := range rt.newPolicies {
+		newRuleIden := sets.NewString()
+		for _, opt := range policy.RulesOpts {
+			newRuleIden.Insert(string(opt.RuleType), string(opt.CompareType), opt.Value)
+		}
+		rulesKey := utils.Hash(strings.Join(newRuleIden.List(), ","))
+
+		poolID := poolMapping[policy.RedirectPoolName]
+
+		oldPolicy, isPresent := rt.oldPolicyMapping[rulesKey]
+		if !isPresent || oldPolicy.Policy.RedirectPoolID != poolID {
+			// Create new policy with rules
+			rt.logger.WithFields(log.Fields{"listenerID": rt.listenerID, "poolID": poolID}).Info("creating l7 policy")
+			policy.Opts.RedirectPoolID = poolID
+			newPolicy, err := openstackutil.CreateL7Policy(rt.client, policy.Opts, rt.lbID)
+			if err != nil {
+				return fmt.Errorf("failed to create l7policy, error: %v", err)
+			}
+			rt.logger.WithFields(log.Fields{"listenerID": rt.listenerID, "poolID": poolID}).Info("l7 policy created")
+
+			rt.logger.WithFields(log.Fields{"listenerID": rt.listenerID, "policyID": newPolicy.ID}).Info("creating l7 rules")
+			for _, opt := range policy.RulesOpts {
+				if err := openstackutil.CreateL7Rule(rt.client, newPolicy.ID, opt, rt.lbID); err != nil {
+					return fmt.Errorf("failed to create l7 rules for policy %s, error: %v", newPolicy.ID, err)
+				}
+			}
+			rt.logger.WithFields(log.Fields{"listenerID": rt.listenerID, "policyID": newPolicy.ID}).Info("l7 rules created")
+		}
+
+		rt.newPolicyRuleMapping[rulesKey] = poolID
+	}
+
+	rt.logger.Debugf("Current l7 policies: %v", rt.newPolicyRuleMapping)
+
+	return nil
+}
+
+func (rt *ResourceTracker) CleanupResources() error {
+	for key, oldPolicy := range rt.oldPolicyMapping {
+		poolID, isPresent := rt.newPolicyRuleMapping[key]
+		if !isPresent || poolID != oldPolicy.Policy.RedirectPoolID {
+			// Delete invalid policy
+			rt.logger.WithFields(log.Fields{"policyID": oldPolicy.Policy.ID}).Info("deleting policy")
+			if err := openstackutil.DeleteL7policy(rt.client, oldPolicy.Policy.ID, rt.lbID); err != nil {
+				return fmt.Errorf("failed to delete l7 policy %s, error: %v", oldPolicy.Policy.ID, err)
+			}
+			rt.logger.WithFields(log.Fields{"policyID": oldPolicy.Policy.ID}).Info("policy deleted")
+		}
+	}
+
+	for _, pool := range rt.oldPools {
+		if !rt.newPoolNames.Has(pool.Name) {
+			// Delete unused pool
+			rt.logger.WithFields(log.Fields{"poolID": pool.ID}).Info("deleting pool")
+			if err := openstackutil.DeletePool(rt.client, pool.ID, rt.lbID); err != nil {
+				return fmt.Errorf("failed to delete pool %s, error: %v", pool.ID, err)
+			}
+			rt.logger.WithFields(log.Fields{"poolID": pool.ID}).Info("pool deleted")
+		}
+	}
+
+	return nil
 }
 
 func (os *OpenStack) waitLoadbalancerActiveProvisioningStatus(loadbalancerID string) (string, error) {
@@ -89,105 +280,10 @@ func (os *OpenStack) waitLoadbalancerActiveProvisioningStatus(loadbalancerID str
 	return provisioningStatus, err
 }
 
-// GetPools retrives the pools belong to the loadbalancer. If shared is true, only return the shared pools.
-func (os *OpenStack) GetPools(lbID string, shared bool) ([]pools.Pool, error) {
-	var lbPools []pools.Pool
-
-	opts := pools.ListOpts{
-		LoadbalancerID: lbID,
-	}
-	err := pools.List(os.Octavia, opts).EachPage(func(page pagination.Page) (bool, error) {
-		v, err := pools.ExtractPools(page)
-		if err != nil {
-			return false, err
-		}
-		for _, p := range v {
-			if shared && len(p.Listeners) != 0 {
-				continue
-			}
-			lbPools = append(lbPools, p)
-		}
-
-		return true, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return lbPools, nil
-}
-
-// GetMembers retrieve all the members of the specified pool
-func (os *OpenStack) GetMembers(poolID string) ([]pools.Member, error) {
-	var members []pools.Member
-
-	opts := pools.ListMembersOpts{}
-	err := pools.ListMembers(os.Octavia, poolID, opts).EachPage(func(page pagination.Page) (bool, error) {
-		v, err := pools.ExtractMembers(page)
-		if err != nil {
-			return false, err
-		}
-		members = append(members, v...)
-		return true, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return members, nil
-}
-
-// DeletePool deletes a pool
-func (os *OpenStack) DeletePool(poolID string, lbID string) error {
-	if err := pools.Delete(os.Octavia, poolID).ExtractErr(); err != nil {
-		return fmt.Errorf("failed to delete pool %s: %v", poolID, err)
-	}
-
-	_, err := os.waitLoadbalancerActiveProvisioningStatus(lbID)
-	if err != nil {
-		return fmt.Errorf("failed to wait for loadbalancer to be active: %v", err)
-	}
-
-	return nil
-}
-
-// GetL7policies retrieves all l7 policies for the given listener.
-func (os *OpenStack) GetL7policies(listenerID string) ([]l7policies.L7Policy, error) {
-	var policies []l7policies.L7Policy
-	opts := l7policies.ListOpts{
-		ListenerID: listenerID,
-	}
-	err := l7policies.List(os.Octavia, opts).EachPage(func(page pagination.Page) (bool, error) {
-		v, err := l7policies.ExtractL7Policies(page)
-		if err != nil {
-			return false, err
-		}
-		policies = append(policies, v...)
-		return true, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return policies, nil
-}
-
-// DeleteL7policy deletes a l7 policy
-func (os *OpenStack) DeleteL7policy(policyID string, lbID string) error {
-	if err := l7policies.Delete(os.Octavia, policyID).ExtractErr(); err != nil {
-		return fmt.Errorf("failed to delete l7 policy: %v", err)
-	}
-
-	_, err := os.waitLoadbalancerActiveProvisioningStatus(lbID)
-	if err != nil {
-		return fmt.Errorf("failed to wait for loadbalancer to be active: %v", err)
-	}
-
-	return nil
-}
-
 // EnsureLoadBalancer creates a loadbalancer in octavia if it does not exist, wait for the loadbalancer to be ACTIVE.
 func (os *OpenStack) EnsureLoadBalancer(name string, subnetID string, ingNamespace string, ingName string, clusterName string) (*loadbalancers.LoadBalancer, error) {
+	logger := log.WithFields(log.Fields{"ingress": fmt.Sprintf("%s/%s", ingNamespace, ingName)})
+
 	loadbalancer, err := openstackutil.GetLoadbalancerByName(os.Octavia, name)
 	if err != nil {
 		if err != openstackutil.ErrNotFound {
@@ -212,14 +308,14 @@ func (os *OpenStack) EnsureLoadBalancer(name string, subnetID string, ingNamespa
 			return nil, fmt.Errorf("error creating loadbalancer %v: %v", createOpts, err)
 		}
 
-		log.WithFields(log.Fields{"name": name, "ID": loadbalancer.ID}).Info("creating loadbalancer")
+		logger.WithFields(log.Fields{"lbName": name, "lbID": loadbalancer.ID}).Info("creating loadbalancer")
 	} else {
-		log.WithFields(log.Fields{"name": name}).Debug("loadbalancer exists")
+		logger.WithFields(log.Fields{"lbName": name, "lbID": loadbalancer.ID}).Debug("loadbalancer exists")
 	}
 
 	_, err = os.waitLoadbalancerActiveProvisioningStatus(loadbalancer.ID)
 	if err != nil {
-		return nil, fmt.Errorf("error creating loadbalancer: %v", err)
+		return nil, fmt.Errorf("loadbalancer %s not in ACTIVE status, error: %v", loadbalancer.ID, err)
 	}
 
 	return loadbalancer, nil
@@ -234,7 +330,7 @@ func (os *OpenStack) UpdateLoadBalancerDescription(lbID string, newDescription s
 		return fmt.Errorf("failed to update loadbalancer description: %v", err)
 	}
 
-	log.WithFields(log.Fields{"lb": lbID}).Debug("loadbalancer description updated")
+	log.WithFields(log.Fields{"lbID": lbID}).Debug("loadbalancer description updated")
 	return nil
 }
 
@@ -246,7 +342,7 @@ func (os *OpenStack) EnsureListener(name string, lbID string, secretRefs []strin
 			return nil, fmt.Errorf("error getting listener %s: %v", name, err)
 		}
 
-		log.WithFields(log.Fields{"lb": lbID, "listenerName": name}).Debug("creating listener")
+		log.WithFields(log.Fields{"lbID": lbID, "listenerName": name}).Info("creating listener")
 
 		opts := listeners.CreateOpts{
 			Name:           name,
@@ -265,12 +361,12 @@ func (os *OpenStack) EnsureListener(name string, lbID string, secretRefs []strin
 			return nil, fmt.Errorf("error creating listener: %v", err)
 		}
 
-		log.WithFields(log.Fields{"lb": lbID, "listenerName": name}).Info("listener created")
+		log.WithFields(log.Fields{"lbID": lbID, "listenerName": name}).Info("listener created")
 	}
 
 	_, err = os.waitLoadbalancerActiveProvisioningStatus(lbID)
 	if err != nil {
-		return nil, fmt.Errorf("error creating listener: %v", err)
+		return nil, fmt.Errorf("loadbalancer %s not in ACTIVE status after creating listener, error: %v", lbID, err)
 	}
 
 	return listener, nil
@@ -278,6 +374,8 @@ func (os *OpenStack) EnsureListener(name string, lbID string, secretRefs []strin
 
 // EnsurePoolMembers ensure the pool and its members exist if deleted flag is not set, delete the pool and all its members otherwise.
 func (os *OpenStack) EnsurePoolMembers(deleted bool, poolName string, lbID string, listenerID string, nodePort *int, nodes []*apiv1.Node) (*string, error) {
+	logger := log.WithFields(log.Fields{"lbID": lbID, "listenerID": listenerID, "poolName": poolName})
+
 	if deleted {
 		pool, err := openstackutil.GetPoolByName(os.Octavia, poolName, lbID)
 		if err != nil {
@@ -307,7 +405,7 @@ func (os *OpenStack) EnsurePoolMembers(deleted bool, poolName string, lbID strin
 			return nil, fmt.Errorf("error getting pool %s: %v", poolName, err)
 		}
 
-		log.WithFields(log.Fields{"lb": lbID, "listenerID": listenerID, "poolName": poolName}).Debug("creating pool")
+		logger.Info("creating pool")
 
 		// Create new pool
 		var opts pools.CreateOptsBuilder
@@ -333,7 +431,7 @@ func (os *OpenStack) EnsurePoolMembers(deleted bool, poolName string, lbID strin
 			return nil, fmt.Errorf("error creating pool: %v", err)
 		}
 
-		log.WithFields(log.Fields{"lb": lbID, "listenerID": listenerID, "poolName": poolName, "pooID": pool.ID}).Info("pool created")
+		logger.Info("pool created")
 
 	}
 
@@ -348,7 +446,7 @@ func (os *OpenStack) EnsurePoolMembers(deleted bool, poolName string, lbID strin
 		addr, err := getNodeAddressForLB(node)
 		if err != nil {
 			// Node failure, do not create member
-			log.WithFields(log.Fields{"node": node.Name, "poolName": poolName, "pooID": pool.ID, "error": err}).Warn("failed to create LB pool member for node")
+			logger.WithFields(log.Fields{"nodeName": node.Name, "error": err}).Warn("failed to create LB pool member for node")
 			continue
 		}
 
@@ -371,80 +469,14 @@ func (os *OpenStack) EnsurePoolMembers(deleted bool, poolName string, lbID strin
 		return nil, fmt.Errorf("error waiting for loadbalancer %s to be active: %v", lbID, err)
 	}
 
-	log.WithFields(log.Fields{"lb": lbID, "listenerID": listenerID, "poolName": poolName, "pooID": pool.ID}).Info("pool members updated")
+	logger.Info("pool members updated")
 
 	return &pool.ID, nil
 }
 
-// CreatePolicyRules creates l7 policy and its rules for the listener
-func (os *OpenStack) CreatePolicyRules(lbID, listenerID, poolID, host, path string, port int) error {
-	log.WithFields(log.Fields{"lb": lbID, "listenerID": listenerID}).Debug("creating policy")
-
-	policy, err := l7policies.Create(os.Octavia, l7policies.CreateOpts{
-		ListenerID:     listenerID,
-		Action:         l7policies.ActionRedirectToPool,
-		Description:    "Created by kubernetes ingress",
-		RedirectPoolID: poolID,
-	}).Extract()
-	if err != nil {
-		return fmt.Errorf("error creating l7policy: %v", err)
-	}
-
-	_, err = os.waitLoadbalancerActiveProvisioningStatus(lbID)
-	if err != nil {
-		return fmt.Errorf("error waiting for loadbalancer %s to be active: %v", lbID, err)
-	}
-
-	log.WithFields(log.Fields{"lb": lbID, "listenerID": listenerID, "policyID": policy.ID}).Info("policy created")
-
-	if host != "" {
-		log.WithFields(log.Fields{"type": l7policies.TypeHostName, "host": host, "policyID": policy.ID, "listenerID": listenerID}).Debug("creating policy rule")
-
-		// Create HOST_NAME type rule. Use REGEX type rule to support both host and host:port
-		_, err = l7policies.CreateRule(os.Octavia, policy.ID, l7policies.CreateRuleOpts{
-			RuleType:    l7policies.TypeHostName,
-			CompareType: l7policies.CompareTypeRegex,
-			Value:       fmt.Sprintf("^%s(:%d)?$", strings.ReplaceAll(host, ".", "\\."), port),
-		}).Extract()
-		if err != nil {
-			return fmt.Errorf("error creating l7 rule: %v", err)
-		}
-
-		_, err = os.waitLoadbalancerActiveProvisioningStatus(lbID)
-		if err != nil {
-			return fmt.Errorf("error waiting for loadbalancer %s to be active: %v", lbID, err)
-		}
-
-		log.WithFields(log.Fields{"type": l7policies.TypeHostName, "host": host, "policyID": policy.ID, "listenerID": listenerID}).Info("policy rule created")
-	}
-
-	if path != "" {
-		log.WithFields(log.Fields{"type": l7policies.TypePath, "path": path, "policyID": policy.ID, "listenerID": listenerID}).Debug("creating policy rule")
-
-		// Create PATH type rule
-		_, err = l7policies.CreateRule(os.Octavia, policy.ID, l7policies.CreateRuleOpts{
-			RuleType:    l7policies.TypePath,
-			CompareType: l7policies.CompareTypeStartWith,
-			Value:       path,
-		}).Extract()
-		if err != nil {
-			return fmt.Errorf("error creating l7 rule: %v", err)
-		}
-
-		_, err = os.waitLoadbalancerActiveProvisioningStatus(lbID)
-		if err != nil {
-			return fmt.Errorf("error waiting for loadbalancer %s to be active: %v", lbID, err)
-		}
-
-		log.WithFields(log.Fields{"type": l7policies.TypePath, "path": path, "policyID": policy.ID, "listenerID": listenerID}).Info("policy rule created")
-	}
-
-	return nil
-}
-
 // UpdateLoadbalancerMembers update members for all the pools in the specified load balancer.
 func (os *OpenStack) UpdateLoadbalancerMembers(lbID string, nodes []*apiv1.Node) error {
-	lbPools, err := os.GetPools(lbID, false)
+	lbPools, err := openstackutil.GetPools(os.Octavia, lbID)
 	if err != nil {
 		return err
 	}
@@ -452,7 +484,7 @@ func (os *OpenStack) UpdateLoadbalancerMembers(lbID string, nodes []*apiv1.Node)
 	for _, pool := range lbPools {
 		log.WithFields(log.Fields{"poolID": pool.ID}).Debug("Starting to update pool members")
 
-		members, err := os.GetMembers(pool.ID)
+		members, err := openstackutil.GetMembersbyPool(os.Octavia, pool.ID)
 		if err != nil {
 			log.WithFields(log.Fields{"poolID": pool.ID}).Errorf("Failed to get pool members: %v", err)
 			continue

--- a/tests/e2e/cloudprovider/test-lb-service.sh
+++ b/tests/e2e/cloudprovider/test-lb-service.sh
@@ -326,7 +326,7 @@ EOF
     printf "\n>>>>>>> Expected: NodePorts ${member_ports} before updating service.\n"
 
     printf "\n>>>>>>> Removing port2 and update NodePort of port1.\n"
-    kubectl patch svc $service --type json -p '[{"op": "remove","path": "/spec/ports/1"},{"op": "remove","path": "/spec/ports/0/nodePort"}]'
+    kubectl -n $NAMESPACE patch svc $service --type json -p '[{"op": "remove","path": "/spec/ports/1"},{"op": "remove","path": "/spec/ports/0/nodePort"}]'
 
     printf "\n>>>>>>> Waiting for load balancer $lbid ACTIVE.\n"
     wait_for_loadbalancer $lbid


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry picked from https://github.com/kubernetes/cloud-provider-openstack/pull/1418

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
```release-note
[octavia-ingress-controller] Fixed the issue that pools and l7 policies are removed no matter how the Ingress is changed.
```
