### PR TITLE
[all/helm] Pin appVersion to v1.21.0

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.21.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 1.3.7
+version: 1.3.8
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: latest
+appVersion: v1.21.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
 version: 1.3.7

--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.21.0
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 1.1.1
+version: 1.1.2
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: latest
+appVersion: v1.21.0
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
 version: 1.1.1

--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 1.0.0
+version: 1.0.1
 maintainers:
   - name: morremeyer
     email: kubernetes@maurice-meyer.de

--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "latest"
+appVersion: v1.21.0
 description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR pins `appVersion` of all currently available CPO Helm charts in `release-1.21` branch to `v1.21.0`.

**Which issue this PR fixes(if applicable)**:
fixes #1525

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
