### PR TITLE
[occm] add missing RBAC for serviceaccount token (#1521)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,8 +12,17 @@ jobs:
       - name: Fetch history
         run: git fetch --prune --unshallow
 
-      - id: lint
-        name: Run chart-testing (lint)
-        uses: helm/chart-testing-action@v1.0.0
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
         with:
-          command: lint
+          version: v3.6.1
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.1.0
+
+      - name: Run chart-testing (lint)
+        run: ct lint --target-branch ${GITHUB_BASE_REF}

--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 1.0.1
+version: 1.0.2
 maintainers:
   - name: morremeyer
     email: kubernetes@maurice-meyer.de

--- a/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
@@ -43,6 +43,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
   verbs:
   - create


### PR DESCRIPTION
* [osccm-helm] add missing RBAC for serviceaccount token

* [osccm-helm] bump version

(cherry picked from commit dcef7202697f7caead1055dcef50c2e0c3388951)

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

New clientbuilder needs permission to create serviceaccount token

**Which issue this PR fixes(if applicable)**:
fixes #1514

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
