### PR TITLE
[occm][CI] Use pre-built amphora image in DevStack

### DIFF
--- a/tests/ci-occm-e2e.sh
+++ b/tests/ci-occm-e2e.sh
@@ -36,7 +36,7 @@ PR_BRANCH="${PULL_BASE_REF:-master}"
 CONFIG_ANSIBLE="${CONFIG_ANSIBLE:-"true"}"
 RESOURCE_TYPE="${RESOURCE_TYPE:-"gce-project"}"
 ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
-mkdir -p "${ARTIFACTS}/logs/devstack"
+mkdir -p "${ARTIFACTS}/logs"
 
 cleanup() {
   # stop boskos heartbeat
@@ -113,6 +113,11 @@ exit_code=$?
 #scp -i ~/.ssh/google_compute_engine \
 #  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
 #  -r ${USERNAME}@${PUBLIC_IP}:/opt/stack/logs $ARTIFACTS/logs/devstack || true
+
+# Fetch octavia amphora image build logs for debugging purpose
+scp -i ~/.ssh/google_compute_engine \
+    -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+    -r ${USERNAME}@${PUBLIC_IP}:/var/log/dib-build/amphora-x64-haproxy.qcow2.log $ARTIFACTS/logs/octavia-image-build.log || true
 
 # If Boskos is being used then release the resource back to Boskos.
 [ -z "${BOSKOS_HOST:-}" ] || python3 tests/scripts/boskos.py --release >> "$ARTIFACTS/logs/boskos.log" 2>&1

--- a/tests/playbooks/roles/install-devstack/defaults/main.yaml
+++ b/tests/playbooks/roles/install-devstack/defaults/main.yaml
@@ -9,3 +9,6 @@ enable_services:
   - neutron
   - octavia
   - barbican
+octavia_amphora_url: "https://tarballs.opendev.org/openstack/octavia/test-images/test-only-amphora-x64-haproxy-ubuntu-focal.qcow2"
+octavia_amphora_dir: /opt/octavia-amphora
+octavia_amphora_filename: amphora-x64-haproxy.qcow2

--- a/tests/playbooks/roles/install-devstack/tasks/main.yml
+++ b/tests/playbooks/roles/install-devstack/tasks/main.yml
@@ -73,6 +73,21 @@
     - set_fact:
         local_ip_address: "{{ local_ip_output.stdout }}"
 
+    - name: Download octavia amphora image
+      when: octavia_amphora_url != ""
+      block:
+        - name: Ensure amphora image dest folder
+          file:
+            path: "{{ octavia_amphora_dir }}"
+            state: directory
+            mode: '0755'
+        - name: Download octavia amphora image
+          get_url:
+            url: "{{ octavia_amphora_url }}"
+            dest: "{{ octavia_amphora_dir }}/{{ octavia_amphora_filename }}"
+            mode: 0755
+            force: no
+
     - name: Prepare local.conf
       template:
         src: local.conf.j2

--- a/tests/playbooks/roles/install-devstack/templates/local.conf.j2
+++ b/tests/playbooks/roles/install-devstack/templates/local.conf.j2
@@ -78,10 +78,15 @@ enable_service o-hk
 enable_service o-api
 
 LIBS_FROM_GIT+=,python-octaviaclient
+DIB_REPOLOCATION_amphora_agent=https://github.com/openstack/octavia.git
+DIB_REPOLOCATION_octavia_lib=https://github.com/openstack/octavia-lib.git
 
 OCTAVIA_MGMT_SUBNET=10.51.0.0/16
 OCTAVIA_MGMT_SUBNET_START=10.51.0.2
 OCTAVIA_MGMT_SUBNET_END=10.51.0.254
+{% if octavia_amphora_url %}
+OCTAVIA_AMP_IMAGE_FILE={{ octavia_amphora_dir }}/{{ octavia_amphora_filename }}
+{% endif %}
 {% endif %}
 
 {% if "barbican" in enable_services %}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

* Use pre-built amphora image to avoid the creation during the devstack run.
* Copy the image build log when necessary.
* Enable auto resource clean up option in the script, default true.
* Added the function to wait for the load balancer IP address accessible.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
