### PR TITLE
[CI] Make devstack local.conf configurable

### DIFF
--- a/tests/playbooks/roles/install-devstack/defaults/main.yaml
+++ b/tests/playbooks/roles/install-devstack/defaults/main.yaml
@@ -3,9 +3,6 @@ user: "stack"
 workdir: "/home/{{ user }}/devstack"
 branch: "stable/wallaby"
 enable_services:
-  - rabbit
-  - mysql
-  - key
   - nova
   - glance
   - cinder

--- a/tests/playbooks/roles/install-devstack/defaults/main.yaml
+++ b/tests/playbooks/roles/install-devstack/defaults/main.yaml
@@ -2,3 +2,13 @@
 user: "stack"
 workdir: "/home/{{ user }}/devstack"
 branch: "stable/wallaby"
+enable_services:
+  - rabbit
+  - mysql
+  - key
+  - nova
+  - glance
+  - cinder
+  - neutron
+  - octavia
+  - barbican

--- a/tests/playbooks/roles/install-devstack/tasks/main.yml
+++ b/tests/playbooks/roles/install-devstack/tasks/main.yml
@@ -62,16 +62,21 @@
         version: "{{ branch }}"
         force: false
 
-    - name: Prepare local.conf
+    - name: Retrieve local IP address
       shell:
         executable: /bin/bash
         cmd: |
           set -ex
-          branch={{ branch }}
-          curl -sSL https://gist.github.com/lingxiankong/a109303f48e9a74fc8a7c01de4156d71/raw -o {{ workdir }}/local.conf
-          local_ip=$(ip route get 8.8.8.8 | head -1 | awk '{print $7}')
-          sed -i "s/LOCAL_IP_ADDRESS/$local_ip/g" {{ workdir }}/local.conf
-          sed -i "s,MYBRANCH,$branch,g" {{ workdir }}/local.conf
+          ip route get 8.8.8.8 | head -1 | awk '{print $7}'
+      register: local_ip_output
+
+    - set_fact:
+        local_ip_address: "{{ local_ip_output.stdout }}"
+
+    - name: Prepare local.conf
+      template:
+        src: local.conf.j2
+        dest: {{ workdir }}/local.conf
 
     - name: Fix localhost
       shell:

--- a/tests/playbooks/roles/install-devstack/tasks/main.yml
+++ b/tests/playbooks/roles/install-devstack/tasks/main.yml
@@ -76,7 +76,7 @@
     - name: Prepare local.conf
       template:
         src: local.conf.j2
-        dest: {{ workdir }}/local.conf
+        dest: "{{ workdir }}/local.conf"
 
     - name: Fix localhost
       shell:

