### PR TITLE
[manila-csi-plugin] ControllerExpandVolume rounds up size to GiB

### DIFF
--- a/pkg/csi/manila/util.go
+++ b/pkg/csi/manila/util.go
@@ -38,7 +38,7 @@ type (
 )
 
 const (
-	bytesInGiB = 1024 * 1024 * 1024
+	bytesInGiB int64 = 1024 * 1024 * 1024
 )
 
 type manilaError int
@@ -122,9 +122,9 @@ func fmtGrpcConnError(fwdEndpoint string, err error) string {
 func bytesToGiB(sizeInBytes int64) int {
 	sizeInGiB := int(sizeInBytes / bytesInGiB)
 
-	if int64(sizeInGiB)*bytesInGiB < sizeInBytes {
+	if sizeInBytes%bytesInGiB > 0 {
 		// Round up
-		return sizeInGiB + 1
+		sizeInGiB++
 	}
 
 	return sizeInGiB


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

`ControllerExpandVolume` doesn't round up new size to GiB leading to an error described in #1764. This PR fixes `bytesToGiB` which `ControllerExpandVolume` uses to convert the input size in bytes to GiB.

**Which issue this PR fixes(if applicable)**:
fixes #1764 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

Logs:
```
I0124 13:50:37.660046       1 driver.go:314] [ID:15] GRPC call: /csi.v1.Controller/ControllerExpandVolume
I0124 13:50:37.660069       1 driver.go:315] [ID:15] GRPC request: {"capacity_range":{"required_bytes":2000000000},"secrets":"***stripped***","volume_capability":{"AccessType":{"Mount":{}},"access_mode":{"mode":5}},"volume_id":"b9eeed27-a1f8-4de2-8161-9af786ba24b8"}
I0124 13:50:37.660393       1 client.go:252] Using user-agent manila-csi-plugin/f1499fbb-dirty gophercloud/2.0.0
I0124 13:50:40.961397       1 driver.go:320] [ID:15] GRPC response: {"capacity_bytes":2147483648}
I0124 14:04:45.315667       1 driver.go:314] [ID:16] GRPC call: /csi.v1.Controller/ControllerGetCapabilities
I0124 14:04:45.315761       1 driver.go:315] [ID:16] GRPC request: {}
I0124 14:04:45.316042       1 driver.go:320] [ID:16] GRPC response: {"capabilities":[{"Type":{"Rpc":{"type":1}}},{"Type":{"Rpc":{"type":5}}},{"Type":{"Rpc":{"type":9}}}]}
I0124 14:04:45.318129       1 driver.go:314] [ID:17] GRPC call: /csi.v1.Controller/ControllerExpandVolume
I0124 14:04:45.318151       1 driver.go:315] [ID:17] GRPC request: {"capacity_range":{"required_bytes":3221225472},"secrets":"***stripped***","volume_capability":{"AccessType":{"Mount":{}},"access_mode":{"mode":5}},"volume_id":"b9eeed27-a1f8-4de2-8161-9af786ba24b8"}
I0124 14:04:45.318986       1 client.go:252] Using user-agent manila-csi-plugin/f1499fbb-dirty gophercloud/2.0.0
I0124 14:04:49.177117       1 driver.go:320] [ID:17] GRPC response: {"capacity_bytes":3221225472}
```

Issue in the linked bug report now goes away and resizing works correctly despite requesting new size in wrong units.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
