### PR TITLE
[cinder-csi-plugin] Tag volume with optional pvc/pv metadata

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 1.3.6
+version: 1.3.7
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -46,6 +46,7 @@ spec:
             - "--timeout={{ .Values.timeout }}"
             - "--default-fstype=ext4"
             - "--feature-gates=Topology={{ .Values.csi.provisioner.topology }}"
+            - "--extra-create-metadata"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -54,6 +54,7 @@ spec:
             - "--timeout=3m"
             - "--default-fstype=ext4"
             - "--feature-gates=Topology=true"
+            - "--extra-create-metadata"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -103,6 +103,12 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 
 	// Volume Create
 	properties := map[string]string{"cinder.csi.openstack.org/cluster": cs.Driver.cluster}
+	//Tag volume with metadata if present: https://github.com/kubernetes-csi/external-provisioner/pull/399
+	for _, mKey := range []string{"csi.storage.k8s.io/pvc/name", "csi.storage.k8s.io/pvc/namespace", "csi.storage.k8s.io/pv/name"} {
+		if v, ok := req.Parameters[mKey]; ok {
+			properties[mKey] = v
+		}
+	}
 	content := req.GetVolumeContentSource()
 	var snapshotID string
 	var sourcevolID string

--- a/pkg/csi/cinder/fake.go
+++ b/pkg/csi/cinder/fake.go
@@ -38,6 +38,9 @@ var FakeAvailability = "nova"
 var FakeDevicePath = "/dev/xxx"
 var FakeTargetPath = "/mnt/cinder"
 var FakeStagingTargetPath = "/mnt/globalmount"
+var FakePVName = "fakepv-1"
+var FakePVCName = "fakepvc-1"
+var FakePVCNamespace = "fakepvc-ns"
 var FakeAttachment = volumes.Attachment{
 	ServerID: FakeNodeID,
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The external CSI provisioner optionally injects metadata in the CreateVolume that we can pass onto the volume as additional tags.
See https://github.com/kubernetes-csi/external-provisioner/pull/399

** Release notes **
```release-note
Tag volumes with additional metadata about pv and pvc if provided
```
