### PR TITLE
[Charts] Add logVerbosityLevel variable to all Helm charts

### DIFF
--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -27,6 +27,7 @@ spec:
           image: "{{ .Values.csi.attacher.image.repository }}:{{ .Values.csi.attacher.image.tag }}"
           imagePullPolicy: {{ .Values.csi.attacher.image.pullPolicy }}
           args:
+            - "-v={{ .Values.logVerbosityLevel }}"
             - "--csi-address=$(ADDRESS)"
             - "--timeout={{ .Values.timeout }}"
             - "--leader-election=true"
@@ -41,6 +42,7 @@ spec:
           image: "{{ .Values.csi.provisioner.image.repository }}:{{ .Values.csi.provisioner.image.tag }}"
           imagePullPolicy: {{ .Values.csi.provisioner.image.pullPolicy }}
           args:
+            - "-v={{ .Values.logVerbosityLevel }}"
             - "--csi-address=$(ADDRESS)"
             - "--timeout={{ .Values.timeout }}"
             - "--leader-election=true"
@@ -58,6 +60,7 @@ spec:
           image: "{{ .Values.csi.snapshotter.image.repository }}:{{ .Values.csi.snapshotter.image.tag }}"
           imagePullPolicy: {{ .Values.csi.snapshotter.image.pullPolicy }}
           args:
+            - "-v={{ .Values.logVerbosityLevel }}"
             - "--csi-address=$(ADDRESS)"
             - "--timeout={{ .Values.timeout }}"
             - "--leader-election=true"
@@ -72,6 +75,7 @@ spec:
           image: "{{ .Values.csi.resizer.image.repository }}:{{ .Values.csi.resizer.image.tag }}"
           imagePullPolicy: {{ .Values.csi.resizer.image.pullPolicy }}
           args:
+            - "-v={{ .Values.logVerbosityLevel }}"
             - "--csi-address=$(ADDRESS)"
             - "--timeout={{ .Values.timeout }}"
             - "--handle-volume-inuse-error=false"
@@ -87,6 +91,7 @@ spec:
           image: "{{ .Values.csi.livenessprobe.image.repository }}:{{ .Values.csi.livenessprobe.image.tag }}"
           imagePullPolicy: {{ .Values.csi.livenessprobe.image.pullPolicy }}
           args:
+            - "-v={{ .Values.logVerbosityLevel }}"
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
@@ -100,6 +105,7 @@ spec:
           imagePullPolicy: {{ .Values.csi.plugin.image.pullPolicy }}
           args:
             - /bin/cinder-csi-plugin
+            - "-v={{ .Values.logVerbosityLevel }}"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--cloud-config=$(CLOUD_CONFIG)"
             - "--cluster=$(CLUSTER_NAME)"

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -20,6 +20,7 @@ spec:
           image: "{{ .Values.csi.nodeDriverRegistrar.image.repository }}:{{ .Values.csi.nodeDriverRegistrar.image.tag }}"
           imagePullPolicy: {{ .Values.csi.nodeDriverRegistrar.image.pullPolicy }}
           args:
+            - "-v={{ .Values.logVerbosityLevel }}"
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
           env:
@@ -41,6 +42,7 @@ spec:
           image: "{{ .Values.csi.livenessprobe.image.repository }}:{{ .Values.csi.livenessprobe.image.tag }}"
           imagePullPolicy: {{ .Values.csi.livenessprobe.image.pullPolicy }}
           args:
+            - "-v={{ .Values.logVerbosityLevel }}"
             - --csi-address=/csi/csi.sock
           volumeMounts:
             - name: socket-dir
@@ -56,6 +58,7 @@ spec:
           imagePullPolicy: {{ .Values.csi.plugin.image.pullPolicy }}
           args:
             - /bin/cinder-csi-plugin
+            - "-v={{ .Values.logVerbosityLevel }}"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--cloud-config=$(CLOUD_CONFIG)"
           env:

--- a/charts/cinder-csi-plugin/templates/snapshot-controller-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/snapshot-controller-statefulset.yaml
@@ -29,6 +29,7 @@ spec:
         - name: snapshot-controller
           image: "{{ .Values.csi.snapshotController.image.repository }}:{{ .Values.csi.snapshotController.image.tag }}"
           args:
+            - "-v={{ .Values.logVerbosityLevel }}"
             - "--leader-election=false"
           imagePullPolicy: IfNotPresent
           resources: {{ toYaml .Values.csi.snapshotController.resources | nindent 12 }}

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -96,7 +96,7 @@ csi:
 # Log verbosity level.
 # See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md
 # for description of individual verbosity levels.
-logVerbosityLevel: 0
+logVerbosityLevel: 2
 
 secret:
   enabled: false

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -93,6 +93,11 @@ csi:
     nodeSelector: {}
     tolerations: []
 
