### PR TITLE
fix the words to correct ones

### DIFF
--- a/cmd/cinder-csi-plugin/main.go
+++ b/cmd/cinder-csi-plugin/main.go
@@ -101,19 +101,19 @@ func main() {
 func handle() {
 
 	d := cinder.NewDriver(nodeID, endpoint, cluster)
-	// Initiliaze cloud
+	// Initialize cloud
 	openstack.InitOpenStackProvider(cloudconfig)
 	cloud, err := openstack.GetOpenStackProvider()
 	if err != nil {
 		klog.Warningf("Failed to GetOpenStackProvider: %v", err)
 		return
 	}
-	//Intiliaze mount
+	//Initialize mount
 	mount := mount.GetMountProvider()
 
-	//Intiliaze Metadatda
-	metadatda := metadata.GetMetadataProvider(cloud.GetMetadataOpts().SearchOrder)
+	//Initialize Metadata
+	metadata := metadata.GetMetadataProvider(cloud.GetMetadataOpts().SearchOrder)
 
-	d.SetupDriver(cloud, mount, metadatda)
+	d.SetupDriver(cloud, mount, metadata)
 	d.Run()
 }


### PR DESCRIPTION
Signed-off-by: kcx2366425574 <18279911430@163.com>

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
