### PR TITLE
[cinder-csi-plugin] Add clusterID Helm value

### DIFF
--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -115,7 +115,7 @@ spec:
             - name: CLOUD_CONFIG
               value: /etc/kubernetes/cloud-config
             - name: CLUSTER_NAME
-              value: kubernetes
+              value: "{{ .Values.clusterID }}"
           ports:
             - containerPort: 9808
               name: healthz

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -140,4 +140,8 @@ storageClass:
 #     driver: cinder.csi.openstack.org
 #     deletionPolicy: Delete
 
+# You may set ID of the cluster where openstack-cinder-csi is deployed. This value will be appended
+# to volume metadata in newly provisioned volumes as `cinder.csi.openstack.org/cluster=<cluster ID>`.
+clusterID: "kubernetes"
+
 priorityClassName: ""


### PR DESCRIPTION
**What this PR does / why we need it**:

cinder-csi doesn't currently allow to set the cluster ID via its helm chart. It's hardcoded to `kubernetes`. This PR adds a Helm value `clusterID` so that it's configurable.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[cinder-csi-plugin] Add clusterID Helm chart value
```
