### PR TITLE
[OCCM] Add --cluster-name=$(CLUSTER_NAME) support

### DIFF
--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -37,6 +37,7 @@ spec:
             - /bin/openstack-cloud-controller-manager
             - --v={{ .Values.logVerbosityLevel }}
             - --cloud-config=$(CLOUD_CONFIG)
+            - --cluster-name=$(CLUSTER_NAME)
             - --cloud-provider=openstack
             - --use-service-account-credentials=true
             - --controllers={{- trimAll "," (include "occm.enabledControllers" . ) -}}
@@ -79,6 +80,8 @@ spec:
           env:
             - name: CLOUD_CONFIG
               value: /etc/config/cloud.conf
+            - name: CLUSTER_NAME
+              value: {{ .Values.cluster.name }}
       {{- if .Values.extraInitContainers }}
       initContainers: {{ toYaml .Values.extraInitContainers | nindent 6 }}
       {{- end }}

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -115,3 +115,7 @@ extraVolumeMounts:
   - name: k8s-certs
     mountPath: /etc/kubernetes/pki
     readOnly: true
+
+# cluster name that used for created cluster
+cluster:
+  name: kubernetes

--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -40,6 +40,7 @@ spec:
           args:
             - /bin/openstack-cloud-controller-manager
             - --v=1
+            - --cluster-name=$(CLUSTER_NAME)
             - --cloud-config=$(CLOUD_CONFIG)
             - --cloud-provider=openstack
             - --use-service-account-credentials=true
@@ -60,6 +61,8 @@ spec:
           env:
             - name: CLOUD_CONFIG
               value: /etc/config/cloud.conf
+            - name: CLUSTER_NAME
+              value: kubernetes
       hostNetwork: true
       volumes:
       - hostPath:

--- a/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
@@ -15,6 +15,7 @@ spec:
       args:
         - /bin/openstack-cloud-controller-manager
         - --v=1
+        - --cluster-name=$(CLUSTER_NAME)
         - --cloud-config=$(CLOUD_CONFIG)
         - --cloud-provider=openstack
         - --use-service-account-credentials=true
@@ -35,6 +36,8 @@ spec:
       env:
         - name: CLOUD_CONFIG
           value: /etc/config/cloud.conf
+        - name: CLUSTER_NAME
+          value: kubernetes
   hostNetwork: true
   securityContext:
     runAsUser: 1001


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #1807 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
