### PR TITLE
[OCCM] Restore the previous name for e2e-conformance job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -115,9 +115,9 @@
               - ^OWNERS$
               - ^SECURITY_CONTACTS$
               - ^.gitignore$
-    cloud-provider-openstack-test-occm-e2e-conformance:
+    cloud-provider-openstack-acceptance-test-e2e-conformance:
       jobs:
-        - cloud-provider-openstack-test-occm-e2e-conformance:
+        - cloud-provider-openstack-acceptance-test-e2e-conformance:
             files:
               - cmd/openstack-cloud-controller-manager/.*
               - pkg/openstack/.*


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
The job name is still used in https://github.com/kubernetes/test-infra/blob/master/config/testgrids/kubernetes/sig-cloud-provider/openstack/config.yaml, this PR changes the job name back (but using the new job definition, see [here](https://github.com/theopenlab/openlab-zuul-jobs/blob/master/zuul.d/jobs.yaml#L616)) to avoid test-infra change.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
