### PR TITLE
[CI] Add install-k8s role

### DIFF
--- a/tests/playbooks/roles/install-k8s/defaults/main.yaml
+++ b/tests/playbooks/roles/install-k8s/defaults/main.yaml
@@ -1,0 +1,7 @@
+---
+k8s_version: 'master'
+etcd_version: 'v3.5.0'
+
+k8s_src_dir: '{{ ansible_user_dir }}/src/k8s.io/kubernetes'
+k8s_log_dir: '{{ ansible_user_dir }}/workspace/logs/kubernetes'
+kubectl: '{{ ansible_user_dir }}/src/k8s.io/kubernetes/cluster/kubectl.sh'

--- a/tests/playbooks/roles/install-k8s/task/main.yaml
+++ b/tests/playbooks/roles/install-k8s/task/main.yaml
@@ -1,0 +1,22 @@
+- name: Install etcd {{ etcd_version }}
+  shell:
+    executable: /bin/bash
+    cmd: |
+      set -x
+      set -e
+
+      # Install etcd
+      wget https://github.com/coreos/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-amd64.tar.gz
+      tar -zxf etcd-{{ etcd_version }}-linux-amd64.tar.gz
+      cp etcd-{{ etcd_version }}-linux-amd64/etcd{,ctl} /usr/local/bin/
+
+- name: Install Kubernetes {{ k8s_version }}
+  shell:
+    executable: /bin/bash
+    cmd: |
+      set -x
+      set -e
+
+      # Build Kubernetes binaries
+      git clone https://github.com/kubernetes/kubernetes '{{ k8s_src_dir }}' -b '{{ k8s_version }}'
+      make -C '{{ k8s_src_dir }}' WHAT="cmd/kubectl cmd/kube-apiserver cmd/kube-controller-manager cmd/cloud-controller-manager cmd/kubelet cmd/kube-proxy cmd/kube-scheduler"


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This PR adds `install-k8s` role for the CI Ansible playbooks.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:

`install-k3s` brings in many OpenStack dependencies. manila-csi e2e test (https://github.com/kubernetes/cloud-provider-openstack/pull/1656) doesn't install these, so it fails to run.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
