### PR TITLE
WIP: Add ci for keystone e2e

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,99 @@
+- project:
+    cloud-provider-openstack-multinode-csi-migration-test:
+      jobs:
+        - cloud-provider-openstack-multinode-csi-migration-test:
+            files:
+              - cmd/cinder-csi-plugin/.*
+              - manifests/cinder-csi-plugin/.*
+              - pkg/csi/cinder/.*
+              - pkg/util/.*
+              - go.mod$
+              - go.sum$
+              - Makefile$
+    cloud-provider-openstack-acceptance-test-csi-manila:
+      jobs:
+        - cloud-provider-openstack-acceptance-test-csi-manila:
+            files:
+              - cmd/manila-csi-plugin/.*
+              - examples/manila-csi-plugin/.*
+              - pkg/csi/manila/.*
+              - pkg/util/errors/.*
+              - pkg/cloudprovider/providers/openstack/.*
+              - pkg/share/manila/shareoptions/validator/.*
+              - go.mod$
+              - go.sum$
+              - Makefile$
+            irrelevant-files:
+              - ^docs/.*$
+              - ^.*\.md$
+              - ^OWNERS$
+              - ^SECURITY_CONTACTS$
+              - ^.gitignore$
+    cloud-provider-openstack-acceptance-test-e2e-conformance:
+      jobs:
+        - cloud-provider-openstack-acceptance-test-e2e-conformance:
+            files:
+              - cmd/openstack-cloud-controller-manager/.*
+              - pkg/openstack/.*
+              - pkg/util/.*
+              - tests/e2e/cloudprovider/.*
+              - go.mod$
+              - go.sum$
+              - Makefile$
+            irrelevant-files:
+              - ^docs/.*$
+              - ^.*\.md$
+              - ^OWNERS$
+              - ^SECURITY_CONTACTS$
+              - ^.gitignore$
+    cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.21:
+      jobs:
+        - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.21:
+            files:
+              - cmd/openstack-cloud-controller-manager/.*
+              - pkg/openstack/.*
+              - pkg/util/.*
+              - tests/e2e/cloudprovider/.*
+              - go.mod$
+              - go.sum$
+              - Makefile$
+            irrelevant-files:
+              - ^docs/.*$
+              - ^.*\.md$
+              - ^OWNERS$
+              - ^SECURITY_CONTACTS$
+              - ^.gitignore$
+    cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.20:
+      jobs:
+        - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.20:
+            files:
+              - cmd/openstack-cloud-controller-manager/.*
+              - pkg/openstack/.*
+              - pkg/util/.*
+              - tests/e2e/cloudprovider/.*
+              - go.mod$
+              - go.sum$
+              - Makefile$
+            irrelevant-files:
+              - ^docs/.*$
+              - ^.*\.md$
+              - ^OWNERS$
+              - ^SECURITY_CONTACTS$
+              - ^.gitignore$
+    cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.19:
+      jobs:
+        - cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.19:
+            files:
+              - cmd/openstack-cloud-controller-manager/.*
+              - pkg/openstack/.*
+              - pkg/util/.*
+              - tests/e2e/cloudprovider/.*
+              - go.mod$
+              - go.sum$
+              - Makefile$
+            irrelevant-files:
+              - ^docs/.*$
+              - ^.*\.md$
+              - ^OWNERS$
+              - ^SECURITY_CONTACTS$
+              - ^.gitignore$

