### PR TITLE
[general] return error early to avoid nil pointer usage

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -208,7 +208,7 @@ func ReadClouds(authOpts *AuthOpts) error {
 		co.Cloud = authOpts.Cloud
 	}
 	cloud, err := clientconfig.GetCloudFromYAML(co)
-	if err != nil && err.Error() != "unable to load clouds.yaml: no clouds.yaml file found" {
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
Related #1684

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
