### PR TITLE
[cinder-csi-plugin] Bump driver version to 2.0.0

### DIFF
--- a/pkg/csi/cinder/driver.go
+++ b/pkg/csi/cinder/driver.go
@@ -44,7 +44,8 @@ var (
 	// * 1.3.1: Bump for 1.21 release
 	// * 1.3.2: Allow --cloud-config to be given multiple times
 	// * 1.3.3: Bump for 1.22 release
-	Version = "1.3.3"
+	// * 2.0.0: Bump for 1.23 release
+	Version = "2.0.0"
 )
 
 type CinderDriver struct {

--- a/pkg/csi/cinder/driver_test.go
+++ b/pkg/csi/cinder/driver_test.go
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	vendorVersion = "1.3.3"
+	vendorVersion = "2.0.0"
 )
 
 func NewFakeDriver() *CinderDriver {


### PR DESCRIPTION
cinder csi driver version bumped to 2.0.0 to match the chart version
and because of the breaking change introduced in deploying driver
from statefulset to Deployment.

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
