### PR TITLE
[manila-csi-plugin] Pass CreateVolumeRequest.parameters in volume context

### DIFF
--- a/pkg/csi/manila/controllerserver.go
+++ b/pkg/csi/manila/controllerserver.go
@@ -61,6 +61,18 @@ func getVolumeCreator(source *csi.VolumeContentSource, shareOpts *options.Contro
 	return nil, status.Error(codes.InvalidArgument, "invalid volume content source")
 }
 
+func filterParametersForVolumeContext(params map[string]string, recognizedFields []string) map[string]string {
+	volCtx := make(map[string]string)
+
+	for _, fieldName := range recognizedFields {
+		if val, ok := params[fieldName]; ok {
+			volCtx[fieldName] = val
+		}
+	}
+
+	return volCtx
+}
+
 func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	if err := validateCreateVolumeRequest(req); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
@@ -150,17 +162,17 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		accessibleTopology = req.GetAccessibilityRequirements().GetPreferred()
 	}
 
+	volCtx := filterParametersForVolumeContext(params, options.NodeVolumeContextFields())
+	volCtx["shareID"] = share.ID
+	volCtx["shareAccessID"] = accessRight.ID
+
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
 			VolumeId:           share.ID,
 			ContentSource:      req.GetVolumeContentSource(),
 			AccessibleTopology: accessibleTopology,
 			CapacityBytes:      int64(sizeInGiB) * bytesInGiB,
-			VolumeContext: map[string]string{
-				"shareID":        share.ID,
-				"shareAccessID":  accessRight.ID,
-				"cephfs-mounter": shareOpts.CephfsMounter,
-			},
+			VolumeContext:      volCtx,
 		},
 	}, nil
 }

--- a/pkg/csi/manila/options/shareoptions.go
+++ b/pkg/csi/manila/options/shareoptions.go
@@ -70,3 +70,7 @@ func NewNodeVolumeContext(data map[string]string) (*NodeVolumeContext, error) {
 
 	return opts, nil
 }
+
+func NodeVolumeContextFields() []string {
+	return nodeVolumeCtxValidator.Fields
+}

--- a/pkg/csi/manila/validator/validator.go
+++ b/pkg/csi/manila/validator/validator.go
@@ -48,6 +48,9 @@ type Validator struct {
 	nameIdxMap nameIndexMap
 	idxNameMap indexNameMap
 
+	// Field names in the struct.
+	Fields []string
+
 	valueExprs *valueExpressions
 	depsMap    dependenciesMap
 	preclsMap  preclusionsMap
@@ -67,11 +70,21 @@ func New(stringStruct interface{}) *Validator {
 		t:          t,
 		nameIdxMap: nameIdxMap,
 		idxNameMap: idxNameMap,
+		Fields:     buildFieldNames(idxNameMap),
 		valueExprs: buildValueExpressions(t, idxNameMap, nameIdxMap),
 		depsMap:    buildDependenciesMap(t, idxNameMap, nameIdxMap),
 		preclsMap:  buildPreclusionsMap(t, idxNameMap, nameIdxMap),
 		matchMap:   buildMatchRegexMap(t),
 	}
+}
+
+func buildFieldNames(m indexNameMap) []string {
+	s := make([]string, 0, len(m))
+	for _, fieldName := range m {
+		s = append(s, string(fieldName))
+	}
+
+	return s
 }
 
 // Populate validates input data and populates the output struct.

--- a/pkg/csi/manila/validator/validator_test.go
+++ b/pkg/csi/manila/validator/validator_test.go
@@ -193,3 +193,34 @@ func TestMatches(t *testing.T) {
 		t.Error(`matches:"true|false" violated, should succeed on matching parameter`)
 	}
 }
+
+func TestFieldNames(t *testing.T) {
+	type s struct {
+		A string `name:"a"`
+		B string `name:"b"`
+	}
+
+	v := New(&s{})
+
+	expected := []string{"a", "b"}
+
+	findElem := func(x string, xs []string) bool {
+		for _, e := range xs {
+			if e == x {
+				return true
+			}
+		}
+		return false
+	}
+
+	if len(expected) != len(v.Fields) {
+		t.Errorf("expected number of entries %d (%v), got %d (%v)",
+			len(expected), expected, len(v.Fields), v.Fields)
+	}
+
+	for i := range v.Fields {
+		if !findElem(v.Fields[i], expected) {
+			t.Error("found unexpected field", v.Fields[i], "; expected fields", expected, "actual fields", v.Fields)
+		}
+	}
+}


### PR DESCRIPTION
(cherry picked from 88654df74232c3509eedd1208ddd7fb1d9499751)

* validator: added Validator.Fields exposing recognized field names

* options: added NodeVolumeContextFields() to expose nodeVolumeCtxValidator.Fields

* CreateVolume: pass all recognized CreateVolumeRequest.parameters fields as Volume.volume_context

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
