### PR TITLE
[cinder-csi-plugin] Fix filesystem resize

### DIFF
--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -525,7 +525,7 @@ func (ns *nodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 	}
 	volumePath := req.GetVolumePath()
 
-	args := []string{"-o", "source", "--noheadings", "--target", volumePath}
+	args := []string{"-o", "source", "--first-only", "--noheadings", "--target", volumePath}
 	output, err := ns.Mount.Mounter().Exec.Command("findmnt", args...).CombinedOutput()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not determine device path: %v", err)


### PR DESCRIPTION
Now we use "findmnt" command to find the device path. Unfortunately, this command may return multiple entries of the same mount, but in fact we need just the first one.  To prevent this issue we add "--first-only" flag to the command.

Fixes #1436 

```release-note
[cinder-csi-plugin] Fixed the issue where the file system size stays the same when expanding the volume.
```
