### PR TITLE
[magnum-auto-healer] use Cinder v3

### DIFF
--- a/pkg/autohealing/cloudprovider/register/register.go
+++ b/pkg/autohealing/cloudprovider/register/register.go
@@ -65,7 +65,7 @@ func registerOpenStack(cfg config.Config, kubeClient kubernetes.Interface) (clou
 
 	// get cinder service client
 	var cinderClient *gophercloud.ServiceClient
-	cinderClient, err = gopenstack.NewBlockStorageV2(client, eoOpts)
+	cinderClient, err = gopenstack.NewBlockStorageV3(client, eoOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find Cinder service endpoint in the region %s: %v", cfg.OpenStack.Region, err)
 	}


### PR DESCRIPTION
Cinder v2 has been deprecated since Pike release, let's use v3.

Fixes #1738

**Release note**:
```release-note
[magnum-auto-healer] Remove Cinder V2 support. Action required.
```