--- a/tests/playbooks/roles/install-devstack/templates/local.conf.j2
+++ b/tests/playbooks/roles/install-devstack/templates/local.conf.j2
@@ -1,0 +1,116 @@
+[[local|localrc]]
+RECLONE=False
+HOST_IP={{ local_ip_address }}
+DEST=/opt/stack
+DATA_DIR=${DEST}/data
+USE_PYTHON3=True
+LOGFILE=$DEST/logs/stack.sh.log
+VERBOSE=True
+LOG_COLOR=False
+LOGDAYS=1
+SERVICE_TIMEOUT=300
+
+DATABASE_PASSWORD=password
+ADMIN_PASSWORD=password
+SERVICE_PASSWORD=password
+SERVICE_TOKEN=password
+RABBIT_PASSWORD=password
+
+TARGET_BRANCH={{ branch }}
+
+ENABLED_SERVICES={{ enable_services | join(',') }}
+
+{% if "nova" in enable_services %}
+# Nova
+enable_plugin nova https://opendev.org/openstack/nova.git {{ branch }}
+enable_service n-api
+enable_service n-cpu
+enable_service n-cond
+enable_service n-sch
+enable_service n-api-meta
+
+enable_service placement-api
+enable_service placement-client
+{% endif %}
+
+{% if "glance" in enable_services %}
+# Glance
+enable_plugin glance https://opendev.org/openstack/glance.git {{ branch }}
+enable_service g-api
+enable_service g-reg
+
+[[post-config|$GLANCE_API_CONF]]
+[glance_store]
+default_store = file
+{% endif %}
+
+{% if "cinder" in enable_services %}
+# Cinder
+enable_plugin cinder https://opendev.org/openstack/cinder.git {{ branch }}
+enable_service cinder
+enable_service c-api
+enable_service c-vol
+enable_service c-sch
+{% endif %}
+
+{% if "neutron" in enable_services %}
+# Neutron
+enable_plugin neutron https://opendev.org/openstack/neutron.git {{ branch }}
+enable_service q-svc
+enable_service q-agt
+enable_service q-dhcp
+enable_service q-l3
+enable_service q-meta
+IP_VERSION=4
+IPV4_ADDRS_SAFE_TO_USE=10.1.0.0/26
+FIXED_RANGE=10.1.0.0/26
+NETWORK_GATEWAY=10.1.0.1
+FLOATING_RANGE=172.24.5.0/24
+PUBLIC_NETWORK_GATEWAY=172.24.5.1
+Q_PLUGIN=ml2
+Q_ML2_TENANT_NETWORK_TYPE=vxlan
+Q_DVR_MODE=legacy
+Q_AGENT=openvswitch
+Q_ML2_PLUGIN_MECHANISM_DRIVERS=openvswitch
+
+[[post-config|$NEUTRON_CONF]]
+[DEFAULT]
+global_physnet_mtu = 1430
+{% endif %}
+
+{% if "octavia" in enable_services %}
+# Octavia
+enable_plugin octavia https://opendev.org/openstack/octavia.git {{ branch }}
+enable_service octavia
+enable_service o-cw
+enable_service o-hm
+enable_service o-hk
+enable_service o-api
+
+LIBS_FROM_GIT+=,python-octaviaclient
+
+OCTAVIA_MGMT_SUBNET=10.51.0.0/16
+OCTAVIA_MGMT_SUBNET_START=10.51.0.2
+OCTAVIA_MGMT_SUBNET_END=10.51.0.254
+
+[[post-config|$OCTAVIA_CONF]]
+[api_settings]
+allow_tls_terminated_listeners = True
+[controller_worker]
+loadbalancer_topology = SINGLE
+amp_active_retries = 60
+amp_active_wait_sec = 10
+[haproxy_amphora]
+rest_request_conn_timeout = 300
+rest_request_read_timeout = 600
+[health_manager]
+health_check_interval = 30
+{% endif %}
+
+{% if "barbican" in enable_services %}
+# Barbican
+enable_plugin barbican https://opendev.org/openstack/barbican.git {{ branch }}
+enable_service barbican-vault
+
+LIBS_FROM_GIT+=,python-barbicanclient
+{% endif %}

--- a/tests/playbooks/roles/install-devstack/templates/local.conf.j2
+++ b/tests/playbooks/roles/install-devstack/templates/local.conf.j2
@@ -36,10 +36,6 @@ enable_service placement-client
 # Glance
 enable_service g-api
 enable_service g-reg
-
-[[post-config|$GLANCE_API_CONF]]
-[glance_store]
-default_store = file
 {% endif %}
 
 {% if "cinder" in enable_services %}
@@ -69,10 +65,6 @@ Q_ML2_TENANT_NETWORK_TYPE=vxlan
 Q_DVR_MODE=legacy
 Q_AGENT=openvswitch
 Q_ML2_PLUGIN_MECHANISM_DRIVERS=openvswitch
-
-[[post-config|$NEUTRON_CONF]]
-[DEFAULT]
-global_physnet_mtu = 1430
 {% endif %}
 
 {% if "octavia" in enable_services %}
