### PR TITLE
[cinder-csi-plugin] helm: Expose scheduler constraints in values.yaml

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 1.4.0
+version: 1.4.1
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -138,3 +138,6 @@ spec:
             path: /etc/kubernetes
         {{- end }}
         {{ .Values.csi.plugin.volumes | toYaml | trimSuffix "\n" | nindent 8 }}
+      affinity: {{ toYaml .Values.csi.plugin.controllerPlugin.affinity | nindent 8 }}
+      nodeSelector: {{ toYaml .Values.csi.plugin.controllerPlugin.nodeSelector | nindent 8 }}
+      tolerations: {{ toYaml .Values.csi.plugin.controllerPlugin.tolerations | nindent 8 }}

--- a/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -38,6 +38,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources: {{ toYaml .Values.csi.attacher.resources | nindent 12 }}
         - name: csi-provisioner
           image: "{{ .Values.csi.provisioner.image.repository }}:{{ .Values.csi.provisioner.image.tag }}"
           imagePullPolicy: {{ .Values.csi.provisioner.image.pullPolicy }}
@@ -53,6 +54,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources: {{ toYaml .Values.csi.provisioner.resources | nindent 12 }}
         - name: csi-snapshotter
           image: "{{ .Values.csi.snapshotter.image.repository }}:{{ .Values.csi.snapshotter.image.tag }}"
           imagePullPolicy: {{ .Values.csi.snapshotter.image.pullPolicy }}
@@ -65,6 +67,7 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
+          resources: {{ toYaml .Values.csi.snapshotter.resources | nindent 12 }}
         - name: csi-resizer
           image: "{{ .Values.csi.resizer.image.repository }}:{{ .Values.csi.resizer.image.tag }}"
           imagePullPolicy: {{ .Values.csi.resizer.image.pullPolicy }}
@@ -78,6 +81,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources: {{ toYaml .Values.csi.resizer.resources | nindent 12 }}
         - name: liveness-probe
           image: "{{ .Values.csi.livenessprobe.image.repository }}:{{ .Values.csi.livenessprobe.image.tag }}"
           imagePullPolicy: {{ .Values.csi.livenessprobe.image.pullPolicy }}
@@ -89,6 +93,7 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
+          resources: {{ toYaml .Values.csi.livenessprobe.resources | nindent 12 }}
         - name: cinder-csi-plugin
           image: "{{ .Values.csi.plugin.image.repository }}:{{ .Values.csi.plugin.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.csi.plugin.image.pullPolicy }}
@@ -126,6 +131,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
             {{- .Values.csi.plugin.volumeMounts | toYaml | trimSuffix "\n" | nindent 12 }}
+          resources: {{ toYaml .Values.csi.plugin.resources | nindent 12 }}
       volumes:
         - name: socket-dir
           emptyDir:

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -43,6 +43,7 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+          resources: {{ toYaml .Values.csi.nodeDriverRegistrar.resources | nindent 12 }}
         - name: liveness-probe
           image: "{{ .Values.csi.livenessprobe.image.repository }}:{{ .Values.csi.livenessprobe.image.tag }}"
           imagePullPolicy: {{ .Values.csi.livenessprobe.image.pullPolicy }}
@@ -51,6 +52,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          resources: {{ toYaml .Values.csi.livenessprobe.resources | nindent 12 }}
         - name: cinder-csi-plugin
           securityContext:
             privileged: true
@@ -97,6 +99,7 @@ spec:
               mountPath: /dev
               mountPropagation: "HostToContainer"
             {{- .Values.csi.plugin.volumeMounts | toYaml | trimSuffix "\n" | nindent 12 }}
+          resources: {{ toYaml .Values.csi.plugin.resources | nindent 12 }}
       volumes:
         - name: socket-dir
           hostPath:

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -127,3 +127,6 @@ spec:
             path: /etc/kubernetes
         {{- end }}
         {{ .Values.csi.plugin.volumes | toYaml | trimSuffix "\n" | nindent 8 }}
