### PR TITLE
[Doc] Refactor dev guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,24 +2,16 @@
 
 The **kubernetes/cloud-provider-openstack** project accepts contribution via github [pull request](https://help.github.com/articles/about-pull-requests/). This document outlines the process to help get your contribution accepted. Please also read the [Kubernetes contributor guide](https://github.com/kubernetes/community/blob/master/contributors/guide/README.md)
 
-### Sign the Contributor License Agreement
-
+## Sign the Contributor License Agreement
 We'd love to accept your patches! Before we can accept them you need to sign Cloud Native Computing Foundation (CNCF) [CLA](https://github.com/kubernetes/community/blob/master/CLA.md).
 
-### Setup the Development Environment 
-Refer [getting started](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/getting-started-provider-dev.md)  document to setup development environment
-
-### Reporting an issue
+## Reporting an issue
 If you find a bug or a feature request related to cloud-provider-openstack you can create a new github issue in this repo @[kubernetes/cloud-provider-openstack](https://github.com/kubernetes/cloud-provider-openstack/issues).
 
-### Contributing a Patch
-1. Submit an issue describing your proposed change to the repo.
-2. Fork the cloud-provider-openstack repo, develop and test your code changes.
-3. Submit a pull request.
-4. The bot will automatically assigns someone to review your PR. Check the full list of bot commands [here](https://prow.k8s.io/command-help)
+## Submiting a Pull Request
+* Fork the cloud-provider-openstack repo, develop and test your code changes.
+* Submit a pull request.
+* The bot will automatically assigns someone to review your PR.
 
-### Contact and Meeting Time
-
-* [Slack](https://kubernetes.slack.com/messages/sig-openstack).
-* [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-openstack).
-* Please check the [sig-openstack community page](https://github.com/kubernetes/community/tree/master/sig-cloud-provider#provider-openstack) for meeting time.
+## Contact
+* [Slack](https://kubernetes.slack.com/messages/provider-openstack).

--- a/README.md
+++ b/README.md
@@ -13,13 +13,14 @@ This Repository hosts various plugins relevant to OpenStack and Kubernetes Integ
 * [Barbican KMS Plugin](/docs/barbican-kms-plugin/using-barbican-kms-plugin.md/)
 * [Magnum Auto Healer](/docs/magnum-auto-healer/using-magnum-auto-healer.md/)
 
-> NOTE: Cinder Standalone Provisioner, Manila Provisioner and Cinder FlexVolume Driver were removed since release v1.18.0.
+**NOTE:**
 
-> Version 1.17 was the last release of Manila Provisioner, which is unmaintained from now on. Due to dependency issues, we removed the code from master but it is still accessible in the [release-1.17](https://github.com/kubernetes/cloud-provider-openstack/tree/release-1.17) branch. Please consider migrating to Manila CSI Plugin.
+* Cinder Standalone Provisioner, Manila Provisioner and Cinder FlexVolume Driver were removed since release v1.18.0.
+* Version 1.17 was the last release of Manila Provisioner, which is unmaintained from now on. Due to dependency issues, we removed the code from master but it is still accessible in the [release-1.17](https://github.com/kubernetes/cloud-provider-openstack/tree/release-1.17) branch. Please consider migrating to Manila CSI Plugin.
 
 ## Developing
 
-Please Refer [Getting Started Guide](/docs/developers-guide.md/) for setting up development environment.
+Refer to [Getting Started Guide](/docs/developers-guide.md/) for setting up development environment and contributing.
 
 ## Contact
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -3,31 +3,24 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Getting Started with Cloud Provider OpenStack Development](#getting-started-with-cloud-provider-openstack-development)
-  - [Prerequisites](#prerequisites)
-    - [OpenStack Cloud](#openstack-cloud)
-    - [Docker](#docker)
-    - [Development tools](#development-tools)
-  - [Development](#development)
-    - [Getting and Building Cloud Provider OpenStack](#getting-and-building-cloud-provider-openstack)
-      - [Building inside container](#building-inside-container)
-    - [Getting and Building Kubernetes](#getting-and-building-kubernetes)
-    - [Running the Cloud Provider](#running-the-cloud-provider)
-  - [Publish Container images](#publish-container-images)
-    - [Build and push images](#build-and-push-images)
-    - [Only Build Image](#only-build-image)
-  - [Troubleshooting](#troubleshooting)
+    - [Prerequisites](#prerequisites)
+        - [OpenStack Cloud](#openstack-cloud)
+        - [Kubernetes cluster](#kubernetes-cluster)
+    - [Contribution](#contribution)
+    - [Development](#development)
+        - [Build openstack-cloud-controller-manager image](#build-openstack-cloud-controller-manager-image)
+        - [Troubleshooting](#troubleshooting)
+        - [Review process](#review-process)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Getting Started with Cloud Provider OpenStack Development
 
-This guide will help you get started with building a development environment for you
-to build and run a single node Kubernetes cluster with the OpenStack Cloud Provider
+This guide will help you get started with building a development environment run a single node Kubernetes cluster with the OpenStack Cloud Provider
 enabled.
 
-## Prerequisites
 
-To get started, you will need to set up your development environment.
+## Prerequisites
 
 ### OpenStack Cloud
 You will need access to an OpenStack cloud, either public or private. You can sign up
@@ -35,287 +28,108 @@ for a public OpenStack Cloud through the [OpenStack Passport](https://www.openst
 program, or you can install a small private development cloud with
 [DevStack](https://docs.openstack.org/devstack/latest/).
 
-Once you have obtained access to an OpenStack cloud, you will need to start a development
-VM. The rest of this guide assumes a CentOS 7 cloud image, but should be easily transferrable
-to whatever development environment you prefer. You will need to have your cloud credentials
-loaded into your environment. For example, I use this `openrc` file:
+openstack-cloud-controller-manager relies on [Octavia](https://docs.openstack.org/octavia/latest/) to create Kubernetes Service of type LoadBalancer, so make sure Octavia is available in the OpenStack cloud. For public cloud, you need to check the cloud documentation. For devstack, refer to Octavia deployment [quick start guide](https://docs.openstack.org/octavia/latest/contributor/guides/dev-quick-start.html). If you want to create service with TLS termination, [Barbican](https://docs.openstack.org/barbican/latest/) is also required.
 
-```
-export OS_PROJECT_DOMAIN_NAME=Default
-export OS_USER_DOMAIN_NAME=Default
-export OS_DOMAIN_ID=<domain_id_that_matches_name>
-export OS_PROJECT_NAME=<project_name>
-export OS_TENANT_NAME=<project_name>
-export OS_TENANT_ID=<project_id_that_matches_name>
-export OS_USERNAME=<username>
-export OS_PASSWORD=<password>
-export OS_AUTH_URL=http://<openstack_keystone_endpoint>/v3
-export OS_INTERFACE=public
-export OS_IDENTITY_API_VERSION=3
-export OS_REGION_NAME=<region_name>
-```
+DevStack is recommended for cloud provider openstack development as some features are dependent on latest versions of openstack services, which is not always the case for public cloud providers. To get better performance, it's recommended to enable [nested virtualization](https://docs.openstack.org/devstack/latest/guides/devstack-with-nested-kvm.html) on the devstack host.
 
-The specific values you use will vary based on your particular environment. You may
-notice that several values are aliases of one another. This is in part because the
-values expected by the OpenStack client and
-[Gopher Cloud](https://github.com/gophercloud/gophercloud) are slightly different,
-especially with respect to the change from using `tenant` to `project`. One of our
-development goals is to make this setup easier and more consistent.
+### Kubernetes cluster
+Deploy a kubernetes cluster in the openstack cloud.
 
-### Docker
+There are many [deployment tools](https://kubernetes.io/docs/tasks/tools/) out there to help you set up a kubernetes cluster, you can also follow the [kubernetes contributor guide](https://github.com/kubernetes/community/blob/master/contributors/devel/running-locally.md) to run a cluster locally. As you already have openstack, you can take a look at [Cluster API Provider OpenStack](https://github.com/kubernetes-sigs/cluster-api-provider-openstack) as well.
 
-Your cloud instance will need to have Docker installed. To install, please refer to [Docker Container runtime](https://kubernetes.io/docs/setup/production-environment/container-runtimes/#docker).
+Choose the one you are familiar with and easy to customize. Config the cluster with [external cloud controller manager](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller).
 
-### Development tools
+Using kubeadm, openstack-cloud-controller-manager can be deployed easily with predefined manifests, see the [deployment guide with kubeadm](openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#deploy-a-kubernetes-cluster-with-openstack-cloud-controller-manager-using-kubeadm).
 
-You're going to need a few basic development tools and applications to get, build, and run
-the source code. With your package manager you can install `git`, `gcc` and `etcd`.
 
-```
-sudo yum install -y -q git gcc etcd
+## Contribution
+Now you should have a kubernetes cluster running in openstack and openstack-cloud-controller-manager is deployed in the cluster. Over time, you may find a bug or have some feature requirements, it's time for contribution!
 
-```
+A contribution can be anything which helps this project improving. In addition to code contribution it can be testing, documentation, requirements gathering, bug reporting and so forth.
 
-You will also need a recent version of Go and set your environment variables.
+See [Contributing Guidelines](../CONTRIBUTING.md) for some general information about contribution.
 
-```
-GO_VERSION=1.13.4
-GO_ARCH=linux-amd64
-curl -o go.tgz https://dl.google.com/go/go${GO_VERSION}.${GO_ARCH}.tar.gz
-sudo tar -C /usr/local/ -xvzf go.tgz
-export GOROOT=/usr/local/go
-export GOPATH=$HOME/go
-```
-
-Finally, set up your Git identity and GitHub integrations.
-
-More comprehensive setup instructions are available in the
-[Development Guide](https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#building-kubernetes-on-a-local-osshell-environment)
-in the Kubernetes repository. When in doubt, check there for additional setup
-and versioning information.
 
 ## Development
+If you are ready for code contribution, you need to have development environment.
 
-### Getting and Building Cloud Provider OpenStack
+1. Install [Golang](https://golang.org/doc/install). You can choose the golang version same with the version defined in [go.mod](https://github.com/kubernetes/cloud-provider-openstack/blob/master/go.mod#L3) file.
+1. IDE. You can choose any IDE that supports Golang, e.g. Visual Studio Code, GoLand, etc.
+1. Install [Docker Engine](https://docs.docker.com/engine/install/) or other tools that could build container images such as [podman](https://podman.io/). After writing the code, the best way to test openstack-cloud-controller-manager is to replace the container image specified in its Deployment/StatefulSet/DaemonSet manifest in the kubernetes cluster. We are using docker in this guide.
 
-Following the [GitHub Workflow](https://github.com/kubernetes/community/blob/master/contributors/guide/github-workflow.md) guidelines for Kubernetes development, set up your environment and get the latest development repository. Begin by forking both the Kubernetes and Cloud-Provider-OpenStack projects into your GitHub into your local workspace (or bringing your current fork up to date with the current state of both repositories).
-
-`make` will build, test, and package this project. This project uses [go modules](https://github.com/golang/go/wiki/Modules) for dependency management since v1.17.
-
-Set up some environment variables to help download the repositories
-
-```
-export GOPATH=$HOME/go
-export GOROOT=/usr/local/go
-export PATH=$PATH:$GOROOT/bin
-export user={your github profile name}
-export working_dir=$GOPATH/src/k8s.io
-```
-
-With your environment variables set up, clone the forks into your go environment.
+### Build openstack-cloud-controller-manager image
+In cloud-provider-openstack repo directory, run:
 
 ```
-mkdir -p $working_dir
-cd $working_dir
-git clone https://github.com/{user}/cloud-provider-openstack
-cd cloud-provider-openstack
-```
-
-If you want to build the plugins for single architecture:
-
-```
-# ARCH default to amd64
-export ARCH=arm64
-make build
-```
-
-And if you want to build the plugins for multiple architectures:
-
-```
-# ARCHS default to 'amd64 arm arm64 ppc64le s390x'
-export ARCHS='amd64 arm arm64 ppc64le s390x'
-make build-all-archs
-```
-
-If you want to run unit tests:
-
-```
-make test
-```
-
-#### Building inside container
-
-If you don't have a Go Environment setup, we also offer the ability to run make
-in a Docker Container.  The only requirement for this is that you have Docker
-installed and configured (of course).  You don't need to have a Golang
-environment setup, and you don't need to follow rules in terms of directory
-structure for the code checkout.
-
-To use this method, just call the `hack/make.sh` script with the desired argument:
-    `hack/make.sh build`  for example will run `make build` in a container.
-
-> NOTE: You MUST run the script from the root source directory as shown above,
-attempting to do something like `cd hack && make.sh build` will not work
-because we won't bind mount the source files into the container.
-
-### Getting and Building Kubernetes
-
-To get and build Kubernetes
-
-```
-cd $working_dir
-export KUBE_FASTBUILD=true
-git clone https://github.com/{user}/kubernetes
-cd kubernetes
-make cross
-```
-
-### Running the Cloud Provider
-
-To run the OpenStack provider, integrated with your cloud, be sure to have sourced the
-environment variables. You will also need to create an `/etc/kubernetes/cloud-config` file
-with the minimum options:
-
-```
-[Global]
-username=<username>
-password=<password>
-auth-url=http://<auth_endpoint>/v3
-tenant-id=<project_id>
-domain-id=<domain_id>
-```
-
-Start your cluster with the `hack/local-up-cluster.sh` with the proper environment variable set to
-enable the external cloud provider:
-
-```
-export EXTERNAL_CLOUD_PROVIDER_BINARY=$GOPATH/src/k8s.io/cloud-provider-openstack/openstack-cloud-controller-manager
-export EXTERNAL_CLOUD_PROVIDER=true
-export CLOUD_PROVIDER=openstack
-export CLOUD_CONFIG=/etc/kubernetes/cloud-config
-./hack/local-up-cluster.sh
-```
-
-After giving the cluster time to build and start, you can access it through the directions
-provided by the script:
-
-```
-export KUBECONFIG=/var/run/kubernetes/admin.kubeconfig
-./cluster/kubectl.sh
-```
-
-The cluster/addons/rbac has a set of yaml files, currently it has
-cloud-controller-manager-role-bindings.yaml
-cloud-controller-manager-roles.yaml
-
-you need use following command to create ClusterRole and ClusterRoleBinding
-otherwise the cloud-controller-manager is not able to access k8s API.
-```
-./cluster/kubectl.sh create -f $working_dir/cloud-provider-openstack/cluster/addons/rbac/
-```
-
-Have a good time with OpenStack and Kubernetes!
-
-## Publish Container images
-
-We allow build and publish container images for multiple architectures.
-
-### Build and push images
-
-To build and push all supported images for all architecture.
-
-```
-# default value of VERSION is "{part of latest commit id}-dirty"
-export VERSION=latest
-# default registry is "k8scloudprovider"
-export REGISTRY=k8scloudprovider
-# No need to provide "DOCKER_PASSWORD" and "DOCKER_USERNAME" if environment already logged in.
-export DOCKER_PASSWORD=password
-export DOCKER_USERNAME=username
-
-# default value for IMAGE_NAMES includes all supported images.
-export IMAGE_NAMES='openstack-cloud-controller-manager cinder-flex-volume-driver cinder-provisioner cinder-csi-plugin k8s-keystone-auth octavia-ingress-controller manila-provisioner manila-csi-plugin barbican-kms-plugin magnum-auto-healer'
-# default value for ARCHS includes all supported architectures.
-export ARCHS='amd64 arm arm64 ppc64le s390x'
-
-make upload-images
-```
-
-Here's example to explain `make upload-images`
-`upload-images` will first build images with architectures.
-For example with `REGISTRY=k8scloudprovider`, `VERSION=latest`, `IMAGE_NAMES=openstack-cloud-controller-manager`,
-and `ARCHS=arm64 amd64` will build following two images
-- `k8scloudprovider/openstack-cloud-controller-manager-arm64:latest`
-- `k8scloudprovider/openstack-cloud-controller-manager-amd64:latest`
-
-Second, it will than upload above two images.
-And finally, it will build image manifest to upload image `k8scloudprovider/openstack-cloud-controller-manager:latest` (with no architecture in image name).
-
-Image `k8scloudprovider/openstack-cloud-controller-manager:latest` will support two different `OS/ARCH` tag: `linux/arm64` and `linux/amd64`.
-
-From this point all images are ready in image repositories.
-To start using image with specific architecture. You can use `--platform` or without if you plan to use default platform:
-
-```
-docker pull --platform=linux/amd64 k8scloudprovider/openstack-cloud-controller-manager:latest
-```
-
-Or you can use image with architecture tagged in name:
-
-```
-docker pull k8scloudprovider/openstack-cloud-controller-manager-amd64:latest
-```
-
-Note that since image `k8scloudprovider/openstack-cloud-controller-manager:latest` is build by manifest,
-the image digest for image pull from `k8scloudprovider/openstack-cloud-controller-manager:latest` will be different to
-image you pull from `k8scloudprovider/openstack-cloud-controller-manager-amd64:latest`.
-
-### Only Build Image
-
-It's generally more recommended to use `make upload-images` to build and push image.
-But you might need to build image and run test on it if you're running a test job to verify that image.
-
-To prepare default environment variables:
-
-```
-# default value of VERSION is "{part of latest commit id}-dirty"
-export VERSION=latest
-
-# default value for IMAGE_NAMES includes all supported images.
-export IMAGE_NAMES='openstack-cloud-controller-manager magnum-auto-healer'
-# default value for ARCHS includes all supported architectures.
-```
-
-If you not plan to build image, you can directly run `make images-all-archs` to support build for all specified images with all specified architectures.
-
-```
-export ARCHS='amd64 arm arm64 ppc64le s390x'
-make images-all-archs
-```
-
-If you plan to build image for single architecture, you can either specify `ARCHS` as `amd64` or run below commands
-
-```
-export ARCH=amd64
-make build-images
-```
-
-Or if you wish to ony build for specific architecture with specific image
-
-```
-export ARCH=amd64
+REGISTRY=<your-dockerhub-account> \
+VERSION=<image-tag> \
 make image-openstack-cloud-controller-manager
 ```
-In case of building images, by default, images built are appended with this -$ARCH tag at the end.
-For example, for the above case, openstack-cloud-controller-manager-amd64 is built.
-In case needed without it, tag it separately as required.
+
+The above command builds a container image locally with the name:
 
 ```
-docker image tag openstack-cloud-controller-manager-amd64:latest openstack-cloud-controller-manager:latest
+<your-dockerhub-account>/openstack-cloud-controller-manager-amd64:<image-tag>
 ```
 
-This will create image with tag `openstack-cloud-controller-manager:latest` in your local environment.
+You may notice there is a suffix `-amd64` because cloud-provider-openstack supports to build images with multiple architectures (`amd64 arm arm64 ppc64le s390x`) and `amd64` is the default. You can specify others with the command:
 
-## Troubleshooting
+```
+ARCH=amd64 \
+REGISTRY=<your-dockerhub-account> \
+VERSION=<image-tag> \
+make image-openstack-cloud-controller-manager
+```
 
-You can increase a log level verbosity (`-v` parameter) to know better what is happening during the OpenStack Cloud Controller Manager runtime. Setting the log level to **6** allows you to see OpenStack API JSON requests and responses. It is recommended to set a `--concurrent-service-syncs` parameter to **1** for a better output tracking.
+If the kubernetes cluster can't access the image locally, you need to upload the image to container registry first by running `docker push`.
+
+
+The image can also be uploaded automatically together with build:
+
+```
+REGISTRY=<your-dockerhub-account> \
+VERSION=<image-tag> \
+DOCKER_USERNAME=<your-dockerhub-account> \
+DOCKER_PASSWORD=<your-dockerhub-password> \
+IMAGE_NAMES=openstack-cloud-controller-manager \
+make upload-image-amd64
+```
+
+Now, you can change openstack-cloud-controller-manager image in the kubernetes cluster, assuming the openstack-cloud-controller-manager is running as a DaemonSet:
+
+```
+kubectl -n kube-system set image \
+  daemonset/openstack-cloud-controller-manager \
+  openstack-cloud-controller-manager=<your-dockerhub-account>/openstack-cloud-controller-manager-amd64:<image-tag>
+```
+
+### Troubleshooting
+* Show verbose information for openstack API request
+
+  To get better understanding about communication with openstack, you can set `--v=6` to see more detailed API requests and responses. It is recommended to set `--concurrent-service-syncs=1` as well.
+
+### Review process
+Everyone is encouraged to review code. You don't need to know every detail of the code base. You need to understand only what the code related to the fix does.
+
+As a reviewer, remember that you are providing a service to submitters, not the other way around. As a submitter, remember that everyone is subject to the same rules: even the repo maintainers voting on your patch put their changes through the same code review process.
+
+Read [reviewing changes](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/reviewing-changes-in-pull-requests) for how the github review process looks like.
+
+Guidance for the code reviewer:
+
+* We need at least two `/lgtm` from reviewers before `/approve` a PR. However, two `lgtm` is not equal to a `/approve`.
+* Only the people in the `approvers` section of the OWNERS file have the `/approve` permission.
+* Do not `/approve` in your own PR.
+* In certain circumstances we allow `/approve` with only one `/lgtm` such as:
+  * Typo fix
+  * CI job quick fix
+  * Changing document with no more than 3 lines
+* If a PR needs further discussion and to avoid unintentional merge, use `/hold` (and remember to `/hold cancel` if all concerns are sorted).
+
+Guidance for the code submitter:
+
+* Follow the PR template by providing sufficient information for the reviewers.
+* Make sure all the CI jobs pass before the PR is reviewed
+* If the PR is not ready for review, add `[WIP]` in the PR title to save reviewer's time.
+* If the job failure is unrelated to the PR, type `/test <job name>` in the comment to re-trigger the job, e.g. `/test cloud-provider-openstack-acceptance-test-lb-octavia`
+* If the job keeps failing and you are not sure what to do, contact the repo maintainers for help (either using `/cc` in the PR or in `#provider-openstack` Slack channel).

--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -89,8 +89,12 @@ Implementation of openstack-cloud-controller-manager relies on several OpenStack
 | Compute (Nova)                 | v2             | No         | Yes      |
 | Load Balancing (Neutron-LBaaS) | v1, v2         | Yes        | No       |
 | Load Balancing (Octavia)       | v2             | No         | Yes      |
+| Key Manager (Barbican)         | v1             | No         | No       |
 
-> NOTE: Block Storage is not needed for openstack-cloud-controller-manager in favor of [cinder-csi-plugin](./cinder-csi-plugin/using-cinder-csi-plugin.md).
+NOTE:
+
+* Block Storage is not needed for openstack-cloud-controller-manager in favor of [cinder-csi-plugin](./cinder-csi-plugin/using-cinder-csi-plugin.md).
+* Barbican is required to support creating Service of LoadBalancer type with TLS termination.
 
 ### Global
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Add some guide for reviewers and contributors.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
