### PR TITLE
[cinder-csi-plugin][doc] Update CSIMigration status

### DIFF
--- a/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
+++ b/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
@@ -242,9 +242,7 @@ Optionally, to test the driver csc tool could be used. please refer, [usage guid
 
 ## In-tree Cinder provisioner to cinder CSI Migration
 
-Starting from Kubernetes 1.18, CSI migration is supported as beta feature. If you have persistence volumes that are created with in-tree `kubernetes.io/cinder` plugin, you could migrate to use `cinder.csi.openstack.org` Container Storage Interface (CSI) Driver. 
+Starting from Kubernetes 1.21, OpenStack Cinder CSI migration is supported as beta feature and is `ON` by default. Cinder CSI driver must be installed on clusters on OpenStack for Cinder volumes to work. If you have persistence volumes that are created with in-tree `kubernetes.io/cinder` plugin, you could migrate to use `cinder.csi.openstack.org` Container Storage Interface (CSI) Driver.
 
 * The CSI Migration feature for Cinder, when enabled, shims all plugin operations from the existing in-tree plugin to the `cinder.csi.openstack.org` CSI Driver. 
-* In order to use this feature, the OpenStack Cinder CSI Driver must be installed on the cluster.
-* To turn on the migration, set `CSIMigration` and `CSIMigrationOpenstack` feature gates to true for kube-controller-manager and kubelet.
 * For more info, please refer [Migrate to CCM with CSI Migration](../openstack-cloud-controller-manager/migrate-to-ccm-with-csimigration.md#migrate-from-in-tree-cloud-provider-to-openstack-cloud-controller-manager-and-enable-csimigration) guide

--- a/docs/openstack-cloud-controller-manager/migrate-to-ccm-with-csimigration.md
+++ b/docs/openstack-cloud-controller-manager/migrate-to-ccm-with-csimigration.md
@@ -109,6 +109,8 @@ This walks you through enabling needed `feature-gates` and explains necessary st
 
 The first step is to ebale the `feature-gates` on the control plane. We again use `kubeadm.yaml` and `kubeadm` to perform necessary tasks.
 
+**Note: From Kubernetes 1.21 or later, `CSIMigrationOpenStack` is enabled by default.**
+
 ```yaml
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration
@@ -116,12 +118,8 @@ kubernetesVersion: "1.17.0-beta.1"
 networking:
   podSubnet: 10.96.0.0/16
   serviceSubnet: 10.97.0.0/16
-apiServer:
-  extraArgs:
-    feature-gates: "CSIMigration=true,CSIMigrationOpenStack=true,ExpandCSIVolumes=true"
 controllerManager:
   extraArgs:
-    feature-gates: "CSIMigration=true,CSIMigrationOpenStack=true,ExpandCSIVolumes=true"
     controllers: "*,bootstrapsigner,tokencleaner,-cloud-node-lifecycle,-route,-service"
     cloud-config: /etc/kubernetes/cloud.conf
     cloud-provider: openstack
@@ -141,6 +139,8 @@ kubeadm init --config ~ubuntu/kubeadm-migrate-1.yaml phase control-plane control
 ```
 
 You must now drain an existing node and enable the `feature-gates` on `kubelet`. (At this point, you could also change to `--cloud-provider=external` and remove the `--cloud-config` argument)
+
+**Note: For kubernetes 1.21 or later, all the feature gates are enabled by default.**
 
 ```bash
 cat >> /var/lib/kubelet/config.yaml<<EOF
@@ -188,12 +188,6 @@ kubernetesVersion: "1.17.0-beta.1"
 networking:
   podSubnet: 10.96.0.0/16
   serviceSubnet: 10.97.0.0/16
-apiServer:
-  extraArgs:
-    feature-gates: "CSIMigration=true,CSIMigrationOpenStack=true,ExpandCSIVolumes=true"
-controllerManager:
-  extraArgs:
-    feature-gates: "CSIMigration=true,CSIMigrationOpenStack=true,ExpandCSIVolumes=true"
 ```
 
 ```bash


### PR DESCRIPTION
From release1.21 , CSIMigration is ON by default. This PR
is to reflect the same in doc.

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
