### PR TITLE
[occm] add missing RBAC for serviceaccount token

### DIFF
--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 1.1.0
+version: 1.1.1
 maintainers:
   - name: morremeyer
     email: kubernetes@maurice-meyer.de

--- a/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
@@ -43,6 +43,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
   verbs:
   - create


### PR DESCRIPTION
**What this PR does / why we need it**:

New clientbuilder needs permission to create serviceaccount token

**Which issue this PR fixes(if applicable)**:
fixes #1514 

**Special notes for reviewers**:
none

**Release note**:
```release-note
NONE
```
