### PR TITLE
[magnum-auto-healer] Fix duplicated repair action

### DIFF
--- a/pkg/autohealing/config/config.go
+++ b/pkg/autohealing/config/config.go
@@ -56,6 +56,9 @@ type Config struct {
 
 	// (Optional) How long after new node added that the node will be checked for health status. Default: 10m
 	CheckDelayAfterAdd time.Duration `mapstructure:"check-delay-after-add"`
+
+	// (Optional) How long to wait after a node being rebooted
+	RebuildDelayAfterReboot time.Duration `mapstructure:"rebuild-delay-after-reboot"`
 }
 
 type healthCheck struct {
@@ -83,12 +86,13 @@ type kubeConfig struct {
 // NewConfig defines the default values for Config
 func NewConfig() Config {
 	return Config{
-		DryRun:               false,
-		CloudProvider:        "openstack",
-		MonitorInterval:      30 * time.Second,
-		MasterMonitorEnabled: true,
-		WorkerMonitorEnabled: true,
-		LeaderElect:          true,
-		CheckDelayAfterAdd:   10 * time.Minute,
+		DryRun:                  false,
+		CloudProvider:           "openstack",
+		MonitorInterval:         60 * time.Second,
+		MasterMonitorEnabled:    true,
+		WorkerMonitorEnabled:    true,
+		LeaderElect:             true,
+		CheckDelayAfterAdd:      10 * time.Minute,
+		RebuildDelayAfterReboot: 5 * time.Minute,
 	}
 }

--- a/pkg/autohealing/controller/controller.go
+++ b/pkg/autohealing/controller/controller.go
@@ -316,6 +316,10 @@ func (c *Controller) repairNodes(unhealthyNodes []healthcheck.NodeInfo) {
 					newNode := node.KubeNode.DeepCopy()
 					newNode.Spec.Unschedulable = true
 
+					// Skip cordon for master node
+					if node.IsWorker == false {
+						continue
+					}
 					if _, err := c.kubeClient.CoreV1().Nodes().Update(context.TODO(), newNode, metav1.UpdateOptions{}); err != nil {
 						log.Errorf("Failed to cordon node %s, error: %v", nodeName, err)
 					} else {

--- a/pkg/autohealing/healthcheck/healthcheck.go
+++ b/pkg/autohealing/healthcheck/healthcheck.go
@@ -17,6 +17,8 @@ limitations under the License.
 package healthcheck
 
 import (
+	"time"
+
 	apiv1 "k8s.io/api/core/v1"
 	log "k8s.io/klog/v2"
 )
@@ -32,6 +34,8 @@ type NodeInfo struct {
 	KubeNode    apiv1.Node
 	IsWorker    bool
 	FailedCheck string
+	FoundAt     time.Time
+	RebootAt    time.Time
 }
 
 type HealthCheck interface {
@@ -81,6 +85,7 @@ func CheckNodes(checkers []HealthCheck, nodes []NodeInfo, controller NodeControl
 		for _, checker := range checkers {
 			if !checker.Check(node, controller) {
 				node.FailedCheck = checker.GetName()
+				node.FoundAt = time.Now()
 				unhealthyNodes = append(unhealthyNodes, node)
 				break
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is kind of a regression issue. After introducing the feature that restarts the broken node if it's found the first time, then the stack update action is quick because there is no real action involved. But the controller is still polling the status periodically, so another round check coming and will trigger the repair again.

**Which issue this PR fixes(if applicable)**:
fixes #1529 

**Special notes for reviewers**:


**Release note**:
```release-note
[magnum-auto-healer] Fix duplicated auto-healing actions and the default health check period is changed from 30s to 60s.
```
