### PR TITLE
[octavia-ingress-controller] Set log formatter

### DIFF
--- a/pkg/ingress/cmd/root.go
+++ b/pkg/ingress/cmd/root.go
@@ -67,6 +67,12 @@ func Execute() {
 
 func init() {
 	log.SetOutput(os.Stdout)
+	log.SetFormatter(&log.TextFormatter{
+		ForceColors:            true,
+		FullTimestamp:          true,
+		DisableLevelTruncation: true,
+		PadLevelText:           true,
+	})
 
 	cobra.OnInitialize(initConfig)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve the log format for octavia-ingress-controller, with this formatter in place, the logs is like below:

```
$ ksys logs -f octavia-ingress-controller-0
W0305 02:18:01.332625       1 client_config.go:608] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
INFO   [2021-03-05T02:18:01Z] Using config file                             file=/etc/config/octavia-ingress-controller-config.yaml
DEBUG  [2021-03-05T02:18:01Z] creating kubernetes API client
DEBUG  [2021-03-05T02:18:01Z] kubernetes API client created                 version=v1.20
WARNING[2021-03-05T02:18:01Z] Barbican not suppported.
DEBUG  [2021-03-05T02:18:01Z] openstack client initialized
DEBUG  [2021-03-05T02:18:01Z] starting Ingress controller
I0305 02:18:01.679843       1 event.go:282] Event(v1.ObjectReference{Kind:"Ingress", Namespace:"default", Name:"test-v1beta1", UID:"1701dc74-c100-4d2b-95f4-7e74e27632db", APIVersion:"networking.k8s.io/v1beta1", ResourceVersion:"8515001", FieldPath:""}): type: 'Normal' reason: 'Creating' Ingress default/test-v1beta1
I0305 02:18:01.680037       1 event.go:282] Event(v1.ObjectReference{Kind:"Ingress", Namespace:"default", Name:"test-octavia-ingress", UID:"473b80cb-4254-415d-8b74-b04d1a03d361", APIVersion:"networking.k8s.io/v1beta1", ResourceVersion:"8515371", FieldPath:""}): type: 'Normal' reason: 'Creating' Ingress default/test-octavia-ingress
INFO   [2021-03-05T02:18:01Z] ingress controller synced and ready
INFO   [2021-03-05T02:18:02Z] creating ingress                              ingress=default/test-octavia-ingress
DEBUG  [2021-03-05T02:18:02Z] loadbalancer exists                           ingress=default/test-octavia-ingress lbID=fc56259b-f1c6-4946-affb-f3e0126c170a lbName=kube_ingress_lingxian-hlz-k8s_default_test-octavia-ingress
INFO   [2021-03-05T02:18:03Z] ingress not changed                           ingress=default/test-octavia-ingress lbID=fc56259b-f1c6-4946-affb-f3e0126c170a
INFO   [2021-03-05T02:18:03Z] creating ingress                              ingress=default/test-v1beta1
I0305 02:18:03.075997       1 event.go:282] Event(v1.ObjectReference{Kind:"Ingress", Namespace:"default", Name:"test-octavia-ingress", UID:"473b80cb-4254-415d-8b74-b04d1a03d361", APIVersion:"networking.k8s.io/v1beta1", ResourceVersion:"8515371", FieldPath:""}): type: 'Normal' reason: 'Created' Ingress default/test-octavia-ingress
DEBUG  [2021-03-05T02:18:03Z] loadbalancer exists                           ingress=default/test-v1beta1 lbID=a983841c-8f79-4ac3-bda2-899ed93f36eb lbName=kube_ingress_lingxian-hlz-k8s_default_test-v1beta1
INFO   [2021-03-05T02:18:03Z] ingress not changed                           ingress=default/test-v1beta1 lbID=a983841c-8f79-4ac3-bda2-899ed93f36eb
I0305 02:18:03.402649       1 event.go:282] Event(v1.ObjectReference{Kind:"Ingress", Namespace:"default", Name:"test-v1beta1", UID:"1701dc74-c100-4d2b-95f4-7e74e27632db", APIVersion:"networking.k8s.io/v1beta1", ResourceVersion:"8515001", FieldPath:""}): type: 'Normal' reason: 'Created' Ingress default/test-v1beta1
```

compared with before:

```
$ ksys logs -f octavia-ingress-controller-0
time="2021-03-05T02:03:11Z" level=info msg="Using config file" file=/etc/config/octavia-ingress-controller-config.yaml
W0305 02:03:11.159717       1 client_config.go:608] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
time="2021-03-05T02:03:11Z" level=debug msg="creating kubernetes API client"
time="2021-03-05T02:03:11Z" level=debug msg="kubernetes API client created" version=v1.20
time="2021-03-05T02:03:11Z" level=warning msg="Barbican not suppported."
time="2021-03-05T02:03:11Z" level=debug msg="openstack client initialized"
time="2021-03-05T02:03:11Z" level=debug msg="starting Ingress controller"
W0305 02:03:11.428079       1 warnings.go:67] networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
I0305 02:03:11.428527       1 event.go:282] Event(v1.ObjectReference{Kind:"Ingress", Namespace:"default", Name:"test-octavia-ingress", UID:"99d3f57e-3db0-4f89-8b44-98fc2a613e3f", APIVersion:"networking.k8s.io/v1beta1
", ResourceVersion:"7657640", FieldPath:""}): type: 'Normal' reason: 'Creating' Ingress default/test-octavia-ingress
I0305 02:03:11.428590       1 event.go:282] Event(v1.ObjectReference{Kind:"Ingress", Namespace:"default", Name:"test-v1beta1", UID:"017bc8ca-fbea-4b7c-aa69-d3d6d1c731da", APIVersion:"networking.k8s.io/v1beta1", Resou
rceVersion:"8497054", FieldPath:""}): type: 'Normal' reason: 'Creating' Ingress default/test-v1beta1
W0305 02:03:11.430518       1 warnings.go:67] networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
time="2021-03-05T02:03:11Z" level=info msg="ingress controller synced and ready"
time="2021-03-05T02:03:11Z" level=info msg="creating ingress" ingress=default/test-octavia-ingress
time="2021-03-05T02:03:12Z" level=debug msg="loadbalancer exists" ingress=default/test-octavia-ingress lbID=f80597bd-593a-41c5-a414-e20264d5d8dd lbName=kube_ingress_lingxian-hlz-k8s_default_test-octavia-ingress
time="2021-03-05T02:03:13Z" level=info msg="ingress not changed" ingress=default/test-octavia-ingress lbID=f80597bd-593a-41c5-a414-e20264d5d8dd
time="2021-03-05T02:03:13Z" level=info msg="creating ingress" ingress=default/test-v1beta1
```

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
