### PR TITLE
[cinder-csi-plugin] Verify filesystem size after resize

### DIFF
--- a/pkg/util/filesystem/filesystem_linux.go
+++ b/pkg/util/filesystem/filesystem_linux.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filesystem
+
+import "golang.org/x/sys/unix"
+
+func GetFilesystemSize(path string) (int64, error) {
+	var statfs unix.Statfs_t
+	err := unix.Statfs(path, &statfs)
+	if err != nil {
+		return 0, err
+	}
+
+	return statfs.Bsize * int64(statfs.Blocks), nil
+}

--- a/pkg/util/filesystem/filesystem_unsupported.go
+++ b/pkg/util/filesystem/filesystem_unsupported.go
@@ -1,0 +1,25 @@
+// +build !linux
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filesystem
+
+import "errors"
+
+func GetFilesystemSize(path string) (int64, error) {
+	return false, errors.New("GetFilesystemSize is not implemented for this OS")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Here is an issue that triggered a waterfall of "successful" Expands, which led to improper filesystem size: https://bugs.launchpad.net/openstack-ansible/+bug/1902914. Rescan does not work.

This means that in some cases, we can't trust a positive response from an API, and we should check an actual filesystem size after Expanding it.

**Release note**:
<!--
1. Release note is required if a significant change is introduced; otherwise, please keep this section.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[cinder-csi-plugin] Verify filesystem size after resize
```
