### PR TITLE
[cinder-csi-plugin] Remove redundant imagePullPolicy

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.21.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 1.3.8
+version: 1.3.9
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -37,7 +37,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -86,7 +85,6 @@ spec:
             initialDelaySeconds: {{ .Values.csi.livenessprobe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.csi.livenessprobe.timeoutSeconds }}
             periodSeconds: {{ .Values.csi.livenessprobe.periodSeconds }}
-          imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
               mountPath: /csi


### PR DESCRIPTION
Signed-off-by: Victor Sollerhed <victor.sollerhed@pagero.com>

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes https://github.com/kubernetes/cloud-provider-openstack/issues/1598

...as done for cinder-csi-plugin chart version `1.4.x` in: https://github.com/kubernetes/cloud-provider-openstack/pull/1602

...but now for cinder-csi-plugin chart version `1.3.x`.

...to ensure a smooth upgrade for anyone else passing Kubernetes v1.21 before v1.22.

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
