### PR TITLE
[cinder-csi-plugin] add snapshot controller to Helm Chart

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 1.3.4
+version: 1.3.5
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/_helpers.tpl
+++ b/charts/cinder-csi-plugin/templates/_helpers.tpl
@@ -88,3 +88,13 @@ component: nodeplugin
 {{ include "cinder-csi.nodeplugin.matchLabels" . }}
 {{ include "cinder-csi.common.metaLabels" . }}
 {{- end -}}
+
+{{- define "cinder-csi.snapshot-controller.matchLabels" -}}
+component: snapshot-controller
+{{ include "cinder-csi.common.matchLabels" . }}
+{{- end -}}
+
+{{- define "cinder-csi.snapshot-controller.labels" -}}
+{{ include "cinder-csi.snapshot-controller.matchLabels" . }}
+{{ include "cinder-csi.common.metaLabels" . }}
+{{- end -}}

--- a/charts/cinder-csi-plugin/templates/snapshot-controller-rbac.yaml
+++ b/charts/cinder-csi-plugin/templates/snapshot-controller-rbac.yaml
@@ -1,0 +1,85 @@
+{{- if .Values.csi.snapshotController.enabled -}}
+# RBAC file for the snapshot controller.
+#
+# The snapshot controller implements the control loop for CSI snapshot functionality.
+# It should be installed as part of the base Kubernetes distribution in an appropriate
+# namespace for components implementing base system functionality. For installing with
+# Vanilla Kubernetes, kube-system makes sense for the namespace.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: snapshot-controller-sa
+  namespace: {{ .Release.Namespace }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-controller-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-controller-role
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-controller-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  # change the name also here if the ClusterRole gets renamed
+  name: snapshot-controller-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-controller-leaderelection
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-controller-leaderelection
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: snapshot-controller-leaderelection
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/cinder-csi-plugin/templates/snapshot-controller-rbac.yaml
+++ b/charts/cinder-csi-plugin/templates/snapshot-controller-rbac.yaml
@@ -5,6 +5,9 @@
 # It should be installed as part of the base Kubernetes distribution in an appropriate
 # namespace for components implementing base system functionality. For installing with
 # Vanilla Kubernetes, kube-system makes sense for the namespace.
+# 
+# Enable this only if your Kubernetes distribution does not bundle the snapshot controller.
+# It should be installed only once per cluster, independent of CSI driver.
 
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/cinder-csi-plugin/templates/snapshot-controller-rbac.yaml
+++ b/charts/cinder-csi-plugin/templates/snapshot-controller-rbac.yaml
@@ -9,7 +9,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: snapshot-controller-sa
+  name: snapshot-controller
   namespace: {{ .Release.Namespace }}
 ---
 kind: ClusterRole
@@ -34,9 +34,6 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["create", "get", "list", "watch", "update", "delete"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshotcontents/status"]
     verbs: ["create", "get", "list", "watch", "update", "delete"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]

--- a/charts/cinder-csi-plugin/templates/snapshot-controller-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/snapshot-controller-statefulset.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.csi.snapshotController.enabled -}}
+# This YAML file shows how to deploy the snapshot controller
+
+# The snapshot controller implements the control loop for CSI snapshot functionality.
+# It should be installed as part of the base Kubernetes distribution in an appropriate
+# namespace for components implementing base system functionality. For installing with
+# Vanilla Kubernetes, kube-system makes sense for the namespace.
+
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  labels:
+    {{- include "cinder-csi.snapshot-controller.labels" . | nindent 4 }}
+  name: {{ include "cinder-csi.name" . }}-snapshot-controller
+spec:
+  serviceName: "snapshot-controller-sa"
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "cinder-csi.snapshot-controller.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "cinder-csi.snapshot-controller.labels" . | nindent 8 }}
+    spec:
+      serviceAccount: snapshot-controller-sa
+      containers:
+        - name: snapshot-controller
+          image: "{{ .Values.csi.snapshotController.image.repository }}:{{ .Values.csi.snapshotController.image.tag }}"
+          args:
+            - "--v=5"
+            - "--leader-election=false"
+          imagePullPolicy: IfNotPresent
+{{- end }}

--- a/charts/cinder-csi-plugin/templates/snapshot-controller-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/snapshot-controller-statefulset.yaml
@@ -29,7 +29,6 @@ spec:
         - name: snapshot-controller
           image: "{{ .Values.csi.snapshotController.image.repository }}:{{ .Values.csi.snapshotController.image.tag }}"
           args:
-            - "--v=5"
             - "--leader-election=false"
           imagePullPolicy: IfNotPresent
 {{- end }}

--- a/charts/cinder-csi-plugin/templates/snapshot-controller-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/snapshot-controller-statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- include "cinder-csi.snapshot-controller.labels" . | nindent 4 }}
   name: {{ include "cinder-csi.name" . }}-snapshot-controller
 spec:
-  serviceName: "snapshot-controller-sa"
+  serviceName: "snapshot-controller"
   replicas: 1
   selector:
     matchLabels:

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -58,7 +58,7 @@ csi:
     enabled: false
     image:
       repository: k8s.gcr.io/sig-storage/snapshot-controller
-      tag: v3.0.0
+      tag: v2.1.3
 
 secret:
   enabled: false

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -54,6 +54,11 @@ csi:
       - name: cloud-config
         mountPath: /etc/kubernetes
         readOnly: true
+  snapshotController:
+    enabled: false
+    image:
+      repository: k8s.gcr.io/sig-storage/snapshot-controller
+      tag: v3.0.0
 
 secret:
   enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Extends the current Helm Chart for Cinder CSI Plugin with a deployment of a Snapshot Controller

**Which issue this PR fixes(if applicable)**:

none

**Special notes for reviewers**:

none

**Release note**:
```release-note
[cinder-csi-plugin] Support Snapshot Controller deployment in Helm Chart.
```
