### PR TITLE
[cinder-csi-plugin]update doc on minor issues

### DIFF
--- a/docs/cinder-csi-plugin/features.md
+++ b/docs/cinder-csi-plugin/features.md
@@ -66,7 +66,7 @@ Not all hypervizors have a `/sys/class/block/XXX/device/rescan` location, theref
 This feature enables creating volume snapshots and restore volume from snapshot. The corresponding CSI feature (VolumeSnapshotDataSource) is GA since kubernetes 1.20.
 
 * To avail the feature. deploy the snapshot-controller and CRDs as part of their Kubernetes cluster management process (independent of any CSI Driver) . For more info, refer [Snapshot Controller](https://kubernetes-csi.github.io/docs/snapshot-controller.html)
-* For example on using snapshot feature, refer [sample app](./examples#snapshot-create-and-restore)
+* For example on using snapshot feature, refer [sample app](./examples.md#snapshot-create-and-restore)
 
 ## Ephemeral Volumes
 

--- a/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
+++ b/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
@@ -170,8 +170,8 @@ To get information about CSI Drivers running in a cluster -
 
 ```
 $ kubectl get csidrivers.storage.k8s.io
-NAME                       CREATED AT
-cinder.csi.openstack.org   2019-07-29T09:02:40Z
+NAME                       ATTACHREQUIRED   PODINFOONMOUNT   STORAGECAPACITY   TOKENREQUESTS   REQUIRESREPUBLISH   MODES                  AGE
+cinder.csi.openstack.org   true             true             false             <unset>         false               Persistent,Ephemeral   19h
 
 ```
 


### PR DESCRIPTION
1) update output of kubectl get csidrivers.storage.k8s.io
2) a incorrect link

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
