### PR TITLE
[cinder-csi-plugin] make SA snapshot-controller-sa references match across templates 

### DIFF
--- a/charts/cinder-csi-plugin/templates/snapshot-controller-rbac.yaml
+++ b/charts/cinder-csi-plugin/templates/snapshot-controller-rbac.yaml
@@ -12,7 +12,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: snapshot-controller
+  name: snapshot-controller-sa
   namespace: {{ .Release.Namespace }}
 ---
 kind: ClusterRole
@@ -76,7 +76,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
-    name: snapshot-controller
+    name: snapshot-controller-sa
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role


### PR DESCRIPTION
**What this PR does / why we need it**:

fix typo with service account name for snapshot-controller. Different occurrences found here:

* https://github.com/kubernetes/cloud-provider-openstack/blob/fd836e90ef52ebf15dc5cb353395f75b814953c7/charts/cinder-csi-plugin/templates/snapshot-controller-statefulset.yaml#L27
* https://github.com/kubernetes/cloud-provider-openstack/blob/fd836e90ef52ebf15dc5cb353395f75b814953c7/charts/cinder-csi-plugin/templates/snapshot-controller-rbac.yaml#L15
* https://github.com/kubernetes/cloud-provider-openstack/blob/fd836e90ef52ebf15dc5cb353395f75b814953c7/charts/cinder-csi-plugin/templates/snapshot-controller-rbac.yaml#L54
* https://github.com/kubernetes/cloud-provider-openstack/blob/fd836e90ef52ebf15dc5cb353395f75b814953c7/charts/cinder-csi-plugin/templates/snapshot-controller-rbac.yaml#L79


**Special notes for reviewers**:

Without this change, trying to deploy the release fails

* snapshot-controller sts is not ready:

```
NAME                                       READY   AGE
openstack-cinder-csi-snapshot-controller   0/1     12m
```

* related resource details returned:

```
Events:
  Type     Reason        Age                   From                    Message
  ----     ------        ----                  ----                    -------
  Warning  FailedCreate  2m19s (x18 over 13m)  statefulset-controller  create Pod openstack-cinder-csi-snapshot-controller-0 in StatefulSet openstack-cinder-csi-snapshot-controller failed error: pods "openstack-cinder-csi-snapshot-controller-0" is forbidden: error looking up service account kube-system/snapshot-controller-sa: serviceaccount "snapshot-controller-sa" not found
``` 