### PR TITLE
[cinder-csi-pluging] Add pod logs for cinder e2e

### DIFF
--- a/tests/ci-csi-cinder-e2e.sh
+++ b/tests/ci-csi-cinder-e2e.sh
@@ -109,10 +109,10 @@ ansible-playbook -v \
   -e github_pr_branch=${PR_BRANCH}
 exit_code=$?
 
-# Fetch cinder-csi e2e tests logs for debugging purpose
+# Fetch cinder-csi tests logs for debugging purpose
 scp -i ~/.ssh/google_compute_engine \
   -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-  -r ${USERNAME}@${PUBLIC_IP}:/var/log/cinder-csi-e2e.log $ARTIFACTS/logs/cinder-csi-e2e.log || true
+  -r ${USERNAME}@${PUBLIC_IP}:/var/log/csi-pod/* $ARTIFACTS/logs/ || true
 
 # If Boskos is being used then release the resource back to Boskos.
 [ -z "${BOSKOS_HOST:-}" ] || python3 tests/scripts/boskos.py --release >> "$ARTIFACTS/logs/boskos.log" 2>&1

--- a/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
@@ -123,4 +123,21 @@
       set -o pipefail
 
       cd $GOPATH/src/k8s.io/cloud-provider-openstack
-      go test -v ./cmd/tests/cinder-csi-e2e-suite/cinder_csi_e2e_suite_test.go -ginkgo.v -ginkgo.progress -ginkgo.skip="\[Disruptive\]" -ginkgo.focus="\[cinder-csi-e2e\]" -ginkgo.noColor -timeout=0 -report-dir="/var/log/" | tee "/var/log/cinder-csi-e2e.log"
+      mkdir /var/log/csi-pod
+      go test -v ./cmd/tests/cinder-csi-e2e-suite/cinder_csi_e2e_suite_test.go -ginkgo.v -ginkgo.progress -ginkgo.skip="\[Disruptive\]" -ginkgo.focus="\[cinder-csi-e2e\]" -ginkgo.noColor -timeout=0 -report-dir="/var/log/csi-pod" | tee "/var/log/csi-pod/cinder-csi-e2e.log"
+  register: functional_test_result
+  ignore_errors: true
+
+- name: Collect pod logs for debug purpose
+  shell:
+    executable: /bin/bash
+    cmd: |
+      set -x
+      set -e
+      
+      kubectl logs deployment/csi-cinder-controllerplugin -n kube-system -c cinder-csi-plugin > /var/log/csi-pod/csi-cinder-controllerplugin.log
+      kubectl logs daemonset/csi-cinder-nodeplugin -n kube-system -c cinder-csi-plugin > /var/log/csi-pod/csi-cinder-nodeplugin.log
+  ignore_errors: true
+
+- fail: msg="The execution has failed because of errors."
+  when: functional_test_result.failed


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

add more logs for Cinder CSI pod for debug purpose

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
