### PR TITLE
[cinder-csi-plugin] Enabled Topology Support by default

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 1.3.3
+version: 1.3.4
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -45,6 +45,7 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--timeout={{ .Values.timeout }}"
             - "--default-fstype=ext4"
+            - "--feature-gates=Topology={{ .Values.csi.provisioner.topology }}"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -9,9 +9,10 @@ csi:
       tag: v3.1.0
       pullPolicy: IfNotPresent
   provisioner:
+    topology: "true"
     image:
       repository: k8s.gcr.io/sig-storage/csi-provisioner
-      tag: v2.1.0
+      tag: v2.1.1
       pullPolicy: IfNotPresent
   snapshotter:
     image:

--- a/docs/cinder-csi-plugin/features.md
+++ b/docs/cinder-csi-plugin/features.md
@@ -28,10 +28,11 @@ For usage, refer [sample app](./examples.md#dynamic-volume-provisioning)
 
 This feature enables driver to consider the topology constraints while creating the volume. For more info, refer [Topology Support](https://github.com/kubernetes-csi/external-provisioner/blob/master/README.md#topology-support)
 
+* Enabled by default
 * Supported topology keys:
   `topology.cinder.csi.openstack.org/zone` : Availability by Zone
-* `--feature-gates=Topology=true` needs to be enabled in external-provisioner.
 * `allowedTopologies` can be specified in storage class to restrict the topology of provisioned volumes to specific zones and should be used as replacement of `availability` parameter.
+* To disable: set `--feature-gates=Topology=false` in external-provisioner (container `csi-provisioner` of `csi-cinder-controllerplugin`).
 
 ## Block Volume
 

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -48,11 +48,12 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
             - "--default-fstype=ext4"
+            - "--feature-gates=Topology=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/tests/e2e/csi/cinder/cinder-testdriver.go
+++ b/tests/e2e/csi/cinder/cinder-testdriver.go
@@ -51,6 +51,10 @@ func initCinderDriver(name string, manifests ...string) testsuites.TestDriver {
 				testsuites.CapBlock:              true,
 				testsuites.CapSnapshotDataSource: true,
 				testsuites.CapPVCDataSource:      true,
+				testsuites.CapTopology:           true,
+			},
+			TopologyKeys: []string{
+				"topology.cinder.csi.openstack.org/zone",
 			},
 		},
 		manifests: manifests,
@@ -58,22 +62,21 @@ func initCinderDriver(name string, manifests ...string) testsuites.TestDriver {
 }
 
 func InitCinderDriver() testsuites.TestDriver {
-
 	return initCinderDriver("cinder.csi.openstack.org",
 		"cinder-csi-controllerplugin.yaml",
 		"cinder-csi-controllerplugin-rbac.yaml",
 		"cinder-csi-nodeplugin.yaml",
 		"cinder-csi-nodeplugin-rbac.yaml",
 		"csi-secret-cinderplugin.yaml")
-
 }
-
-var _ testsuites.TestDriver = &cinderDriver{}
 
 // var _ testsuites.PreprovisionedVolumeTestDriver = &cinderDriver{}
 // var _ testsuites.PreprovisionedPVTestDriver = &cinderDriver{}
-var _ testsuites.DynamicPVTestDriver = &cinderDriver{}
-var _ testsuites.SnapshottableTestDriver = &cinderDriver{}
+var (
+	_ testsuites.DynamicPVTestDriver     = &cinderDriver{}
+	_ testsuites.SnapshottableTestDriver = &cinderDriver{}
+	_ testsuites.TestDriver              = &cinderDriver{}
+)
 
 func (d *cinderDriver) GetDriverInfo() *testsuites.DriverInfo {
 	return &d.driverInfo

--- a/tests/e2e/csi/cinder/cinder-testdriver.go
+++ b/tests/e2e/csi/cinder/cinder-testdriver.go
@@ -70,9 +70,9 @@ func InitCinderDriver() testsuites.TestDriver {
 		"csi-secret-cinderplugin.yaml")
 }
 
-// var _ testsuites.PreprovisionedVolumeTestDriver = &cinderDriver{}
-// var _ testsuites.PreprovisionedPVTestDriver = &cinderDriver{}
 var (
+	// _ testsuites.PreprovisionedVolumeTestDriver = &cinderDriver{}
+	// _ testsuites.PreprovisionedPVTestDriver = &cinderDriver{}
 	_ testsuites.DynamicPVTestDriver     = &cinderDriver{}
 	_ testsuites.SnapshottableTestDriver = &cinderDriver{}
 	_ testsuites.TestDriver              = &cinderDriver{}

--- a/tests/e2e/csi/cinder/csi-volumes.go
+++ b/tests/e2e/csi/cinder/csi-volumes.go
@@ -16,9 +16,11 @@ var CSITestSuites = []func() testsuites.TestSuite{
 	testsuites.InitSubPathTestSuite,
 	testsuites.InitProvisioningTestSuite,
 	testsuites.InitVolumeModeTestSuite,
-	//testsuites.InitVolumeIOTestSuite,
 	testsuites.InitSnapshottableTestSuite,
-	//testsuites.InitMultiVolumeTestSuite,
+	testsuites.InitMultiVolumeTestSuite,
+	testsuites.InitFsGroupChangePolicyTestSuite,
+	testsuites.InitTopologyTestSuite,
+	// testsuites.InitVolumeIOTestSuite,
 }
 
 // This executes testSuites for csi volumes.
@@ -29,5 +31,4 @@ var _ = utils.SIGDescribe("[cinder-csi-e2e] CSI Volumes", func() {
 	Context(testsuites.GetDriverNameWithFeatureTags(curDriver), func() {
 		testsuites.DefineTestSuite(curDriver, CSITestSuites)
 	})
-
 })


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

* Enabled Topology by default
* Updated external-provisioner for Topology support of CSIMigration
* Added more testsuites to e2e of cinder csi

**Which issue this PR fixes(if applicable)**:
fixes #1407

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

Topology is GA from perspective of external-provisioner. https://github.com/kubernetes-csi/external-provisioner/issues/569

```release-note
[cinder-csi-plugin] : Enabled Topology by default
```
