### PR TITLE
[occm] Make volume mounts configurable in Helm Chart

### DIFF
--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -38,9 +38,9 @@ spec:
             - --cloud-provider=openstack
             - --use-service-account-credentials=true
             {{- if .Values.serviceMonitor.enabled }}
-            - --address=0.0.0.0
+            - --bind-address=0.0.0.0
             {{- else }}
-            - --address=127.0.0.1
+            - --bind-address=127.0.0.1
             {{- end }}
             {{- if .Values.controllerExtraArgs }}
             {{- with .Values.controllerExtraArgs }}
@@ -55,17 +55,12 @@ spec:
             protocol: TCP
           {{- end }}
           volumeMounts:
-            - mountPath: /etc/kubernetes/pki
-              name: k8s-certs
-              readOnly: true
-            - mountPath: /etc/ssl/certs
-              name: ca-certs
-              readOnly: true
             - mountPath: /etc/config
               name: cloud-config-volume
               readOnly: true
-            - mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-              name: flexvolume-dir
+          {{- if .Values.extraVolumeMounts }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
           {{- if .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
@@ -83,18 +78,9 @@ spec:
               value: /etc/config/cloud.conf
       hostNetwork: true
       volumes:
-      - hostPath:
-          path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-          type: DirectoryOrCreate
-        name: flexvolume-dir
-      - hostPath:
-          path: /etc/kubernetes/pki
-          type: DirectoryOrCreate
-        name: k8s-certs
-      - hostPath:
-          path: /etc/ssl/certs
-          type: DirectoryOrCreate
-        name: ca-certs
       - name: cloud-config-volume
         secret:
-          secretName: {{ .Values.secret.name | default "cloud-config" }}
+          secretName: {{ .Values.secret.name }}
+      {{- if .Values.extraVolumes }}
+        {{ toYaml .Values.extraVolumes | nindent 6 }}
+      {{- end }}

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -52,9 +52,11 @@ serviceMonitor: {}
 #   enabled: true
 
 # Create a secret resource cloud-config (or other name) to store credentials and settings from cloudConfig
+# You can also provide your own secret (not created by the Helm chart), in this case set create to false
+# and adjust the name of the secret as necessary
 secret:
   create: true
-#  name:
+  name: cloud-config
 
 # Specify settings with the same key as the CCM config: https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#config-openstack-cloud-controller-manager
 cloudConfig:
@@ -63,3 +65,28 @@ cloudConfig:
   loadBalancer:
   blockStorage:
   metadata:
+
+# The following three volumes are required to use all OCCM controllers,
+# but might not be needed if you just use a specific controller
+# Additional volumes that should be available to the pods:
+extraVolumes:
+  - name: flexvolume-dir
+    hostPath:
+      path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+  - name: ca-certs
+    hostPath:
+      path: /etc/ssl/certs
+  - name: k8s-certs
+    hostPath:
+      path: /etc/kubernetes/pki
+# Where the additional volumes should be mounted into the pods:
+extraVolumeMounts:
+  - name: flexvolume-dir
+    mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+    readOnly: true
+  - name: ca-certs
+    mountPath: /etc/ssl/certs
+    readOnly: true
+  - name: k8s-certs
+    mountPath: /etc/kubernetes/pki
+    readOnly: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Depending on which controllers of the OCCM are being used, not all
volume mounts specified in the Helm chart are necessary.
Furthermore, some systems use different paths for these components [1] or
they don't have them at all [2], which will result in failure to attach
the volume to the pod and subsequently run the pod.

This patch makes the volume mounts configurable for the Helm chart
user. By default, the same volumes as before (flexvolume-dir,
ca-certs, k8s-certs) are mounted into the pods.
This makes this change transparent to current users of the Helm
chart (no breaking change).

This patch also updates the deprecated --address parameter to use
--bind-address instead.

**Which issue this PR fixes(if applicable)**: N/A

**Special notes for reviewers**:
I performed manual testing with these changes, i.e. using `helm template occm charts/openstack-cloud-controller-manager/` to verify that 1) the output is as expected and 2) the generated YAML manifests are the same as before (no breaking changes).

**Release note**:
```release-note
[openstack-cloud-controller-manager] Make volume mounts of openstack-cloud-controller-manager Helm Chart configurable
```

[1] Depending on the Kubernetes distribution (e.g. OCP, k3s etc.)
[2] For example, our Fedora CoreOS nodes simply don't have /usr/libexec/kubernetes/plugins/volume/exec and since the entire root filesystems of these nodes is read-only, the directory also cannot be created. Consequently, the entire mount fails.