### PR TITLE
[cinder-csi-plugin]Avoid create tag from metadata req of snapshot

### DIFF
--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -363,8 +363,12 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 	} else {
 		// Add cluster ID to the snapshot metadata
 		properties := map[string]string{cinderCSIClusterIDKey: cs.Driver.cluster}
-		for mKey, mVal := range req.Parameters {
-			properties[mKey] = mVal
+
+		// see https://github.com/kubernetes-csi/external-snapshotter/pull/375/
+		for _, mKey := range []string{"csi.storage.k8s.io/volumesnapshot/name", "csi.storage.k8s.io/volumesnapshot/namespace", "csi.storage.k8s.io/volumesnapshotcontent/name"} {
+			if v, ok := req.Parameters[mKey]; ok {
+				properties[mKey] = v
+			}
 		}
 
 		// TODO: Delegate the check to openstack itself and ignore the conflict

--- a/pkg/csi/cinder/fake.go
+++ b/pkg/csi/cinder/fake.go
@@ -41,6 +41,8 @@ var FakeStagingTargetPath = "/mnt/globalmount"
 var FakePVName = "fakepv-1"
 var FakePVCName = "fakepvc-1"
 var FakePVCNamespace = "fakepvc-ns"
+var FakeSnapshotContentName = "fake-content"
+var FakeSnapshotNamespace = "fakesnapshot-ns"
 var FakeAttachment = volumes.Attachment{
 	ServerID: FakeNodeID,
 }


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #1545

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[cinder-csi-plugin] Add metadata for creating snapshot if `--extra-create-metadata` is enabled in external-snapshotter.
```
