### PR TITLE
[manila-csi-plugin] ControllerExpandVolume: fix bad key for deleting from pendingVolumes (release-1.22)

### DIFF
--- a/pkg/csi/manila/controllerserver.go
+++ b/pkg/csi/manila/controllerserver.go
@@ -445,7 +445,7 @@ func (cs *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 	}
 
 	// Check for pending operations on this volume
-	if _, isPending := pendingVolumes.LoadOrStore(req.GetVolumeId(), true); isPending {
+	if _, isPending := pendingVolumes.LoadOrStore(share.Name, true); isPending {
 		return nil, status.Errorf(codes.Aborted, "volume %s is already being processed", share.Name)
 	}
 	defer pendingVolumes.Delete(share.Name)


### PR DESCRIPTION
This is a backport of https://github.com/kubernetes/cloud-provider-openstack/pull/1667 into the release-1.22 branch.

Cherry-picked from 4128209d8f6013137516cfe04a50ee45af6b9990.

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Without this fix, `ControllerExpandVolume` breaks locks on the affected volume. Controller plugin would need a manual restart (pod deletion).

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[manila-csi-plugin] Fixed locking in ControllerExpandVolume
```
