### PR TITLE
[cinder-csi-plugin] Updated CLOUD_CONFIG in helm chart.

### DIFF
--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -113,7 +113,7 @@ spec:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
-              value: /etc/kubernetes/cloud-config
+              value: /etc/kubernetes/cloud.conf
             - name: CLUSTER_NAME
               value: "{{ .Values.clusterID }}"
           ports:

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -65,7 +65,7 @@ spec:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
-              value: /etc/kubernetes/cloud-config
+              value: /etc/kubernetes/cloud.conf
           ports:
             - containerPort: 9808
               name: healthz

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -103,7 +103,7 @@ secret:
   create: false
 #  name: cinder-csi-cloud-config
 #  data:
-#    cloud-config: |-
+#    cloud.conf: |-
 #      [Global]
 #      auth-url=http://openstack-control-plane
 #      user-id=user-id

--- a/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
+++ b/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
@@ -194,9 +194,9 @@ cinder.csi.openstack.org   2019-07-29T09:02:40Z
 
 ### Using the Helm chart
 
-> NOTE: With default values, this chart assumes that the `cloud-config` is found on the host under `/etc/kubernetes/` and that your OpenStack cloud has cert under `/etc/cacert`.
+> NOTE: With default values, this chart assumes that the `cloud.conf` is found on the host under `/etc/kubernetes/` and that your OpenStack cloud has cert under `/etc/cacert`.
 
-You can specify a K8S Secret for `cloud-config` :
+You can specify a K8S Secret for `cloud.conf` :
 ```
 secret:
   enabled: true
@@ -210,7 +210,7 @@ secret:
   enabled: true
   name: cinder-csi-cloud-config
   data:
-    cloud-config: |-
+    cloud.conf: |-
       ...
 ```
 


### PR DESCRIPTION
My apologies for messing up the previous one.

**What this PR does / why we need it**: 

Currently the openstack-ccm helm chart [hardcodes its key name](https://github.com/kubernetes/cloud-provider-openstack/blob/master/charts/openstack-cloud-controller-manager/templates/secret.yaml#L8) when creating its secret as `cloud.conf`. Due to the different secret keys, you must create two separate secrets if running both the CCM and CSI plugin. This change would allow the `cinder-csi-plugin` reuse the existing secret created by the CCM.


```release-note
 [cinder-csi-plugin] Make CLOUD_CONFIG secret keys consistent in helm chart for better re-usability 
```
