### PR TITLE
[octavia-ingress-controller] Include CA certs into Barbican secret

### DIFF
--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -626,7 +626,11 @@ func (c *Controller) toBarbicanSecret(name string, namespace string, toSecretNam
 	}
 
 	var caCerts []*x509.Certificate
-	// TODO(lingxiankong): We assume the 'tls.cert' data only contains the end user certificate.
+	// We assume that the rest of the PEM bundle contains the CA certificate.
+	if len(cb) > 1 {
+		caCerts = append(caCerts, cb[1:]...)
+	}
+
 	pfxData, err := pkcs12.Encode(rand.Reader, pk, cb[0], caCerts, "")
 	if err != nil {
 		return "", fmt.Errorf("failed to create PKCS#12 bundle: %v", err)


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->
[octavia-ingress-controller] Include CA certs into Barbican secret

**What this PR does / why we need it**:

It adds the CA certificates into the Barbican secret.

**Which issue this PR fixes(if applicable):**
fixes #1700

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
