### PR TITLE
[OCCM] add support for TLS terminated loadbalancers

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -166,6 +166,10 @@ Request Body:
 
   The name of the loadbalancer availability zone to use. It is ignored if the Octavia version doesn't support availability zones yet.
 
+- `loadbalancer.openstack.org/default-tls-container-ref`
+
+  Reference to a tls container. This option works with Octavia, when this option is set then a TLS Terminated loadbalancer will be created by cloud provider.
+  Format for tls container ref: `https://{keymanager_host}/v1/containers/{uuid}`
 ### Switching between Floating Subnets by using preconfigured Classes
 
 If you have multiple `FloatingIPPools` and/or `FloatingIPSubnets` it might be desirable to offer the user logical meanings for `LoadBalancers` like `internetFacing` or `DMZ` instead of requiring the user to select a dedicated network or subnet ID at the service object level as an annotation.

--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -132,7 +132,9 @@ Request Body:
 
 - `loadbalancer.openstack.org/x-forwarded-for`
 
-  If 'true', `X-Forwarded-For` is inserted into the HTTP headers which contains the original client IP address so that the backend HTTP service is able to get the real source IP of the request. Only applies when using Octavia.
+  If 'true', `X-Forwarded-For` is inserted into the HTTP headers which contains the original client IP address so that the backend HTTP service is able to get the real source IP of the request. Please note that the cloud provider will force the creation of an Octavia listener of type `HTTP` if this option is set. Only applies when using Octavia.
+
+  This annotation also works in conjunction with the `loadbalancer.openstack.org/default-tls-container-ref` annotation. In this case the cloud provider will create an Octavia listener of type `TERMINATED_HTTPS` instead of an `HTTP` listener.
 
 - `loadbalancer.openstack.org/timeout-client-data`
 
@@ -168,8 +170,9 @@ Request Body:
 
 - `loadbalancer.openstack.org/default-tls-container-ref`
 
-  Reference to a tls container. This option works with Octavia, when this option is set then a TLS Terminated loadbalancer will be created by cloud provider.
+  Reference to a tls container. This option works with Octavia, when this option is set then the cloud provider will create an Octavia Listener of type `TERMINATED_HTTPS` for a TLS Terminated loadbalancer.
   Format for tls container ref: `https://{keymanager_host}/v1/containers/{uuid}`
+
 ### Switching between Floating Subnets by using preconfigured Classes
 
 If you have multiple `FloatingIPPools` and/or `FloatingIPSubnets` it might be desirable to offer the user logical meanings for `LoadBalancers` like `internetFacing` or `DMZ` instead of requiring the user to select a dedicated network or subnet ID at the service object level as an annotation.

--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -244,6 +244,11 @@ Although the openstack-cloud-controller-manager was initially implemented with N
 
   This option is currently a workaround for the issue https://github.com/kubernetes/ingress-nginx/issues/3996, should be removed or refactored after the Kubernetes [KEP-1860](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1860-kube-proxy-IP-node-binding) is implemented.
 
+* `default-tls-container-ref`
+  Reference to a tls container. This option works with Octavia, when this option is set then a TLS Terminated loadbalancer will be created by cloud provider.
+
+  Format for tls container ref: `https://{keymanager_host}/v1/containers/{uuid}`
+
 ### Metadata
 
 * `search-order`

--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -245,7 +245,7 @@ Although the openstack-cloud-controller-manager was initially implemented with N
   This option is currently a workaround for the issue https://github.com/kubernetes/ingress-nginx/issues/3996, should be removed or refactored after the Kubernetes [KEP-1860](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1860-kube-proxy-IP-node-binding) is implemented.
 
 * `default-tls-container-ref`
-  Reference to a tls container. This option works with Octavia, when this option is set then a TLS Terminated loadbalancer will be created by cloud provider.
+  Reference to a tls container. This option works with Octavia, when this option is set then the cloud provider will create an Octavia Listener of type TERMINATED_HTTPS for a TLS Terminated loadbalancer.
 
   Format for tls container ref: `https://{keymanager_host}/v1/containers/{uuid}`
 

--- a/pkg/client/service.go
+++ b/pkg/client/service.go
@@ -64,3 +64,12 @@ func NewLoadBalancerV2(provider *gophercloud.ProviderClient, eo *gophercloud.End
 	}
 	return lb, nil
 }
+
+// NewKeyManagerV1 creates a ServiceClient that can be used with KeyManager v1 API
+func NewKeyManagerV1(provider *gophercloud.ProviderClient, eo *gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	secret, err := openstack.NewKeyManagerV1(provider, *eo)
+	if err != nil {
+		return nil, fmt.Errorf("unable to initialize keymanager client for region %s: %v", eo.Region, err)
+	}
+	return secret, nil
+}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This PR brings support for creating TLS Terminated loadbalancers. User can specify tls container ref either in cloud-config file using `default-tls-container-ref` option or pass tls container ref in service spec using annotation `loadbalancer.openstack.org/default-tls-container-ref`. Cloud provider will create a listener with protocol **TERMINATED_HTTPS** and a pool with protocol **HTTP**.

This feature is supported only for Octavia.

This PR also fixes #1294 

**Special notes for reviewers**:
To test this feature you have to create an openstack secret container of type certificate:
```
$ openstack secret container get https://X.X.X.X:9311/v1/containers/3898c759-ef67-4096-8ccf-3719cef674a3
+----------------+-----------------------------------------------------------------------------------+
| Field          | Value                                                                             |
+----------------+-----------------------------------------------------------------------------------+
| Container href | https://X.X.X.X:9311/v1/containers/3898c759-ef67-4096-8ccf-3719cef674a3|
| Name           | test_lb_tls_container                                                             |
| Created        | 2021-04-09 10:21:49+00:00                                                         |
| Status         | ACTIVE                                                                            |
| Type           | certificate                                                                       |
| Certificate    | https://X.X.X.X:9311/v1/secrets/a57f4d6d-9a45-48af-9a45-fdffccd7e967    |
| Intermediates  | None                                                                              |
| Private Key    | https://X.X.X.X:9311/v1/secrets/ed002ebe-9c81-4c75-9c81-fc6cfde81c55    |
| PK Passphrase  | None                                                                              |
| Consumers      | None                                                                              |
+----------------+-----------------------------------------------------------------------------------+
```
You can pass the default-tls-container-ref `https://X.X.X.X:9311/v1/containers/3898c759-ef67-4096-8ccf-3719cef674a3` in an annotation `loadbalancer.openstack.org/default-tls-container-ref` to create an external cloud loadbalancer with a `TERMINATED_HTTPS` listener.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] Added support for creating TLS terminated loadbalancers.
```