--- a/tests/ci-keystone-e2e.sh
+++ b/tests/ci-keystone-e2e.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+########################################################################
+#
+# Desc: Entrypoint of CSI cinder e2e CI job
+#
+# This script may be invoked for different branches (first added in
+# release-1.23). It is getting GCP credentials from boskos and provision
+# a GCP VM, then run ansible for the rest tasks.
+#
+########################################################################
+
+set -x
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${REPO_ROOT}" || exit 1
+# PULL_NUMBER and PULL_BASE_REF are Prow job environment variables
+PR_NUMBER="${PULL_NUMBER:-}"
+[[ -z $PR_NUMBER ]] && echo "PR_NUMBER is required" && exit 1
+PR_BRANCH="${PULL_BASE_REF:-master}"
+CONFIG_ANSIBLE="${CONFIG_ANSIBLE:-"true"}"
+RESOURCE_TYPE="${RESOURCE_TYPE:-"gce-project"}"
+ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
+mkdir -p "${ARTIFACTS}/logs/devstack"
+
+cleanup() {
+  # stop boskos heartbeat
+  [[ -z ${HEART_BEAT_PID:-} ]] || kill -9 "${HEART_BEAT_PID}"
+}
+trap cleanup EXIT
+
+python3 -m pip install requests ansible
+
+# If BOSKOS_HOST is set then acquire a resource of type ${RESOURCE_TYPE} from Boskos.
+if [ -n "${BOSKOS_HOST:-}" ]; then
+  # Check out the account from Boskos and store the produced environment
+  # variables in a temporary file.
+  account_env_var_file="$(mktemp)"
+  python3 tests/scripts/boskos.py --get --resource-type="${RESOURCE_TYPE}" 1>"${account_env_var_file}"
+  checkout_account_status="${?}"
+
+  # If the checkout process was a success then load the account's
+  # environment variables into this process.
+  # shellcheck disable=SC1090
+  [ "${checkout_account_status}" = "0" ] && . "${account_env_var_file}"
+
+  # Always remove the account environment variable file. It contains
+  # sensitive information.
+  rm -f "${account_env_var_file}"
+
+  if [ ! "${checkout_account_status}" = "0" ]; then
+    echo "Failed to get account from boskos, type: ${RESOURCE_TYPE}" 1>&2
+    exit "${checkout_account_status}"
+  fi
+
+  # run the heart beat process to tell boskos that we are still
+  # using the checked out account periodically
+  python3 -u tests/scripts/boskos.py --heartbeat >> "${ARTIFACTS}/logs/boskos.log" 2>&1 &
+  HEART_BEAT_PID=$!
+fi
+
+case "${RESOURCE_TYPE}" in
+"gce-project")
+    . tests/scripts/create-gce-vm.sh
+    ;;
+*)
+    echo "Unsupported resource type: ${RESOURCE_TYPE}"
+    exit 1
+    ;;
+esac
+
+# Config ansible. If Ansible is installed from pip or from source,
+# we need to create the config file manually.
+if [[ "$CONFIG_ANSIBLE" == "true" ]]; then
+  mkdir -p /etc/ansible
+  cat <<EOF > /etc/ansible/ansible.cfg
+[defaults]
+private_key_file = ~/.ssh/google_compute_engine
+host_key_checking = False
+timeout = 30
+stdout_callback = debug
+EOF
+fi
+
+# Run ansible playbook on the CI host, e.g. a VM in GCP
+# USERNAME and PUBLIC_IP are global env variables set after creating the CI host.
+ansible-playbook -v \
+  --user ${USERNAME} \
+  --private-key ~/.ssh/google_compute_engine \
+  --inventory ${PUBLIC_IP}, \
+  --ssh-common-args "-o StrictHostKeyChecking=no" \
+  tests/playbooks/test-keystone-e2e.yaml \
+  -e github_pr=${PR_NUMBER} \
+  -e github_pr_branch=${PR_BRANCH}
+exit_code=$?
+
+# Fetch devstack logs for debugging purpose
+#scp -i ~/.ssh/google_compute_engine \
+#  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+#  -r ${USERNAME}@${PUBLIC_IP}:/opt/stack/logs $ARTIFACTS/logs/devstack || true
+
+# If Boskos is being used then release the resource back to Boskos.
+[ -z "${BOSKOS_HOST:-}" ] || python3 tests/scripts/boskos.py --release >> "$ARTIFACTS/logs/boskos.log" 2>&1
+
+exit ${exit_code}

