### PR TITLE
[cinder-csi-plugin] Bump chart to 2.1.1

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.1.0
+version: 2.1.1
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Makes these changes available in a version:
- https://github.com/kubernetes/cloud-provider-openstack/pull/1789
- https://github.com/kubernetes/cloud-provider-openstack/pull/1792

**Which issue this PR fixes(if applicable)**:
See those PRs.

**Special notes for reviewers**:
Included changes since last version, https://github.com/kubernetes/cloud-provider-openstack/releases/tag/openstack-cinder-csi-2.1.0:
```shell
$ git log --oneline openstack-cinder-csi-2.1.0.. charts/cinder-csi-plugin
31236ba [cinder-csi-plugin] Configurable secret filename (#1789)
c55b41d [Cinder-csi-plugin] Provide capability to add extra labels for Cinder (#1792)
204a990 Updated CLOUD_CONFIG in helm chart. (#1747)
0d1d1ec [helm charts] Make the chart versions consistent with release-1.23 (#1745)
```

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[cinder-csi-plugin] Make CLOUD_CONFIG secret keys consistent in helm chart for better re-usability 
[cinder-csi-plugin] Make CLOUD_CONFIG secret filename configurable in helm chart for backwards-compatibility
[cinder-csi-plugin] Adding optional extra labels to be set in `.Values.extraLabels` in Helm Chart.
```
