### PR TITLE
[cinder-csi-plugin] made ControllerUnpublishVolume call idempotent

### DIFF
--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -282,7 +282,8 @@ func (os *OpenStack) DetachVolume(instanceID, volumeID string) error {
 		}
 	}
 
-	return fmt.Errorf("disk: %s has no attachments or not attached to compute %s", volume.ID, instanceID)
+	// Disk has no attachments or not attached to provided compute
+	return nil
 }
 
 // WaitDiskDetached waits for detached


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

The [CSI spec](https://github.com/container-storage-interface/spec/blob/master/spec.md#controllerunpublishvolume) lists that the `ControllerUnpublishVolume` function should be idempotent. If the volume corresponding to the `volume_id` is not attached to the node corresponding to the `node_id`, the Plugin MUST reply `0 OK`.

This is not the case for the cinder-csi-plugin. If the disk is not attached to the compute, the `DetachVolume` function returns an [error](https://github.com/kubernetes/cloud-provider-openstack/blob/master/pkg/csi/cinder/openstack/openstack_volumes.go#L285). This in turn causes the `ControllerUnpublishVolume` function to return an [error](https://github.com/kubernetes/cloud-provider-openstack/blob/master/pkg/csi/cinder/controllerserver.go#L256).

The non-idempotency of the `ControllerUnpublishVolume` function causes Kubernetes to keep retrying detachment of volumes that have somehow been detached via a different process than the cinder-csi-plugin. It is not able to recover from this state by itself. Generally, the cinder-csi-plugin should manage all volume detachments, but it is always possible that this happens externally. We should prevent such state inconsistencies from occuring.

This PR ensures that `DetachVolume` does not return an error if the volume is not attached to the compute, making the `ControllerUnpublishVolume` function idempotent to adhere to the CSI spec. This ensures that Kubernetes is able to put `VolumeAttachments` in the expected state, even if some external processes detached a volume from a node.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
I have tested this fix in our Kubernetes cluster, where the above described `VolumeAttachment` inconsistencies were present. The problem was solved by this fix, and the plugin is still functioning as it should.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
