### PR TITLE
[occm] Enable cloud-provider-openstack-test-occm job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -10,24 +10,22 @@
               - ^.gitignore$
               - ^.*\.sh$
 
-# Disable the job temporarily until we fix the cluster issue.
-#    cloud-provider-openstack-acceptance-test-lb-octavia:
-#      jobs:
-#        - cloud-provider-openstack-acceptance-test-lb-octavia:
-#            files:
-#              - cmd/openstack-cloud-controller-manager/.*
-#              - pkg/openstack/.*
-#              - pkg/util/.*
-#              - tests/e2e/cloudprovider/.*
-#              - go.mod$
-#              - go.sum$
-#              - Makefile$
-#            irrelevant-files:
-#              - docs/.*$
-#              - ^.*\.md$
-#              - ^OWNERS$
-#              - ^SECURITY_CONTACTS$
-#              - ^.gitignore$
+    cloud-provider-openstack-test-occm:
+      jobs:
+        - cloud-provider-openstack-test-occm:
+            files:
+              - cmd/openstack-cloud-controller-manager/.*
+              - pkg/openstack/.*
+              - pkg/util/.*
+              - tests/e2e/cloudprovider/.*
+              - Makefile$
+            irrelevant-files:
+              - docs/.*$
+              - ^.*\.md$
+              - ^OWNERS$
+              - ^SECURITY_CONTACTS$
+              - ^.gitignore$
+
     cloud-provider-openstack-format:
       jobs:
         - cloud-provider-openstack-format:


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
