### PR TITLE
doc: from k8s_ing to kube_ingress in doc

### DIFF
--- a/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
+++ b/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
@@ -139,7 +139,7 @@ Here are several other config options are not included in the example configurat
 
     Notes for the security group:
 
-    - The security group name is in the format: `k8s_ing_<cluster-name>_<ingress-namespace>_<ingress-name>`
+    - The security group name is in the format: `kube_ingress_<cluster-name>_<ingress-namespace>_<ingress-name>`
     - The security group description is in the format: `Security group created for Ingress <ingress-namespace>/<ingress-name> from cluster <cluster-name>`
     - The security group has tags: `["octavia.ingress.kubernetes.io", "<ingress-namespace>_<ingress-name>"]`
     - The security group is associated with all the Neutron ports of the Kubernetes worker nodes. 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

doc update, according to 

https://github.com/kubernetes/cloud-provider-openstack/blob/master/pkg/ingress/utils/utils.go#L37

and 
```
+--------------------------------------+----------------------------------------------------+---------------------------------------------------------------------------------------+----------------------------------+-------------------------------------------------------------------+
| ID                                   | Name                                               | Description                                                                           | Project                          | Tags                                                              |
+--------------------------------------+----------------------------------------------------+---------------------------------------------------------------------------------------+----------------------------------+-------------------------------------------------------------------+
| 2a392976-9f0c-4797-8c24-9978fc77eb23 | kube_ingress_cluster1_default_test-octavia-ingress | Security group created for Ingress default/test-octavia-ingress from cluster cluster1 | 20e007a8fd9f470da61305ae7e765031 | ['default_test-octavia-ingress', 'octavia.ingress.kubernetes.io'] |
```

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
