### PR TITLE
Refactor the openstack provider code

### DIFF
--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -17,10 +17,27 @@ limitations under the License.
 package errors
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gophercloud/gophercloud"
 )
+
+// ErrNotFound is used to inform that the object is missing
+var ErrNotFound = errors.New("failed to find object")
+
+// ErrMultipleResults is used when we unexpectedly get back multiple results
+var ErrMultipleResults = errors.New("multiple results where only one expected")
+
+// ErrNoAddressFound is used when we cannot find an ip address for the host
+var ErrNoAddressFound = errors.New("no address found for host")
+
+// ErrIPv6SupportDisabled is used when one tries to use IPv6 Addresses when
+// IPv6 support is disabled by config
+var ErrIPv6SupportDisabled = errors.New("IPv6 support is disabled")
+
+//ErrNoRouterID is used when router-id is not set
+var ErrNoRouterID = errors.New("router-id not set in cloud provider config")
 
 func IsNotFound(err error) bool {
 	if _, ok := err.(gophercloud.ErrDefault404); ok {


### PR DESCRIPTION

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This PR refactors/moves the provider code for better readability and also removes the unused code in the repo

/kind cleanup
**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
