### PR TITLE
[manila-CSI-plugin] Add extra labels to k8s resources

### DIFF
--- a/charts/manila-csi-plugin/templates/_helpers.tpl
+++ b/charts/manila-csi-plugin/templates/_helpers.tpl
@@ -81,3 +81,12 @@ Create chart name and version as used by the chart label.
 {{- define "openstack-manila-csi.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Extra labels for all resources.
+*/}}
+{{- define "openstack-manila-csi.extraLabels" -}}
+    {{- if .Values.extraLabels.enabled }}
+{{ toYaml .Values.extraLabels.labels | indent 4 -}}
+    {{- end }}
+{{- end }}

--- a/charts/manila-csi-plugin/templates/controllerplugin-clusterrole.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-clusterrole.yaml
@@ -8,6 +8,7 @@ metadata:
     component: {{ .Values.controllerplugin.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "openstack-manila-csi.extraLabels" . }}
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:

--- a/charts/manila-csi-plugin/templates/controllerplugin-clusterrolebinding.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-clusterrolebinding.yaml
@@ -8,6 +8,7 @@ metadata:
     component: {{ .Values.controllerplugin.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "openstack-manila-csi.extraLabels" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "openstack-manila-csi.serviceAccountName.controllerplugin" . }}

--- a/charts/manila-csi-plugin/templates/controllerplugin-role.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-role.yaml
@@ -8,6 +8,7 @@ metadata:
     component: {{ .Values.controllerplugin.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "openstack-manila-csi.extraLabels" . }}
 rules:
   - apiGroups: [""]
     resources: ["endpoints"]

--- a/charts/manila-csi-plugin/templates/controllerplugin-rolebinding.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-rolebinding.yaml
@@ -8,6 +8,7 @@ metadata:
     component: {{ .Values.controllerplugin.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "openstack-manila-csi.extraLabels" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "openstack-manila-csi.serviceAccountName.controllerplugin" . }}

--- a/charts/manila-csi-plugin/templates/controllerplugin-rules-clusterrole.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-rules-clusterrole.yaml
@@ -9,6 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     rbac.manila.csi.openstack.org/aggregate-to-{{ include "openstack-manila-csi.controllerplugin.fullname" . }}: "true"
+    {{- include "openstack-manila-csi.extraLabels" . }}
 rules:
   - apiGroups: [""]
     resources: ["nodes"]

--- a/charts/manila-csi-plugin/templates/controllerplugin-service.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-service.yaml
@@ -8,6 +8,7 @@ metadata:
     component: {{ .Values.controllerplugin.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "openstack-manila-csi.extraLabels" . }}
 spec:
   selector:
     app: {{ include "openstack-manila-csi.name" . }}

--- a/charts/manila-csi-plugin/templates/controllerplugin-serviceaccount.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-serviceaccount.yaml
@@ -8,3 +8,4 @@ metadata:
     component: {{ .Values.controllerplugin.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "openstack-manila-csi.extraLabels" . }}

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -8,6 +8,7 @@ metadata:
     component: {{ .Values.controllerplugin.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "openstack-manila-csi.extraLabels" . }}
 spec:
   serviceName: {{ include "openstack-manila-csi.controllerplugin.fullname" . }}
   replicas: 1

--- a/charts/manila-csi-plugin/templates/nodeplugin-clusterrole.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-clusterrole.yaml
@@ -8,6 +8,7 @@ metadata:
     component: {{ .Values.nodeplugin.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "openstack-manila-csi.extraLabels" . }}
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:

--- a/charts/manila-csi-plugin/templates/nodeplugin-clusterrolebinding.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-clusterrolebinding.yaml
@@ -8,6 +8,7 @@ metadata:
     component: {{ .Values.nodeplugin.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "openstack-manila-csi.extraLabels" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "openstack-manila-csi.serviceAccountName.nodeplugin" . }}

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -8,6 +8,7 @@ metadata:
     component: {{ .Values.nodeplugin.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "openstack-manila-csi.extraLabels" . }}
 spec:
   selector:
     matchLabels:

--- a/charts/manila-csi-plugin/templates/nodeplugin-rules-clusterrole.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-rules-clusterrole.yaml
@@ -9,6 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     rbac.manila.csi.openstack.org/aggregate-to-{{ include "openstack-manila-csi.nodeplugin.fullname" . }}: "true"
+    {{- include "openstack-manila-csi.extraLabels" . }}
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]

--- a/charts/manila-csi-plugin/templates/nodeplugin-serviceaccount.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-serviceaccount.yaml
@@ -8,3 +8,4 @@ metadata:
     component: {{ .Values.nodeplugin.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "openstack-manila-csi.extraLabels" . }}

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -15,6 +15,9 @@ shareProtocols:
  #     dir: /var/lib/kubelet/plugins/cephfs.csi.ceph.com
  #     sockFile: csi.sock
 
+extraLabels:
+  enabled: false
+  labels: {}
 # CSI Manila spec
 csimanila:
   # Set topologyAwarenessEnabled to true to enable topology awareness


### PR DESCRIPTION
Extra labels are optional and applied to all resources already sporting labels

**What this PR does / why we need it**:
This provides the capability of adding optional extra labels to manila-csi-plugin k8s resources

**Which issue this PR fixes(if applicable)**:
fixes #1786

**Special notes for reviewers**:
I've tested it setting extraLabels.enabled to true and adding some arbitrary labels, as well as leaving extraLabels.enabled set to false.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
