### PR TITLE
[cinder-csi-plugin] Configurable secret filename

### DIFF
--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -113,7 +113,7 @@ spec:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
-              value: /etc/kubernetes/cloud.conf
+              value: /etc/kubernetes/{{ .Values.secret.filename }}
             - name: CLUSTER_NAME
               value: "{{ .Values.clusterID }}"
           ports:

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -65,7 +65,7 @@ spec:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
-              value: /etc/kubernetes/cloud.conf
+              value: /etc/kubernetes/{{ .Values.secret.filename }}
           ports:
             - containerPort: 9808
               name: healthz

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -101,6 +101,7 @@ logVerbosityLevel: 2
 secret:
   enabled: false
   create: false
+  filename: cloud.conf
 #  name: cinder-csi-cloud-config
 #  data:
 #    cloud.conf: |-


### PR DESCRIPTION
Making the change from #1747 backwards-compatible, when using `secret.enabled: true` and `secret.create: false`, and thus creating the secret externally (referred from `secret.name`). Some users might even be sharing the same secret between OCCM and Cinder CSI out of convenience.

#### Before #1747:

```yaml
$ helm template cinder-csi-plugin charts/cinder-csi-plugin | grep "value: /etc/kubernetes"
              value: /etc/kubernetes/cloud-config
              value: /etc/kubernetes/cloud-config
```

#### After #1747:

```yaml
$ helm template cinder-csi-plugin charts/cinder-csi-plugin | grep "value: /etc/kubernetes"
              value: /etc/kubernetes/cloud.conf
              value: /etc/kubernetes/cloud.conf
```

#### After this PR (by default):

```yaml
$ helm template cinder-csi-plugin charts/cinder-csi-plugin | grep "value: /etc/kubernetes"
              value: /etc/kubernetes/cloud.conf
              value: /etc/kubernetes/cloud.conf
```

#### After this PR (when configured for backwards-compatibility):

```yaml
$ helm template --set secret.filename="cloud-config" cinder-csi-plugin charts/cinder-csi-plugin | grep "value: /etc/kubernetes"
              value: /etc/kubernetes/cloud-config
              value: /etc/kubernetes/cloud-config
```

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[cinder-csi-plugin] Make CLOUD_CONFIG secret filename configurable in helm chart for backwards-compatibility
```
