### PR TITLE
[OCCM] Set Hostname in load balancer status when using PROXY protocol

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -121,7 +121,7 @@
         - cloud-provider-openstack-acceptance-test-e2e-conformance:
             files:
               - cmd/openstack-cloud-controller-manager/.*
-              - pkg/cloudprovider/.*
+              - pkg/openstack/.*
               - pkg/util/.*
               - tests/e2e/cloudprovider/.*
               - go.mod$
@@ -138,7 +138,7 @@
         - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.20:
             files:
               - cmd/openstack-cloud-controller-manager/.*
-              - pkg/cloudprovider/.*
+              - pkg/openstack/.*
               - pkg/util/.*
               - tests/e2e/cloudprovider/.*
               - go.mod$
@@ -155,7 +155,7 @@
         - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.19:
             files:
               - cmd/openstack-cloud-controller-manager/.*
-              - pkg/cloudprovider/.*
+              - pkg/openstack/.*
               - pkg/util/.*
               - tests/e2e/cloudprovider/.*
               - go.mod$
@@ -172,7 +172,7 @@
         - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.18:
             files:
               - cmd/openstack-cloud-controller-manager/.*
-              - pkg/cloudprovider/.*
+              - pkg/openstack/.*
               - pkg/util/.*
               - tests/e2e/cloudprovider/.*
               - go.mod$

