### PR TITLE
[cinder-csi-plugin] add cluster id to snapshot metadata

### DIFF
--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -407,7 +407,7 @@ func TestListVolumes(t *testing.T) {
 // Test CreateSnapshot
 func TestCreateSnapshot(t *testing.T) {
 
-	osmock.On("CreateSnapshot", FakeSnapshotName, FakeVolID, &map[string]string{"tag": "tag1"}).Return(&FakeSnapshotRes, nil)
+	osmock.On("CreateSnapshot", FakeSnapshotName, FakeVolID, &map[string]string{cinderCSIClusterIDKey: "cluster", "tag": "tag1"}).Return(&FakeSnapshotRes, nil)
 	osmock.On("ListSnapshots", map[string]string{"Name": FakeSnapshotName}).Return(FakeSnapshotListEmpty, "", nil)
 	osmock.On("WaitSnapshotReady", FakeSnapshotID).Return(nil)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Now cluster id is set by --cluster argument at the driver's start. When it's set, cinder CSI controller appends the cluster id to volumes metadata during creation. Unfortunately it doesn't happen for volume snapshots, which makes it harder to find them after cluster deletion.

This commit adds cluster id to snapshots metadata to unify the behavior with volumes.

```release-note
[cinder-csi-plugin] Append cluster ID (value of `--cluster`) to metadata of snapshots in the cloud when creating VolumeSnapshot.
```
