### PR TITLE
[Cinder-csi-plugin] Provide capability to add extra labels for Cinder

### DIFF
--- a/charts/cinder-csi-plugin/templates/_helpers.tpl
+++ b/charts/cinder-csi-plugin/templates/_helpers.tpl
@@ -62,14 +62,14 @@ Create unified labels for cinder-csi components
 {{- define "cinder-csi.common.matchLabels" -}}
 app: {{ template "cinder-csi.name" . }}
 release: {{ .Release.Name }}
-{{- if .Values.extraLabels }}
-{{ toYaml .Values.extraLabels -}}
-{{- end }}
 {{- end -}}
 
 {{- define "cinder-csi.common.metaLabels" -}}
 chart: {{ template "cinder-csi.chart" . }}
 heritage: {{ .Release.Service }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels -}}
+{{- end }}
 {{- end -}}
 
 {{- define "cinder-csi.controllerplugin.matchLabels" -}}

--- a/charts/cinder-csi-plugin/templates/_helpers.tpl
+++ b/charts/cinder-csi-plugin/templates/_helpers.tpl
@@ -62,6 +62,9 @@ Create unified labels for cinder-csi components
 {{- define "cinder-csi.common.matchLabels" -}}
 app: {{ template "cinder-csi.name" . }}
 release: {{ .Release.Name }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels -}}
+{{- end }}
 {{- end -}}
 
 {{- define "cinder-csi.common.metaLabels" -}}

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -1,3 +1,5 @@
+extraLabels: {}
+
 nameOverride: ""
 fullnameOverride: ""
 timeout: 3m


### PR DESCRIPTION
**What this PR does / why we need it**:
As per comment in PR#1788 (https://github.com/kubernetes/cloud-provider-openstack/pull/1788#issuecomment-1038868091) it's been considered a good idea to provide extraLabels capability yo Cinder plugin too.

**Which issue this PR fixes(if applicable)**:
N/A

**Special notes for reviewers**:
This has been tested templating the Cinder plugin Helm chart with and without a test.yaml file containing extra labels

```helm3 template . -f test.yaml```

**Release note**:

```release-note
[Cinder-CSI-plugin]
Adding optional extra labels to be set in .Values.extraLabels. Enable the usage of extra labels adding the desired labels to Values.extraLabels
```
