### PR TITLE
[occm] Add support of trunk ports

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -801,7 +801,7 @@ func getBoolFromServiceAnnotation(service *corev1.Service, annotationKey string,
 }
 
 // getSubnetIDForLB returns subnet-id for a specific node
-func getSubnetIDForLB(compute *gophercloud.ServiceClient, node corev1.Node) (string, error) {
+func getSubnetIDForLB(compute *gophercloud.ServiceClient, node corev1.Node, network *gophercloud.ServiceClient) (string, error) {
 	ipAddress, err := nodeAddressForLB(&node)
 	if err != nil {
 		return "", err
@@ -812,7 +812,7 @@ func getSubnetIDForLB(compute *gophercloud.ServiceClient, node corev1.Node) (str
 		instanceID = instanceID[(ind + 1):]
 	}
 
-	interfaces, err := getAttachedInterfacesByID(compute, instanceID)
+	interfaces, err := getAttachedInterfacesByID(compute, instanceID, network)
 	if err != nil {
 		return "", err
 	}
@@ -1497,7 +1497,7 @@ func (lbaas *LbaasV2) checkServiceUpdate(service *corev1.Service, nodes []*corev
 		} else {
 			svcConf.lbMemberSubnetID = getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerSubnetID, lbaas.opts.SubnetID)
 			if len(svcConf.lbMemberSubnetID) == 0 && len(nodes) > 0 {
-				subnetID, err := getSubnetIDForLB(lbaas.compute, *nodes[0])
+				subnetID, err := getSubnetIDForLB(lbaas.compute, *nodes[0], lbaas.network)
 				if err != nil {
 					return fmt.Errorf("no subnet-id found for service %s: %v", serviceName, err)
 				}
@@ -1590,7 +1590,7 @@ func (lbaas *LbaasV2) checkService(service *corev1.Service, nodes []*corev1.Node
 		svcConf.lbMemberSubnetID = svcConf.lbSubnetID
 	}
 	if len(svcConf.lbNetworkID) == 0 && len(svcConf.lbSubnetID) == 0 {
-		subnetID, err := getSubnetIDForLB(lbaas.compute, *nodes[0])
+		subnetID, err := getSubnetIDForLB(lbaas.compute, *nodes[0], lbaas.network)
 		if err != nil {
 			return fmt.Errorf("failed to get subnet to create load balancer for service %s: %v", serviceName, err)
 		}
@@ -1972,7 +1972,7 @@ func (lbaas *LbaasV2) ensureLoadBalancer(ctx context.Context, clusterName string
 	if len(lbaas.opts.SubnetID) == 0 && len(lbaas.opts.NetworkID) == 0 {
 		// Get SubnetID automatically.
 		// The LB needs to be configured with instance addresses on the same subnet, so get SubnetID by one node.
-		subnetID, err := getSubnetIDForLB(lbaas.compute, *nodes[0])
+		subnetID, err := getSubnetIDForLB(lbaas.compute, *nodes[0], lbaas.network)
 		if err != nil {
 			klog.Warningf("Failed to find subnet-id for loadbalancer service %s/%s: %v", apiService.Namespace, apiService.Name, err)
 			return nil, fmt.Errorf("no subnet-id for service %s/%s : subnet-id not set in cloud provider config, "+
@@ -2797,7 +2797,7 @@ func (lbaas *LbaasV2) updateLoadBalancer(ctx context.Context, clusterName string
 	if len(lbaas.opts.SubnetID) == 0 && len(nodes) > 0 {
 		// Get SubnetID automatically.
 		// The LB needs to be configured with instance addresses on the same subnet, so get SubnetID by one node.
-		subnetID, err := getSubnetIDForLB(lbaas.compute, *nodes[0])
+		subnetID, err := getSubnetIDForLB(lbaas.compute, *nodes[0], lbaas.network)
 		if err != nil {
 			klog.Warningf("Failed to find subnet-id for loadbalancer service %s/%s: %v", service.Namespace, service.Name, err)
 			return fmt.Errorf("no subnet-id for service %s/%s : subnet-id not set in cloud provider config, "+


### PR DESCRIPTION
Currenlty, getAttachedInterfacesByID() only returns neutron ports directly attached to VM.
For vlan-aware VMs that have trunk ports, subports attached to the trunk ports are not returned.
This pull request checks if VM has trunk ports, if so, adds their subports in the return.

Signed-off-by: Jing Zhang <jing.c.zhang@nokia.com>

<!--
Please add the affected binary name in the title unless multiple binaries are affected
For openstack-cloud-controller-manager, you can use [occm] for short.

**What this PR does / why we need it**:

This PR is to support vlan-aware VMs. This type of VMs are assigned with neutron trunk ports and subports.

**Special notes for reviewers**:

Testing has been done by deploying Kuberetes cluster over nova instances using trunk ports.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
