### PR TITLE
[manila-csi-plugin] helm: added clusterID value

### DIFF
--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 1.2.0
+version: 1.2.1
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -83,7 +83,8 @@ spec:
             --fwdendpoint=$(FWD_CSI_ENDPOINT)
             {{- if .compatibilitySettings }}
             --compatibility-settings={{ .compatibilitySettings }}
-            {{- end }}'
+            {{- end }}
+            --cluster-id="{{ $.Values.csimanila.clusterID }}"'
           ]
           env:
             - name: DRIVER_NAME

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -76,7 +76,8 @@ spec:
             --endpoint=$(CSI_ENDPOINT)
             --drivername=$(DRIVER_NAME)
             --share-protocol-selector=$(MANILA_SHARE_PROTO)
-            --fwdendpoint=$(FWD_CSI_ENDPOINT)'
+            --fwdendpoint=$(FWD_CSI_ENDPOINT)
+            --cluster-id="{{ $.Values.csimanila.clusterID }}"'
           ]
           env:
             - name: DRIVER_NAME

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -10,10 +10,10 @@ shareProtocols:
     fwdNodePluginEndpoint:
       dir: /var/lib/kubelet/plugins/csi-nfsplugin
       sockFile: csi.sock
-#  - protocolSelector: CEPHFS
-#    fwdNodePluginEndpoint:
-#      dir: /var/lib/kubelet/plugins/cephfs.csi.ceph.com
-#      sockFile: csi.sock
+ # - protocolSelector: CEPHFS
+ #   fwdNodePluginEndpoint:
+ #     dir: /var/lib/kubelet/plugins/cephfs.csi.ceph.com
+ #     sockFile: csi.sock
 
 # CSI Manila spec
 csimanila:
@@ -28,9 +28,15 @@ csimanila:
           "matchExportLocationAddress": "172.168.122.0/24"
         }
       }
+
   # Availability zone for each node. topologyAwarenessEnabled must be set to true for this option to have any effect.
   # If your Kubernetes cluster runs atop of Nova and want to use Nova AZs as AZs for the nodes of the cluster, uncomment the line below:
   # nodeAZ: "$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq -r .availability_zone)"
+
+  # You may set ID of the cluster where manila-csi is deployed. This value will be appended
+  # to share metadata in newly provisioned shares as `manila.csi.openstack.org/cluster=<cluster ID>`.
+  clusterID: ""
+
   # Image spec
   image:
     repository: k8scloudprovider/manila-csi-plugin


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/kubernetes/cloud-provider-openstack/pull/1459 added `--cluster-id` cmd arg. This PR makes it possible to set it via the Helm chart.

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[manila-csi-plugin] Helm: Added optional clusterID value
```
