### PR TITLE
[cinder-csi-plugin] Fix filesystem resize (#1434)

### DIFF
--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -525,7 +525,7 @@ func (ns *nodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 	}
 	volumePath := req.GetVolumePath()
 
-	args := []string{"-o", "source", "--noheadings", "--target", volumePath}
+	args := []string{"-o", "source", "--first-only", "--noheadings", "--target", volumePath}
 	output, err := ns.Mount.Mounter().Exec.Command("findmnt", args...).CombinedOutput()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not determine device path: %v", err)


### PR DESCRIPTION
Now we use "findmnt" command to find the device path. Unfortunately,
this command may return multiple entries of the same mount, but in
fact we need just the first one.

To prevent this issue we add "--first-only" flag to the command.

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
cherry-pick: aa5e9fe41c38291cad2c888b81b9c5c524b1c209
**Which issue this PR fixes(if applicable)**:
fixes #1436 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
