### PR TITLE
[manila-csi-plugin] close GRPC connections (release-1.20)

### DIFF
--- a/pkg/csi/manila/driver.go
+++ b/pkg/csi/manila/driver.go
@@ -244,6 +244,7 @@ func (d *Driver) initProxiedDriver() (csiNodeCapabilitySet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("connecting to %s endpoint failed: %v", d.fwdEndpoint, err)
 	}
+	defer conn.Close()
 
 	identityClient := d.csiClientBuilder.NewIdentityServiceClient(conn)
 

--- a/pkg/csi/manila/identityserver.go
+++ b/pkg/csi/manila/identityserver.go
@@ -43,6 +43,7 @@ func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*c
 	if err != nil {
 		return nil, status.Error(codes.FailedPrecondition, fmtGrpcConnError(ids.d.fwdEndpoint, err))
 	}
+	defer csiConn.Close()
 
 	return ids.d.csiClientBuilder.NewIdentityServiceClient(csiConn).Probe(ctx, req)
 }

--- a/pkg/csi/manila/nodeserver.go
+++ b/pkg/csi/manila/nodeserver.go
@@ -211,6 +211,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	if err != nil {
 		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
 	}
+	defer csiConn.Close()
 
 	req.Secrets = secret
 	req.VolumeContext = volumeCtx
@@ -227,6 +228,7 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	if err != nil {
 		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
 	}
+	defer csiConn.Close()
 
 	return ns.d.csiClientBuilder.NewNodeServiceClient(csiConn).UnpublishVolume(ctx, req)
 }
@@ -285,6 +287,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	if err != nil {
 		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
 	}
+	defer csiConn.Close()
 
 	req.Secrets = stageSecret
 	req.VolumeContext = volumeCtx
@@ -305,6 +308,7 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 	if err != nil {
 		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
 	}
+	defer csiConn.Close()
 
 	return ns.d.csiClientBuilder.NewNodeServiceClient(csiConn).UnstageVolume(ctx, req)
 }

--- a/tests/sanity/manila/fakecsiclient.go
+++ b/tests/sanity/manila/fakecsiclient.go
@@ -80,10 +80,12 @@ func (c fakeNodeSvcClient) UnpublishVolume(context.Context, *csi.NodeUnpublishVo
 
 type fakeCSIClientBuilder struct{}
 
-func (b fakeCSIClientBuilder) NewConnection(string) (*grpc.ClientConn, error) { return nil, nil }
+func (b fakeCSIClientBuilder) NewConnection(string) (*grpc.ClientConn, error) {
+	return grpc.Dial("", grpc.WithInsecure())
+}
 
 func (b fakeCSIClientBuilder) NewConnectionWithContext(context.Context, string) (*grpc.ClientConn, error) {
-	return nil, nil
+	return grpc.Dial("", grpc.WithInsecure())
 }
 
 func (b fakeCSIClientBuilder) NewNodeServiceClient(conn *grpc.ClientConn) csiclient.Node {


### PR DESCRIPTION
This is a backport of https://github.com/kubernetes/cloud-provider-openstack/pull/1473 into the release-1.20 branch.

Cherry-picked from b20ce967f4b9f259c4148cf809c5111245a53f12.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[manila-csi-plugin] Fixed a leak causing high memory consumption
```
