### PR TITLE
[cinder-csi-plugin] Ephemeral volumes: wait for volume status to be available

### DIFF
--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -133,6 +133,7 @@ func TestNodePublishVolumeEphermeral(t *testing.T) {
 
 	omock.On("AttachVolume", FakeNodeID, FakeVolID).Return(FakeVolID, nil)
 	omock.On("WaitDiskAttached", FakeNodeID, FakeVolID).Return(nil)
+	omock.On("WaitVolumeStatusAvailable", FakeVolID).Return(nil)
 	mmock.On("GetDevicePath", FakeVolID).Return(FakeDevicePath, nil)
 	mmock.On("IsLikelyNotMountPointAttach", FakeTargetPath).Return(true, nil)
 	metamock.On("GetAvailabilityZone").Return(FakeAvailability, nil)

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -49,6 +49,7 @@ type IOpenStack interface {
 	WaitDiskAttached(instanceID string, volumeID string) error
 	DetachVolume(instanceID, volumeID string) error
 	WaitDiskDetached(instanceID string, volumeID string) error
+	WaitVolumeStatusAvailable(volumeID string) error
 	GetAttachmentDiskPath(instanceID, volumeID string) (string, error)
 	GetVolume(volumeID string) (*volumes.Volume, error)
 	GetVolumesByName(name string) ([]volumes.Volume, error)

--- a/pkg/csi/cinder/openstack/openstack_mock.go
+++ b/pkg/csi/cinder/openstack/openstack_mock.go
@@ -170,6 +170,20 @@ func (_m *OpenStackMock) WaitDiskAttached(instanceID string, volumeID string) er
 	return r0
 }
 
+// WaitVolumeStatusAvailable provides a mock function with given fields: volumeID
+func (_m *OpenStackMock) WaitVolumeStatusAvailable(volumeID string) error {
+	ret := _m.Called(volumeID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(volumeID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // WaitDiskDetached provides a mock function with given fields: instanceID, volumeID
 func (_m *OpenStackMock) WaitDiskDetached(instanceID string, volumeID string) error {
 	ret := _m.Called(instanceID, volumeID)

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -38,6 +38,7 @@ const (
 	VolumeInUseStatus        = "in-use"
 	VolumeDeletedStatus      = "deleted"
 	VolumeErrorStatus        = "error"
+	VolumeCreatingStatus     = "creating"
 	operationFinishInitDelay = 1 * time.Second
 	operationFinishFactor    = 1.1
 	operationFinishSteps     = 10
@@ -220,6 +221,35 @@ func (os *OpenStack) WaitDiskAttached(instanceID string, volumeID string) error 
 	}
 
 	return err
+}
+
+//WaitVolumeStatusAvailable waits for volume to be "Available" from "Creating".
+func (os *OpenStack) WaitVolumeStatusAvailable(volumeID string) error {
+	backoff := wait.Backoff{
+		Duration: operationFinishInitDelay,
+		Factor:   operationFinishFactor,
+		Steps:    operationFinishSteps,
+	}
+
+	waitErr := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		vol, err := os.GetVolume(volumeID)
+		if err != nil {
+			return false, err
+		}
+		if vol.Status == VolumeAvailableStatus {
+			return true, nil
+		}
+		if vol.Status != VolumeCreatingStatus {
+			return false, fmt.Errorf("Volume Status is %s", vol.Status)
+		}
+		return false, nil
+	})
+
+	if waitErr == wait.ErrWaitTimeout {
+		waitErr = fmt.Errorf("Timeout on waiting for volume %s status to be 'Available'", volumeID)
+	}
+
+	return waitErr
 }
 
 // DetachVolume detaches given cinder volume from the compute

--- a/tests/sanity/cinder/fakecloud.go
+++ b/tests/sanity/cinder/fakecloud.go
@@ -54,7 +54,6 @@ func (cloud *cloud) DeleteVolume(volumeID string) error {
 	delete(cloud.volumes, volumeID)
 
 	return nil
-
 }
 
 func (cloud *cloud) CheckBlockStorageAPI() error {
@@ -102,27 +101,26 @@ func (cloud *cloud) ListVolumes(limit int, marker string) ([]volumes.Volume, str
 
 	}
 	return vollist, retToken, nil
-
 }
 
 func (cloud *cloud) WaitDiskAttached(instanceID string, volumeID string) error {
 	return nil
-
 }
 
 func (cloud *cloud) DetachVolume(instanceID, volumeID string) error {
 	return nil
-
 }
 
 func (cloud *cloud) WaitDiskDetached(instanceID string, volumeID string) error {
 	return nil
+}
 
+func (cloud *cloud) WaitVolumeStatusAvailable(volumeID string) error {
+	return nil
 }
 
 func (cloud *cloud) GetAttachmentDiskPath(instanceID, volumeID string) (string, error) {
 	return cinder.FakeDevicePath, nil
-
 }
 
 func (cloud *cloud) GetVolumesByName(name string) ([]volumes.Volume, error) {
@@ -135,7 +133,6 @@ func (cloud *cloud) GetVolumesByName(name string) ([]volumes.Volume, error) {
 	}
 
 	return vlist, nil
-
 }
 
 func (cloud *cloud) GetVolume(volumeID string) (*volumes.Volume, error) {
@@ -214,7 +211,6 @@ func (cloud *cloud) DeleteSnapshot(snapID string) error {
 	delete(cloud.snapshots, snapID)
 
 	return nil
-
 }
 
 func (cloud *cloud) GetSnapshotByID(snapshotID string) (*snapshots.Snapshot, error) {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
**Which issue this PR fixes(if applicable)**:
fixes #1403 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[cinder-csi-plugin] Fixed the issue that the ephemeral inline volume is yet available when attaching to the node.
```
