### PR TITLE
[manila-csi-plugin] close GRPC connections

### DIFF
--- a/pkg/csi/manila/driver.go
+++ b/pkg/csi/manila/driver.go
@@ -247,6 +247,7 @@ func (d *Driver) initProxiedDriver() (csiNodeCapabilitySet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("connecting to %s endpoint failed: %v", d.fwdEndpoint, err)
 	}
+	defer conn.Close()
 
 	identityClient := d.csiClientBuilder.NewIdentityServiceClient(conn)
 

--- a/pkg/csi/manila/identityserver.go
+++ b/pkg/csi/manila/identityserver.go
@@ -43,6 +43,7 @@ func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*c
 	if err != nil {
 		return nil, status.Error(codes.FailedPrecondition, fmtGrpcConnError(ids.d.fwdEndpoint, err))
 	}
+	defer csiConn.Close()
 
 	return ids.d.csiClientBuilder.NewIdentityServiceClient(csiConn).Probe(ctx, req)
 }

--- a/pkg/csi/manila/nodeserver.go
+++ b/pkg/csi/manila/nodeserver.go
@@ -211,6 +211,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	if err != nil {
 		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
 	}
+	defer csiConn.Close()
 
 	req.Secrets = secret
 	req.VolumeContext = volumeCtx
@@ -227,6 +228,7 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	if err != nil {
 		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
 	}
+	defer csiConn.Close()
 
 	return ns.d.csiClientBuilder.NewNodeServiceClient(csiConn).UnpublishVolume(ctx, req)
 }
@@ -285,6 +287,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	if err != nil {
 		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
 	}
+	defer csiConn.Close()
 
 	req.Secrets = stageSecret
 	req.VolumeContext = volumeCtx
@@ -305,6 +308,7 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 	if err != nil {
 		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
 	}
+	defer csiConn.Close()
 
 	return ns.d.csiClientBuilder.NewNodeServiceClient(csiConn).UnstageVolume(ctx, req)
 }

--- a/tests/sanity/manila/fakecsiclient.go
+++ b/tests/sanity/manila/fakecsiclient.go
@@ -80,10 +80,12 @@ func (c fakeNodeSvcClient) UnpublishVolume(context.Context, *csi.NodeUnpublishVo
 
 type fakeCSIClientBuilder struct{}
 
-func (b fakeCSIClientBuilder) NewConnection(string) (*grpc.ClientConn, error) { return nil, nil }
+func (b fakeCSIClientBuilder) NewConnection(string) (*grpc.ClientConn, error) {
+	return grpc.Dial("", grpc.WithInsecure())
+}
 
 func (b fakeCSIClientBuilder) NewConnectionWithContext(context.Context, string) (*grpc.ClientConn, error) {
-	return nil, nil
+	return grpc.Dial("", grpc.WithInsecure())
 }
 
 func (b fakeCSIClientBuilder) NewNodeServiceClient(conn *grpc.ClientConn) csiclient.Node {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This PR closes opened gRPC connections made to the partner node plugins.

Please see the table below for memory consumption comparison without and with this patch:

![manila-csi-mem-consumption-comparison](https://user-images.githubusercontent.com/1104680/114151757-bda8f500-991d-11eb-8c7a-6ea6eeb9bc07.png)


Without this fix, the memory consumption gradually increases. This PR fixes this and keeps the consumption more or less constant.

**Which issue this PR fixes(if applicable)**:
fixes #1472

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
