### PR TITLE
[manila-csi-plugin] pass CreateVolumeRequest.parameters as Volume.volume_context

### DIFF
--- a/pkg/csi/manila/options/shareoptions.go
+++ b/pkg/csi/manila/options/shareoptions.go
@@ -70,3 +70,7 @@ func NewNodeVolumeContext(data map[string]string) (*NodeVolumeContext, error) {
 
 	return opts, nil
 }
+
+func NodeVolumeContextFields() []string {
+	return nodeVolumeCtxValidator.Fields
+}

--- a/pkg/csi/manila/validator/validator.go
+++ b/pkg/csi/manila/validator/validator.go
@@ -48,6 +48,9 @@ type Validator struct {
 	nameIdxMap nameIndexMap
 	idxNameMap indexNameMap
 
+	// Field names in the struct.
+	Fields []string
+
 	valueExprs *valueExpressions
 	depsMap    dependenciesMap
 	preclsMap  preclusionsMap
@@ -67,11 +70,21 @@ func New(stringStruct interface{}) *Validator {
 		t:          t,
 		nameIdxMap: nameIdxMap,
 		idxNameMap: idxNameMap,
+		Fields:     buildFieldNames(idxNameMap),
 		valueExprs: buildValueExpressions(t, idxNameMap, nameIdxMap),
 		depsMap:    buildDependenciesMap(t, idxNameMap, nameIdxMap),
 		preclsMap:  buildPreclusionsMap(t, idxNameMap, nameIdxMap),
 		matchMap:   buildMatchRegexMap(t),
 	}
+}
+
+func buildFieldNames(m indexNameMap) []string {
+	s := make([]string, 0, len(m))
+	for _, fieldName := range m {
+		s = append(s, string(fieldName))
+	}
+
+	return s
 }
 
 // Populate validates input data and populates the output struct.

--- a/pkg/csi/manila/validator/validator_test.go
+++ b/pkg/csi/manila/validator/validator_test.go
@@ -193,3 +193,34 @@ func TestMatches(t *testing.T) {
 		t.Error(`matches:"true|false" violated, should succeed on matching parameter`)
 	}
 }
+
+func TestFieldNames(t *testing.T) {
+	type s struct {
+		A string `name:"a"`
+		B string `name:"b"`
+	}
+
+	v := New(&s{})
+
+	expected := []string{"a", "b"}
+
+	findElem := func(x string, xs []string) bool {
+		for _, e := range xs {
+			if e == x {
+				return true
+			}
+		}
+		return false
+	}
+
+	if len(expected) != len(v.Fields) {
+		t.Errorf("expected number of entries %d (%v), got %d (%v)",
+			len(expected), expected, len(v.Fields), v.Fields)
+	}
+
+	for i := range v.Fields {
+		if !findElem(v.Fields[i], expected) {
+			t.Error("found unexpected field", v.Fields[i], "; expected fields", expected, "actual fields", v.Fields)
+		}
+	}
+}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Currently, `Volume.volume_context` is populated manually:

https://github.com/kubernetes/cloud-provider-openstack/blob/61bdbe5bf4b75453b67e77b543891e1a5bb3eea2/pkg/csi/manila/controllerserver.go#L167-L179

If we wanted to add more entries to the map, we'd need to do it explicitly which is tedious and error prone. https://github.com/kubernetes/cloud-provider-openstack/pull/1605 added two new parameters, and I forgot to add them into the map. As a result, they are missing in provisioned volumes, despite having them set in my storage class.

This PR makes it so that *all* recognized volume parameters(*) in `CreateVolumeRequest.parameters` map are automatically passed as `Volume.volume_context`. Doing so makes sure no similar bug should happen in the future.

(*) Recognized volume parameters: `validator.Validator` now offers `Fields []string` that's populated with all recognized field names of a struct. `CreateVolumeRequest.parameters` is then filtered against [`options.NodeVolumeContext`](https://github.com/kubernetes/cloud-provider-openstack/blob/61bdbe5bf4b75453b67e77b543891e1a5bb3eea2/pkg/csi/manila/options/shareoptions.go#L39-L49)'s fields, so that only recognized fields will be passed to the resulting `Volume.volume_context`.

No backwards-compatibility breakage is expected.

**Special notes for reviewers**:

This is what the resulting PV `volumeAttributes` looks like with this patch:

```json
$ kubectl get pv pvc-19e0358e-12b2-469c-8d13-0d5d61c8668d -o json | jq .spec.csi.volumeAttributes
{
  "cephfs-kernelMountOptions": "context=system_u:system_r:container_t:s0",
  "cephfs-mounter": "kernel",
  "shareAccessID": "025c0070-89cd-4706-b542-90c7c4d8f1d7",
  "shareID": "5ae16a16-727a-4493-a4e3-1c634f9e67a0",
  "storage.kubernetes.io/csiProvisionerIdentity": "1627906097137-8081-cephfs.manila.csi.openstack.org"
}
```

for this storage class:
```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: devstack-cephfs
provisioner: cephfs.manila.csi.openstack.org
parameters:
  type: cephfstype

  cephfs-mounter: kernel
  cephfs-kernelMountOptions: context=system_u:system_r:container_t:s0
  
  csi.storage.k8s.io/provisioner-secret-name: devstack-manila
  csi.storage.k8s.io/provisioner-secret-namespace: default
  csi.storage.k8s.io/node-stage-secret-name: devstack-manila
  csi.storage.k8s.io/node-stage-secret-namespace: default
  csi.storage.k8s.io/node-publish-secret-name: devstack-manila
  csi.storage.k8s.io/node-publish-secret-namespace: default
```

You can see that PV volume attributes contain only `cephfs-mounter`, `cephfs-kernelMountOptions`, `shareID` and `shareAccessID`. Other options from the storage class (`type`, as well as the implied `protocol` field) have been filtered away as they are not recognized fields in `NodeVolumeContext`.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
