### PR TITLE
[manila-csi-plugin] Update e2e tests to re-use occm role

### DIFF
--- a/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
@@ -47,87 +47,6 @@
 
       kubectl create secret -n kube-system generic cloud-config --from-file={{ ansible_user_dir }}/cloud.conf
 
-- name: Deploy openstack-cloud-controller-manager
-  shell:
-    executable: /bin/bash
-    cmd: |
-      set -x
-
-      cat <<EOF | kubectl apply -f -
-      ---
-      apiVersion: v1
-      kind: ServiceAccount
-      metadata:
-        name: cloud-controller-manager
-        namespace: kube-system
-      ---
-      apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRoleBinding
-      metadata:
-        name: system:cloud-controller-manager
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: cluster-admin
-      subjects:
-      - kind: ServiceAccount
-        name: cloud-controller-manager
-        namespace: kube-system
-      ---
-      apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        name: openstack-cloud-controller-manager
-        namespace: kube-system
-        labels:
-          k8s-app: openstack-cloud-controller-manager
-      spec:
-        replicas: 1
-        selector:
-          matchLabels:
-            k8s-app: openstack-cloud-controller-manager
-        template:
-          metadata:
-            labels:
-              k8s-app: openstack-cloud-controller-manager
-          spec:
-            tolerations:
-            - key: node.cloudprovider.kubernetes.io/uninitialized
-              value: "true"
-              effect: NoSchedule
-            - key: node-role.kubernetes.io/master
-              effect: NoSchedule
-            serviceAccountName: cloud-controller-manager
-            containers:
-              - name: openstack-cloud-controller-manager
-                image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:latest
-                args:
-                  - /bin/openstack-cloud-controller-manager
-                  - --cloud-config=/etc/config/cloud.conf
-                  - --cloud-provider=openstack
-                  - --use-service-account-credentials=true
-                  - --bind-address=127.0.0.1
-                volumeMounts:
-                  - mountPath: /etc/config
-                    name: cloud-config-volume
-                    readOnly: true
-            hostNetwork: true
-            volumes:
-            - name: cloud-config-volume
-              secret:
-                secretName: cloud-config
-      EOF
-
-- name: Wait for openstack-cloud-controller-manager up and running
-  shell:
-    executable: /bin/bash
-    cmd: |
-      kubectl -n kube-system get pod | grep openstack-cloud-controller-manager | grep Running
-  register: check_occm
-  until: check_occm.rc == 0
-  retries: 24
-  delay: 5
-
 - name: Deploy Kubernetes VolumeSnapshot CRDs and snapshot controller
   shell:
     executable: /bin/bash
@@ -223,7 +142,7 @@
   until: check_csi_controller.rc == 0
   retries: 24
   delay: 5
-  ignore_errors: yes
+  ignore_errors: true
 
 - name: Wait for manila-csi-plugin node plugin up and running
   shell:
@@ -234,7 +153,7 @@
   until: check_csi_node.rc == 0
   retries: 24
   delay: 5
-  ignore_errors: yes
+  ignore_errors: true
 
 - name: Gather additional evidence if csi-manila-plugin failed to come up
   when: check_csi_controller.failed or check_csi_node.failed

--- a/tests/playbooks/test-csi-manila-e2e.yaml
+++ b/tests/playbooks/test-csi-manila-e2e.yaml
@@ -23,6 +23,9 @@
     - role: install-docker
     - role: install-docker-registry
       cert_hosts: ' ["{{ ansible_default_ipv4.address }}"]'
+    - role: install-cpo-occm
+      run_e2e: false
+      build_image: false
     - role: install-helm
     - role: install-csi-manila
       environment: "{{ global_env }}"


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This PR updates e2e job of manila csi plugin to reuse existing occm role

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
