### PR TITLE
[manila-csi-plugin] Bump sidecar versions for v1.22 release

### DIFF
--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 1.3.1
+version: 1.3.2
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -33,14 +33,6 @@ spec:
           args:
             - "--csi-address=/csi/csi.sock"
             - "--kubelet-registration-path=/var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}/csi.sock"
-          lifecycle:
-            preStop:
-              exec:
-                  command: [
-                    "/bin/sh", "-c",
-                    'rm -rf /registration/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}
-                  /registration/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}-reg.sock'
-                  ]
           env:
             - name: KUBE_NODE_NAME
               valueFrom:

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -54,7 +54,7 @@ nodeplugin:
   registrar:
     image:
       repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-      tag: v1.3.0
+      tag: v2.2.0
       pullPolicy: IfNotPresent
     resources: {}
   nodeSelector: {}
@@ -74,14 +74,14 @@ controllerplugin:
   provisioner:
     image:
       repository: k8s.gcr.io/sig-storage/csi-provisioner
-      tag: v2.0.2
+      tag: v2.2.2
       pullPolicy: IfNotPresent
     resources: {}
   # CSI external-snapshotter container spec
   snapshotter:
     image:
       repository: k8s.gcr.io/sig-storage/csi-snapshotter
-      tag: v2.1.3
+      tag: v4.1.1
       pullPolicy: IfNotPresent
     resources: {}
   # CSI external-resizer container spec

--- a/manifests/manila-csi-plugin/csi-controllerplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-controllerplugin.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: openstack-manila-csi-controllerplugin
       containers:
         - name: provisioner
-          image: "k8s.gcr.io/sig-storage/csi-provisioner:v2.0.2"
+          image: "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2"
           args:
             - "--csi-address=$(ADDRESS)"
             # To enable topology awareness in csi-provisioner, uncomment the following line:
@@ -49,7 +49,7 @@ spec:
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
         - name: snapshotter
-          image: "k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.3"
+          image: "k8s.gcr.io/sig-storage/csi-snapshotter:v4.1.1"
           args:
             - "--csi-address=$(ADDRESS)"
           env:

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -21,7 +21,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: registrar
-          image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0"
+          image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0"
           args:
             - "--csi-address=/csi/csi.sock"
             - "--kubelet-registration-path=/var/lib/kubelet/plugins/manila.csi.openstack.org/csi.sock"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates sidecars for v1.22:

* csi-node-driver-registrar: v1.3.0 -> v2.2.0
* csi-provisioner: v2.0.2 -> v2.2.2
* csi-snapshotter: v2.1.3 -> v4.1.1

Also, removed `preStop` hook from node-driver-registrar container spec, as it's no longer needed: https://github.com/kubernetes-csi/node-driver-registrar/pull/61


**Special notes for reviewers**:

In the light of current issues with CPO's CI infra, I've run the acceptance manually and everything seems to remain working just fine.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[manila-csi-plugin] Updated sidecar versions: csi-node-driver-registrar v2.2.0, csi-provisioner v2.2.2, csi-snapshotter v4.1.1
```
