### PR TITLE
[cinder-csi-plugin] Allow multiple config files

### DIFF
--- a/cmd/cinder-csi-plugin/main.go
+++ b/cmd/cinder-csi-plugin/main.go
@@ -34,7 +34,7 @@ import (
 var (
 	endpoint    string
 	nodeID      string
-	cloudconfig string
+	cloudconfig []string
 	cluster     string
 )
 
@@ -80,7 +80,7 @@ func main() {
 	cmd.PersistentFlags().StringVar(&endpoint, "endpoint", "", "CSI endpoint")
 	cmd.MarkPersistentFlagRequired("endpoint")
 
-	cmd.PersistentFlags().StringVar(&cloudconfig, "cloud-config", "", "CSI driver cloud config")
+	cmd.PersistentFlags().StringSliceVar(&cloudconfig, "cloud-config", nil, "CSI driver cloud config. This option can be given multiple times")
 	cmd.MarkPersistentFlagRequired("cloud-config")
 
 	cmd.PersistentFlags().StringVar(&cluster, "cluster", "", "The identifier of the cluster that the plugin is running in.")

--- a/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
+++ b/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
@@ -6,11 +6,12 @@
   - [CSI Compatibility](#csi-compatibility)
   - [Downloads](#downloads)
   - [Kubernetes Compatibility](#kubernetes-compatibility)
+  - [Driver Deployment](#driver-deployment)
+    - [Command-line arguments](#command-line-arguments)
   - [Driver Config](#driver-config)
     - [Global](#global)
     - [Block Storage](#block-storage)
     - [Metadata](#metadata)
-  - [Driver Deployment](#driver-deployment)
     - [Using the manifests](#using-the-manifests)
     - [Using the Helm chart](#using-the-helm-chart)
   - [Supported Features](#supported-features)
@@ -42,6 +43,52 @@ Stable released version images of the plugin can be found at [Docker Hub](https:
 For each kubernetes official release, there is a corresponding release of Cinder CSI driver which is compatible with k8s release. It is recommended to use the corresponding version w.r.t kubernetes.
 
 For sidecar version compatibility with kubernetes, please refer [Compatibility Matrix](https://kubernetes-csi.github.io/docs/sidecar-containers.html) of each sidecar.
+
+## Driver Deployment
+
+You can either use the manifests under `manifests/cinder-csi-plugin` or the Helm chart `charts/cinder-csi-plugin`.
+
+### Command-line arguments
+
+In addition to the standard set of klog flags, `cinder-csi-plugin` accepts the following command-line arguments:
+
+<dl>
+  <dt>--nodeid &lt;node id&gt;</dt>
+  <dd>
+  This argument is required.
+
+  An identifier for the current node which will be used in OpenStack API calls.  This can be either the UUID or name of the OpenStack server, but note that if using name it must be unique.
+  </dd>
+
+  <dt>--endpoint &lt;endpoint&gt;</dt>
+  <dd>
+  This argument is required.
+
+  The endpoint of the gRPC server agents will use to connect to this CSI plugin, typically a local unix socket.
+
+  The manifests default this to `unix://csi/csi.sock`, which is supplied via the `CSI_ENDPOINT` environment variable.
+  </dd>
+
+  <dt>--cloud-config &lt;config file&gt; [--cloud-config &lt;config file&gt; ...]</dt>
+  <dd>
+  This argument must be given at least once.
+
+  The path to a driver config file. The format of this file is specified in [Driver Config](#driver-config).
+
+  If multiple configuration files are supplied they will be merged. In the case of a conflict, the last supplied config file will take precedence.
+
+  The manifests default this to `/etc/config/cloud.conf`, which is supplied via the `CLOUD_CONFIG` environment variable.
+  </dd>
+
+  <dt>--cluster &lt;cluster name&gt;</dt>
+  <dd>
+  This argument is optional.
+
+  The identifier of the cluster that the plugin is running in.
+
+  This will be added as metadata to every Cinder volume created by this plugin.
+  </dd>
+</dl>
 
 ## Driver Config
 
@@ -83,10 +130,6 @@ These configuration options pertain to metadata and should appear in the `[Metad
     service first if available, then the configuration drive.
 
   Influencing this behavior may be desirable as the metadata on the configuration drive may grow stale over time, whereas the metadata service always provides the most up to date view. Not all OpenStack clouds provide both configuration drive and metadata service though and only one or the other may be available which is why the default is to check both.
-
-## Driver Deployment
-
-You can either use the manifests under `manifests/cinder-csi-plugin` or the Helm chart `charts/cinder-csi-plugin`.
 
 ### Using the manifests
 

--- a/pkg/csi/cinder/driver.go
+++ b/pkg/csi/cinder/driver.go
@@ -35,9 +35,15 @@ const (
 )
 
 var (
+	// CSI spec version
 	specVersion = "1.3.0"
-	// we used to use spec version as driver version, now separate them
-	Version = "1.3.1"
+
+	// Driver version
+	// Version history:
+	// * 1.3.0: Up to version 1.3.0 driver version was the same as CSI spec version
+	// * 1.3.1: Bump for 1.21 release
+	// * 1.3.2: Allow --cloud-config to be given multiple times
+	Version = "1.3.2"
 )
 
 type CinderDriver struct {

--- a/pkg/csi/cinder/driver_test.go
+++ b/pkg/csi/cinder/driver_test.go
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	vendorVersion = "1.3.1"
+	vendorVersion = "1.3.2"
 )
 
 func NewFakeDriver() *CinderDriver {


### PR DESCRIPTION
This change allows cinder-csi-plugin to be invoked with multiple config
files. These will be parsed sequentially in the order specified. Values
in later config files override values in earlier config files.

This makes 'layered' configurations simpler to manage. For example a
base configuration containing authentication information and a per-node
override configuration which applies only to a single node. Keeping
these in separate files simplifies the task of changing the base
configuration for all nodes.

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #1481 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[cinder-csi-plugin] The --cloud-config option may now be given multiple times. Multiple configuration files will be merged, with later configuration files taking precedence.
```
