### PR TITLE
magnum-auto-healer: use Cinder v3 (#1769)

### DIFF
--- a/pkg/autohealing/cloudprovider/register/register.go
+++ b/pkg/autohealing/cloudprovider/register/register.go
@@ -65,7 +65,7 @@ func registerOpenStack(cfg config.Config, kubeClient kubernetes.Interface) (clou
 
 	// get cinder service client
 	var cinderClient *gophercloud.ServiceClient
-	cinderClient, err = gopenstack.NewBlockStorageV2(client, eoOpts)
+	cinderClient, err = gopenstack.NewBlockStorageV3(client, eoOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find Cinder service endpoint in the region %s: %v", cfg.OpenStack.Region, err)
 	}


### PR DESCRIPTION
Cinder v2 has been deprecated since Pike release, let's use v3.

Cherry-pick of #1769 
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[magnum-auto-healer] Remove Cinder V2 support. Action required.
```
