### PR TITLE
[occm] recreate load balancer pool on protocol mismatch

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1346,7 +1346,7 @@ func (lbaas *LbaasV2) ensureOctaviaPool(lbID string, listener *listeners.Listene
 	if svcConf.enableProxyProtocol {
 		poolProto = v2pools.ProtocolPROXY
 	} else if svcConf.keepClientIP && poolProto != v2pools.ProtocolHTTP {
-		// klog.V(4).Infof("Forcing to use %q protocol for pool because annotation %q is set", v2pools.ProtocolHTTP, ServiceAnnotationLoadBalancerXForwardedFor)
+		klog.V(4).Infof("Forcing to use %q protocol for pool because annotation %q is set", v2pools.ProtocolHTTP, ServiceAnnotationLoadBalancerXForwardedFor)
 		poolProto = v2pools.ProtocolHTTP
 	}
 

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1345,8 +1345,7 @@ func (lbaas *LbaasV2) ensureOctaviaPool(lbID string, listener *listeners.Listene
 	poolProto := v2pools.Protocol(listener.Protocol)
 	if svcConf.enableProxyProtocol {
 		poolProto = v2pools.ProtocolPROXY
-	} else if svcConf.keepClientIP && poolProto != v2pools.ProtocolHTTP {
-		klog.V(4).Infof("Forcing to use %q protocol for pool because annotation %q is set", v2pools.ProtocolHTTP, ServiceAnnotationLoadBalancerXForwardedFor)
+	} else if (svcConf.keepClientIP || svcConf.tlsContainerRef != "") && poolProto != v2pools.ProtocolHTTP {
 		poolProto = v2pools.ProtocolHTTP
 	}
 

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1340,6 +1340,38 @@ func (lbaas *LbaasV2) ensureOctaviaPool(lbID string, listener *listeners.Listene
 	if err != nil && err != openstackutil.ErrNotFound {
 		return nil, fmt.Errorf("error getting pool for listener %s: %v", listener.ID, err)
 	}
+
+	// By default, use the protocol of the listener
+	poolProto := v2pools.Protocol(listener.Protocol)
+	if svcConf.enableProxyProtocol {
+		poolProto = v2pools.ProtocolPROXY
+	} else if svcConf.keepClientIP && poolProto != v2pools.ProtocolHTTP {
+		// klog.V(4).Infof("Forcing to use %q protocol for pool because annotation %q is set", v2pools.ProtocolHTTP, ServiceAnnotationLoadBalancerXForwardedFor)
+		poolProto = v2pools.ProtocolHTTP
+	}
+
+	// Delete the pool and its members if it already exists and has the wrong protocol
+	if pool != nil && v2pools.Protocol(pool.Protocol) != poolProto {
+		klog.V(2).Infof("Deleting wrong pool %s for listener %s because the protocol does not match", pool.ID, listener.ID)
+
+		// Delete pool automatically deletes all its members.
+		mc := metrics.NewMetricContext("loadbalancer_pool", "delete")
+		if err = v2pools.Delete(lbaas.lb, pool.ID).ExtractErr(); err != nil {
+			if cpoerrors.IsNotFound(err) {
+				klog.V(2).Infof("Wrong pool %s for listener %s was already deleted: %v", pool.ID, listener.ID, err)
+			} else {
+				_ = mc.ObserveRequest(err)
+				return nil, fmt.Errorf("error deleting wrong pool %s for listener %s: %v", pool.ID, listener.ID, err)
+			}
+		}
+		_ = mc.ObserveRequest(nil)
+		provisioningStatus, err := waitLoadbalancerActiveProvisioningStatus(lbaas.lb, lbID)
+		if err != nil {
+			return nil, fmt.Errorf("timeout when waiting for loadbalancer to be ACTIVE after deleting pool, current provisioning status %s", provisioningStatus)
+		}
+		pool = nil
+	}
+
 	if pool == nil {
 		createOpt := lbaas.buildPoolCreateOpt(listener.Protocol, service, svcConf)
 		createOpt.ListenerID = listener.ID
@@ -2159,7 +2191,7 @@ func (lbaas *LbaasV2) ensureLoadBalancer(ctx context.Context, clusterName string
 			return nil, fmt.Errorf("error getting pool for listener %s: %v", listener.ID, err)
 		}
 		if pool == nil {
-			// Use the protocol of the listerner
+			// Use the protocol of the listener
 			poolProto := v2pools.Protocol(listener.Protocol)
 
 			if lbaas.opts.UseOctavia {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Previously adding the proxy-protocol annotation after the pool got
created did not change anything. With this fix changing the annotation
also recreates the load balancer pool because the protocol of a pool
can't get changed via an update call.

**Which issue this PR fixes(if applicable)**:

fixes #1167 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] Recreate load balancer pool if the protocol changed based on the service definition.
```

---
<sup>
Christian Schlotter <christian.schlotter@daimler.com>, Daimler TSS GmbH,
<a href="https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md">Imprint</a>
</sup>