### PR TITLE
[cinder-csi-plugin] Add volume condition for controller and node plugin

### DIFF
--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -313,6 +313,12 @@ func (cs *controllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 		for _, attachment := range v.Attachments {
 			status.PublishedNodeIds = append(status.PublishedNodeIds, attachment.ServerID)
 		}
+
+		condition := &csi.VolumeCondition{
+			Abnormal: openstack.IsAbnormalVolume(v.Status),
+			Message:  v.Status,
+		}
+		status.VolumeCondition = condition
 		ventry.Status = status
 
 		ventries = append(ventries, &ventry)
@@ -586,6 +592,11 @@ func (cs *controllerServer) ControllerGetVolume(ctx context.Context, req *csi.Co
 	for _, attachment := range volume.Attachments {
 		status.PublishedNodeIds = append(status.PublishedNodeIds, attachment.ServerID)
 	}
+	condition := &csi.VolumeCondition{
+		Abnormal: openstack.IsAbnormalVolume(volume.Status),
+		Message:  volume.Status,
+	}
+	status.VolumeCondition = condition
 	ventry.Status = status
 
 	return &ventry, nil

--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -381,6 +381,10 @@ func TestListVolumes(t *testing.T) {
 				},
 				Status: &csi.ListVolumesResponse_VolumeStatus{
 					PublishedNodeIds: []string{FakeNodeID},
+					VolumeCondition: &csi.VolumeCondition{
+						Abnormal: false,
+						Message:  "available",
+					},
 				},
 			},
 			{
@@ -388,7 +392,12 @@ func TestListVolumes(t *testing.T) {
 					VolumeId:      FakeVol3.ID,
 					CapacityBytes: int64(FakeVol3.Size * 1024 * 1024 * 1024),
 				},
-				Status: &csi.ListVolumesResponse_VolumeStatus{},
+				Status: &csi.ListVolumesResponse_VolumeStatus{
+					VolumeCondition: &csi.VolumeCondition{
+						Abnormal: false,
+						Message:  "available",
+					},
+				},
 			},
 		},
 		NextToken: "",

--- a/pkg/csi/cinder/driver.go
+++ b/pkg/csi/cinder/driver.go
@@ -86,6 +86,7 @@ func NewDriver(endpoint, cluster string) *CinderDriver {
 			csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
 			csi.ControllerServiceCapability_RPC_LIST_VOLUMES_PUBLISHED_NODES,
 			csi.ControllerServiceCapability_RPC_GET_VOLUME,
+			csi.ControllerServiceCapability_RPC_VOLUME_CONDITION,
 		})
 	d.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER})
 

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -398,3 +398,14 @@ func (os *OpenStack) diskIsUsed(volumeID string) (bool, error) {
 func (os *OpenStack) GetBlockStorageOpts() BlockStorageOpts {
 	return os.bsOpts
 }
+
+// IsAbnormalVolume returns whether the volume is abnormal
+func IsAbnormalVolume(status string) bool {
+	for _, eState := range volumeErrorStates {
+		if status == eState {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #1584

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
