### PR TITLE
[cinder-csi-plugin] Enable Snapshot e2e tests

### DIFF
--- a/tests/e2e/csi/cinder/cinder-testdriver.go
+++ b/tests/e2e/csi/cinder/cinder-testdriver.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 
 	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	"k8s.io/kubernetes/test/e2e/storage/testpatterns"
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 )
@@ -38,12 +40,16 @@ func initCinderDriver(name string, manifests ...string) testsuites.TestDriver {
 				"ext4",
 				"xfs",
 			),
+			SupportedSizeRange: e2evolume.SizeRange{
+				Min: "1Gi",
+			},
 			Capabilities: map[testsuites.Capability]bool{
-				testsuites.CapPersistence: true,
-				testsuites.CapFsGroup:     true,
-				testsuites.CapExec:        true,
-				testsuites.CapMultiPODs:   true,
-				testsuites.CapBlock:       true,
+				testsuites.CapPersistence:        true,
+				testsuites.CapFsGroup:            true,
+				testsuites.CapExec:               true,
+				testsuites.CapMultiPODs:          true,
+				testsuites.CapBlock:              true,
+				testsuites.CapSnapshotDataSource: true,
 			},
 		},
 		manifests: manifests,
@@ -66,6 +72,7 @@ var _ testsuites.TestDriver = &cinderDriver{}
 // var _ testsuites.PreprovisionedVolumeTestDriver = &cinderDriver{}
 // var _ testsuites.PreprovisionedPVTestDriver = &cinderDriver{}
 var _ testsuites.DynamicPVTestDriver = &cinderDriver{}
+var _ testsuites.SnapshottableTestDriver = &cinderDriver{}
 
 func (d *cinderDriver) GetDriverInfo() *testsuites.DriverInfo {
 	return &d.driverInfo
@@ -84,6 +91,14 @@ func (d *cinderDriver) GetDynamicProvisionStorageClass(config *testsuites.PerTes
 	suffix := fmt.Sprintf("%s-sc", d.driverInfo.Name)
 
 	return testsuites.GetStorageClass(provisioner, parameters, nil, ns, suffix)
+}
+
+func (d *cinderDriver) GetSnapshotClass(config *testsuites.PerTestConfig) *unstructured.Unstructured {
+	parameters := map[string]string{}
+	snapshotter := d.driverInfo.Name
+	suffix := fmt.Sprintf("%s-vsc", snapshotter)
+	ns := config.Framework.Namespace.Name
+	return testsuites.GetSnapshotClass(snapshotter, parameters, ns, suffix)
 }
 
 func (d *cinderDriver) GetClaimSize() string {

--- a/tests/e2e/csi/cinder/csi-volumes.go
+++ b/tests/e2e/csi/cinder/csi-volumes.go
@@ -17,7 +17,7 @@ var CSITestSuites = []func() testsuites.TestSuite{
 	testsuites.InitProvisioningTestSuite,
 	testsuites.InitVolumeModeTestSuite,
 	//testsuites.InitVolumeIOTestSuite,
-	//testsuites.InitSnapshottableTestSuite,
+	testsuites.InitSnapshottableTestSuite,
 	//testsuites.InitMultiVolumeTestSuite,
 }
 


### PR DESCRIPTION
This commit enables snapshot e2e tests.

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
