### PR TITLE
Remove darwin/amd64 from OS arch support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ HAS_LINT := $(shell command -v golint;)
 HAS_GOX := $(shell command -v gox;)
 GOX_PARALLEL ?= 3
 
-TARGETS		?= darwin/amd64 linux/amd64 linux/386 linux/arm linux/arm64 linux/ppc64le linux/s390x
+TARGETS		?= linux/amd64 linux/386 linux/arm linux/arm64 linux/ppc64le linux/s390x
 DIST_DIRS	= find * -type d -exec
 
 TEMP_DIR	:=$(shell mktemp -d)


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
darwin/amd64 is blocking the build-cross target in Makefile, we don't have a proper reason to keep that.

The related error:

```
1 errors occurred:
--> darwin/amd64 error: exit status 2
Stderr: # k8s.io/cloud-provider-openstack/pkg/csi/cinder
pkg/csi/cinder/nodeserver.go:419:23: r.NeedResize undefined (type *"k8s.io/mount-utils".ResizeFs has no field or method NeedResize)

make: *** [Makefile:311: build-cross] Error 1
```

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
