### PR TITLE
Update snapshots examples to start using v1 API

### DIFF
--- a/examples/cinder-csi-plugin/snapshot/example.yaml
+++ b/examples/cinder-csi-plugin/snapshot/example.yaml
@@ -6,7 +6,7 @@ provisioner: cinder.csi.openstack.org
 
 ---
 
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   name: csi-cinder-snapclass

--- a/examples/cinder-csi-plugin/snapshot/snapshotcreate.yaml
+++ b/examples/cinder-csi-plugin/snapshot/snapshotcreate.yaml
@@ -1,4 +1,4 @@
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: new-snapshot-demo

--- a/examples/manila-csi-plugin/nfs/snapshot/snapshotclass.yaml
+++ b/examples/manila-csi-plugin/nfs/snapshot/snapshotclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   name: csi-manila-nfs

--- a/examples/manila-csi-plugin/nfs/snapshot/snapshotcreate.yaml
+++ b/examples/manila-csi-plugin/nfs/snapshot/snapshotcreate.yaml
@@ -1,4 +1,4 @@
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: new-nfs-share-snap


### PR DESCRIPTION
**What this PR does / why we need it**:

Snapshots v1 API is GA from 1.20, so we can address it in our examples:
https://kubernetes.io/blog/2020/12/10/kubernetes-1.20-volume-snapshot-moves-to-ga/

**Release note**:
```release-note
NONE
```