### PR TITLE
[cinder-csi-plugin (chart)] Make a cinder chart compatible with the occm one

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 1.4.4
+version: 1.4.5
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -136,7 +136,7 @@ spec:
             secretName: {{ .Values.secret.name }}
         {{- else }}
           hostPath:
-            path: /etc/kubernetes
+            path: /etc/config
         {{- end }}
         {{ .Values.csi.plugin.volumes | toYaml | trimSuffix "\n" | nindent 8 }}
       affinity: {{ toYaml .Values.csi.plugin.controllerPlugin.affinity | nindent 8 }}

--- a/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -106,7 +106,7 @@ spec:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
-              value: /etc/kubernetes/cloud-config
+              value: /etc/config/cloud.conf
             - name: CLUSTER_NAME
               value: kubernetes
           ports:

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -122,7 +122,7 @@ spec:
             secretName: {{ .Values.secret.name }}
         {{- else }}
           hostPath:
-            path: /etc/kubernetes
+            path: /etc/config
         {{- end }}
         {{ .Values.csi.plugin.volumes | toYaml | trimSuffix "\n" | nindent 8 }}
       affinity: {{ toYaml .Values.csi.plugin.nodePlugin.affinity | nindent 8 }}

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -69,7 +69,7 @@ spec:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
-              value: /etc/kubernetes/cloud-config
+              value: /etc/config/cloud.conf
           ports:
             - containerPort: 9808
               name: healthz

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -52,13 +52,13 @@ csi:
     volumes:
       - name: cacert
         hostPath:
-          path: /etc/cacert
+          path: /etc/ssl/certs
     volumeMounts:
       - name: cacert
-        mountPath: /etc/cacert
+        mountPath: /etc/ssl/certs
         readOnly: true
       - name: cloud-config
-        mountPath: /etc/kubernetes
+        mountPath: /etc/config
         readOnly: true
     nodePlugin:
       affinity: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Make cinder plugin installation more seamless, i.e. make it easier to install the plugin right after installation of occm.

**Release note**:
```release-note
NONE
```
