### PR TITLE
Less hasty backoff for loadbalancers

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -66,19 +66,19 @@ const (
 	defaultLoadBalancerSourceRanges = "0.0.0.0/0"
 	// loadbalancerActive* is configuration of exponential backoff for
 	// going into ACTIVE loadbalancer provisioning status. Starting with 1
-	// seconds, multiplying by 1.2 with each step and taking 19 steps at maximum
-	// it will time out after 128s, which roughly corresponds to 120s
+	// seconds, multiplying by 1.75 with each step and taking 8 steps at maximum
+	// it will time out after 114s
 	loadbalancerActiveInitDelay = 1 * time.Second
-	loadbalancerActiveFactor    = 1.2
-	loadbalancerActiveSteps     = 19
+	loadbalancerActiveFactor    = 1.75
+	loadbalancerActiveSteps     = 8
 
 	// loadbalancerDelete* is configuration of exponential backoff for
 	// waiting for delete operation to complete. Starting with 1
-	// seconds, multiplying by 1.2 with each step and taking 13 steps at maximum
-	// it will time out after 32s, which roughly corresponds to 30s
+	// seconds, multiplying by 1.75 with each step and taking 6 steps at maximum
+	// it will time out after 35s
 	loadbalancerDeleteInitDelay = 1 * time.Second
-	loadbalancerDeleteFactor    = 1.2
-	loadbalancerDeleteSteps     = 13
+	loadbalancerDeleteFactor    = 1.75
+	loadbalancerDeleteSteps     = 6
 
 	activeStatus = "ACTIVE"
 	errorStatus  = "ERROR"


### PR DESCRIPTION
Affects:
* openstack-cloud-controller-manager (occm)
* octavia-ingress-controller

**What this PR does / why we need it**:

Current backoff factor when creating or deleting Octavia loadbalancers is only 1.2. If a large number of loadbalancers is created at the same time, the load can be too much for OpenStack API. The proposed change helps OpenStack API cope with the number of requests, while still maintaining a good total backoff time.