### PR TITLE
[docs] Update the apiVersions (#1622)

### DIFF
--- a/docs/keystone-auth/using-keystone-webhook-authenticator-and-authorizer.md
+++ b/docs/keystone-auth/using-keystone-webhook-authenticator-and-authorizer.md
@@ -297,7 +297,7 @@ $ kubectl apply -f examples/webhook/keystone-service.yaml
   $ kubectl run curl --rm -it --restart=Never --image curlimages/curl -- \
     -k -XPOST https://k8s-keystone-auth-service.kube-system:8443/webhook -d '
   {
-    "apiVersion": "authentication.k8s.io/v1beta1",
+    "apiVersion": "authentication.k8s.io/v1",
     "kind": "TokenReview",
     "metadata": {
       "creationTimestamp": null
@@ -316,7 +316,7 @@ $ kubectl apply -f examples/webhook/keystone-service.yaml
 
   ```shell
   {
-      "apiVersion": "authentication.k8s.io/v1beta1",
+      "apiVersion": "authentication.k8s.io/v1",
       "kind": "TokenReview",
       "metadata": {
           "creationTimestamp": null
@@ -370,18 +370,18 @@ $ kubectl apply -f examples/webhook/keystone-service.yaml
   $ kubectl run curl --rm -it --restart=Never --image curlimages/curl -- \
     -k -XPOST https://k8s-keystone-auth-service.kube-system:8443/webhook -d '
   {
-    "apiVersion": "authorization.k8s.io/v1beta1",
+    "apiVersion": "authorization.k8s.io/v1",
     "kind": "SubjectAccessReview",
     "spec": {
       "resourceAttributes": {
         "namespace": "default",
         "verb": "get",
-        "group": "",
+        "groups": "",
         "resource": "pods",
         "name": "pod1"
       },
       "user": "demo",
-      "group": ["423d41d3a02f4b77b4a9bbfbc3a1b3c6"],
+      "groups": ["423d41d3a02f4b77b4a9bbfbc3a1b3c6"],
       "extra": {
           "alpha.kubernetes.io/identity/project/id": ["423d41d3a02f4b77b4a9bbfbc3a1b3c6"],
           "alpha.kubernetes.io/identity/project/name": ["demo"],
@@ -395,7 +395,7 @@ $ kubectl apply -f examples/webhook/keystone-service.yaml
 
   ```shell
   {
-      "apiVersion": "authorization.k8s.io/v1beta1",
+      "apiVersion": "authorization.k8s.io/v1",
       "kind": "SubjectAccessReview",
       "status": {
           "allowed": true
@@ -409,18 +409,18 @@ $ kubectl apply -f examples/webhook/keystone-service.yaml
   $ kubectl run curl --rm -it --restart=Never --image curlimages/curl -- \
     -k -XPOST https://k8s-keystone-auth-service.kube-system:8443/webhook -d '
   {
-    "apiVersion": "authorization.k8s.io/v1beta1",
+    "apiVersion": "authorization.k8s.io/v1",
     "kind": "SubjectAccessReview",
     "spec": {
       "resourceAttributes": {
         "namespace": "default",
         "verb": "create",
-        "group": "",
+        "groups": "",
         "resource": "pods",
         "name": "pod1"
       },
       "user": "demo",
-      "group": ["423d41d3a02f4b77b4a9bbfbc3a1b3c6"],
+      "groups": ["423d41d3a02f4b77b4a9bbfbc3a1b3c6"],
       "extra": {
           "alpha.kubernetes.io/identity/project/id": ["423d41d3a02f4b77b4a9bbfbc3a1b3c6"],
           "alpha.kubernetes.io/identity/project/name": ["demo"],
@@ -434,7 +434,7 @@ $ kubectl apply -f examples/webhook/keystone-service.yaml
 
   ```shell
   {
-      "apiVersion": "authorization.k8s.io/v1beta1",
+      "apiVersion": "authorization.k8s.io/v1",
       "kind": "SubjectAccessReview",
       "status": {
           "allowed": false


### PR DESCRIPTION
(cherry picked from commit 8d484ee00032c51825a4f909d044db07235456db)

TokenReview, SubjectAccessReview v1beta1 apiVersions are removed
in 1.22. This PR updates the docs for the same.

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
