### PR TITLE
[occm] The service monitor svc should select the pods of the occm DS

### DIFF
--- a/charts/openstack-cloud-controller-manager/templates/service-sm.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/service-sm.yaml
@@ -11,5 +11,5 @@ spec:
     port: 10258
     protocol: TCP
   selector:
-    {{- include "occm.labels" . | nindent 4 }}
+    {{- include "occm.controllermanager.matchLabels" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
The `occm.labels` helm helper in the occm chart doesn't match the pods of the DS as they instead uses the `occm.controllermanager.labels` helper. By changing the service selector to use the `occm.controllermanager.matchLabels` helper we ensure that it matches the occm DS pods.
