### PR TITLE
[cinder-csi-plugin] Enable logs for e2e tests

### DIFF
--- a/tests/ci-csi-cinder-e2e.sh
+++ b/tests/ci-csi-cinder-e2e.sh
@@ -109,10 +109,10 @@ ansible-playbook -v \
   -e github_pr_branch=${PR_BRANCH}
 exit_code=$?
 
-# Fetch devstack logs for debugging purpose
-#scp -i ~/.ssh/google_compute_engine \
-#  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-#  -r ${USERNAME}@${PUBLIC_IP}:/opt/stack/logs $ARTIFACTS/logs/devstack || true
+# Fetch cinder-csi e2e tests logs for debugging purpose
+scp -i ~/.ssh/google_compute_engine \
+  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+  -r ${USERNAME}@${PUBLIC_IP}:/var/log/cinder-csi-e2e.log $ARTIFACTS/logs/cinder-csi-e2e.log || true
 
 # If Boskos is being used then release the resource back to Boskos.
 [ -z "${BOSKOS_HOST:-}" ] || python3 tests/scripts/boskos.py --release >> "$ARTIFACTS/logs/boskos.log" 2>&1

--- a/tests/playbooks/roles/install-csi-cinder/defaults/main.yaml
+++ b/tests/playbooks/roles/install-csi-cinder/defaults/main.yaml
@@ -6,5 +6,3 @@ devstack_workdir: "{{ ansible_user_dir }}/devstack"
 image_registry_host: localhost
 # Used for access the private registry image from k8s
 remote_registry_host: "{{ ansible_default_ipv4.address }}"
-
-k8s_log_dir: "/var/log/"

--- a/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
@@ -61,7 +61,6 @@
 
       # replace image with built image
       sed -i "s#docker.io/k8scloudprovider/cinder-csi-plugin:latest#{{ remote_registry_host }}/cinder-csi-plugin-amd64:{{ github_pr }}#" manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
-
       sed -i "s#docker.io/k8scloudprovider/cinder-csi-plugin:latest#{{ remote_registry_host }}/cinder-csi-plugin-amd64:{{ github_pr }}#" manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
 
 - name: Deploy cinder-csi-plugin
@@ -70,7 +69,7 @@
     cmd: |
       cd $GOPATH/src/k8s.io/cloud-provider-openstack
       kubectl apply -f manifests/cinder-csi-plugin
-  ignore_errors: yes
+  ignore_errors: true
 
 - name: Wait for csi-cinder-controllerplugin up and running
   shell:
@@ -81,7 +80,7 @@
   until: check_csi_controller.rc == 0
   retries: 24
   delay: 5
-  ignore_errors: yes
+  ignore_errors: true
 
 - name: Wait for csi-cinder-nodeplugin up and running
   shell:
@@ -92,7 +91,7 @@
   until: check_csi_node.rc == 0
   retries: 24
   delay: 5
-  ignore_errors: yes
+  ignore_errors: true
 
 - name: Gather additional evidence if csi-cinder-plugin failed to come up
   when: check_csi_controller.failed or check_csi_node.failed
@@ -124,4 +123,4 @@
       set -o pipefail
 
       cd $GOPATH/src/k8s.io/cloud-provider-openstack
-      go test -v ./cmd/tests/cinder-csi-e2e-suite/cinder_csi_e2e_suite_test.go -ginkgo.v -ginkgo.progress -ginkgo.skip="\[Disruptive\]" -ginkgo.focus="\[cinder-csi-e2e\]" -ginkgo.noColor -timeout=0
+      go test -v ./cmd/tests/cinder-csi-e2e-suite/cinder_csi_e2e_suite_test.go -ginkgo.v -ginkgo.progress -ginkgo.skip="\[Disruptive\]" -ginkgo.focus="\[cinder-csi-e2e\]" -ginkgo.noColor -timeout=0 -report-dir="/var/log/" | tee "/var/log/cinder-csi-e2e.log"


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This PR enables logs  of e2e tests for debugging purpose
**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
