### PR TITLE
[occm] Tls exclude ports

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -194,6 +194,14 @@ Request Body:
 
   Not supported when `lb-provider=ovn` is configured in openstack-cloud-controller-manager.
 
+  To specify which ports should be served over https and not http use `loadbalancer.openstack.org/service-ssl-ports`
+
+- `loadbalancer.openstack.org/service-ssl-ports`
+
+  In conjunction with `loadbalancer.openstack.org/default-tls-container-ref`, a comma separated list of ports to terminate in https
+
+  example: `loadbalancer.openstack.org/service-ssl-ports: "443,8443"`
+
 - `loadbalancer.openstack.org/load-balancer-id`
 
   This annotation is automatically added to the Service if it's not specified when creating. After the Service is created successfully it shouldn't be changed, otherwise the Service won't behave as expected.  

--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+	cpoutil "k8s.io/cloud-provider-openstack/pkg/util"
+)
+
+func TestGetTlsServicePorts(t *testing.T) {
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "myservice",
+			Namespace: "a-namespace",
+		},
+	}
+
+	var ports []int32
+
+	service.ObjectMeta.Annotations = map[string]string{
+	}
+	ports = GetTlsServicePorts(service)
+	if len(ports) != 0 {
+		t.Errorf("no annotation should give empty ports: ports = %v", ports)
+	}
+
+	service.ObjectMeta.Annotations = map[string]string{
+		"loadbalancer.openstack.org/service-ssl-ports": "xxx 443",
+	}
+	ports = GetTlsServicePorts(service)
+	if len(ports) != 0 {
+		t.Errorf("wrong annotation format should give empty ports: ports = %v", ports)
+	}
+
+	service.ObjectMeta.Annotations = map[string]string{
+		"loadbalancer.openstack.org/service-ssl-ports": "443",
+	}
+	ports = GetTlsServicePorts(service)
+	if len(ports) != 1 {
+		t.Errorf("ports should not be empty: ports = %v", ports)
+	}
+	if ports[0] != 443 {
+		t.Errorf("ports should be [443]: ports = %v", ports)
+	}
+
+	service.ObjectMeta.Annotations = map[string]string{
+		"loadbalancer.openstack.org/service-ssl-ports": "443,8443",
+	}
+	ports = GetTlsServicePorts(service)
+	if len(ports) != 2 {
+		t.Errorf("ports should not be empty: %v", ports)
+	}
+
+	if !cpoutil.ContainsInt(ports, 443) {
+		t.Errorf("port 443 should be excluded: %v", ports)
+	}
+
+	if !cpoutil.ContainsInt(ports, 8443) {
+		t.Errorf("port 8443 should be excluded: %v", ports)
+	}
+
+	if cpoutil.ContainsInt(ports, 1002) {
+		t.Errorf("port 1002 should not be excluded: %v", ports)
+	}
+
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -61,6 +61,17 @@ func Contains(list []string, strToSearch string) bool {
 	return false
 }
 
+// Contains searches if an integer list contains the given value or not.
+func ContainsInt(list []int32, intToSearch int32) bool {
+	for _, item := range list {
+		if item == intToSearch {
+			// match
+			return true
+		}
+	}
+	return false
+}
+
 // RoundUpSize calculates how many allocation units are needed to accommodate
 // a volume of given size. E.g. when user wants 1500MiB volume, while AWS EBS
 // allocates volumes in gibibyte-sized chunks,


### PR DESCRIPTION
[oocm] Add annotation to exclude ports from TERMINATED_HTTPS: tls-ports-exclude

**What this PR does / why we need it**:

It adds support for the annotation `loadbalancer.openstack.org/service-ssl-ports`.
When using `loadbalancer.openstack.org/default-tls-container-ref`, all listeners for ports included in this annotations are creating using TERMINATED_HTTPS

For a multi-port service, having for example, ports 80 and 443, we want some ports to be excluded and use proto HTTP instead, to have plain http on some ports and https on the others

Example:

```yaml
apiVersion: v1
kind: Service
metadata:
  labels:
    app: myapp
  name: myapp
  annotations:
    loadbalancer.openstack.org/x-forwarded-for: "true"
    loadbalancer.openstack.org/default-tls-container-ref: "https://api.pub1.infomaniak.cloud/keymanager/v1/containers/e53fd5d0-c3d0-4707-8c20-bbf11796e1b5"
    loadbalancer.openstack.org/service-ssl-ports: "443"
spec:
  ports:
  - port: 80
    protocol: TCP
    targetPort: 80
  - port: 443
    protocol: TCP
    targetPort: 443
  selector:
    app: myapp
  type: LoadBalancer
status:
  loadBalancer: {}
```

**Which issue this PR fixes(if applicable)**:
-none-

**Special notes for reviewers**:

Create the above service with this image, listing listeners for this load balancer via the openstack api, you should get:

```
+--------------------------------------+--------------------------------------+------+----------------------------------+------------------+---------------+----------------+
| id                                   | default_pool_id                      | name | project_id                       | protocol         | protocol_port | admin_state_up |
+--------------------------------------+--------------------------------------+------+----------------------------------+------------------+---------------+----------------+
| 7f8295ee-ae54-4025-8c12-1ce0695f45b8 | 9ff787d0-87fe-4c2a-ba74-6a819fdf006c |      | 4c08a353d2414273aa43ee0bf6ec2683 | HTTP             |            80 | True           |
| b1e17721-83c8-44d3-ae5a-63b4bd7fcefe | fbeedf15-36d0-45b9-a181-be47d66430cf |      | 4c08a353d2414273aa43ee0bf6ec2683 | TERMINATED_HTTPS |           443 | True           |
+--------------------------------------+--------------------------------------+------+----------------------------------+------------------+---------------+----------------+
```

**Release note**:
```release-note
NONE
```
