### PR TITLE
[occm] cherry pick of #1755: Fix the service account name

### DIFF
--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -178,7 +178,7 @@ func init() {
 
 // Initialize passes a Kubernetes clientBuilder interface to the cloud provider
 func (os *OpenStack) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
-	clientset := clientBuilder.ClientOrDie("cloud-provider-openstack")
+	clientset := clientBuilder.ClientOrDie("cloud-controller-manager")
 	os.kclient = clientset
 }
 


### PR DESCRIPTION
What this PR does / why we need it:
We were using incorrect service account name which causes service creation failure.

Which issue this PR fixes(if applicable):
fixes #1722

Special notes for reviewers:

Release note:

```release-note
NONE
```