### PR TITLE
[manila-csi-plugin] Use low verbosity logging by default

### DIFF
--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 1.3.0
+version: 1.3.1
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -31,7 +31,6 @@ spec:
         - name: {{ .protocolSelector | lower }}-provisioner
           image: "{{ $.Values.controllerplugin.provisioner.image.repository }}:{{ $.Values.controllerplugin.provisioner.image.tag }}"
           args:
-            - "--v=5"
             - "--csi-address=$(ADDRESS)"
             {{- if $.Values.csimanila.topologyAwarenessEnabled }}
             - "--feature-gates=Topology=true"
@@ -48,7 +47,6 @@ spec:
         - name: {{ .protocolSelector | lower }}-snapshotter
           image: "{{ $.Values.controllerplugin.snapshotter.image.repository }}:{{ $.Values.controllerplugin.snapshotter.image.tag }}"
           args:
-            - "--v=5"
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
@@ -62,7 +60,6 @@ spec:
         - name: {{ .protocolSelector | lower }}-resizer
           image: "{{ $.Values.controllerplugin.resizer.image.repository }}:{{ $.Values.controllerplugin.resizer.image.tag }}"
           args:
-            - "--v=5"
             - "--csi-address=$(ADDRESS)"
             - "--handle-volume-inuse-error=false"
           env:
@@ -83,7 +80,6 @@ spec:
           image: "{{ $.Values.csimanila.image.repository }}:{{ $.Values.csimanila.image.tag | default $.Chart.AppVersion }}"
           command: ["/bin/sh", "-c",
             '/bin/manila-csi-plugin
-            --v=5
             --nodeid=$(NODE_ID)
             {{- if $.Values.csimanila.topologyAwarenessEnabled }}
             --with-topology

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -31,7 +31,6 @@ spec:
         - name: {{ .protocolSelector | lower }}-registrar
           image: "{{ $.Values.nodeplugin.registrar.image.repository }}:{{ $.Values.nodeplugin.registrar.image.tag }}"
           args:
-            - "--v=5"
             - "--csi-address=/csi/csi.sock"
             - "--kubelet-registration-path=/var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}/csi.sock"
           lifecycle:
@@ -64,7 +63,6 @@ spec:
           image: "{{ $.Values.csimanila.image.repository }}:{{ $.Values.csimanila.image.tag | default $.Chart.AppVersion }}"
           command: ["/bin/sh", "-c",
             '/bin/manila-csi-plugin
-            --v=5
             --nodeid=$(NODE_ID)
             {{- if $.Values.csimanila.runtimeConfig.enabled }}
             --runtime-config-file=/runtimeconfig/runtimeconfig.json

--- a/manifests/manila-csi-plugin/csi-controllerplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-controllerplugin.yaml
@@ -38,7 +38,6 @@ spec:
         - name: provisioner
           image: "k8s.gcr.io/sig-storage/csi-provisioner:v2.0.2"
           args:
-            - "--v=5"
             - "--csi-address=$(ADDRESS)"
             # To enable topology awareness in csi-provisioner, uncomment the following line:
             # - "--feature-gates=Topology=true"
@@ -52,7 +51,6 @@ spec:
         - name: snapshotter
           image: "k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.3"
           args:
-            - "--v=5"
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
@@ -64,7 +62,6 @@ spec:
         - name: resizer
           image: "k8s.gcr.io/sig-storage/csi-resizer:v1.2.0"
           args:
-            - "--v=5"
             - "--csi-address=$(ADDRESS)"
             - "--handle-volume-inuse-error=false"
           env:
@@ -83,7 +80,6 @@ spec:
           image: "k8scloudprovider/manila-csi-plugin:latest"
           command: ["/bin/sh", "-c",
             '/bin/manila-csi-plugin
-            --v=5
             --nodeid=$(NODE_ID)
             --endpoint=$(CSI_ENDPOINT)
             --drivername=$(DRIVER_NAME)

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -23,7 +23,6 @@ spec:
         - name: registrar
           image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0"
           args:
-            - "--v=5"
             - "--csi-address=/csi/csi.sock"
             - "--kubelet-registration-path=/var/lib/kubelet/plugins/manila.csi.openstack.org/csi.sock"
           lifecycle:
@@ -54,7 +53,6 @@ spec:
           image: "k8scloudprovider/manila-csi-plugin:latest"
           command: ["/bin/sh", "-c",
             '/bin/manila-csi-plugin
-            --v=5
             --nodeid=$(NODE_ID)
             --endpoint=$(CSI_ENDPOINT)
             --drivername=$(DRIVER_NAME)


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This PR addresses a review comment here https://github.com/kubernetes/cloud-provider-openstack/pull/1579#discussion_r660297101 .

Deployment manifests and manila-csi helm chart have been modified so that they don't use `--v=LEVEL` log verbosity level flags by default.

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
