### PR TITLE
[openstack-cloud-controller-manager] Log warning when internal-lb=true and requesting external LB

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1514,6 +1514,9 @@ func (lbaas *LbaasV2) checkService(service *corev1.Service, nodes []*corev1.Node
 
 	// If in the config file internal-lb=true, user is not allowed to create external service.
 	if lbaas.opts.InternalLB {
+		if !getBoolFromServiceAnnotation(service, ServiceAnnotationLoadBalancerInternal, false) {
+			klog.V(1).Infof("Annotation %q is set to false (default) but internal-lb=true, enforcing internal LB", ServiceAnnotationLoadBalancerInternal)
+		}
 		svcConf.internal = true
 	} else {
 		svcConf.internal = getBoolFromServiceAnnotation(service, ServiceAnnotationLoadBalancerInternal, lbaas.opts.InternalLB)

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1515,7 +1515,7 @@ func (lbaas *LbaasV2) checkService(service *corev1.Service, nodes []*corev1.Node
 	// If in the config file internal-lb=true, user is not allowed to create external service.
 	if lbaas.opts.InternalLB {
 		if !getBoolFromServiceAnnotation(service, ServiceAnnotationLoadBalancerInternal, false) {
-			klog.V(1).Infof("Annotation %q is set to false (default) but internal-lb=true, enforcing internal LB", ServiceAnnotationLoadBalancerInternal)
+			klog.V(3).InfoS("Enforcing internal LB", "annotation", true, "config", false)
 		}
 		svcConf.internal = true
 	} else {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This logs a warning when `internal-lb=false` is set and external service is requested. The documentation [here](https://github.com/kubernetes/cloud-provider-openstack/tree/master/examples/loadbalancers) says `service.beta.kubernetes.io/openstack-internal-load-balancer` is `false` by default. But `internal-lb` is also `false` by default. We spent some time debugging it without any indication in the logs.

**Which issue this PR fixes(if applicable)**:

**Special notes for reviewers**:
This is my first PR here, so sorry if I messed up with something. Also for me it could be an error, but I'm not sure how important is backward-compatibility here.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
