### PR TITLE
[cinder-csi-plugin]update CSI logs Log.Infof to Log.Errorf in error case

### DIFF
--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -95,14 +95,14 @@ func GetConfigFromFile(configFilePath string) (Config, error) {
 	var cfg Config
 	config, err := os.Open(configFilePath)
 	if err != nil {
-		klog.V(3).Infof("Failed to open OpenStack configuration file: %v", err)
+		klog.Errorf("Failed to open OpenStack configuration file: %v", err)
 		return cfg, err
 	}
 	defer config.Close()
 
 	err = gcfg.FatalOnly(gcfg.ReadInto(&cfg, config))
 	if err != nil {
-		klog.V(3).Infof("Failed to read OpenStack configuration file: %v", err)
+		klog.Errorf("Failed to read OpenStack configuration file: %v", err)
 		return cfg, err
 	}
 

--- a/pkg/csi/cinder/openstack/openstack_snapshots.go
+++ b/pkg/csi/cinder/openstack/openstack_snapshots.go
@@ -137,7 +137,7 @@ func (os *OpenStack) ListSnapshots(filters map[string]string) ([]snapshots.Snaps
 func (os *OpenStack) DeleteSnapshot(snapID string) error {
 	err := snapshots.Delete(os.blockstorage, snapID).ExtractErr()
 	if err != nil {
-		klog.V(3).Infof("Failed to delete snapshot: %v", err)
+		klog.Errorf("Failed to delete snapshot: %v", err)
 	}
 	return err
 }
@@ -146,7 +146,7 @@ func (os *OpenStack) DeleteSnapshot(snapID string) error {
 func (os *OpenStack) GetSnapshotByID(snapshotID string) (*snapshots.Snapshot, error) {
 	s, err := snapshots.Get(os.blockstorage, snapshotID).Extract()
 	if err != nil {
-		klog.V(3).Infof("Failed to get snapshot: %v", err)
+		klog.Errorf("Failed to get snapshot: %v", err)
 		return nil, err
 	}
 	return s, nil


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

update all error related Infof to Errorf

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
