### PR TITLE
[Charts] Do not check chart version in dev cycle

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,6 +1,9 @@
 name: Lint Charts
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'charts/**'
 
 jobs:
   lint:
@@ -25,4 +28,4 @@ jobs:
         uses: helm/chart-testing-action@v2.1.0
 
       - name: Run chart-testing (lint)
-        run: ct lint --target-branch ${GITHUB_BASE_REF}
+        run: ct lint --target-branch ${GITHUB_BASE_REF} --check-version-increment false

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -11,6 +11,7 @@
         - [Build openstack-cloud-controller-manager image](#build-openstack-cloud-controller-manager-image)
         - [Troubleshooting](#troubleshooting)
         - [Review process](#review-process)
+        - [Helm charts](#helm-charts)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -133,3 +134,18 @@ Guidance for the code submitter:
 * If the PR is not ready for review, add `[WIP]` in the PR title to save reviewer's time.
 * If the job failure is unrelated to the PR, type `/test <job name>` in the comment to re-trigger the job, e.g. `/test cloud-provider-openstack-acceptance-test-lb-octavia`
 * If the job keeps failing and you are not sure what to do, contact the repo maintainers for help (either using `/cc` in the PR or in `#provider-openstack` Slack channel).
+
+### Helm Charts
+
+There are several helm charts maintained in this repository, the charts are placed under `/charts` directory at the top-level of the directory tree. To install the chart, e.g. openstack-cloud-controller-manager:
+
+```shell
+helm repo add cpo https://kubernetes.github.io/cloud-provider-openstack
+helm repo update
+helm install occm cpo/openstack-cloud-controller-manager
+```
+
+The chart version should be bumped in the following situations:
+
+* Official release following the new Kubernetes major/minor version, e.g. v1.22.0, v1.23.0, etc. The chart should bump its major or minor version based on the fact that if there are backward incompatible changes committed during the past development cycle.
+* cloud-provider-openstack own patch version release for stable branches, especially when backporting bugfix for the charts.


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
With the current chart version bump behavior, the charts version has
been bumped each time when there are changes in the current development
cycle but those versions are never released until the final official
release which could confuse the user.

The chart version should be bumped in the following situations:

* Official release following the new Kubernetes major/minor version, we should bump at least the minor version unless there are backward-incompatible chart changes.
* cloud-provider-openstack own patch version release for stable branches when there are related chart changes.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
