### PR TITLE
[manila-csi-plugin] Add NodeGetVolumeStats

### DIFF
--- a/pkg/csi/manila/csiclient/client.go
+++ b/pkg/csi/manila/csiclient/client.go
@@ -37,6 +37,10 @@ func (c *NodeSvcClient) GetCapabilities(ctx context.Context) (*csi.NodeGetCapabi
 	return c.cl.NodeGetCapabilities(ctx, &csi.NodeGetCapabilitiesRequest{})
 }
 
+func (c *NodeSvcClient) GetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+	return c.cl.NodeGetVolumeStats(ctx, req)
+}
+
 func (c *NodeSvcClient) StageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
 	return c.cl.NodeStageVolume(ctx, req)
 }

--- a/pkg/csi/manila/csiclient/interface.go
+++ b/pkg/csi/manila/csiclient/interface.go
@@ -25,6 +25,7 @@ import (
 
 type Node interface {
 	GetCapabilities(ctx context.Context) (*csi.NodeGetCapabilitiesResponse, error)
+	GetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error)
 
 	StageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error)
 	UnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error)

--- a/pkg/csi/manila/nodeserver.go
+++ b/pkg/csi/manila/nodeserver.go
@@ -337,7 +337,13 @@ func (ns *nodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetC
 }
 
 func (ns *nodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "")
+	csiConn, err := ns.d.csiClientBuilder.NewConnectionWithContext(ctx, ns.d.fwdEndpoint)
+	if err != nil {
+		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
+	}
+	defer csiConn.Close()
+
+	return ns.d.csiClientBuilder.NewNodeServiceClient(csiConn).GetVolumeStats(ctx, req)
 }
 
 func (ns *nodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {

--- a/tests/sanity/manila/fakecsiclient.go
+++ b/tests/sanity/manila/fakecsiclient.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila/csiclient"
 )
 
@@ -60,6 +62,10 @@ func (c fakeNodeSvcClient) GetCapabilities(context.Context) (*csi.NodeGetCapabil
 			},
 		},
 	}, nil
+}
+
+func (c fakeNodeSvcClient) GetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
 }
 
 func (c fakeNodeSvcClient) StageVolume(context.Context, *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

`NodeGetVolumeStats` is now forwarded to the partner plugin if it supports `GET_VOLUME_STATS` Node Service capability.

Tested with a CephFS share.

Logs:
```
I0107 15:22:15.382326       1 driver.go:314] [ID:10] GRPC call: /csi.v1.Node/NodeGetVolumeStats
I0107 15:22:15.382340       1 driver.go:315] [ID:10] GRPC request: {"volume_id":"94f7e992-9be2-462d-a679-59d7cf275a17","volume_path":"/var/lib/kubelet/pods/93883049-72db-404d-8f2e-7c64b5252475/volumes/kubernetes.io~csi/pvc-b479a5de-5274-488e-8951-de5cc8223390/mount"}
I0107 15:22:15.382852       1 builder.go:45] [ID:6] FWD GRPC call: /csi.v1.Node/NodeGetVolumeStats
I0107 15:22:15.382865       1 builder.go:46] [ID:6] FWD GRPC request: {"volume_id":"94f7e992-9be2-462d-a679-59d7cf275a17","volume_path":"/var/lib/kubelet/pods/93883049-72db-404d-8f2e-7c64b5252475/volumes/kubernetes.io~csi/pvc-b479a5de-5274-488e-8951-de5cc8223390/mount"}
I0107 15:22:15.392865       1 builder.go:52] [ID:6] FWD GRPC response: {"usage":[{"available":1073741824,"total":1073741824,"unit":1},{"available":-1,"total":1,"unit":2,"used":2}]}
I0107 15:22:15.393021       1 driver.go:320] [ID:10] GRPC response: {"usage":[{"available":1073741824,"total":1073741824,"unit":1},{"available":-1,"total":1,"unit":2,"used":2}]}
```

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[manila-csi-plugin] NodeGetVolumeStats is now forwarded to the partner plugin if it supports GET_VOLUME_STATS Node Service capability.
```
