### PR TITLE
[cinder-csi-plugin] add leader election

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 1.4.8
+version: 1.5.0
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 1.5.0
+version: 2.0.0
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -11,6 +11,7 @@ spec:
 {{- if eq .Values.csi.controllerPlugin.strategy.type "RollingUpdate" }}
     rollingUpdate:
       maxUnavailable: {{ .Values.csi.controllerPlugin.strategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.csi.controllerPlugin.strategy.rollingUpdate.maxSurge }}
 {{- end }}
   selector:
     matchLabels:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -1,21 +1,17 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "cinder-csi.name" . }}-controllerplugin
-  labels:
-    {{- include "cinder-csi.controllerplugin.labels" . | nindent 4 }}
-spec:
-  clusterIP: None
----
-kind: StatefulSet
+kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: {{ include "cinder-csi.name" . }}-controllerplugin
   labels:
     {{- include "cinder-csi.controllerplugin.labels" . | nindent 4 }}
 spec:
-  serviceName: {{ include "cinder-csi.name" . }}-controllerplugin
   replicas: {{ .Values.csi.plugin.controllerPlugin.replicas }}
+  strategy:
+    type: {{ .Values.csi.controllerPlugin.strategy.type }}
+{{- if eq .Values.csi.controllerPlugin.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.csi.controllerPlugin.strategy.rollingUpdate.maxUnavailable }}
+{{- end }}
   selector:
     matchLabels:
       {{- include "cinder-csi.controllerplugin.matchLabels" . | nindent 6 }}

--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -7,11 +7,11 @@ metadata:
 spec:
   replicas: {{ .Values.csi.plugin.controllerPlugin.replicas }}
   strategy:
-    type: {{ .Values.csi.controllerPlugin.strategy.type }}
-{{- if eq .Values.csi.controllerPlugin.strategy.type "RollingUpdate" }}
+    type: {{ .Values.csi.plugin.controllerPlugin.strategy.type }}
+{{- if eq .Values.csi.plugin.controllerPlugin.strategy.type "RollingUpdate" }}
     rollingUpdate:
-      maxUnavailable: {{ .Values.csi.controllerPlugin.strategy.rollingUpdate.maxUnavailable }}
-      maxSurge: {{ .Values.csi.controllerPlugin.strategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.csi.plugin.controllerPlugin.strategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.csi.plugin.controllerPlugin.strategy.rollingUpdate.maxSurge }}
 {{- end }}
   selector:
     matchLabels:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-rbac.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-rbac.yaml
@@ -24,6 +24,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments/status"]
     verbs: ["patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -68,7 +71,9 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
     verbs: ["get", "list"]
-
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -108,6 +113,9 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -147,6 +155,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -161,26 +172,3 @@ roleRef:
   name: csi-resizer-role
   apiGroup: rbac.authorization.k8s.io
 ---
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: external-resizer-cfg
-  namespace: {{ .Release.Namespace }}
-rules:
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["get", "watch", "list", "delete", "update", "create"]
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: csi-resizer-role-cfg
-  namespace: {{ .Release.Namespace }}
-subjects:
-  - kind: ServiceAccount
-    name: csi-cinder-controller-sa
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: Role
-  name: external-resizer-cfg
-  apiGroup: rbac.authorization.k8s.io

--- a/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "cinder-csi.controllerplugin.labels" . | nindent 4 }}
 spec:
   clusterIP: None
----    
+---
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
@@ -15,7 +15,7 @@ metadata:
     {{- include "cinder-csi.controllerplugin.labels" . | nindent 4 }}
 spec:
   serviceName: {{ include "cinder-csi.name" . }}-controllerplugin
-  replicas: 1
+  replicas: {{ .Values.csi.plugin.controllerPlugin.replicas }}
   selector:
     matchLabels:
       {{- include "cinder-csi.controllerplugin.matchLabels" . | nindent 6 }}
@@ -45,6 +45,7 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout={{ .Values.timeout }}"
+            - "--leader-election=true"
             - "--default-fstype=ext4"
             - "--feature-gates=Topology={{ .Values.csi.provisioner.topology }}"
             - "--extra-create-metadata"
@@ -61,6 +62,7 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout={{ .Values.timeout }}"
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -75,6 +77,7 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--timeout={{ .Values.timeout }}"
             - "--handle-volume-inuse-error=false"
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -32,6 +32,7 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout={{ .Values.timeout }}"
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/charts/cinder-csi-plugin/templates/snapshot-controller-rbac.yaml
+++ b/charts/cinder-csi-plugin/templates/snapshot-controller-rbac.yaml
@@ -5,7 +5,7 @@
 # It should be installed as part of the base Kubernetes distribution in an appropriate
 # namespace for components implementing base system functionality. For installing with
 # Vanilla Kubernetes, kube-system makes sense for the namespace.
-# 
+#
 # Enable this only if your Kubernetes distribution does not bundle the snapshot controller.
 # It should be installed only once per cluster, independent of CSI driver.
 

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -67,7 +67,15 @@ csi:
         - operator: Exists
       kubeletDir: /var/lib/kubelet
     controllerPlugin:
