### PR TITLE
Add cloud-provider-openstack-test-csi-cinder for CI job on devstack

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -69,6 +69,24 @@
               - ^.*\.md$
               - ^OWNERS$
               - ^SECURITY_CONTACTS$
+    cloud-provider-openstack-test-csi-cinder:
+       jobs:
+        - cloud-provider-openstack-test-csi-cinder:
+            files:
+              - cmd/cinder-csi-plugin/.*
+              - manifests/cinder-csi-plugin/.*
+              - pkg/csi/cinder/.*
+              - pkg/util/.*
+              - tests/e2e/csi/cinder/.*
+              - cmd/tests/.*
+              - go.mod$
+              - go.sum$
+              - Makefile$
+            irrelevant-files:
+              - docs/.*$
+              - ^.*\.md$
+              - ^OWNERS$
+              - ^SECURITY_CONTACTS$
     cloud-provider-openstack-sanity-test-csi-cinder:
       jobs:
         - cloud-provider-openstack-sanity-test-csi-cinder:


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

need this for new CI job that run on devstack

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
