### PR TITLE
[OCCM] fix listener pop during iteration

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1874,9 +1874,6 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 				return nil, err
 			}
 
-			// After all ports have been processed, remaining listeners are removed if they were created by this Service.
-			curListeners = popListener(curListeners, listener.ID)
-
 			pool, err := lbaas.ensureOctaviaPool(loadbalancer.ID, cutString(fmt.Sprintf("pool_%d_%s", portIndex, lbName)), listener, service, port, nodes, svcConf)
 			if err != nil {
 				return nil, err
@@ -1885,6 +1882,11 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 			if err := lbaas.ensureOctaviaHealthMonitor(loadbalancer.ID, cutString(fmt.Sprintf("monitor_%d_%s", portIndex, lbName)), pool, port, svcConf); err != nil {
 				return nil, err
 			}
+
+			// After all ports have been processed, remaining listeners are removed if they were created by this Service.
+			// The remove of the listener must always happen at the end of the loop to avoid wrong assignment.
+			// Modifying the curListeners would also change the mapping.
+			curListeners = popListener(curListeners, listener.ID)
 		}
 
 		// Deal with the remaining listeners, delete the listener if it was created by this Service previously.


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[occm] Fix listener pop during iteration
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Move the remove of the listener at the end of the loop.
Since the listener is a pointer and needed during the loop the removal will mess up the logic.
We observed on a k8s service with 4 ports that a load balancer listener pool were updated on every reconcile loop.

**Which issue this PR fixes(if applicable)**:
fixes https://github.com/kubernetes/cloud-provider-openstack/issues/1795

**Special notes for reviewers**:


**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