-      replicas: 1
+      replicas: 3
+      strategy:
+        # RollingUpdate strategy replaces old pods with new ones gradually,
+        # without incurring downtime.
+        type: RollingUpdate
+        rollingUpdate:
+          # maxUnavailable is the maximum number of pods that can be
+          # unavailable during the update process.
+          maxUnavailable: 50%
       affinity: {}
       nodeSelector: {}
       tolerations: []

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -67,7 +67,7 @@ csi:
         - operator: Exists
       kubeletDir: /var/lib/kubelet
     controllerPlugin:
-      replicas: 3
+      replicas: 1
       strategy:
         # RollingUpdate strategy replaces old pods with new ones gradually,
         # without incurring downtime.

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -75,7 +75,10 @@ csi:
         rollingUpdate:
           # maxUnavailable is the maximum number of pods that can be
           # unavailable during the update process.
-          maxUnavailable: 50%
+          maxUnavailable: 0
+          # maxSurge is the maximum number of pods that can be
+          # created over the desired number of pods
+          maxSurge: 1
       affinity: {}
       nodeSelector: {}
       tolerations: []

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -67,6 +67,7 @@ csi:
         - operator: Exists
       kubeletDir: /var/lib/kubelet
     controllerPlugin:
+      replicas: 1
       affinity: {}
       nodeSelector: {}
       tolerations: []

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin-rbac.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin-rbac.yaml
@@ -26,7 +26,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments/status"]
     verbs: ["patch"]
-
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 
 ---
 kind: ClusterRoleBinding
@@ -76,7 +78,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch"]
-
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -117,6 +121,9 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -158,7 +165,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -173,28 +182,3 @@ roleRef:
   name: csi-resizer-role
   apiGroup: rbac.authorization.k8s.io
 
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: kube-system
-  name: external-resizer-cfg
-rules:
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["get", "watch", "list", "delete", "update", "create"]
-
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: csi-resizer-role-cfg
-  namespace: kube-system
-subjects:
-  - kind: ServiceAccount
-    name: csi-cinder-controller-sa
-    namespace: kube-system
-roleRef:
-  kind: Role
-  name: external-resizer-cfg
-  apiGroup: rbac.authorization.k8s.io

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -2,29 +2,18 @@
 # external-attacher, external-provisioner, external-snapshotter
 # external-resize, liveness-probe
 
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-cinder-controller-service
-  namespace: kube-system
-  labels:
-    app: csi-cinder-controllerplugin
-spec:
-  selector:
-    app: csi-cinder-controllerplugin
-  ports:
-    - name: dummy
-      port: 12345
-
----
-kind: StatefulSet
+kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: csi-cinder-controllerplugin
   namespace: kube-system
 spec:
-  serviceName: "csi-cinder-controller-service"
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: csi-cinder-controllerplugin
@@ -40,6 +29,7 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -55,6 +45,7 @@ spec:
             - "--default-fstype=ext4"
             - "--feature-gates=Topology=true"
             - "--extra-create-metadata"
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -68,6 +59,7 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
             - "--extra-create-metadata"
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -81,6 +73,7 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
             - "--handle-volume-inuse-error=false"
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
 Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Adding support for running HA CSI controller.

**Which issue this PR fixes(if applicable)**:
fixes #702

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

Increase replicas to 3, all operations should work as expected (attach, detach, provision, deprovision, resize, snapshot).

I tested it on k8s 1.20, all operations are completing without errors. Also I can see successful leader election change events:

```
29m         Normal    LeaderElection      lease/csi-cinderplugin                               csi-cinder-controllerplugin-0 became leader
3m30s       Normal    LeaderElection      lease/csi-cinderplugin                               csi-cinder-controllerplugin-0 became leader
29m         Normal    LeaderElection      lease/external-attacher-leader-csi-cinderplugin      csi-cinder-controllerplugin-0 became leader
3m30s       Normal    LeaderElection      lease/external-attacher-leader-csi-cinderplugin      csi-cinder-controllerplugin-0 became leader
29m         Normal    LeaderElection      lease/external-resizer-csi-cinderplugin              csi-cinder-controllerplugin-0 became leader
3m30s       Normal    LeaderElection      lease/external-resizer-csi-cinderplugin              csi-cinder-controllerplugin-0 became leader
29m         Normal    LeaderElection      lease/external-snapshotter-leader-csi-cinderplugin   csi-cinder-controllerplugin-0 became leader
3m30s       Normal    LeaderElection      lease/external-snapshotter-leader-csi-cinderplugin   csi-cinder-controllerplugin-0 became leader
```

Cordon all nodes, deletetd `csi-cinder-controllerplugin-0` (so it won't be scheduled again),  leader changed to `csi-cinder-controllerplugin-2` successfully and all CSI operations still working.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[cinder-csi-plugin] Add leader election flag (for HA CSI controller) in the manifests and switch from StatefulSet to Deployment. The existing cinder-csi-plugin helm chart should be uninstalled before installing the new version. Action required
```