@@ -89,7 +81,29 @@ LIBS_FROM_GIT+=,python-octaviaclient
 OCTAVIA_MGMT_SUBNET=10.51.0.0/16
 OCTAVIA_MGMT_SUBNET_START=10.51.0.2
 OCTAVIA_MGMT_SUBNET_END=10.51.0.254
+{% endif %}
 
+{% if "barbican" in enable_services %}
+# Barbican
+enable_plugin barbican https://opendev.org/openstack/barbican.git {{ branch }}
+enable_service barbican-vault
+
+LIBS_FROM_GIT+=,python-barbicanclient
+{% endif %}
+
+{% if "glance" in enable_services %}
+[[post-config|$GLANCE_API_CONF]]
+[glance_store]
+default_store = file
+{% endif %}
+
+{% if "neutron" in enable_services %}
+[[post-config|$NEUTRON_CONF]]
+[DEFAULT]
+global_physnet_mtu = 1430
+{% endif %}
+
+{% if "octavia" in enable_services %}
 [[post-config|$OCTAVIA_CONF]]
 [api_settings]
 allow_tls_terminated_listeners = True
@@ -102,12 +116,4 @@ rest_request_conn_timeout = 300
 rest_request_read_timeout = 600
 [health_manager]
 health_check_interval = 30
-{% endif %}
-
-{% if "barbican" in enable_services %}
-# Barbican
-enable_plugin barbican https://opendev.org/openstack/barbican.git {{ branch }}
-enable_service barbican-vault
-
-LIBS_FROM_GIT+=,python-barbicanclient
 {% endif %}

--- a/tests/playbooks/roles/install-devstack/templates/local.conf.j2
+++ b/tests/playbooks/roles/install-devstack/templates/local.conf.j2
@@ -18,11 +18,10 @@ RABBIT_PASSWORD=password
 
 TARGET_BRANCH={{ branch }}
 
-ENABLED_SERVICES={{ enable_services | join(',') }}
+ENABLED_SERVICES=rabbit,mysql,key
 
 {% if "nova" in enable_services %}
 # Nova
-enable_plugin nova https://opendev.org/openstack/nova.git {{ branch }}
 enable_service n-api
 enable_service n-cpu
 enable_service n-cond
@@ -35,7 +34,6 @@ enable_service placement-client
 
 {% if "glance" in enable_services %}
 # Glance
-enable_plugin glance https://opendev.org/openstack/glance.git {{ branch }}
 enable_service g-api
 enable_service g-reg
 
@@ -46,7 +44,6 @@ default_store = file
 
 {% if "cinder" in enable_services %}
 # Cinder
-enable_plugin cinder https://opendev.org/openstack/cinder.git {{ branch }}
 enable_service cinder
 enable_service c-api
 enable_service c-vol

--- a/tests/playbooks/test-occm-e2e.yaml
+++ b/tests/playbooks/test-occm-e2e.yaml
@@ -12,6 +12,16 @@
   roles:
     - role: install-golang
     - role: install-devstack
+      enable_services:
+        - rabbit
+        - mysql
+        - key
+        - nova
+        - glance
+        - cinder
+        - neutron
+        - octavia
+        - barbican
     - role: install-k3s
       worker_node_count: 0
       k8s_branch: release-1.22

--- a/tests/playbooks/test-occm-e2e.yaml
+++ b/tests/playbooks/test-occm-e2e.yaml
@@ -13,9 +13,6 @@
     - role: install-golang
     - role: install-devstack
       enable_services:
-        - rabbit
-        - mysql
-        - key
         - nova
         - glance
         - cinder


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This PR makes `local.conf` configurable via `enable_services` variable set in playbooks.

**Which issue this PR fixes(if applicable)**:
fixes #1650 

**Special notes for reviewers**:

The contents of the config file are based on @lingxiankong's https://gist.github.com/lingxiankong/a109303f48e9a74fc8a7c01de4156d71/raw . I've only reshuffled the plugin sections and added `enable_plugin <PLUGIN NAME> https://opendev.org/openstack/<PLUGIN NAME>.git {{ branch }}` for each plugin.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