--- a/tests/playbooks/roles/install-keystone-auth/README.md
+++ b/tests/playbooks/roles/install-keystone-auth/README.md
@@ -1,0 +1,10 @@
+The ansible role builds and uploads cinder-csi-plugin image and deploys in a k8s cluster.
+
+Prerequisites:
+
+* The playbook is running on a host with devstack installed.
+* golang, docker and kubectl should be installed.
+* docker registry is up and running.
+* GOPATH should be configured in {{ global_env }}
+* KUBECONFIG should be configured in {{ global_env }}
+* k8s cluster is running inside VMs on the devstack host.

--- a/tests/playbooks/roles/install-keystone-auth/defaults/main.yaml
+++ b/tests/playbooks/roles/install-keystone-auth/defaults/main.yaml
@@ -1,0 +1,10 @@
+---
+github_pr: 123
+devstack_workdir: "{{ ansible_user_dir }}/devstack"
+
+# Used for uploading image to local registry.
+image_registry_host: localhost
+# Used for access the private registry image from k8s
+remote_registry_host: "{{ ansible_default_ipv4.address }}"
+
+k8s_log_dir: "/var/log/"

--- a/tests/playbooks/roles/install-keystone-auth/tasks/main.yaml
+++ b/tests/playbooks/roles/install-keystone-auth/tasks/main.yaml
@@ -1,0 +1,151 @@
+---
+- name: Ensure CPO source folder
+  shell:
+    executable: /bin/bash
+    cmd: |
+      rm -rf $GOPATH/src/k8s.io/cloud-provider-openstack
+      mkdir -p $GOPATH/src/k8s.io; cd $_
+      git clone https://github.com/kubernetes/cloud-provider-openstack
+      cd cloud-provider-openstack
+      git fetch origin +refs/pull/{{ github_pr }}/merge
+      git checkout FETCH_HEAD; git checkout -b PR{{ github_pr }}
+
+- name: Build k8s-keystone-auth binary
+  environment: "{{ global_env }}"
+  shell:
+    executable: /bin/bash
+    cmd: |
+      cd $GOPATH/src/k8s.io/cloud-provider-openstack
+      set -ex
+
+      export ARCH=${ARCH:-amd64}
+      export BUILD_CMDS='k8s-keystone-auth'
+      make build
+
+- name: Deploy config maps for k8s-keystone-auth
+  environment: "{{ global_env }}"
+  shell:
+    executable: /bin/bash
+    cmd: |
+      set -ex
+
+      cat <<EOF | kubectl apply -f -
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: keystone-auth-policy
+        namespace: kube-system
+      data:
+        policies: |
+          [
+            {
+              "users": {
+                "projects": ["demo"],
+                "roles": ["member"]
+              },
+              "resource_permissions": {
+                "default/pods": ["get", "list"]
+              }
+            }
+          ]
+      EOF
+
+      cat <<EOF | kubectl apply -f -
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: keystone-sync-policy
+        namespace: kube-system
+      data:
+        syncConfig: |
+          role-mappings:
+            - keystone-role: member
+              groups: ["member"]
+      EOF
+
+# global_env is needed to access openstack credentials.
+- name: Deploy k8s-keystone-auth
+  environment: "{{ global_env }}"
+  shell:
+    creates: "{{ k8s_log_dir }}/keystone-auth.log"
+    executable: /bin/bash
+    cmd: |
+      set -ex
+
+      mkdir -p {{ k8s_log_dir }}
+      export LOG_DIR={{ k8s_log_dir }}
+      export keystone_auth_conf={{ ansible_user_dir }}/keystone-auth
+      mkdir -p ${keystone_auth_conf}
+      export kubeconfig="{{ ansible_user_dir }}/.kube/config"
+      [ ! -f ${keystone_auth_conf}/ca.crt ] && openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ${keystone_auth_conf}/ca.key -out ${keystone_auth_conf}/ca.crt -subj "/CN=keystone-auth"
+
+      keystone_auth_url=${OS_AUTH_URL}/v3
+      nohup ./k8s-keystone-auth \
+            --tls-cert-file ${keystone_auth_conf}/ca.crt \
+            --tls-private-key-file ${keystone_auth_conf}/ca.key \
+            --policy-configmap-name keystone-auth-policy \
+            --sync-configmap-name keystone-sync-policy \
+            --log-dir=${LOG_DIR} \
+            --v=2 \
+            --kubeconfig ${kubeconfig} \
+            --keystone-url ${keystone_auth_url} >"${LOG_DIR}/keystone-auth.log" 2>&1 &
+
+- name: Get kubeconfig contexts
+  shell:
+    executable: /bin/bash
+    cmd: |
+      export KUBECONFIG="{{ ansible_user_dir }}/.kube/config"
+      kubectl config get-contexts --no-headers=true -o name
+  register: contexts_ret
+
+- name: Config openstack user in kubeconfig
+  when: '"openstack" not in contexts_ret.stdout_lines'
+  blockinfile:
+    path: "{{ ansible_user_dir }}/.kube/config"
+    insertafter: "users:"
+    block: |
+      - name: openstackuser
+        user:
+          exec:
+            command: /bin/bash
+            apiVersion: client.authentication.k8s.io/v1beta1
+            args:
+            - -c
+            - >
+              if [ -z ${OS_TOKEN} ]; then
+                  echo 'Error: Missing OpenStack credential from environment variable $OS_TOKEN' > /dev/stderr
+                  exit 1
+              else
+                  echo '{ "apiVersion": "client.authentication.k8s.io/v1beta1", "kind": "ExecCredential", "status": { "token": "'"${OS_TOKEN}"'"}}'
+              fi
+
+- name: Output "{{ ansible_user_dir }}/.kube/config"
+  shell:
+    executable: /bin/bash
+    cmd: |
+      set -ex
+      cat "{{ ansible_user_dir }}/.kube/config"
+
+- name: Config openstack context in kubeconfig
+  when: '"openstack" not in contexts_ret.stdout_lines'
+  shell:
+    executable: /bin/bash
+    cmd: |
+      set -ex
+      export KUBECONFIG="{{ ansible_user_dir }}/.kube/config"
+      kubectl config set-context --cluster=default --user=openstackuser openstack
+
+- name: Run e2e tests for k8s-keystone-auth webhook
+  shell:
+    executable: /bin/bash
+    cmd: |
+      set -e
+
+      cd $GOPATH/src/k8s.io/cloud-provider-openstack
+
+      source {{ devstack_workdir }}/openrc demo demo > /dev/null
+      # The default Keystone token expiration time in devstack is 3 hours.
+      token=$(openstack token issue -f yaml -c id | awk '{print $2}')
+      export OS_TOKEN=$token
+
+      OS_TOKEN=$token OS_CONTEXT_NAME=openstack AUTH_POLICY_CONFIGMAP=keystone-auth-policy ROLE_MAPPING_CONFIGMAP=keystone-sync-policy tests/e2e/k8s-keystone-auth/test-authz.sh

--- a/tests/playbooks/test-keystone-e2e.yaml
+++ b/tests/playbooks/test-keystone-e2e.yaml
@@ -1,0 +1,27 @@
+- hosts: all
+  become: true
+  become_method: sudo
+  gather_facts: true
+
+  vars:
+    user: stack
+    github_pr: 123
+    global_env: {}
+    devstack_workdir: /home/{{ user }}/devstack
+
+  roles:
+    - role: install-golang
+    - role: install-devstack
+      enable_services:
+        - nova
+        - neutron
+        - glance
+        - cinder
+    - role: install-k3s
+      worker_node_count: 0
+      k8s_branch: release-1.22
+    - role: install-docker
+    - role: install-docker-registry
+      cert_hosts: ' ["{{ ansible_default_ipv4.address }}"]'
+    - role: install-keystone-auth
+      environment: "{{ global_env }}"


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
