### PR TITLE
[occm] Use CI job cloud-provider-openstack-test-occm

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -9,16 +9,14 @@
               - ^SECURITY_CONTACTS$
               - ^.gitignore$
               - ^.*\.sh$
-    cloud-provider-openstack-acceptance-test-lb-octavia:
+    cloud-provider-openstack-test-occm-1.20:
       jobs:
-        - cloud-provider-openstack-acceptance-test-lb-octavia:
+        - cloud-provider-openstack-test-occm-1.20:
             files:
               - cmd/openstack-cloud-controller-manager/.*
               - pkg/cloudprovider/.*
               - pkg/util/.*
               - tests/e2e/cloudprovider/.*
-              - go.mod$
-              - go.sum$
               - Makefile$
             irrelevant-files:
               - docs/.*$
@@ -61,11 +59,10 @@
               - pkg/csi/cinder/.*
               - pkg/util/.*
               - pkg/cloudprovider/providers/openstack/.*
-              - test/.*
+              - tests/e2e/csi/cinder/.*
               - cmd/tests/.*
               - go.mod$
               - go.sum$
-              - Makefile$
             irrelevant-files:
               - ^docs/.*$
               - ^.*\.md$
@@ -77,14 +74,13 @@
         - cloud-provider-openstack-e2e-test-csi-cinder:
             files:
               - cmd/cinder-csi-plugin/.*
-              - manifests/cinder-csi-plugin/.* 
+              - manifests/cinder-csi-plugin/.*
               - pkg/csi/cinder/.*
               - pkg/util/.*
               - tests/e2e/csi/cinder/.*
               - cmd/tests/.*
               - go.mod$
               - go.sum$
-              - Makefile$
             irrelevant-files:
               - docs/.*$
               - ^.*\.md$
@@ -117,7 +113,6 @@
               - go.mod$
               - go.sum$
               - Makefile$
-              - .zuul.yaml$
     cloud-provider-openstack-acceptance-test-csi-manila:
       jobs:
         - cloud-provider-openstack-acceptance-test-csi-manila:
@@ -144,7 +139,6 @@
               - cmd/openstack-cloud-controller-manager/.*
               - pkg/cloudprovider/.*
               - pkg/util/.*
-              - tests/e2e/cloudprovider/.*
               - go.mod$
               - go.sum$
               - Makefile$
@@ -161,7 +155,6 @@
               - cmd/openstack-cloud-controller-manager/.*
               - pkg/cloudprovider/.*
               - pkg/util/.*
-              - tests/e2e/cloudprovider/.*
               - go.mod$
               - go.sum$
               - Makefile$
@@ -178,7 +171,6 @@
               - cmd/openstack-cloud-controller-manager/.*
               - pkg/cloudprovider/.*
               - pkg/util/.*
-              - tests/e2e/cloudprovider/.*
               - go.mod$
               - go.sum$
               - Makefile$
@@ -195,7 +187,6 @@
               - cmd/openstack-cloud-controller-manager/.*
               - pkg/cloudprovider/.*
               - pkg/util/.*
-              - tests/e2e/cloudprovider/.*
               - go.mod$
               - go.sum$
               - Makefile$

--- a/tests/e2e/cloudprovider/test-lb-service.sh
+++ b/tests/e2e/cloudprovider/test-lb-service.sh
@@ -1,18 +1,17 @@
 #!/usr/bin/env bash
 
-# This script is used for the openlab CI job cloud-provider-openstack-acceptance-test-lb-octavia.
-# See https://github.com/theopenlab/openlab-zuul-jobs/blob/master/playbooks/cloud-provider-openstack-acceptance-test-lb-octavia/run.yaml#L104
+# This script is used for the openlab CI job cloud-provider-openstack-test-occm.
 #
 # Prerequisites:
-#   - This script is supposed to be running on a host has access to kubernetes cluster.
+#   - This script is supposed to be running on the CI host which is running devstack.
 #   - kubectl is ready to talk with the kubernetes cluster.
-#   - It's recommended to run the script on a host with as less proxies to the public as possible, otherwise the
-#     x-forwarded-for test will probably fail.
 #   - This script is not responsible for resource clean up if there is test case fails.
 
 TIMEOUT=${TIMEOUT:-300}
 FLOATING_IP=${FLOATING_IP:-""}
 NAMESPACE="octavia-lb-test"
