### PR TITLE
[occm] InitContainers Support

### DIFF
--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 1.1.1
+version: 1.1.2
 maintainers:
   - name: morremeyer
     email: kubernetes@maurice-meyer.de

--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 1.1.2
+version: 1.1.1
 maintainers:
   - name: morremeyer
     email: kubernetes@maurice-meyer.de

--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -76,6 +76,9 @@ spec:
           env:
             - name: CLOUD_CONFIG
               value: /etc/config/cloud.conf
+      {{- if .Values.extraInitContainers }}
+      initContainers: {{ toYaml .Values.extraInitContainers | nindent 6 }}
+      {{- end }}
       hostNetwork: true
       volumes:
       - name: cloud-config-volume

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -7,6 +7,12 @@ image:
   repository: docker.io/k8scloudprovider/openstack-cloud-controller-manager
   tag: ""
 
+# Additional containers which are run before the app containers are started.
+extraInitContainers: []
+# - name: wait
+#   image: busybox
+#   command: ['sh', '-c', 'echo waiting for 10 seconds; sleep 10;']
+
 # Set resources for Kubernetes daemonset
 resources: {}
 # resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces the use of `initContainers` in the chart, we need `initContainers` because is some use cases, users may need to run a few more things before OCCM starts (such as waiting for a DNS to come online)

**Which issue this PR fixes(if applicable)**:
fixes: #1709

**Special notes for reviewers**:
To test this PR you can uncomment the example that I have under `extraInitContainers` in the chart values:
```
# - name: wait
#   image: busybox
#   command: ['sh', '-c', 'echo waiting for 10 seconds; sleep 10;']
```
Then if you do a `helm install`, OCCM should start in 10 seconds after the `busybox` container.

**Release note**:
```release-note
[openstack-cloud-controller-manager] Added support for InitContainer in the OCCM chart
```
