### PR TITLE
[cinder-csi-plugin] Start using --nodeid option

### DIFF
--- a/tests/sanity/cinder/sanity_test.go
+++ b/tests/sanity/cinder/sanity_test.go
@@ -23,7 +23,7 @@ func TestDriver(t *testing.T) {
 	socket := path.Join(basePath, "csi.sock")
 	endpoint := "unix://" + socket
 	cluster := "kubernetes"
-	nodeID := "fake-node"
+	nodeID := cinder.FakeInstanceID
 
 	d := cinder.NewDriver(nodeID, endpoint, cluster)
 	fakecloudprovider := getfakecloud()


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently "--nodeid" is not used by the driver and its value is ignored. The real node ID is fetched from metadata service.
With this PR we start using value provided with --nodeid. If it's not set, then the plugin continues fetching node ID from metadata. 

**Which issue this PR fixes(if applicable)**:
fixes #1453 

**Release note**:
```release-note
--nodeid argument is now optional and used by the plugin. If it's not set, then the plugin fetches node ID from metadata.
```
