### PR TITLE
[k8s-keystone-auth]Add build for client-keystone-auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,12 @@ build-all-archs:
 
 build: $(addprefix build-cmd-,$(BUILD_CMDS))
 
+client-keystone-auth: work $(SOURCES)
+	CGO_ENABLED=0 GOOS=$(GOOS) go build \
+		-ldflags $(LDFLAGS) \
+		-o client-keystone-auth \
+		cmd/client-keystone-auth/main.go
+
 # Remove individual go build targets, once we migrate openlab-zuul-jobs
 # to use new build-cmd-% targets.
 cinder-csi-plugin: work $(SOURCES)


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:


**Which issue this PR fixes(if applicable)**:
fixes #https://github.com/kubernetes/cloud-provider-openstack/issues/1554

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
