### PR TITLE
[manila-csi-plugin] added helper named templates for labels

### DIFF
--- a/charts/manila-csi-plugin/templates/_helpers.tpl
+++ b/charts/manila-csi-plugin/templates/_helpers.tpl
@@ -83,10 +83,43 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
-Extra labels for all resources.
+Create unified labels for manila-csi components
 */}}
-{{- define "openstack-manila-csi.extraLabels" -}}
-    {{- if .Values.extraLabels }}
-{{ toYaml .Values.extraLabels | indent 4 -}}
-    {{- end }}
+
+{{- define "openstack-manila-csi.common.matchLabels" -}}
+app: {{ template "openstack-manila-csi.name" . }}
+release: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "openstack-manila-csi.common.metaLabels" -}}
+chart: {{ template "openstack-manila-csi.chart" . }}
+heritage: {{ .Release.Service }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels }}
 {{- end }}
+{{- end -}}
+
+{{- define "openstack-manila-csi.common.labels" -}}
+{{ include "openstack-manila-csi.common.metaLabels" . }}
+{{ include "openstack-manila-csi.common.matchLabels" . }}
+{{- end -}}
+
+{{- define "openstack-manila-csi.controllerplugin.matchLabels" -}}
+component: controllerplugin
+{{ include "openstack-manila-csi.common.matchLabels" . }}
+{{- end -}}
+
+{{- define "openstack-manila-csi.controllerplugin.labels" -}}
+{{ include "openstack-manila-csi.common.metaLabels" . }}
+{{ include "openstack-manila-csi.controllerplugin.matchLabels" . }}
+{{- end -}}
+
+{{- define "openstack-manila-csi.nodeplugin.matchLabels" -}}
+component: nodeplugin
+{{ include "openstack-manila-csi.common.matchLabels" . }}
+{{- end -}}
+
+{{- define "openstack-manila-csi.nodeplugin.labels" -}}
+{{ include "openstack-manila-csi.common.metaLabels" . }}
+{{ include "openstack-manila-csi.nodeplugin.matchLabels" . }}
+{{- end -}}

--- a/charts/manila-csi-plugin/templates/controllerplugin-clusterrole.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-clusterrole.yaml
@@ -3,12 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "openstack-manila-csi.controllerplugin.fullname" . }}
   labels:
-    app: {{ include "openstack-manila-csi.name" . }}
-    chart: {{ include "openstack-manila-csi.chart" . }}
-    component: {{ .Values.controllerplugin.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- include "openstack-manila-csi.extraLabels" . }}
+    {{- include "openstack-manila-csi.controllerplugin.labels" .  | nindent 4 }}
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:

--- a/charts/manila-csi-plugin/templates/controllerplugin-clusterrolebinding.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-clusterrolebinding.yaml
@@ -3,12 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "openstack-manila-csi.controllerplugin.fullname" . }}
   labels:
-    app: {{ include "openstack-manila-csi.name" . }}
-    chart: {{ include "openstack-manila-csi.chart" . }}
-    component: {{ .Values.controllerplugin.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- include "openstack-manila-csi.extraLabels" . }}
+    {{- include "openstack-manila-csi.controllerplugin.labels" .  | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "openstack-manila-csi.serviceAccountName.controllerplugin" . }}

--- a/charts/manila-csi-plugin/templates/controllerplugin-role.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-role.yaml
@@ -3,12 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "openstack-manila-csi.controllerplugin.fullname" . }}
   labels:
-    app: {{ include "openstack-manila-csi.name" . }}
-    chart: {{ include "openstack-manila-csi.chart" . }}
-    component: {{ .Values.controllerplugin.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- include "openstack-manila-csi.extraLabels" . }}
+    {{- include "openstack-manila-csi.controllerplugin.labels" .  | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["endpoints"]

--- a/charts/manila-csi-plugin/templates/controllerplugin-rolebinding.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-rolebinding.yaml
@@ -3,12 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "openstack-manila-csi.controllerplugin.fullname" . }}
   labels:
