### PR TITLE
[manila-csi-plugin] bumped snapshot.storage.k8s.io API to v1

### DIFF
--- a/examples/manila-csi-plugin/nfs/snapshot/snapshotclass.yaml
+++ b/examples/manila-csi-plugin/nfs/snapshot/snapshotclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   name: csi-manila-nfs

--- a/examples/manila-csi-plugin/nfs/snapshot/snapshotcreate.yaml
+++ b/examples/manila-csi-plugin/nfs/snapshot/snapshotcreate.yaml
@@ -1,4 +1,4 @@
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: new-nfs-share-snap


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR bumps `snapshot.storage.k8s.io` API to v1 in manila-csi-plugin snapshot examples.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
