### PR TITLE
[manila-csi-plugin] Add options for passing mount opts to cephfs-csi

### DIFF
--- a/docs/manila-csi-plugin/using-manila-csi-plugin.md
+++ b/docs/manila-csi-plugin/using-manila-csi-plugin.md
@@ -50,6 +50,8 @@ Parameter | Required | Description
 `availability` | _no_ | Manila availability zone of the provisioned share. If none is provided, the default Manila zone will be used. Note that this parameter is opaque to the CO and does not influence placement of workloads that will consume this share, meaning they may be scheduled onto any node of the cluster. If the specified Manila AZ is not equally accessible from all compute nodes of the cluster, use [Topology-aware dynamic provisioning](#topology-aware-dynamic-provisioning).
 `appendShareMetadata` | _no_ | Append user-defined metadata to the provisioned share. If not empty, this field must be a string with a valid JSON object. The object must consist of key-value pairs of type string. Example: `"{..., \"key\": \"value\"}"`.
 `cephfs-mounter` | _no_ | Relevant for CephFS Manila shares. Specifies which mounting method to use with the CSI CephFS driver. Available options are `kernel` and `fuse`, defaults to `fuse`. See [CSI CephFS docs](https://github.com/ceph/ceph-csi/blob/csi-v1.0/docs/deploy-cephfs.md#configuration) for further information.
+`cephfs-kernelMountOptions` | _no_ | Relevant for CephFS Manila shares. Specifies mount options for CephFS kernel client. See [CSI CephFS docs](https://github.com/ceph/ceph-csi/blob/csi-v1.0/docs/deploy-cephfs.md#configuration) for further information.
+`cephfs-fuseMountOptions` | _no_ | Relevant for CephFS Manila shares. Specifies mount options for CephFS FUSE client. See [CSI CephFS docs](https://github.com/ceph/ceph-csi/blob/csi-v1.0/docs/deploy-cephfs.md#configuration) for further information.
 `cephfs-clientID` | _no_ | Relevant for CephFS Manila shares. Specifies the cephx client ID when creating an access rule for the provisioned share. The same cephx client ID may be shared with multiple Manila shares. If no value is provided, client ID for the provisioned Manila share will be set to some unique value (PersistentVolume name).
 `nfs-shareClient` | _no_ | Relevant for NFS Manila shares. Specifies what address has access to the NFS share. Defaults to `0.0.0.0/0`, i.e. anyone. 
 
@@ -63,6 +65,8 @@ Parameter | Required | Description
 `shareName` | if `shareID` is not given | The name of the share
 `shareAccessID` | _yes_ | The UUID of the access rule for the share
 `cephfs-mounter` | _no_ | Relevant for CephFS Manila shares. Specifies which mounting method to use with the CSI CephFS driver. Available options are `kernel` and `fuse`, defaults to `fuse`. See [CSI CephFS docs](https://github.com/ceph/ceph-csi/blob/csi-v1.0/docs/deploy-cephfs.md#configuration) for further information.
+`cephfs-kernelMountOptions` | _no_ | Relevant for CephFS Manila shares. Specifies mount options for CephFS kernel client. See [CSI CephFS docs](https://github.com/ceph/ceph-csi/blob/csi-v1.0/docs/deploy-cephfs.md#configuration) for further information.
+`cephfs-fuseMountOptions` | _no_ | Relevant for CephFS Manila shares. Specifies mount options for CephFS FUSE client. See [CSI CephFS docs](https://github.com/ceph/ceph-csi/blob/csi-v1.0/docs/deploy-cephfs.md#configuration) for further information.
 
 _Note that the Node Plugin of CSI Manila doesn't care about the origin of a share. As long as the share protocol is supported, CSI Manila is able to consume dynamically provisioned as well as pre-provisioned shares (e.g. shares created manually)._
 

--- a/pkg/csi/manila/options/shareoptions.go
+++ b/pkg/csi/manila/options/shareoptions.go
@@ -29,9 +29,11 @@ type ControllerVolumeContext struct {
 
 	// Adapter options
 
-	CephfsMounter  string `name:"cephfs-mounter" value:"default:fuse" matches:"^kernel|fuse$"`
-	CephfsClientID string `name:"cephfs-clientID" value:"optional"`
-	NFSShareClient string `name:"nfs-shareClient" value:"default:0.0.0.0/0"`
+	CephfsMounter            string `name:"cephfs-mounter" value:"default:fuse" matches:"^kernel|fuse$"`
+	CephfsClientID           string `name:"cephfs-clientID" value:"optional"`
+	CephfsKernelMountOptions string `name:"cephfs-kernelMountOptions" value:"optional"`
+	CephfsFuseMountOptions   string `name:"cephfs-fuseMountOptions" value:"optional"`
+	NFSShareClient           string `name:"nfs-shareClient" value:"default:0.0.0.0/0"`
 }
 
 type NodeVolumeContext struct {
@@ -41,7 +43,9 @@ type NodeVolumeContext struct {
 
 	// Adapter options
 
-	CephfsMounter string `name:"cephfs-mounter" value:"default:fuse" matches:"^kernel|fuse$"`
+	CephfsMounter            string `name:"cephfs-mounter" value:"default:fuse" matches:"^kernel|fuse$"`
+	CephfsKernelMountOptions string `name:"cephfs-kernelMountOptions" value:"optional"`
+	CephfsFuseMountOptions   string `name:"cephfs-fuseMountOptions" value:"optional"`
 }
 
 var (

--- a/pkg/csi/manila/shareadapters/cephfs.go
+++ b/pkg/csi/manila/shareadapters/cephfs.go
@@ -117,12 +117,22 @@ func (Cephfs) BuildVolumeContext(args *VolumeContextArgs) (volumeContext map[str
 
 	monitors, rootPath, err := splitExportLocationPath(args.Locations[chosenExportLocationIdx].Path)
 
-	return map[string]string{
+	volCtx := map[string]string{
 		"monitors":        monitors,
 		"rootPath":        rootPath,
 		"mounter":         args.Options.CephfsMounter,
 		"provisionVolume": "false",
-	}, err
+	}
+
+	if args.Options.CephfsKernelMountOptions != "" {
+		volCtx["kernelMountOptions"] = args.Options.CephfsKernelMountOptions
+	}
+
+	if args.Options.CephfsFuseMountOptions != "" {
+		volCtx["fuseMountOptions"] = args.Options.CephfsFuseMountOptions
+	}
+
+	return volCtx, err
 }
 
 func (Cephfs) BuildNodeStageSecret(args *SecretArgs) (secret map[string]string, err error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

manila-csi already passes mount options to its partner Node Plugins. However, cephfs-csi consumes mount options for CephFS kernel and FUSE client via separate volume context parameters: `kernelMountOptions` and `fuseMountOptions`. In order for user to be able to control these, manila-csi needs to expose these params as well.

Please see https://github.com/ceph/ceph-csi/blob/devel/docs/deploy-cephfs.md#configuration for reference (section "Available volume parameters").

Exposing kernel opts are especially important for environments with SELinux enabled, where users may want to pass in SELinux context options.

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[manila-csi-plugin] Add cephfs-kernelMountOptions and cephfs-fuseMountOptions volume parameters
```
