### PR TITLE
[occm] Allow service status changes in ClusterRole

### DIFF
--- a/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
@@ -43,6 +43,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts/token
   verbs:
   - create

--- a/manifests/controller-manager/cloud-controller-manager-roles.yaml
+++ b/manifests/controller-manager/cloud-controller-manager-roles.yaml
@@ -45,6 +45,12 @@ items:
   - apiGroups:
     - ""
     resources:
+    - services/status
+    verbs:
+    - patch
+  - apiGroups:
+    - ""
+    resources:
     - serviceaccounts
     verbs:
     - create


### PR DESCRIPTION
**What this PR does / why we need it**:
This modification allows the Openstack Cloud Controller Manager to send `PATCH` requests specifically for the Status field of a Service (across all namespaces).
This is required when the OCCM uses it's own service account to modify the Service resource (i.e. with `--use-service-account-credentials=false`).

Without this permission I encountered the following error message when installing the Helm chart (from master) and using `--use-service-account-credentials=false`:

```
E0228 11:04:53.120584       1 controller.go:310] error processing service default/my-lb (will retry): failed to add load balancer cleanup finalizer: services "my-lb" is forbidden: User "system:serviceaccount:NAMESPACE:openstack-cloud-controller-manager" cannot patch resource "services/status" in API group "" in the namespace "default"
```

**Which issue this PR fixes(if applicable)**:

This was discussed in https://github.com/kubernetes/cloud-provider-openstack/issues/1722#issuecomment-1054037751

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[occm] Add PATCH services/status permission for ServiceAccount in Helm chart.
```
