### PR TITLE
[cinder-csi-plugin] nit: improve logs

### DIFF
--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -354,7 +354,7 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 			return nil, status.Error(codes.AlreadyExists, "Snapshot with given name already exists, with different source volume ID")
 		}
 
-		klog.V(3).Infof("Found existing snapshot %s on %s", name, volumeID)
+		klog.V(3).Infof("Found existing snapshot %s from volume with ID: %s", name, volumeID)
 
 	} else if len(snapshots) > 1 {
 		klog.Errorf("found multiple existing snapshots with selected name (%s) during create", name)
@@ -381,7 +381,7 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 			return nil, status.Error(codes.Internal, fmt.Sprintf("CreateSnapshot failed with error %v", err))
 		}
 
-		klog.V(3).Infof("CreateSnapshot %s on %s", name, volumeID)
+		klog.V(3).Infof("CreateSnapshot %s from volume with ID: %s", name, volumeID)
 	}
 
 	ctime := timestamppb.New(snap.CreatedAt)


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

updated some logs to make log clear

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
