### PR TITLE
[occm] use yaml list instead of string to pass extra controller arguments

### DIFF
--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -42,10 +42,8 @@ spec:
             {{- else }}
             - --address=127.0.0.1
             {{- end }}
-            {{- if .Values.controllerExtraArgs }}
-            {{- with .Values.controllerExtraArgs }}
-            {{- tpl . $ | trim | nindent 12 }}
-            {{- end }}
+            {{- range .Values.controllerExtraArgs }}
+            - {{ . }}
             {{- end }}
           {{- if .Values.serviceMonitor.enabled }}
           ports:

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -42,8 +42,8 @@ tolerations: []
 #     effect: NoExecute
 
 # Any extra arguments for openstack-cloud-controller-manager
-controllerExtraArgs: {}
-# controllerExtraArgs: |-
+controllerExtraArgs: []
+# controllerExtraArgs:
 #   - --cluster-name=my-cluster
 
 # Create a service monitor for Prometheus Operator


### PR DESCRIPTION
```release note
Action required: the controllerExtraArgs field in the occm helm chart now takes a list of string arguments. Users should remove the |- string quote operator from controllerExtraArgs.
```

fixes #1637
