### PR TITLE
[magnum-auto-healer] Migrate resourcelock to configmapsleases for leader election

### DIFF
--- a/pkg/autohealing/controller/controller.go
+++ b/pkg/autohealing/controller/controller.go
@@ -63,6 +63,9 @@ const (
 	// LabelNodeRoleMaster specifies that a node is a master
 	// Related discussion: https://github.com/kubernetes/kubernetes/pull/39112
 	LabelNodeRoleMaster = "node-role.kubernetes.io/master"
+
+	leaderElectionResourceLockNamespace = "kube-system"
+	leaderElectionResourceLockName      = "magnum-auto-healer"
 )
 
 var (
@@ -212,9 +215,10 @@ func (c *Controller) GetLeaderElectionLock() (resourcelock.Interface, error) {
 	id = id + "_" + string(uuid.NewUUID())
 
 	rl, err := resourcelock.New(
-		"configmaps",
-		"kube-system",
-		"magnum-auto-healer",
+		//TODO(acumino): Migrate configmapsleases to leases in vesrion 1.24.
+		resourcelock.ConfigMapsLeasesResourceLock,
+		leaderElectionResourceLockNamespace,
+		leaderElectionResourceLockName,
 		c.leaderElectionClient.CoreV1(),
 		c.leaderElectionClient.CoordinationV1(),
 		resourcelock.ResourceLockConfig{


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Support for configmaps lock for leaderelection is removed in K8s 1.24 with kubernetes/kubernetes#106852.
More details about the motivation to switch to leases - ref kubernetes/kubernetes#80289.

To preserve the backward compatibility, resource lock for migration purposes (configmapsleases) should be used when switching from the legacy resource locks (configmaps).

`magnum-auto-healer` is currently using configmaps. As the first step, this PR adapts configmapsleases.
Once this is merged, we can migrate to leases.

**Which issue this PR fixes(if applicable)**:
fixes #1732

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
