### PR TITLE
update alpine base images to 3.15

### DIFF
--- a/cluster/images/barbican-kms-plugin/Dockerfile
+++ b/cluster/images/barbican-kms-plugin/Dockerfile
@@ -13,7 +13,7 @@
 ARG ALPINE_ARCH=amd64
 # We not using scratch because we need to keep the basic image information
 # from parent image
-FROM ${ALPINE_ARCH}/alpine:3.11
+FROM ${ALPINE_ARCH}/alpine:3.15
 
 ARG ARCH=amd64
 

--- a/cluster/images/barbican-kms-plugin/Dockerfile.build
+++ b/cluster/images/barbican-kms-plugin/Dockerfile.build
@@ -1,5 +1,5 @@
 ARG ALPINE_ARCH=amd64
-FROM ${ALPINE_ARCH}/alpine:3.11
+FROM ${ALPINE_ARCH}/alpine:3.15
 LABEL maintainers="Kubernetes Authors"
 LABEL description="Barbican KMS Plugin"
 

--- a/cluster/images/k8s-keystone-auth/Dockerfile
+++ b/cluster/images/k8s-keystone-auth/Dockerfile
@@ -13,7 +13,7 @@
 ARG ALPINE_ARCH=amd64
 # We not using scratch because we need to keep the basic image information
 # from parent image
-FROM ${ALPINE_ARCH}/alpine:3.11
+FROM ${ALPINE_ARCH}/alpine:3.15
 
 ARG ARCH=amd64
 

--- a/cluster/images/k8s-keystone-auth/Dockerfile.build
+++ b/cluster/images/k8s-keystone-auth/Dockerfile.build
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 ARG ALPINE_ARCH=amd64
-FROM ${ALPINE_ARCH}/alpine:3.11
+FROM ${ALPINE_ARCH}/alpine:3.15
 
 ARG ARCH=amd64
 

--- a/cluster/images/magnum-auto-healer/Dockerfile
+++ b/cluster/images/magnum-auto-healer/Dockerfile
@@ -13,7 +13,7 @@
 ARG ALPINE_ARCH=amd64
 # We not using scratch because we need to keep the basic image information
 # from parent image
-FROM ${ALPINE_ARCH}/alpine:3.11
+FROM ${ALPINE_ARCH}/alpine:3.15
 
 ARG ARCH=amd64
 

--- a/cluster/images/magnum-auto-healer/Dockerfile.build
+++ b/cluster/images/magnum-auto-healer/Dockerfile.build
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 ARG ALPINE_ARCH=amd64
-FROM ${ALPINE_ARCH}/alpine:3.11
+FROM ${ALPINE_ARCH}/alpine:3.15
 
 ARG ARCH=amd64
 

--- a/cluster/images/manila-csi-plugin/Dockerfile
+++ b/cluster/images/manila-csi-plugin/Dockerfile
@@ -13,7 +13,7 @@
 ARG ALPINE_ARCH=amd64
 # We not using scratch because we need to keep the basic image information
 # from parent image
-FROM ${ALPINE_ARCH}/alpine:3.11
+FROM ${ALPINE_ARCH}/alpine:3.15
 
 ARG ARCH=amd64
 

--- a/cluster/images/manila-csi-plugin/Dockerfile.build
+++ b/cluster/images/manila-csi-plugin/Dockerfile.build
@@ -1,5 +1,5 @@
 ARG ALPINE_ARCH=amd64
-FROM ${ALPINE_ARCH}/alpine:3.11
+FROM ${ALPINE_ARCH}/alpine:3.15
 
 ARG ARCH=amd64
 

--- a/cluster/images/octavia-ingress-controller/Dockerfile
+++ b/cluster/images/octavia-ingress-controller/Dockerfile
@@ -13,7 +13,7 @@
 ARG ALPINE_ARCH=amd64
 # We not using scratch because we need to keep the basic image information
 # from parent image
-FROM ${ALPINE_ARCH}/alpine:3.11
+FROM ${ALPINE_ARCH}/alpine:3.15
 
 ARG ARCH=amd64
 

--- a/cluster/images/octavia-ingress-controller/Dockerfile.build
+++ b/cluster/images/octavia-ingress-controller/Dockerfile.build
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG ALPINE_ARCH=amd64
-FROM ${ALPINE_ARCH}/alpine:3.11
+FROM ${ALPINE_ARCH}/alpine:3.15
 
 ARG ARCH=amd64
 

--- a/cluster/images/openstack-cloud-controller-manager/Dockerfile
+++ b/cluster/images/openstack-cloud-controller-manager/Dockerfile
@@ -13,7 +13,7 @@
 ARG ALPINE_ARCH=amd64
 # We not using scratch because we need to keep the basic image information
 # from parent image
-FROM ${ALPINE_ARCH}/alpine:3.11
+FROM ${ALPINE_ARCH}/alpine:3.15
 
 ARG ARCH=amd64
 

--- a/cluster/images/openstack-cloud-controller-manager/Dockerfile.build
+++ b/cluster/images/openstack-cloud-controller-manager/Dockerfile.build
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 ARG ALPINE_ARCH=amd64
-FROM ${ALPINE_ARCH}/alpine:3.11
+FROM ${ALPINE_ARCH}/alpine:3.15
 
 ARG ARCH=amd64
 RUN apk add --no-cache ca-certificates


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Alpine 3.11 is not supported anymore

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Base images updated to alpine 3.15
```
