### PR TITLE
[manila-csi-plugin] Add --cluster-id option 

### DIFF
--- a/cmd/manila-csi-plugin/main.go
+++ b/cmd/manila-csi-plugin/main.go
@@ -44,6 +44,7 @@ var (
 	fwdEndpoint           string
 	userAgentData         []string
 	compatibilitySettings string
+	clusterID             string
 )
 
 func validateShareProtocolSelector(v string) error {
@@ -140,6 +141,7 @@ func main() {
 					ManilaClientBuilder: manilaClientBuilder,
 					CSIClientBuilder:    csiClientBuilder,
 					CompatOpts:          compatOpts,
+					ClusterID:           clusterID,
 				},
 			)
 
@@ -177,6 +179,8 @@ func main() {
 	cmd.PersistentFlags().StringVar(&compatibilitySettings, "compatibility-settings", "", "settings for the compatibility layer")
 
 	cmd.PersistentFlags().StringArrayVar(&userAgentData, "user-agent", nil, "extra data to add to gophercloud user-agent. Use multiple times to add more than one component.")
+
+	cmd.PersistentFlags().StringVar(&clusterID, "cluster-id", "", "The identifier of the cluster that the plugin is running in.")
 
 	logs.InitLogs()
 	defer logs.FlushLogs()

--- a/docs/manila-csi-plugin/using-manila-csi-plugin.md
+++ b/docs/manila-csi-plugin/using-manila-csi-plugin.md
@@ -37,6 +37,7 @@ Option | Default value | Description
 `--with-topology` | _none_ | CSI Manila is topology-aware. See [Topology-aware dynamic provisioning](#topology-aware-dynamic-provisioning) for more info
 `--share-protocol-selector` | _none_ | Specifies which Manila share protocol to use for this instance of the driver. See [supported protocols](#share-protocol-support-matrix) for valid values.
 `--fwdendpoint` | _none_ | [CSI Node Plugin](https://github.com/container-storage-interface/spec/blob/master/spec.md#rpc-interface) endpoint to which all Node Service RPCs are forwarded. Must be able to handle the file-system specified in `share-protocol-selector`. Check out the [Deployment](#deployment) section to see why this is necessary.
+`--cluster-id` | _none_ | The identifier of the cluster that the plugin is running in. If set then the plugin will add "manila.csi.openstack.org/cluster: \<clusterID\>" to metadata of created shares.
 
 ### Controller Service volume parameters
 

--- a/pkg/csi/manila/controllerserver.go
+++ b/pkg/csi/manila/controllerserver.go
@@ -18,6 +18,7 @@ package manila
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"sync"
 
@@ -32,6 +33,8 @@ import (
 	clouderrors "k8s.io/cloud-provider-openstack/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
+
+const clusterMetadataKey = "manila.csi.openstack.org/cluster"
 
 type controllerServer struct {
 	d *Driver
@@ -82,6 +85,11 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, status.Errorf(codes.InvalidArgument, "invalid volume parameters: %v", err)
 	}
 
+	shareMetadata, err := prepareShareMetadata(shareOpts.AppendShareMetadata, cs.d.clusterID)
+	if err != nil {
+		return nil, err
+	}
+
 	osOpts, err := options.NewOpenstackOptions(req.GetSecrets())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid OpenStack secrets: %v", err)
@@ -118,7 +126,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, err
 	}
 
-	share, err := volCreator.create(req, req.GetName(), sizeInGiB, manilaClient, shareOpts)
+	share, err := volCreator.create(req, req.GetName(), sizeInGiB, manilaClient, shareOpts, shareMetadata)
 	if err != nil {
 		return nil, err
 	}
@@ -421,4 +429,33 @@ func (cs *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 
 func (cs *controllerServer) ControllerGetVolume(context.Context, *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
+}
+
+func parseStringMapFromJson(data string) (m map[string]string, err error) {
+	if data == "" {
+		return
+	}
+
+	err = json.Unmarshal([]byte(data), &m)
+	return
+}
+
+func prepareShareMetadata(appendShareMetadata, clusterID string) (map[string]string, error) {
+	shareMetadata, err := parseStringMapFromJson(appendShareMetadata)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "failed to parse appendShareMetadata field: %v", err)
+	}
+
+	if clusterID != "" {
+		if shareMetadata == nil {
+			shareMetadata = make(map[string]string)
+		}
+		if val, ok := shareMetadata[clusterMetadataKey]; ok && val != clusterID {
+			klog.Warningf("skip adding cluster ID %v to share metadata because appended metadata already defines it as %v", clusterID, val)
+		} else {
+			shareMetadata[clusterMetadataKey] = clusterID
+		}
+	}
+
+	return shareMetadata, nil
 }

--- a/pkg/csi/manila/controllerserver_test.go
+++ b/pkg/csi/manila/controllerserver_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manila
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPrepareShareMetadata(t *testing.T) {
+	ts := []struct {
+		appendShareMetadata string
+		cluster             string
+		expectedResult      map[string]string
+		expectedError       bool
+	}{
+		{
+			// Empty metadata and cluster
+			appendShareMetadata: "",
+			cluster:             "",
+			expectedResult:      nil,
+			expectedError:       false,
+		},
+		{
+			// Existing metadata and empty cluster
+			appendShareMetadata: "{\"keyA\": \"valueA\", \"keyB\": \"valueB\"}",
+			cluster:             "",
+			expectedResult:      map[string]string{"keyA": "valueA", "keyB": "valueB"},
+			expectedError:       false,
+		},
+		{
+			// Just cluster and no metadata
+			appendShareMetadata: "",
+			cluster:             "MyCluster",
+			expectedResult:      map[string]string{clusterMetadataKey: "MyCluster"},
+			expectedError:       false,
+		},
+		{
+			// Both metadata and cluster
+			appendShareMetadata: "{\"keyA\": \"valueA\", \"keyB\": \"valueB\"}",
+			cluster:             "MyCluster",
+			expectedResult:      map[string]string{"keyA": "valueA", "keyB": "valueB", clusterMetadataKey: "MyCluster"},
+			expectedError:       false,
+		},
+		{
+			// Overwrite cluster
+			appendShareMetadata: "{\"keyA\": \"valueA\", \"" + clusterMetadataKey + "\": \"SomeValue\"}",
+			cluster:             "MyCluster",
+			expectedResult:      map[string]string{"keyA": "valueA", clusterMetadataKey: "SomeValue"},
+			expectedError:       false,
+		},
+		{
+			// Incorrect metadata
+			appendShareMetadata: "INVALID",
+			cluster:             "MyCluster",
+			expectedResult:      nil,
+			expectedError:       true,
+		},
+	}
+
+	for i := range ts {
+		result, err := prepareShareMetadata(ts[i].appendShareMetadata, ts[i].cluster)
+
+		if err != nil && !ts[i].expectedError {
+			t.Errorf("test %d: unexpected error: %v", i, err)
+		}
+
+		if fmt.Sprint(result) != fmt.Sprint(ts[i].expectedResult) {
+			t.Errorf("test %d: returned an incorrect result: got %#v, expected %#v", i, result, ts[i].expectedResult)
+		}
+	}
+}

--- a/pkg/csi/manila/driver.go
+++ b/pkg/csi/manila/driver.go
@@ -42,6 +42,7 @@ type DriverOpts struct {
 	NodeAZ       string
 	WithTopology bool
 	ShareProto   string
+	ClusterID    string
 
 	ServerCSIEndpoint string
 	FwdCSIEndpoint    string
@@ -59,6 +60,7 @@ type Driver struct {
 	name         string
 	fqVersion    string // Fully qualified version in format {driverVersion}@{CPO version}
 	shareProto   string
+	clusterID    string
 
 	serverEndpoint string
 	fwdEndpoint    string
@@ -119,6 +121,7 @@ func NewDriver(o *DriverOpts) (*Driver, error) {
 		compatOpts:          o.CompatOpts,
 		manilaClientBuilder: o.ManilaClientBuilder,
 		csiClientBuilder:    o.CSIClientBuilder,
+		clusterID:           o.ClusterID,
 	}
 
 	klog.Info("Driver: ", d.name)


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit add a new optional string parameter "cluster-id" to manila csi plugin binary. If this parameter value is provided, then the plugin will add "manila.csi.openstack.org/cluster: <clusterID>" to metadata of created shares. It simplifies finding shares created for specific clusters.

**Special notes for reviewers**:
Similar solution exists for Cinder: https://github.com/kubernetes/cloud-provider-openstack/blob/master/cmd/cinder-csi-plugin/main.go#L86
https://github.com/kubernetes/cloud-provider-openstack/pull/451

**Release note**:
```release-note
[manila-csi-plugin] support `--cluster-id` argument to get the the CO's identifier.
```
