### PR TITLE
[magnum-auto-healer] Update cluster health status only when needed

### DIFF
--- a/pkg/autohealing/controller/controller.go
+++ b/pkg/autohealing/controller/controller.go
@@ -407,7 +407,10 @@ func (c *Controller) Start(ctx context.Context) {
 			}
 
 			wg.Wait()
-			c.provider.UpdateHealthStatus(masterUnhealthyNodes, workerUnhealthyNodes)
+
+			if c.provider.Enabled() {
+				c.provider.UpdateHealthStatus(masterUnhealthyNodes, workerUnhealthyNodes)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Added check before updating cluster health status.

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
