### PR TITLE
[cinder-csi-plugin] Check volume status after volume expand action

### DIFF
--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -431,15 +431,19 @@ func TestListSnapshots(t *testing.T) {
 
 func TestControllerExpandVolume(t *testing.T) {
 
+	tState := []string{"available", "in-use"}
 	// ExpandVolume(volumeID string, status string, size int)
-	osmock.On("ExpandVolume", FakeVolName, openstack.VolumeAvailableStatus, 5).Return(nil)
+	osmock.On("ExpandVolume", FakeVolID, openstack.VolumeAvailableStatus, 5).Return(nil)
+
+	// WaitVolumeTargetStatus(volumeID string, tState []string) error
+	osmock.On("WaitVolumeTargetStatus", FakeVolID, tState).Return(nil)
 
 	// Init assert
 	assert := assert.New(t)
 
 	// Fake request
 	fakeReq := &csi.ControllerExpandVolumeRequest{
-		VolumeId: FakeVolName,
+		VolumeId: FakeVolID,
 		CapacityRange: &csi.CapacityRange{
 			RequiredBytes: 5 * 1024 * 1024 * 1024,
 		},


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
related-issue: #1437

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
