### PR TITLE
Fix `make import-boss` gate failure 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ endif
 import-boss:
 ifndef HAS_IMPORT_BOSS
 	echo "installing import-boss"
-	go get -u k8s.io/code-generator/cmd/import-boss
+	go install k8s.io/code-generator/cmd/import-boss
 endif
 	hack/verify-import-boss.sh
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This PR enables installing import-boss using go install command

**Which issue this PR fixes(if applicable)**:
fixes #1588

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
