### PR TITLE
[doc] [cinder-csi-plugin]update doc to make add cert clearer

### DIFF
--- a/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
+++ b/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
@@ -133,7 +133,21 @@ cinder.csi.openstack.org   2019-07-29T09:02:40Z
 
 ```
 
-> NOTE: If using certs(`ca-file`), make sure to update the manifests (controller and node plugin) to mount the location of certs as volume onto container as well.
+> NOTE: If using certs(`ca-file`), make sure to add the additional mount to the manifests (controller and node plugin) to mount the location of certs as volume onto container. For example, add `ca-cert` in `/etc/cacert` folder. Uncomment the related sections in `manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml` and `manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml` and replace the path with your own.
+
+```
+       volumeMounts:
+          ....
+          - name: cacert
+              mountPath: /etc/cacert
+              readOnly: true
+
+     volumes:   
+        ....
+        - name: cacert
+          hostPath:
+            path: /etc/cacert
+```
 
 ### Using the Helm chart
 

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -136,9 +136,15 @@ spec:
             - name: secret-cinderplugin
               mountPath: /etc/config
               readOnly: true
+            # - name: cacert
+            #   mountPath: /etc/cacert
+            #   readOnly: true
       volumes:
         - name: socket-dir
           emptyDir:
         - name: secret-cinderplugin
           secret:
             secretName: cloud-config
+        # - name: cacert
+        #   hostPath:
+        #     path: /etc/cacert

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -98,6 +98,9 @@ spec:
             - name: secret-cinderplugin
               mountPath: /etc/config
               readOnly: true
+            # - name: cacert
+            #   mountPath: /etc/cacert
+            #   readOnly: true
       volumes:
         - name: socket-dir
           hostPath:
@@ -118,3 +121,6 @@ spec:
         - name: secret-cinderplugin
           secret:
             secretName: cloud-config
+        # - name: cacert
+        #   hostPath:
+        #     path: /etc/cacert


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #1546 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