+# Log verbosity level.
+# See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md
+# for description of individual verbosity levels.
+logVerbosityLevel: 0
+
 secret:
   enabled: false
   create: false

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -31,6 +31,7 @@ spec:
         - name: {{ .protocolSelector | lower }}-provisioner
           image: "{{ $.Values.controllerplugin.provisioner.image.repository }}:{{ $.Values.controllerplugin.provisioner.image.tag }}"
           args:
+            - "-v={{ $.Values.logVerbosityLevel }}"
             - "--csi-address=$(ADDRESS)"
             {{- if $.Values.csimanila.topologyAwarenessEnabled }}
             - "--feature-gates=Topology=true"
@@ -47,6 +48,7 @@ spec:
         - name: {{ .protocolSelector | lower }}-snapshotter
           image: "{{ $.Values.controllerplugin.snapshotter.image.repository }}:{{ $.Values.controllerplugin.snapshotter.image.tag }}"
           args:
+            - "-v={{ $.Values.logVerbosityLevel }}"
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
@@ -60,6 +62,7 @@ spec:
         - name: {{ .protocolSelector | lower }}-resizer
           image: "{{ $.Values.controllerplugin.resizer.image.repository }}:{{ $.Values.controllerplugin.resizer.image.tag }}"
           args:
+            - "-v={{ $.Values.logVerbosityLevel }}"
             - "--csi-address=$(ADDRESS)"
             - "--handle-volume-inuse-error=false"
           env:
@@ -80,6 +83,7 @@ spec:
           image: "{{ $.Values.csimanila.image.repository }}:{{ $.Values.csimanila.image.tag | default $.Chart.AppVersion }}"
           command: ["/bin/sh", "-c",
             '/bin/manila-csi-plugin
+            -v={{ $.Values.logVerbosityLevel }}
             --nodeid=$(NODE_ID)
             {{- if $.Values.csimanila.topologyAwarenessEnabled }}
             --with-topology

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -31,6 +31,7 @@ spec:
         - name: {{ .protocolSelector | lower }}-registrar
           image: "{{ $.Values.nodeplugin.registrar.image.repository }}:{{ $.Values.nodeplugin.registrar.image.tag }}"
           args:
+            - "-v={{ $.Values.logVerbosityLevel }}"
             - "--csi-address=/csi/csi.sock"
             - "--kubelet-registration-path=/var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}/csi.sock"
           env:
@@ -55,6 +56,7 @@ spec:
           image: "{{ $.Values.csimanila.image.repository }}:{{ $.Values.csimanila.image.tag | default $.Chart.AppVersion }}"
           command: ["/bin/sh", "-c",
             '/bin/manila-csi-plugin
+            -v={{ $.Values.logVerbosityLevel }}
             --nodeid=$(NODE_ID)
             {{- if $.Values.csimanila.runtimeConfig.enabled }}
             --runtime-config-file=/runtimeconfig/runtimeconfig.json

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -96,3 +96,8 @@ controllerplugin:
   affinity: {}
   # Use fullnameOverride to fully override the name of this component
   # fullnameOverride: some-other-name
+
+# Log verbosity level.
+# See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md
+# for description of individual verbosity levels.
+logVerbosityLevel: 0

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -100,4 +100,4 @@ controllerplugin:
 # Log verbosity level.
 # See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md
 # for description of individual verbosity levels.
-logVerbosityLevel: 0
+logVerbosityLevel: 2

--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           args:
             - /bin/openstack-cloud-controller-manager
-            - --v=1
+            - --v={{ .Values.logVerbosityLevel }}
             - --cloud-config=$(CLOUD_CONFIG)
             - --cloud-provider=openstack
             - --use-service-account-credentials=true

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -56,6 +56,11 @@ secret:
   create: true
 #  name:
 
+# Log verbosity level.
+# See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md
+# for description of individual verbosity levels.
+logVerbosityLevel: 1
+
 # Specify settings with the same key as the CCM config: https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#config-openstack-cloud-controller-manager
 cloudConfig:
   global:

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -59,7 +59,7 @@ secret:
 # Log verbosity level.
 # See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md
 # for description of individual verbosity levels.
-logVerbosityLevel: 1
+logVerbosityLevel: 2
 
 # Specify settings with the same key as the CCM config: https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#config-openstack-cloud-controller-manager
 cloudConfig:


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This PR adds `logVerbosityLevel` variable to all Helm charts in this repository. Operators can now choose how verbose they want their logs. Default levels are set to 2.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[Charts] Added logVerbosityLevel variable to cinder-csi-plugin, manila-csi-plugin and openstack-controller-manager Helm charts
```
