### PR TITLE
[cinder-csi-plugin] Refactor waitForVolumeStatus to be generic

### DIFF
--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -157,7 +157,8 @@ func nodePublishEphermeral(req *csi.NodePublishVolumeRequest, ns *nodeServer) (*
 
 	// Wait for volume status to be Available, before attaching
 	if evol.Status != openstack.VolumeAvailableStatus {
-		err := ns.Cloud.WaitVolumeStatusAvailable(evol.ID)
+		targetStatus := []string{openstack.VolumeAvailableStatus}
+		err := ns.Cloud.WaitVolumeTargetStatus(evol.ID, targetStatus)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, err.Error())
 		}

--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -128,12 +128,13 @@ func TestNodePublishVolumeEphermeral(t *testing.T) {
 
 	properties := map[string]string{"cinder.csi.openstack.org/cluster": FakeCluster}
 	fvolName := fmt.Sprintf("ephemeral-%s", FakeVolID)
+	tState := []string{"available"}
 
 	omock.On("CreateVolume", fvolName, 2, "test", "nova", "", "", &properties).Return(&FakeVol, nil)
 
 	omock.On("AttachVolume", FakeNodeID, FakeVolID).Return(FakeVolID, nil)
 	omock.On("WaitDiskAttached", FakeNodeID, FakeVolID).Return(nil)
-	omock.On("WaitVolumeStatusAvailable", FakeVolID).Return(nil)
+	omock.On("WaitVolumeTargetStatus", FakeVolID, tState).Return(nil)
 	mmock.On("GetDevicePath", FakeVolID).Return(FakeDevicePath, nil)
 	mmock.On("IsLikelyNotMountPointAttach", FakeTargetPath).Return(true, nil)
 	metamock.On("GetAvailabilityZone").Return(FakeAvailability, nil)

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -49,7 +49,7 @@ type IOpenStack interface {
 	WaitDiskAttached(instanceID string, volumeID string) error
 	DetachVolume(instanceID, volumeID string) error
 	WaitDiskDetached(instanceID string, volumeID string) error
-	WaitVolumeStatusAvailable(volumeID string) error
+	WaitVolumeTargetStatus(volumeID string, tStatus []string) error
 	GetAttachmentDiskPath(instanceID, volumeID string) (string, error)
 	GetVolume(volumeID string) (*volumes.Volume, error)
 	GetVolumesByName(name string) ([]volumes.Volume, error)

--- a/pkg/csi/cinder/openstack/openstack_mock.go
+++ b/pkg/csi/cinder/openstack/openstack_mock.go
@@ -170,13 +170,13 @@ func (_m *OpenStackMock) WaitDiskAttached(instanceID string, volumeID string) er
 	return r0
 }
 
-// WaitVolumeStatusAvailable provides a mock function with given fields: volumeID
-func (_m *OpenStackMock) WaitVolumeStatusAvailable(volumeID string) error {
-	ret := _m.Called(volumeID)
+// WaitVolumeTargetStatus provides a mock function with given fields: volumeID, tStatus
+func (_m *OpenStackMock) WaitVolumeTargetStatus(volumeID string, tStatus []string) error {
+	ret := _m.Called(volumeID, tStatus)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(volumeID)
+	if rf, ok := ret.Get(0).(func(string, []string) error); ok {
+		r0 = rf(volumeID, tStatus)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/tests/sanity/cinder/fakecloud.go
+++ b/tests/sanity/cinder/fakecloud.go
@@ -115,7 +115,7 @@ func (cloud *cloud) WaitDiskDetached(instanceID string, volumeID string) error {
 	return nil
 }
 
-func (cloud *cloud) WaitVolumeStatusAvailable(volumeID string) error {
+func (cloud *cloud) WaitVolumeTargetStatus(volumeID string, tStatus []string) error {
 	return nil
 }
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This PR refactors waitForVolumeStatusAvailable to be more generic.
Could be reused in other places as well.
**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
