### PR TITLE
[occm] update lb monitoring params via annotations

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -177,6 +177,18 @@ Request Body:
 
   Not supported when `lb-provider=ovn` is configured in openstack-cloud-controller-manager.
 
+- `loadbalancer.openstack.org/health-monitor-delay`
+
+  Defines the health monitor delay in seconds for the loadbalancer pools.
+
+- `loadbalancer.openstack.org/health-monitor-timeout`
+
+  Defines the health monitor timeout in seconds for the loadbalancer pools. This value should be less than delay
+
+- `loadbalancer.openstack.org/health-monitor-max-retries`
+
+  Defines the health monitor retry count for the loadbalancer pools.
+
 - `loadbalancer.openstack.org/flavor-id`
 
   The id of the flavor that is used for creating the loadbalancer.

--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -1,0 +1,135 @@
+package openstack
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
+)
+
+type testPopListener struct {
+	existingListeners []listeners.Listener
+	id                string
+	result            []string
+	name              string
+}
+
+func TestPopListener(t *testing.T) {
+	items := []testPopListener{
+		{
+			existingListeners: []listeners.Listener{},
+			id:                "foobar",
+			result:            []string{},
+			name:              "empty listeners, id not exists",
+		},
+		{
+			existingListeners: []listeners.Listener{
+				{
+					ID: "barfoo",
+				},
+			},
+			id:     "foobar",
+			result: []string{"barfoo"},
+			name:   "id not found from listeners",
+		},
+		{
+			existingListeners: []listeners.Listener{
+				{
+					ID: "barfoo",
+				},
+			},
+			id:     "barfoo",
+			result: []string{},
+			name:   "id found from listeners",
+		},
+		{
+			existingListeners: []listeners.Listener{
+				{
+					ID: "barfoo",
+				},
+				{
+					ID: "barfoo2",
+				},
+				{
+					ID: "barfoo3",
+				},
+				{
+					ID: "barfoo4",
+				},
+			},
+			id:     "barfoo",
+			result: []string{"barfoo2", "barfoo3", "barfoo4"},
+			name:   "barfoo multiple delete id from listeners",
+		},
+		{
+			existingListeners: []listeners.Listener{
+				{
+					ID: "barfoo",
+				},
+				{
+					ID: "barfoo2",
+				},
+				{
+					ID: "barfoo3",
+				},
+				{
+					ID: "barfoo4",
+				},
+			},
+			id:     "barfoo2",
+			result: []string{"barfoo", "barfoo3", "barfoo4"},
+			name:   "barfoo2 multiple delete id from listeners",
+		},
+		{
+			existingListeners: []listeners.Listener{
+				{
+					ID: "barfoo",
+				},
+				{
+					ID: "barfoo2",
+				},
+				{
+					ID: "barfoo3",
+				},
+				{
+					ID: "barfoo4",
+				},
+			},
+			id:     "barfoo3",
+			result: []string{"barfoo", "barfoo2", "barfoo4"},
+			name:   "barfoo3 multiple delete id from listeners",
+		},
+		{
+			existingListeners: []listeners.Listener{
+				{
+					ID: "barfoo",
+				},
+				{
+					ID: "barfoo2",
+				},
+				{
+					ID: "barfoo3",
+				},
+				{
+					ID: "barfoo4",
+				},
+			},
+			id:     "barfoo4",
+			result: []string{"barfoo", "barfoo2", "barfoo3"},
+			name:   "barfoo4 multiple delete id from listeners",
+		},
+	}
+
+	for _, item := range items {
+		result := popListener(item.existingListeners, item.id)
+		ids := []string{}
+		for _, res := range result {
+			ids = append(ids, res.ID)
+		}
+		sort.Strings(item.result)
+		sort.Strings(ids)
+		assert.Equal(t, ids, item.result, item.name)
+	}
+}

--- a/pkg/util/openstack/loadbalancer.go
+++ b/pkg/util/openstack/loadbalancer.go
@@ -639,6 +639,17 @@ func CreateL7Rule(client *gophercloud.ServiceClient, policyID string, opts l7pol
 	return nil
 }
 
+// UpdateHealthMonitor updates a health monitor.
+func UpdateHealthMonitor(client *gophercloud.ServiceClient, monitorID string, opts monitors.UpdateOpts) error {
+	mc := metrics.NewMetricContext("loadbalancer_healthmonitor", "update")
+	_, err := monitors.Update(client, monitorID, opts).Extract()
+	if mc.ObserveRequest(err) != nil {
+		return fmt.Errorf("failed to update healthmonitor: %v", err)
+	}
+
+	return nil
+}
+
 // DeleteHealthMonitor deletes a health monitor.
 func DeleteHealthMonitor(client *gophercloud.ServiceClient, monitorID string, lbID string) error {
 	mc := metrics.NewMetricContext("loadbalancer_healthmonitor", "delete")


### PR DESCRIPTION
**What this PR does / why we need it**: Currently it is possible to define loadbalancer health monitor values only in Kubernetes cluster level. This is not optimal for all workloads. If we want applications to have minimal downtime these parameters should be configurable in service level.

**Which issue this PR fixes(if applicable)**:
fixes https://github.com/kubernetes/cloud-provider-openstack/issues/1763

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] LoadBalancer health monitor values configurable by using annotations `loadbalancer.openstack.org/health-monitor-delay`, `loadbalancer.openstack.org/health-monitor-timeout` and `loadbalancer.openstack.org/health-monitor-max-retries`
```