--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -16,6 +16,7 @@
   - [Metrics](#metrics)
   - [Limitation](#limitation)
     - [OpenStack availability zone must not contain blank](#openstack-availability-zone-must-not-contain-blank)
+    - [externalTrafficPolicy support](#externaltrafficpolicy-support)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -236,6 +237,12 @@ Although the openstack-cloud-controller-manager was initially implemented with N
   * floating-subnet-tags. The same with `floating-subnet-tags` option above.
   * network-id. The same with `network-id` option above.
   * subnet-id. The same with `subnet-id` option above.
+  
+* `enable-ingress-hostname`
+
+  Used with proxy protocol (set by annotation `loadbalancer.openstack.org/proxy-protocol: "true"`) by adding a dns suffix (nip.io) to the load balancer IP address. Default false.
+
+  This option is currently a workaround for the issue https://github.com/kubernetes/ingress-nginx/issues/3996, should be removed or refactored after the Kubernetes [KEP-1860](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1860-kube-proxy-IP-node-binding) is implemented.
 
 ### Metadata
 
@@ -260,3 +267,9 @@ Refer to [Metrics for openstack-cloud-controller-manager](../metrics.md)
 ### OpenStack availability zone must not contain blank
 
 `topology.kubernetes.io/zone` is used to label node and its value comes from availability zone of the node, according to [label spec](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set) it does not support blank (' ') but OpenStack availability zone supports blank. So your OpenStack availability zone must not contain blank otherwise it will lead to node that belongs to this availability zone register failure, see [#1379](https://github.com/kubernetes/cloud-provider-openstack/issues/1379) for further information.
+
+### externalTrafficPolicy support
+
+`externalTrafficPolicy` denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.
+
+openstack-cloud-controller-manager only supports `externalTrafficPolicy: Cluster` for now.

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -92,27 +92,28 @@ type LoadBalancer struct {
 
 // LoadBalancerOpts have the options to talk to Neutron LBaaSV2 or Octavia
 type LoadBalancerOpts struct {
-	LBVersion            string              `gcfg:"lb-version"`           // overrides autodetection. Only support v2.
-	UseOctavia           bool                `gcfg:"use-octavia"`          // uses Octavia V2 service catalog endpoint
-	SubnetID             string              `gcfg:"subnet-id"`            // overrides autodetection.
-	NetworkID            string              `gcfg:"network-id"`           // If specified, will create virtual ip from a subnet in network which has available IP addresses
-	FloatingNetworkID    string              `gcfg:"floating-network-id"`  // If specified, will create floating ip for loadbalancer, or do not create floating ip.
-	FloatingSubnetID     string              `gcfg:"floating-subnet-id"`   // If specified, will create floating ip for loadbalancer in this particular floating pool subnetwork.
-	FloatingSubnet       string              `gcfg:"floating-subnet"`      // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
-	FloatingSubnetTags   string              `gcfg:"floating-subnet-tags"` // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
-	LBClasses            map[string]*LBClass // Predefined named Floating networks and subnets
-	LBMethod             string              `gcfg:"lb-method"` // default to ROUND_ROBIN.
-	LBProvider           string              `gcfg:"lb-provider"`
-	CreateMonitor        bool                `gcfg:"create-monitor"`
-	MonitorDelay         util.MyDuration     `gcfg:"monitor-delay"`
-	MonitorTimeout       util.MyDuration     `gcfg:"monitor-timeout"`
-	MonitorMaxRetries    uint                `gcfg:"monitor-max-retries"`
-	ManageSecurityGroups bool                `gcfg:"manage-security-groups"`
-	NodeSecurityGroupIDs []string            // Do not specify, get it automatically when enable manage-security-groups. TODO(FengyunPan): move it into cache
-	InternalLB           bool                `gcfg:"internal-lb"`    // default false
-	CascadeDelete        bool                `gcfg:"cascade-delete"` // applicable only if use-octavia is set to True
-	FlavorID             string              `gcfg:"flavor-id"`
-	AvailabilityZone     string              `gcfg:"availability-zone"`
+	LBVersion             string              `gcfg:"lb-version"`           // overrides autodetection. Only support v2.
+	UseOctavia            bool                `gcfg:"use-octavia"`          // uses Octavia V2 service catalog endpoint
+	SubnetID              string              `gcfg:"subnet-id"`            // overrides autodetection.
+	NetworkID             string              `gcfg:"network-id"`           // If specified, will create virtual ip from a subnet in network which has available IP addresses
+	FloatingNetworkID     string              `gcfg:"floating-network-id"`  // If specified, will create floating ip for loadbalancer, or do not create floating ip.
+	FloatingSubnetID      string              `gcfg:"floating-subnet-id"`   // If specified, will create floating ip for loadbalancer in this particular floating pool subnetwork.
+	FloatingSubnet        string              `gcfg:"floating-subnet"`      // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
+	FloatingSubnetTags    string              `gcfg:"floating-subnet-tags"` // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
+	LBClasses             map[string]*LBClass // Predefined named Floating networks and subnets
+	LBMethod              string              `gcfg:"lb-method"` // default to ROUND_ROBIN.
+	LBProvider            string              `gcfg:"lb-provider"`
+	CreateMonitor         bool                `gcfg:"create-monitor"`
+	MonitorDelay          util.MyDuration     `gcfg:"monitor-delay"`
+	MonitorTimeout        util.MyDuration     `gcfg:"monitor-timeout"`
+	MonitorMaxRetries     uint                `gcfg:"monitor-max-retries"`
+	ManageSecurityGroups  bool                `gcfg:"manage-security-groups"`
+	NodeSecurityGroupIDs  []string            // Do not specify, get it automatically when enable manage-security-groups. TODO(FengyunPan): move it into cache
+	InternalLB            bool                `gcfg:"internal-lb"`    // default false
+	CascadeDelete         bool                `gcfg:"cascade-delete"` // applicable only if use-octavia is set to True
+	FlavorID              string              `gcfg:"flavor-id"`
+	AvailabilityZone      string              `gcfg:"availability-zone"`
+	EnableIngressHostname bool                `gcfg:"enable-ingress-hostname"` // Used with proxy protocol by adding a dns suffix to the load balancer IP address. Default false.
 }
 
 // LBClass defines the corresponding floating network, floating subnet or internal subnet ID
@@ -208,6 +209,7 @@ func ReadConfig(config io.Reader) (Config, error) {
 	cfg.LoadBalancer.MonitorTimeout = util.MyDuration{Duration: 3 * time.Second}
 	cfg.LoadBalancer.MonitorMaxRetries = 1
 	cfg.LoadBalancer.CascadeDelete = true
+	cfg.LoadBalancer.EnableIngressHostname = false
 
 	err := gcfg.FatalOnly(gcfg.ReadInto(&cfg, config))
 	if err != nil {

--- a/tests/e2e/cloudprovider/test-lb-service.sh
+++ b/tests/e2e/cloudprovider/test-lb-service.sh
@@ -9,6 +9,7 @@
 #   - It's recommended to run the script on a host with as less proxies to the public as possible, otherwise the
 #     x-forwarded-for test will probably fail.
 #   - This script is not responsible for resource clean up if there is test case fails.
+set -x
 
 TIMEOUT=${TIMEOUT:-300}
 FLOATING_IP=${FLOATING_IP:-""}


### PR DESCRIPTION
**What this PR does / why we need it**:
Related issues in other repos:
- https://github.com/kubernetes/kubernetes/issues/66607
- https://github.com/kubernetes/ingress-nginx/issues/3996

In PROXY mode, set Hostname field using IP address and a suffix `.nip.io` to expose the Service of LoadBalancer type.

A new config option `enable-ingress-hostname` is introduced but may be removed in the future, please see the document change.

**Which issue this PR fixes(if applicable)**:
fixes #1287

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] Fixed the broken header issue when accessing the load balancer service with PROXY protocol enabled from within the cluster.
```
