### PR TITLE
Helm Chart for OpenStack Service LoadBalancer

### DIFF
--- a/charts/openstack-service-loadbalancer/Chart.yaml
+++ b/charts/openstack-service-loadbalancer/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+appVersion: "latest"
+description: Openstack Service Loadbalancer Helm Chart
+icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
+home: https://github.com/kubernetes/cloud-provider-openstack
+name: openstack-service-loadbalancer
+version: 1.0.0
+maintainers:
+  - name: eumel8 # Frank Kloeker
+    email: f.kloeker@telekom.de
+    url: https://www.telekom.com

--- a/charts/openstack-service-loadbalancer/README.md
+++ b/charts/openstack-service-loadbalancer/README.md
@@ -1,0 +1,19 @@
+# openstack-service-loadbalancer
+
+Deploys a Kubernetes Service for OpenStack Cloud Controller Manager (OCCM).
+
+## How to install
+
+Install OCCM first
+
+```
+helm repo add cpo https://kubernetes.github.io/cloud-provider-openstack
+helm repo update
+helm install openstack-ccm cpo/openstack-cloud-controller-manager --values openstack-ccm.yaml
+```
+
+Install Service Loadbalancer Chart
+
+```
+helm install openstack-lb cpo/openstack-service-loadblancer
+```

--- a/charts/openstack-service-loadbalancer/templates/service-lb.yaml
+++ b/charts/openstack-service-loadbalancer/templates/service-lb.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.loadbalancerService.servicename | default "openstack-lb" }}
+  namespace: {{ .Values.loadbalancerService.namespace | default "ingress-nginx" }}
+  labels:
+    app: {{ .Values.loadbalancerService.label | default "openstack-lb" }}
+  {{- with .Values.loadbalancerService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: LoadBalancer
+  sessionAffinity: ClientIP
+  externalTrafficPolicy: "Local"
+  ports:
+  - name: http
+    port: 80
+  - name: https
+    port: 443
+  selector:
+    app: {{ .Values.loadbalancerService.selector | default "ingress-nginx" }}

--- a/charts/openstack-service-loadbalancer/values.yaml
+++ b/charts/openstack-service-loadbalancer/values.yaml
@@ -1,0 +1,14 @@
+# Values OpenStack Service Loadbalancer Helm Chart
+#
+# Define loadbalancer service based ony OpenStack Cloud Controller Manager
+#
+# Create a service openstack-lb (or other service name) for OpenStack Loadbalancer
+loadbalancerService: {}
+# loadbalancerService:
+#   namespace:
+#   label:
+#   selector:
+#   servicename:
+#   annotations:
+#     service.beta.kubernetes.io/openstack-internal-load-balancer: "false"
+#     external-dns.alpha.kubernetes.io/hostname: "node.example.com"


### PR DESCRIPTION
**What this PR does / why we need it**:

This Helm Chart will deploy a Kubernetes LoadBalancer service `openstack-lb` for the OpenStack Cloud Controller Manager.

**Which issue this PR fixes(if applicable)**:

none

**Special notes for reviewers**:

none

**Release note**:
```release-note
Helm Chart for OpenStack Service LoadBalancer
```
