### PR TITLE
[occm] possible to disable shared-lb feature

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -468,7 +468,9 @@ By default, different Services of LoadBalancer type should have different corres
 
 The shared load balancer can be created either by other Services or outside the cluster, e.g. created manually by the user in the cloud or by Services from the other Kubernetes clusters. The load balancer is deleted only when the last attached Service is deleted, unless the load balancer was created outside the Kubernetes cluster.
 
-The maximum number of Services that share a load balancer can be configured in `[LoadBalancer] max-shared-lb`, default value is 2. The ports of those Services shouldn't have collisions.
+The maximum number of Services that share a load balancer can be configured in `[LoadBalancer] max-shared-lb`, default value is 2.
+This feature can be disabled by setting the value to 0.
+The ports of those Services shouldn't have collisions.
 
 For example, create a Service `service-1` as before:
 

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1764,8 +1764,10 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 	svcConf := new(serviceConfig)
 
 	// Update the service annotations(e.g. add loadbalancer.openstack.org/load-balancer-id) in the end if it doesn't exist.
-	patcher := newServicePatcher(lbaas.kclient, service)
-	defer func() { err = patcher.Patch(ctx, err) }()
+	if lbaas.opts.MaxSharedLB > 0 {
+		patcher := newServicePatcher(lbaas.kclient, service)
+		defer func() { err = patcher.Patch(ctx, err) }()
+	}
 
 	if err := lbaas.checkService(service, nodes, svcConf); err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**: Currently there is no way to disable "shared-lb" feature that was added in https://github.com/kubernetes/cloud-provider-openstack/pull/1648

However, the current solution updates annotations in services. This makes gitops tools to behave incorrectly and we are already seeing problems with this. We have basically endless loop going on.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] shared-lb feature can be disabled by setting `max-shared-lb` to 0
```
