### PR TITLE
[cinder-csi-plugin] Remove openlab sanity test

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -69,22 +69,6 @@
               - ^.*\.md$
               - ^OWNERS$
               - ^SECURITY_CONTACTS$
-    cloud-provider-openstack-sanity-test-csi-cinder:
-      jobs:
-        - cloud-provider-openstack-sanity-test-csi-cinder:
-            files:
-              - cmd/cinder-csi-plugin/.*
-              - pkg/csi/cinder/.*
-              - pkg/util/.*
-              - tests/sanity/cinder/.*
-              - go.mod$
-              - go.sum$
-              - Makefile$
-            irrelevant-files:
-              - docs/.*$
-              - ^.*\.md$
-              - ^OWNERS$
-              - ^SECURITY_CONTACTS$
     cloud-provider-openstack-multinode-csi-migration-test:
       jobs:
         - cloud-provider-openstack-multinode-csi-migration-test:

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ replace (
 	k8s.io/kubelet => k8s.io/kubelet v0.22.0
 	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.22.0
 	k8s.io/metrics => k8s.io/metrics v0.22.0
-	k8s.io/mount-utils => k8s.io/mount-utils v0.21.1
+	k8s.io/mount-utils => k8s.io/mount-utils v0.22.0
 	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.22.0
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.22.0
 	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.22.0


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
CSI sanity tests have been added to prow , so removing the openlab test to avoid duplicate test.
https://github.com/kubernetes/test-infra/pull/23434
**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
