### PR TITLE
[cinder-csi-plugin] Check volume status in createVolume

### DIFF
--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -47,8 +47,8 @@ func TestCreateVolume(t *testing.T) {
 	properties := map[string]string{"cinder.csi.openstack.org/cluster": FakeCluster}
 	// CreateVolume(name string, size int, vtype, availability string, snapshotID string, tags *map[string]string) (string, string, int, error)
 	osmock.On("CreateVolume", FakeVolName, mock.AnythingOfType("int"), FakeVolType, FakeAvailability, "", "", &properties).Return(&FakeVol, nil)
-
 	osmock.On("GetVolumesByName", FakeVolName).Return(FakeVolListEmpty, nil)
+	osmock.On("WaitVolumeTargetStatus", FakeVolID, []string{"available"}).Return(nil)
 	// Init assert
 	assert := assert.New(t)
 
@@ -93,6 +93,7 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 	// CreateVolume(name string, size int, vtype, availability string, snapshotID string, tags *map[string]string) (string, string, int, error)
 	osmock.On("CreateVolume", FakeVolName, mock.AnythingOfType("int"), FakeVolType, "", FakeSnapshotID, "", &properties).Return(&FakeVolFromSnapshot, nil)
 	osmock.On("GetVolumesByName", FakeVolName).Return(FakeVolListEmpty, nil)
+	osmock.On("WaitVolumeTargetStatus", FakeVolID, []string{"available"}).Return(nil)
 
 	// Init assert
 	assert := assert.New(t)
@@ -141,6 +142,7 @@ func TestCreateVolumeFromSourceVolume(t *testing.T) {
 	// CreateVolume(name string, size int, vtype, availability string, snapshotID string, tags *map[string]string) (string, string, int, error)
 	osmock.On("CreateVolume", FakeVolName, mock.AnythingOfType("int"), FakeVolType, "", "", FakeVolID, &properties).Return(&FakeVolFromSourceVolume, nil)
 	osmock.On("GetVolumesByName", FakeVolName).Return(FakeVolListEmpty, nil)
+	osmock.On("WaitVolumeTargetStatus", FakeVolID, []string{"available"}).Return(nil)
 
 	// Init assert
 	assert := assert.New(t)

--- a/pkg/csi/cinder/fake.go
+++ b/pkg/csi/cinder/fake.go
@@ -56,7 +56,7 @@ var FakeVolFromSnapshot = volumes.Volume{
 }
 
 var FakeVolFromSourceVolume = volumes.Volume{
-	ID:               "test-clone-id",
+	ID:               FakeVolID,
 	Name:             FakeVolName,
 	Size:             FakeCapacityGiB,
 	AvailabilityZone: FakeAvailability,


### PR DESCRIPTION
This commit makes sure volume status to be avaiable before returning from createVolume .
It avoids failure at later stage of controllerPublishVolume

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
