### PR TITLE
[manila-csi-plugin] more e2e tests

### DIFF
--- a/tests/e2e/csi/manila/manilavolume.go
+++ b/tests/e2e/csi/manila/manilavolume.go
@@ -1,0 +1,113 @@
+package test
+
+import (
+	"bytes"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/onsi/ginkgo"
+	"k8s.io/kubernetes/test/e2e/framework"
+	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
+)
+
+func runCmd(name string, args ...string) ([]byte, error) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(name, args...)
+
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	framework.Logf("Running %s %v", cmd.Path, cmd.Args)
+	err := cmd.Run()
+
+	framework.Logf("Stdout output %s %v: `%s`", cmd.Path, cmd.Args, stdout.String())
+	framework.Logf("Stderr output %s %v: `%s`", cmd.Path, cmd.Args, stderr.String())
+
+	return stdout.Bytes(), err
+}
+
+// It is assummed that the `openstack` and other related programs
+// are accessible from $PATH on the node.
+
+type manilaVolume struct {
+	proto    string
+	shareID  string
+	accessID string
+}
+
+func manilaCreateVolume(
+	shareProto,
+	accessType,
+	accessTo string,
+	sizeInGiB int,
+	config *storageframework.PerTestConfig,
+) storageframework.TestVolume {
+	ginkgo.By("Creating a test Manila volume externally")
+
+	// Create share.
+
+	out, err := runCmd(
+		"openstack",
+		"share",
+		"create",
+		shareProto,
+		strconv.Itoa(sizeInGiB),
+		"--property=provisioned-by=manila.csi.openstack.org/e2e.test",
+		"--format=value",
+		"--column=id",
+		"--wait",
+	)
+
+	shareID := strings.TrimSpace(string(out))
+
+	framework.ExpectNoError(err)
+	framework.ExpectNotEqual(shareID, "")
+
+	framework.Logf("Created test Manila volume %s", shareID)
+
+	// Grant access to the share.
+
+	out, err = runCmd(
+		"openstack",
+		"share",
+		"access",
+		"create",
+		shareID,
+		accessType,
+		accessTo,
+		"--format=value",
+		"--column=id",
+	)
+
+	// XXX: In case of cephx access rights, the access_key field might
+	//      not be generated in time for when the volume is mounted.
+	//      Tests may fail. A workaround would be to wait until it is ready.
+
+	accessID := strings.TrimSpace(string(out))
+
+	framework.ExpectNoError(err)
+	framework.ExpectNotEqual(accessID, "")
+
+	framework.Logf("Created access right %s for Manila volume %s", accessID, shareID)
+
+	return &manilaVolume{
+		shareID:  shareID,
+		accessID: accessID,
+	}
+}
+
+func (v *manilaVolume) DeleteVolume() {
+	ginkgo.By("Deleting test Manila volume externally")
+
+	_, err := runCmd(
+		"openstack",
+		"share",
+		"delete",
+		v.shareID,
+	)
+
+	if err != nil {
+		framework.Failf("Failed to remove Manila volume %s: %v", v.shareID, err)
+	}
+}

--- a/tests/e2e/csi/manila/testsuite.go
+++ b/tests/e2e/csi/manila/testsuite.go
@@ -12,19 +12,18 @@ import (
 
 var CSITestSuites = []func() storageframework.TestSuite{
 	testsuites.InitVolumesTestSuite,
-	// testsuites.InitSubPathTestSuite,
-	// testsuites.InitProvisioningTestSuite,
-	// testsuites.InitVolumeModeTestSuite,
-	// testsuites.InitSnapshottableTestSuite,
-	// testsuites.InitFsGroupChangePolicyTestSuite,
+	testsuites.InitSnapshottableTestSuite,
+	testsuites.InitProvisioningTestSuite,
+	testsuites.InitSubPathTestSuite,
+	testsuites.InitVolumeModeTestSuite,
+	testsuites.InitVolumeExpandTestSuite,
+	testsuites.InitVolumeIOTestSuite,
 }
 
 var _ = utils.SIGDescribe("[manila-csi-e2e] CSI Volumes", func() {
 	testfiles.AddFileSource(testfiles.RootFileSource{Root: framework.TestContext.RepoRoot})
 
-	testDriver := newManilaTestDriver(
-		"nfs.manila.csi.openstack.org",
-	)
+	testDriver := newManilaTestDriver()
 
 	Context(storageframework.GetDriverNameWithFeatureTags(testDriver), func() {
 		storageframework.DefineTestSuites(testDriver, CSITestSuites)

--- a/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
@@ -128,6 +128,21 @@
   retries: 24
   delay: 5
 
+- name: Deploy Kubernetes VolumeSnapshot CRDs and snapshot controller
+  shell:
+    executable: /bin/bash
+    cmd: |
+      # TODO: Consider using kustomize once we move to external-snapshotter v5.
+      for f in \
+        'https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-4.2/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml' \
+        'https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-4.2/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml' \
+        'https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-4.2/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml' \
+        'https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-4.2/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml' \
+        'https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-4.2/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml'
+      do
+        kubectl create -f "$f"
+      done
+
 - name: Deploy nfs-csi Node Plugin
   shell:
     executable: /bin/bash
@@ -276,6 +291,8 @@
       set -x
       set -e
       set -o pipefail
+
+      set +x; source {{ devstack_workdir }}/openrc demo demo > /dev/null; set -x
 
       cd {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This PR adds rest of the tests from e2e storage test suite.

Problems I've experienced:
* FsGroupChangePolicyTestSuite:
  * It seems like it's trying to delete a PVC that's still in use by a Pod, and then fails due to timeout when attempting to delete that PVC.
  * It also deleted storage class of a PVC before deleting that PVC, which then causes deletion of that PVC to fail (can't access the provisioner secrets anymore).
* EphemeralTestSuite:
  * Pod: `Warning  FailedMount  16s (x10 over 4m25s)  kubelet            MountVolume.NewMounter initialization failed for volume "my-volume-0" : volume mode "Ephemeral" not supported by driver cephfs.manila.csi.openstack.org (only supports ["Persistent"])`
  * The test doesn't check for this, and is stuck on `STEP: checking the requested inline volume exists in the pod running on node {Name: Selector:map[] Affinity:nil}` forever.

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