+      affinity: {{ toYaml .Values.csi.plugin.nodePlugin.affinity | nindent 8 }}
+      nodeSelector: {{ toYaml .Values.csi.plugin.nodePlugin.nodeSelector | nindent 8 }}
+      tolerations: {{ toYaml .Values.csi.plugin.nodePlugin.tolerations | nindent 8 }}

--- a/charts/cinder-csi-plugin/templates/snapshot-controller-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/snapshot-controller-statefulset.yaml
@@ -31,4 +31,7 @@ spec:
           args:
             - "--leader-election=false"
           imagePullPolicy: IfNotPresent
+      affinity: {{ toYaml .Values.csi.snapshotController.affinity | nindent 8 }}
+      nodeSelector: {{ toYaml .Values.csi.snapshotController.nodeSelector | nindent 8 }}
+      tolerations: {{ toYaml .Values.csi.snapshotController.tolerations | nindent 8 }}
 {{- end }}

--- a/charts/cinder-csi-plugin/templates/snapshot-controller-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/snapshot-controller-statefulset.yaml
@@ -31,6 +31,7 @@ spec:
           args:
             - "--leader-election=false"
           imagePullPolicy: IfNotPresent
+          resources: {{ toYaml .Values.csi.snapshotController.resources | nindent 12 }}
       affinity: {{ toYaml .Values.csi.snapshotController.affinity | nindent 8 }}
       nodeSelector: {{ toYaml .Values.csi.snapshotController.nodeSelector | nindent 8 }}
       tolerations: {{ toYaml .Values.csi.snapshotController.tolerations | nindent 8 }}

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -8,22 +8,26 @@ csi:
       repository: k8s.gcr.io/sig-storage/csi-attacher
       tag: v3.1.0
       pullPolicy: IfNotPresent
+    resources: {}
   provisioner:
     topology: "true"
     image:
       repository: k8s.gcr.io/sig-storage/csi-provisioner
       tag: v2.1.1
       pullPolicy: IfNotPresent
+    resources: {}
   snapshotter:
     image:
       repository: k8s.gcr.io/sig-storage/csi-snapshotter
       tag: v2.1.3
       pullPolicy: IfNotPresent
+    resources: {}
   resizer:
     image:
       repository: k8s.gcr.io/sig-storage/csi-resizer
       tag: v1.1.0
       pullPolicy: IfNotPresent
+    resources: {}
   livenessprobe:
     image:
       repository: k8s.gcr.io/sig-storage/livenessprobe
@@ -33,11 +37,13 @@ csi:
     initialDelaySeconds: 10
     timeoutSeconds: 10
     periodSeconds: 60
+    resources: {}
   nodeDriverRegistrar:
     image:
       repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
       tag: v1.3.0
       pullPolicy: IfNotPresent
+    resources: {}
   plugin:
     image:
       repository: docker.io/k8scloudprovider/cinder-csi-plugin
@@ -62,11 +68,13 @@ csi:
       affinity: {}
       nodeSelector: {}
       tolerations: []
+    resources: {}
   snapshotController:
     enabled: false
     image:
       repository: k8s.gcr.io/sig-storage/snapshot-controller
       tag: v2.1.3
+    resources: {}
     affinity: {}
     nodeSelector: {}
     tolerations: []

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -54,11 +54,22 @@ csi:
       - name: cloud-config
         mountPath: /etc/kubernetes
         readOnly: true
+    nodePlugin:
+      affinity: {}
+      nodeSelector: {}
+      tolerations: []
+    controllerPlugin:
+      affinity: {}
+      nodeSelector: {}
+      tolerations: []
   snapshotController:
     enabled: false
     image:
       repository: k8s.gcr.io/sig-storage/snapshot-controller
       tag: v2.1.3
+    affinity: {}
+    nodeSelector: {}
+    tolerations: []
 
 secret:
   enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently there is no way in cinder-csi's Helm chart to convince the scheduler to e.g. schedule the Controller plugin only on master nodes, or set resource constraints. This PR exposes `affinity`, `nodeSelector`, `tolerations` and `resources` PodSpec attributes in the values file, making it possible to influence scheduling the driver in Helm deployments.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