+GATEWAY_IP=${GATEWAY_IP:-""}
+OS_RC=${OS_RC:-"/home/zuul/devstack/openrc"}
 
 delete_resources() {
   ERROR_CODE="$?"
@@ -62,7 +61,7 @@ function wait_for_loadbalancer {
 
   end=$(($(date +%s) + ${TIMEOUT}))
   while true; do
-    status=$(kubectl -n $NAMESPACE exec openstackcli -- openstack loadbalancer show $lbid -f value -c provisioning_status)
+    status=$(openstack loadbalancer show $lbid -f value -c provisioning_status)
     if [[ $status == "ACTIVE" ]]; then
       if [[ $i == 2 ]]; then
         printf "\n>>>>>>> Load balancer ${lbid} is ACTIVE\n"
@@ -152,37 +151,6 @@ EOF
 }
 
 ########################################################################
-## Name: create_openstackcli_pod
-## Desc: Makes sure the openstackcli pod is running.
-## Params: None
-########################################################################
-function create_openstackcli_pod {
-    kubectl -n $NAMESPACE get pod | grep openstackcli | grep Running > /dev/null
-    if [[ $? -eq 1 ]]; then
-      printf "\n>>>>>>> Creating openstackcli pod\n"
-      cat <<EOF | kubectl apply -f -
-apiVersion: v1
-kind: Pod
-metadata:
-  name: openstackcli
-  namespace: $NAMESPACE
-spec:
-  containers:
-    - name: openstackcli
-      image: lingxiankong/openstack-cli:1.0.0
-      envFrom:
-      - secretRef:
-          name: openrc
-      command:
-        - sleep
-        - "3600"
-EOF
-    kubectl -n $NAMESPACE wait --for=condition=Ready pod/openstackcli
-    printf "\n>>>>>>> Pod openstackcli created.\n"
-    fi
-}
-
-########################################################################
 ## Name: test_basic
 ## Desc: Create a k8s service and send request to the service external
 ##       IP
@@ -259,9 +227,9 @@ EOF
     wait_for_service ${service}
 
     printf "\n>>>>>>> Sending request to the Service ${service}\n"
-    orig_ip=$(curl -s http://${ipaddr} | grep  x-forwarded-for | awk -F'=' '{print $2}')
-    if [[ "${orig_ip}" != "${local_ip}" && "${orig_ip}" != "${public_ip}" ]]; then
-        printf "\n>>>>>>> FAIL: Get incorrect response from Service ${service}, orig_ip: ${local_ip}, public_ip: ${public_ip}\n"
+    ip_in_header=$(curl -s http://${ipaddr} | grep  x-forwarded-for | awk -F'=' '{print $2}')
+    if [[ "${ip_in_header}" != "${local_ip}" && "${ip_in_header}" != "${public_ip}" && "${ip_in_header}" != "${GATEWAY_IP}" ]]; then
+        printf "\n>>>>>>> FAIL: Get incorrect response from Service ${service}, ip_in_header: ${ip_in_header}, local_ip: ${local_ip}, gateway_ip: ${GATEWAY_IP}, public_ip: ${public_ip}\n"
         exit -1
     else
         printf "\n>>>>>>> Expected: Get correct response from Service ${service}\n"
@@ -307,12 +275,12 @@ EOF
     wait_for_service ${service}
 
     printf "\n>>>>>>> Validating openstack load balancer\n"
-    create_openstackcli_pod
-    lbid=$(kubectl -n $NAMESPACE exec openstackcli -- openstack loadbalancer list -c id -c name | grep "octavia-lb-test_${service}" | awk '{print $2}')
-    lb_info=$(kubectl -n $NAMESPACE exec openstackcli -- openstack loadbalancer status show $lbid)
+    set +x; source $OS_RC demo demo; set -x
+    lbid=$(openstack loadbalancer list -c id -c name | grep "octavia-lb-test_${service}" | awk '{print $2}')
+    lb_info=$(openstack loadbalancer status show $lbid)
     listener_count=$(echo $lb_info | jq '.loadbalancer.listeners | length')
     member_ports=$(echo $lb_info | jq '.loadbalancer.listeners | .[].pools | .[].members | .[].protocol_port' | uniq)
-    service_nodeports=$(kubectl -n $NAMESPACE  get svc $service -o json | jq '.spec.ports | .[].nodePort')
+    service_nodeports=$(kubectl -n $NAMESPACE get svc $service -o json | jq '.spec.ports | .[].nodePort')
 
     if [[ ${listener_count} != 2 ]]; then
         printf "\n>>>>>>> FAIL: Unexpected number of listeners(${listener_count}) created for service ${service}\n"
@@ -333,7 +301,7 @@ EOF
 
     printf "\n>>>>>>> Validating openstack load balancer after updating the service.\n"
     create_openstackcli_pod
-    lb_info=$(kubectl -n $NAMESPACE exec openstackcli -- openstack loadbalancer status show $lbid)
+    lb_info=$(openstack loadbalancer status show $lbid)
     listener_count=$(echo $lb_info | jq '.loadbalancer.listeners | length')
     member_port=$(echo $lb_info | jq '.loadbalancer.listeners | .[].pools | .[].members | .[].protocol_port' | uniq)
     service_nodeport=$(kubectl -n $NAMESPACE  get svc $service -o json | jq '.spec.ports | .[].nodePort')


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
The job cloud-provider-openstack-acceptance-test-lb-octavia is not used anymore.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
