### PR TITLE
[cinder-csi-plugin] cherry-pick of #1747

### DIFF
--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -113,7 +113,7 @@ spec:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
-              value: /etc/kubernetes/cloud-config
+              value: /etc/kubernetes/cloud.conf
             - name: CLUSTER_NAME
               value: "{{ .Values.clusterID }}"
           ports:

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -65,7 +65,7 @@ spec:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
-              value: /etc/kubernetes/cloud-config
+              value: /etc/kubernetes/cloud.conf
           ports:
             - containerPort: 9808
               name: healthz

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -103,7 +103,7 @@ secret:
   create: false
 #  name: cinder-csi-cloud-config
 #  data:
-#    cloud-config: |-
+#    cloud.conf: |-
 #      [Global]
 #      auth-url=http://openstack-control-plane
 #      user-id=user-id

--- a/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
+++ b/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
@@ -194,9 +194,9 @@ cinder.csi.openstack.org   2019-07-29T09:02:40Z
 
 ### Using the Helm chart
 
-> NOTE: With default values, this chart assumes that the `cloud-config` is found on the host under `/etc/kubernetes/` and that your OpenStack cloud has cert under `/etc/cacert`.
+> NOTE: With default values, this chart assumes that the `cloud.conf` is found on the host under `/etc/kubernetes/` and that your OpenStack cloud has cert under `/etc/cacert`.
 
-You can specify a K8S Secret for `cloud-config` :
+You can specify a K8S Secret for `cloud.conf` :
 ```
 secret:
   enabled: true
@@ -210,7 +210,7 @@ secret:
   enabled: true
   name: cinder-csi-cloud-config
   data:
-    cloud-config: |-
+    cloud.conf: |-
       ...
 ```
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Cherry-picks https://github.com/kubernetes/cloud-provider-openstack/pull/1747 into the `release-1.23` branch.

**Which issue this PR fixes(if applicable)**:
See https://github.com/kubernetes/cloud-provider-openstack/pull/1747 for description.

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[cinder-csi-plugin] Make CLOUD_CONFIG secret keys consistent in helm chart for better re-usability
```
