### PR TITLE
[all] Remove deprecated option `bs-version`

### DIFF
--- a/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
+++ b/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
@@ -96,7 +96,6 @@ Implementation of `cinder-csi-plugin` relies on following OpenStack services.
 
 | Service                        | API Version(s) | Deprecated | Required |
 |--------------------------------|----------------|------------|----------|
-| Identity (Keystone)            | v2             | Yes        | No       |
 | Identity (Keystone)            | v3             | No         | Yes      |
 | Compute (Nova)                 | v2             | No         | Yes      |
 | Block Storage (Cinder)         | v3             | No         | Yes      |

--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -83,7 +83,6 @@ Implementation of openstack-cloud-controller-manager relies on several OpenStack
 
 | Service                        | API Version(s) | Deprecated | Required |
 |--------------------------------|----------------|------------|----------|
-| Identity (Keystone)            | v2             | Yes        | No       |
 | Identity (Keystone)            | v3             | No         | Yes      |
 | Compute (Nova)                 | v2             | No         | Yes      |
 | Load Balancing (Neutron-LBaaS) | v1, v2         | Yes        | No       |

--- a/manifests/controller-manager/cloud-config
+++ b/manifests/controller-manager/cloud-config
@@ -14,6 +14,3 @@ domain-id=
 use-octavia=true
 subnet-id=9c018814-f2a8-45dd-9679-5400d49b333a
 floating-network-id=80c9fc78-a2be-45d5-a85b-f17a6c98df92
-
-[BlockStorage]
-bs-version=v2

--- a/pkg/openstack/openstack_test.go
+++ b/pkg/openstack/openstack_test.go
@@ -82,7 +82,6 @@ func ConfigFromEnv() Config {
 	cfg.Global.ApplicationCredentialSecret = os.Getenv("OS_APPLICATION_CREDENTIAL_SECRET")
 
 	// Set default values for config params
-	cfg.BlockStorage.BSVersion = "auto"
 	cfg.BlockStorage.TrustDevicePath = false
 	cfg.BlockStorage.IgnoreVolumeAZ = false
 	cfg.Metadata.SearchOrder = fmt.Sprintf("%s,%s", metadata.ConfigDriveID, metadata.MetadataID)
@@ -113,7 +112,6 @@ func TestReadConfig(t *testing.T) {
  monitor-timeout = 30s
  monitor-max-retries = 3
  [BlockStorage]
- bs-version = auto
  trust-device-path = yes
  ignore-volume-az = yes
  [Metadata]
@@ -161,9 +159,6 @@ func TestReadConfig(t *testing.T) {
 	}
 	if cfg.BlockStorage.TrustDevicePath != true {
 		t.Errorf("incorrect bs.trustdevicepath: %v", cfg.BlockStorage.TrustDevicePath)
-	}
-	if cfg.BlockStorage.BSVersion != "auto" {
-		t.Errorf("incorrect bs.bs-version: %v", cfg.BlockStorage.BSVersion)
 	}
 	if cfg.BlockStorage.IgnoreVolumeAZ != true {
 		t.Errorf("incorrect bs.IgnoreVolumeAZ: %v", cfg.BlockStorage.IgnoreVolumeAZ)
@@ -215,7 +210,6 @@ clouds:
  monitor-timeout = 30s
  monitor-max-retries = 3
  [BlockStorage]
- bs-version = auto
  trust-device-path = yes
  ignore-volume-az = yes
  [Metadata]
@@ -258,9 +252,6 @@ clouds:
 	// Make non-global sections dont get overwritten
 	if cfg.BlockStorage.TrustDevicePath != true {
 		t.Errorf("incorrect bs.trustdevicepath: %v", cfg.BlockStorage.TrustDevicePath)
-	}
-	if cfg.BlockStorage.BSVersion != "auto" {
-		t.Errorf("incorrect bs.bs-version: %v", cfg.BlockStorage.BSVersion)
 	}
 	if !cfg.LoadBalancer.CreateMonitor {
 		t.Errorf("incorrect lb.createmonitor: %t", cfg.LoadBalancer.CreateMonitor)

--- a/tests/playbooks/roles/install-cpo-occm/tasks/main.yaml
+++ b/tests/playbooks/roles/install-cpo-occm/tasks/main.yaml
@@ -52,8 +52,6 @@
       subnet-id=$sudnet_id
       floating-network-id=$external_network_id
 
-      [BlockStorage]
-      bs-version=v2
       EOF
 
       kubectl create secret -n kube-system generic cloud-config --from-file={{ ansible_user_dir }}/cloud.conf

--- a/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
@@ -44,8 +44,6 @@
       tenant-id=$tenant_id
       domain-id=default
 
-      [BlockStorage]
-      bs-version=v3
       EOF
 
       kubectl create secret -n kube-system generic cloud-config --from-file={{ ansible_user_dir }}/cloud.conf


### PR DESCRIPTION
`bs-version` config option is not supported anymore and by default
v3 api is used. This PR is to remove the same from the code.

This PR also removes the reference to identity v2 in docs as its support is  removed.
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