-    app: {{ include "openstack-manila-csi.name" . }}
-    chart: {{ include "openstack-manila-csi.chart" . }}
-    component: {{ .Values.controllerplugin.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- include "openstack-manila-csi.extraLabels" . }}
+    {{- include "openstack-manila-csi.controllerplugin.labels" .  | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "openstack-manila-csi.serviceAccountName.controllerplugin" . }}

--- a/charts/manila-csi-plugin/templates/controllerplugin-rules-clusterrole.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-rules-clusterrole.yaml
@@ -3,13 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "openstack-manila-csi.controllerplugin.fullname" . }}-rules
   labels:
-    app: {{ include "openstack-manila-csi.name" . }}
-    chart: {{ include "openstack-manila-csi.chart" . }}
-    component: {{ .Values.controllerplugin.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "openstack-manila-csi.controllerplugin.labels" .  | nindent 4 }}
     rbac.manila.csi.openstack.org/aggregate-to-{{ include "openstack-manila-csi.controllerplugin.fullname" . }}: "true"
-    {{- include "openstack-manila-csi.extraLabels" . }}
 rules:
   - apiGroups: [""]
     resources: ["nodes"]

--- a/charts/manila-csi-plugin/templates/controllerplugin-service.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-service.yaml
@@ -3,12 +3,7 @@ apiVersion: v1
 metadata:
   name: {{ include "openstack-manila-csi.controllerplugin.fullname" . }}
   labels:
-    app: {{ include "openstack-manila-csi.name" . }}
-    chart: {{ include "openstack-manila-csi.chart" . }}
-    component: {{ .Values.controllerplugin.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- include "openstack-manila-csi.extraLabels" . }}
+    {{- include "openstack-manila-csi.controllerplugin.labels" .  | nindent 4 }}
 spec:
   selector:
     app: {{ include "openstack-manila-csi.name" . }}

--- a/charts/manila-csi-plugin/templates/controllerplugin-serviceaccount.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-serviceaccount.yaml
@@ -3,9 +3,4 @@ kind: ServiceAccount
 metadata:
   name: {{ include "openstack-manila-csi.serviceAccountName.controllerplugin" . }}
   labels:
-    app: {{ include "openstack-manila-csi.name" . }}
-    chart: {{ include "openstack-manila-csi.chart" . }}
-    component: {{ .Values.controllerplugin.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- include "openstack-manila-csi.extraLabels" . }}
+    {{- include "openstack-manila-csi.controllerplugin.labels" .  | nindent 4 }}

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -3,28 +3,17 @@ apiVersion: apps/v1
 metadata:
   name: {{ include "openstack-manila-csi.controllerplugin.fullname" . }}
   labels:
-    app: {{ include "openstack-manila-csi.name" . }}
-    chart: {{ include "openstack-manila-csi.chart" . }}
-    component: {{ .Values.controllerplugin.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- include "openstack-manila-csi.extraLabels" . }}
+    {{- include "openstack-manila-csi.controllerplugin.labels" .  | nindent 4 }}
 spec:
   serviceName: {{ include "openstack-manila-csi.controllerplugin.fullname" . }}
   replicas: 1
   selector:
     matchLabels:
-      app: {{ include "openstack-manila-csi.name" . }}
-      component: {{ .Values.controllerplugin.name }}
-      release: {{ .Release.Name }}
+      {{- include "openstack-manila-csi.controllerplugin.matchLabels" .  | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ include "openstack-manila-csi.name" . }}
-        chart: {{ include "openstack-manila-csi.chart" . }}
-        component: {{ .Values.controllerplugin.name }}
-        release: {{ .Release.Name }}
-        heritage: {{ .Release.Service }}
+        {{- include "openstack-manila-csi.controllerplugin.labels" .  | nindent 8 }}
     spec:
       serviceAccountName: {{ include "openstack-manila-csi.serviceAccountName.controllerplugin" . }}
       containers:

--- a/charts/manila-csi-plugin/templates/nodeplugin-clusterrole.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-clusterrole.yaml
@@ -3,12 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "openstack-manila-csi.nodeplugin.fullname" . }}
   labels:
