### PR TITLE
[manila-csi-plugin] Remove cloud-provider-openstack-acceptance-test-csi-manila job trigger

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -26,25 +26,6 @@
               - go.mod$
               - go.sum$
               - Makefile$
-    cloud-provider-openstack-acceptance-test-csi-manila:
-      jobs:
-        - cloud-provider-openstack-acceptance-test-csi-manila:
-            files:
-              - cmd/manila-csi-plugin/.*
-              - examples/manila-csi-plugin/.*
-              - pkg/csi/manila/.*
-              - pkg/util/errors/.*
-              - pkg/cloudprovider/providers/openstack/.*
-              - pkg/share/manila/shareoptions/validator/.*
-              - go.mod$
-              - go.sum$
-              - Makefile$
-            irrelevant-files:
-              - ^docs/.*$
-              - ^.*\.md$
-              - ^OWNERS$
-              - ^SECURITY_CONTACTS$
-              - ^.gitignore$
     cloud-provider-openstack-acceptance-test-e2e-conformance:
       jobs:
         - cloud-provider-openstack-acceptance-test-e2e-conformance:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes `cloud-provider-openstack-acceptance-test-csi-manila` Zuul CI job trigger. We don't use OpenLab CI infra anymore.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
