### PR TITLE
[cinder-csi-plugin] Remove preStop hook

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 1.4.7
+version: 1.4.8
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -22,15 +22,11 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/cinder.csi.openstack.org /registration/cinder.csi.openstack.org-reg.sock"]
           env:
             - name: ADDRESS
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
-              value: {{ .Values.csi.nodePlugin.kubeletDir }}/plugins/cinder.csi.openstack.org/csi.sock
+              value: {{ .Values.csi.plugin.nodePlugin.kubeletDir }}/plugins/cinder.csi.openstack.org/csi.sock
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -84,7 +80,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
             - name: kubelet-dir
-              mountPath: {{ .Values.csi.nodePlugin.kubeletDir }}
+              mountPath: {{ .Values.csi.plugin.nodePlugin.kubeletDir }}
               mountPropagation: "Bidirectional"
             - name: pods-probe-dir
               mountPath: /dev
@@ -94,15 +90,15 @@ spec:
       volumes:
         - name: socket-dir
           hostPath:
-            path: {{ .Values.csi.nodePlugin.kubeletDir }}/plugins/cinder.csi.openstack.org
+            path: {{ .Values.csi.plugin.nodePlugin.kubeletDir }}/plugins/cinder.csi.openstack.org
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
-            path: {{ .Values.csi.nodePlugin.kubeletDir }}/plugins_registry/
+            path: {{ .Values.csi.plugin.nodePlugin.kubeletDir }}/plugins_registry/
             type: Directory
         - name: kubelet-dir
           hostPath:
-            path: {{ .Values.csi.nodePlugin.kubeletDir }}
+            path: {{ .Values.csi.plugin.nodePlugin.kubeletDir }}
             type: Directory
         # - name: pods-cloud-data
         #   hostPath:

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -25,10 +25,6 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/cinder.csi.openstack.org /registration/cinder.csi.openstack.org-reg.sock"]
           env:
             - name: ADDRESS
               value: /csi/csi.sock


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
preStop hook is not required from node-driver-registrar v2.0.0 as the mechanism of removing the sock is changed . So removing the same.
ref: https://github.com/kubernetes-csi/node-driver-registrar/issues/21
**Which issue this PR fixes(if applicable)**:
fixes #1617 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