-    app: {{ include "openstack-manila-csi.name" . }}
-    chart: {{ include "openstack-manila-csi.chart" . }}
-    component: {{ .Values.nodeplugin.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- include "openstack-manila-csi.extraLabels" . }}
+    {{- include "openstack-manila-csi.nodeplugin.labels" .  | nindent 4 }}
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:

--- a/charts/manila-csi-plugin/templates/nodeplugin-clusterrolebinding.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-clusterrolebinding.yaml
@@ -3,12 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "openstack-manila-csi.nodeplugin.fullname" . }}
   labels:
-    app: {{ include "openstack-manila-csi.name" . }}
-    chart: {{ include "openstack-manila-csi.chart" . }}
-    component: {{ .Values.nodeplugin.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- include "openstack-manila-csi.extraLabels" . }}
+    {{- include "openstack-manila-csi.nodeplugin.labels" .  | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "openstack-manila-csi.serviceAccountName.nodeplugin" . }}

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -3,26 +3,15 @@ apiVersion: apps/v1
 metadata:
   name: {{ include "openstack-manila-csi.nodeplugin.fullname" . }}
   labels:
-    app: {{ include "openstack-manila-csi.name" . }}
-    chart: {{ include "openstack-manila-csi.chart" . }}
-    component: {{ .Values.nodeplugin.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- include "openstack-manila-csi.extraLabels" . }}
+    {{- include "openstack-manila-csi.nodeplugin.labels" .  | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ include "openstack-manila-csi.name" . }}
-      component: {{ .Values.nodeplugin.name }}
-      release: {{ .Release.Name }}
+      {{- include "openstack-manila-csi.nodeplugin.matchLabels" .  | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ include "openstack-manila-csi.name" . }}
-        chart: {{ include "openstack-manila-csi.chart" . }}
-        component: {{ .Values.nodeplugin.name }}
-        release: {{ .Release.Name }}
-        heritage: {{ .Release.Service }}
+        {{- include "openstack-manila-csi.nodeplugin.labels" .  | nindent 8 }}
     spec:
       serviceAccountName: {{ include "openstack-manila-csi.serviceAccountName.nodeplugin" . }}
       hostNetwork: true

--- a/charts/manila-csi-plugin/templates/nodeplugin-rules-clusterrole.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-rules-clusterrole.yaml
@@ -3,13 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "openstack-manila-csi.nodeplugin.fullname" . }}-rules
   labels:
-    app: {{ include "openstack-manila-csi.name" . }}
-    chart: {{ include "openstack-manila-csi.chart" . }}
-    component: {{ .Values.nodeplugin.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "openstack-manila-csi.nodeplugin.labels" .  | nindent 4 }}
     rbac.manila.csi.openstack.org/aggregate-to-{{ include "openstack-manila-csi.nodeplugin.fullname" . }}: "true"
-    {{- include "openstack-manila-csi.extraLabels" . }}
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]

--- a/charts/manila-csi-plugin/templates/nodeplugin-serviceaccount.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-serviceaccount.yaml
@@ -3,9 +3,4 @@ kind: ServiceAccount
 metadata:
   name: {{ include "openstack-manila-csi.serviceAccountName.nodeplugin" . }}
   labels:
-    app: {{ include "openstack-manila-csi.name" . }}
-    chart: {{ include "openstack-manila-csi.chart" . }}
-    component: {{ .Values.nodeplugin.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- include "openstack-manila-csi.extraLabels" . }}
+    {{- include "openstack-manila-csi.nodeplugin.labels" .  | nindent 4 }}


### PR DESCRIPTION
This PR moves various `labels` listings from individual Kubernetes component manifests into common named templates, into `_helpers.tpl`. This is inspired by (borrowed / stolen from :)) cinder-csi's chart that does this too, and I think is nicer than what manila-csi currently does.

No effective change in rendered YAML output, please see https://gist.github.com/gman0/5b711294cdbbbc7445f426bfd0b44c3f (only some key-value pairs are reordered but that has no real effect).

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
