### PR TITLE
[cinder-csi-plugin]add snapshot test back into CI 

### DIFF
--- a/tests/e2e/csi/cinder/cinder-testdriver.go
+++ b/tests/e2e/csi/cinder/cinder-testdriver.go
@@ -55,9 +55,7 @@ func initCinderDriver(name string, manifests ...string) storageframework.TestDri
 				storageframework.CapTopology:            true,
 				storageframework.CapControllerExpansion: true,
 				storageframework.CapNodeExpansion:       true,
-				storageframework.CapOnlineExpansion:     true,
-				//storageframework.CapSnapshotDataSource: true,
-
+				storageframework.CapSnapshotDataSource:  true,
 			},
 		},
 		manifests: manifests,

--- a/tests/e2e/csi/cinder/csi-volumes.go
+++ b/tests/e2e/csi/cinder/csi-volumes.go
@@ -19,7 +19,7 @@ var CSITestSuites = []func() storageframework.TestSuite{
 	testsuites.InitVolumeModeTestSuite,
 	testsuites.InitEphemeralTestSuite,
 	//testsuites.InitVolumeIOTestSuite,
-	//testsuites.InitSnapshottableTestSuite,
+	testsuites.InitSnapshottableTestSuite,
 	testsuites.InitMultiVolumeTestSuite,
 	testsuites.InitFsGroupChangePolicyTestSuite,
 	testsuites.InitTopologyTestSuite,

--- a/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
@@ -72,6 +72,14 @@
       kubectl apply -f manifests/cinder-csi-plugin
   ignore_errors: yes
 
+- name: Deploy snapshot manifests
+  shell:
+    executable: /bin/bash
+    cmd: |
+      kubectl apply -k 'github.com/kubernetes-csi/external-snapshotter/client/config/crd?ref=release-5.0'
+      kubectl apply -k 'github.com/kubernetes-csi/external-snapshotter/deploy/kubernetes/snapshot-controller?ref=release-5.0'
+  ignore_errors: yes
+
 - name: Wait for csi-cinder-controllerplugin up and running
   shell:
     executable: /bin/bash
@@ -94,8 +102,19 @@
   delay: 5
   ignore_errors: yes
 
+- name: Wait for snapshot-controller deployment up and running
+  shell:
+    executable: /bin/bash
+    cmd: |
+      kubectl -n kube-system get pod | grep snapshot-controller  | grep Running
+  register: check_csi_snapshot
+  until: check_csi_snapshot.rc == 0
+  retries: 24
+  delay: 5
+  ignore_errors: yes
+
 - name: Gather additional evidence if csi-cinder-plugin failed to come up
-  when: check_csi_controller.failed or check_csi_node.failed
+  when: check_csi_controller.failed or check_csi_node.failed or check_csi_snapshot.failed
   block:
     - name: Describe failed csi-cinder-plugin
       shell:
@@ -104,6 +123,7 @@
           kubectl get pods -A
           kubectl -n kube-system describe deployment csi-cinder-controllerplugin
           kubectl -n kube-system describe daemonset csi-cinder-nodeplugin
+          kubectl -n kube-system describe deployment snapshot-controller
       register: describe_csi
       changed_when: false
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #1661 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
