### PR TITLE
[occm] Add ability to disable Service controller

### DIFF
--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -172,6 +172,10 @@ The options in `Global` section are used for openstack-cloud-controller-manager 
 
 Although the openstack-cloud-controller-manager was initially implemented with Neutron-LBaaS support, Octavia is recommended now because Neutron-LBaaS has been deprecated since Queens OpenStack release cycle and no longer accepted new feature enhancements. As a result, lots of advanced features in openstack-cloud-controller-manager rely on Octavia, even the CI is running based on Octavia enabled OpenStack environment. Functionalities are not guaranteed if using Neutron-LBaaS.
 
+* `enabled`
+  Whether or not to enable the LoadBalancer type of Services integration at all.
+   Default: true
+
 * `use-octavia`
   Whether or not to use Octavia for LoadBalancer type of Service implementation instead of using Neutron-LBaaS. Default: true
   

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1910,6 +1910,10 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 
 // EnsureLoadBalancer creates a new load balancer or updates the existing one.
 func (lbaas *LbaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string, apiService *corev1.Service, nodes []*corev1.Node) (*corev1.LoadBalancerStatus, error) {
+	if !lbaas.opts.Enabled {
+		return nil, cloudprovider.ImplementedElsewhere
+	}
+
 	mc := metrics.NewMetricContext("loadbalancer", "ensure")
 	status, err := lbaas.ensureLoadBalancer(ctx, clusterName, apiService, nodes)
 	return status, mc.ObserveReconcile(err)
@@ -2733,6 +2737,9 @@ func (lbaas *LbaasV2) updateOctaviaLoadBalancer(ctx context.Context, clusterName
 
 // UpdateLoadBalancer updates hosts under the specified load balancer.
 func (lbaas *LbaasV2) UpdateLoadBalancer(ctx context.Context, clusterName string, service *corev1.Service, nodes []*corev1.Node) error {
+	if !lbaas.opts.Enabled {
+		return cloudprovider.ImplementedElsewhere
+	}
 	mc := metrics.NewMetricContext("loadbalancer", "update")
 	err := lbaas.updateLoadBalancer(ctx, clusterName, service, nodes)
 	return mc.ObserveReconcile(err)

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -73,6 +73,7 @@ type LoadBalancer struct {
 
 // LoadBalancerOpts have the options to talk to Neutron LBaaSV2 or Octavia
 type LoadBalancerOpts struct {
+	Enabled               bool                `gcfg:"enabled"`              // if false, disables the controller
 	LBVersion             string              `gcfg:"lb-version"`           // overrides autodetection. Only support v2.
 	UseOctavia            bool                `gcfg:"use-octavia"`          // uses Octavia V2 service catalog endpoint
 	SubnetID              string              `gcfg:"subnet-id"`            // overrides autodetection.
@@ -190,6 +191,7 @@ func ReadConfig(config io.Reader) (Config, error) {
 	var cfg Config
 
 	// Set default values explicitly
+	cfg.LoadBalancer.Enabled = true
 	cfg.LoadBalancer.UseOctavia = true
 	cfg.LoadBalancer.InternalLB = false
 	cfg.LoadBalancer.LBProvider = "amphora"


### PR DESCRIPTION
**What this PR does / why we need it**:
One of the CNI plugins that can be used when Kubernetes runs on OpenStack is Kuryr-Kubernetes. If it's configured, K8s pods will get wired using OpenStack Neutron and trunk ports. Services, on the other hand, will get represented by internal-facing Octavia load balancers. In case of LoadBalancer Services, Kuryr will use the same approach, only adding a FIP to such an LB. This means that when running with Kuryr the Services controller in cloud-provider-openstack should be disabled, as Kuryr handles that on his own.

This commit adds `enabled` option to the `LoadBalancerOpts`, that will default to `true`. If explicitly disabled, the `EnsureLoadBalancer()` and `UpdateLoadBalancer()` functions will only raise `ImplementedElsewhere` error, effectively telling the controller that integration is disabled.

Please note that `GetLoadBalancer()` and `EnsureLoadBalancerDeleted()` are unchanged, as controller still needs to be able to delete the LB in case integration was enabled earlier on the cluster.

**Release note**:
```release-note
[openstack-cloud-controller-manager] Added `enabled` option in the LoadBalancer section of the configuration, when set to false, the Service of LoadBalancer type is managed by other controllers.
```