### PR TITLE
Fix certificate verification issue when downloading devstack

### DIFF
--- a/tests/playbooks/roles/install-devstack/tasks/main.yml
+++ b/tests/playbooks/roles/install-devstack/tasks/main.yml
@@ -57,7 +57,7 @@
 
     - name: Git checkout devstack
       git:
-        repo: "https://opendev.org/openstack/devstack"
+        repo: "https://github.com/openstack/devstack"
         dest: "{{ workdir }}"
         version: "{{ branch }}"
         force: false

--- a/tests/playbooks/roles/install-devstack/templates/local.conf.j2
+++ b/tests/playbooks/roles/install-devstack/templates/local.conf.j2
@@ -16,6 +16,7 @@ SERVICE_PASSWORD=password
 SERVICE_TOKEN=password
 RABBIT_PASSWORD=password
 
+GIT_BASE=https://github.com
 TARGET_BRANCH={{ branch }}
 
 ENABLED_SERVICES=rabbit,mysql,key
@@ -48,7 +49,7 @@ enable_service c-sch
 
 {% if "neutron" in enable_services %}
 # Neutron
-enable_plugin neutron https://opendev.org/openstack/neutron.git {{ branch }}
+enable_plugin neutron ${GIT_BASE}/openstack/neutron.git {{ branch }}
 enable_service q-svc
 enable_service q-agt
 enable_service q-dhcp
@@ -69,7 +70,7 @@ Q_ML2_PLUGIN_MECHANISM_DRIVERS=openvswitch
 
 {% if "octavia" in enable_services %}
 # Octavia
-enable_plugin octavia https://opendev.org/openstack/octavia.git {{ branch }}
+enable_plugin octavia ${GIT_BASE}/openstack/octavia.git {{ branch }}
 enable_service octavia
 enable_service o-cw
 enable_service o-hm
@@ -85,7 +86,7 @@ OCTAVIA_MGMT_SUBNET_END=10.51.0.254
 
 {% if "barbican" in enable_services %}
 # Barbican
-enable_plugin barbican https://opendev.org/openstack/barbican.git {{ branch }}
+enable_plugin barbican ${GIT_BASE}/openstack/barbican.git {{ branch }}
 enable_service barbican-vault
 
 LIBS_FROM_GIT+=,python-barbicanclient


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
We are experiencing certificate issue with opendev.org at the moment, trying to use github.com for more stable solution.

**Which issue this PR fixes(if applicable)**:
fixes #1663

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
