### PR TITLE
WIP: support get capacity

### DIFF
--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -530,7 +530,9 @@ func (cs *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 }
 
 func (cs *controllerServer) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
-	return nil, status.Error(codes.Unimplemented, fmt.Sprintf("GetCapacity is not yet implemented"))
+	klog.V(4).Infof("GetCapacity: called with args %+v", protosanitizer.StripSecrets(*req))
+
+	
 }
 
 func (cs *controllerServer) ControllerGetVolume(context.Context, *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -63,6 +63,7 @@ type IOpenStack interface {
 	GetMaxVolLimit() int64
 	GetMetadataOpts() metadata.MetadataOpts
 	GetBlockStorageOpts() BlockStorageOpts
+	GetCapacity() int64
 }
 
 type OpenStack struct {
@@ -71,6 +72,7 @@ type OpenStack struct {
 	bsOpts       BlockStorageOpts
 	epOpts       gophercloud.EndpointOpts
 	metadataOpts metadata.MetadataOpts
+	projectInfo  ProjectInfo
 }
 
 type BlockStorageOpts struct {
@@ -83,6 +85,10 @@ type Config struct {
 	Global       client.AuthOpts
 	Metadata     metadata.MetadataOpts
 	BlockStorage BlockStorageOpts
+}
+
+type ProjectInfo struct {
+	ProjectID    string
 }
 
 func logcfg(cfg Config) {
@@ -176,6 +182,7 @@ func CreateOpenStackProvider() (IOpenStack, error) {
 		bsOpts:       cfg.BlockStorage,
 		epOpts:       epOpts,
 		metadataOpts: cfg.Metadata,
+		projectInfo:  ProjectInfo{ProjectID: cfg.Global.TenantID},
 	}
 
 	return OsInstance, nil

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -397,3 +397,8 @@ func (os *OpenStack) diskIsUsed(volumeID string) (bool, error) {
 func (os *OpenStack) GetBlockStorageOpts() BlockStorageOpts {
 	return os.bsOpts
 }
+
+// GetCapacity returns 
+func (os *OpenStack) GetCapacity() int {
+	return 1
+}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
