### PR TITLE
[octavia-ingress-controller] support for whitelist-source-range annotation

### DIFF
--- a/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
+++ b/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
@@ -14,6 +14,7 @@
     - [Create a backend service](#create-a-backend-service)
     - [Create an Ingress resource](#create-an-ingress-resource)
   - [Enable TLS encryption](#enable-tls-encryption)
+  - [Allow CIDRs](#allow-cidrs)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -449,3 +450,33 @@ Ingress and enable the more secure HTTPS protocol.
 > NOTE: octavia-ingress-controller currently doesn't support to integrate with
 > `cert-manager` to create the non-existing secret dynamically. Could be improved
 > in the future.
+
+## Allow CIDRs
+
+You can use the key `ingress.kubernetes.io/whitelist-source-range` annotations to whitelist CIDRs.
+The value should be a comma-separated list of CIDRs.
+
+Example:
+
+    ```yaml
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: test-octavia-ingress
+      annotations:
+        kubernetes.io/ingress.class: "openstack"
+        octavia.ingress.kubernetes.io/internal: "false"
+        ingress.kubernetes.io/whitelist-source-range: 192.168.1.0/23
+    spec:
+      rules:
+        - host: foo.bar.com
+          http:
+            paths:
+            - path: /ping
+              pathType: Exact
+              backend:
+                service:
+                  name: webserver
+                  port:
+                    number: 8080
+    ```

--- a/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
+++ b/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
@@ -453,7 +453,7 @@ Ingress and enable the more secure HTTPS protocol.
 
 ## Allow CIDRs
 
-You can use the key `ingress.kubernetes.io/whitelist-source-range` annotations to whitelist CIDRs.
+You can use the key `octavia.ingress.kubernetes.io/whitelist-source-range` annotations to whitelist CIDRs.
 The value should be a comma-separated list of CIDRs.
 
 Example:
@@ -466,7 +466,7 @@ Example:
       annotations:
         kubernetes.io/ingress.class: "openstack"
         octavia.ingress.kubernetes.io/internal: "false"
-        ingress.kubernetes.io/whitelist-source-range: 192.168.1.0/23
+        octavia.ingress.kubernetes.io/whitelist-source-range: 192.168.1.0/23
     spec:
       rules:
         - host: foo.bar.com

--- a/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
+++ b/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
@@ -453,30 +453,31 @@ Ingress and enable the more secure HTTPS protocol.
 
 ## Allow CIDRs
 
-You can use the key `octavia.ingress.kubernetes.io/whitelist-source-range` annotations to whitelist CIDRs.
+By using the annotation `octavia.ingress.kubernetes.io/whitelist-source-range`,
+you can restrict access to certain IP addresses.
 The value should be a comma-separated list of CIDRs.
 
 Example:
 
-    ```yaml
-    apiVersion: networking.k8s.io/v1
-    kind: Ingress
-    metadata:
-      name: test-octavia-ingress
-      annotations:
-        kubernetes.io/ingress.class: "openstack"
-        octavia.ingress.kubernetes.io/internal: "false"
-        octavia.ingress.kubernetes.io/whitelist-source-range: 192.168.1.0/23
-    spec:
-      rules:
-        - host: foo.bar.com
-          http:
-            paths:
-            - path: /ping
-              pathType: Exact
-              backend:
-                service:
-                  name: webserver
-                  port:
-                    number: 8080
-    ```
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: test-octavia-ingress
+  annotations:
+    kubernetes.io/ingress.class: "openstack"
+    octavia.ingress.kubernetes.io/internal: "false"
+    octavia.ingress.kubernetes.io/whitelist-source-range: 192.168.1.0/23
+spec:
+  rules:
+    - host: foo.bar.com
+      http:
+        paths:
+        - path: /ping
+          pathType: Exact
+          backend:
+            service:
+              name: webserver
+              port:
+                number: 8080
+```

--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -97,7 +97,7 @@ const (
 
 	// IngressAnnotationSourceRangesKey is the key of the annotation on an ingress to set allowed IP ranges on their LoadBalancers.
 	// It should be a comma-separated list of CIDRs.
-	IngressAnnotationSourceRangesKey = "ingress.kubernetes.io/whitelist-source-range"
+	IngressAnnotationSourceRangesKey = "octavia.ingress.kubernetes.io/whitelist-source-range"
 
 	// IngressControllerTag is added to the related resources.
 	IngressControllerTag = "octavia.ingress.kubernetes.io"

--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -705,9 +705,6 @@ func (c *Controller) ensureIngress(ing *nwv1.Ingress) error {
 	// Create listener
 	sourceRanges := getStringFromIngressAnnotation(ing, IngressAnnotationSourceRangesKey, "0.0.0.0/0")
 	listenerAllowedCIDRs := strings.Split(sourceRanges, ",")
-	if err != nil {
-		return fmt.Errorf("unknown annotation %s: %v", IngressAnnotationSourceRangesKey, err)
-	}
 	listener, err := c.osClient.EnsureListener(resName, lb.ID, secretRefs, listenerAllowedCIDRs)
 	if err != nil {
 		return err

--- a/pkg/ingress/controller/openstack/octavia.go
+++ b/pkg/ingress/controller/openstack/octavia.go
@@ -19,6 +19,7 @@ package openstack
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -366,7 +367,7 @@ func (os *OpenStack) EnsureListener(name string, lbID string, secretRefs []strin
 
 		log.WithFields(log.Fields{"lbID": lbID, "listenerName": name}).Info("listener created")
 	} else {
-		if len(listenerAllowedCIDRs) > 0 {
+		if len(listenerAllowedCIDRs) > 0 && !reflect.DeepEqual(listener.AllowedCIDRs, listenerAllowedCIDRs) {
 			_, err := listeners.Update(os.Octavia, listener.ID, listeners.UpdateOpts{
 				AllowedCIDRs: &listenerAllowedCIDRs,
 			}).Extract()


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Add support for `ingress.kubernetes.io/whitelist-source-range` annotation.
**Which issue this PR fixes(if applicable)**:
fixes #1703 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[octavia-ingress-controller] Add support for whitelist-source-range annotation.
```
