### PR TITLE
Fix lint issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ fmt:
 lint:
 ifndef HAS_LINT
 	echo "installing lint"
-	go get -u golang.org/x/lint/golint
+	go install golang.org/x/lint/golint@latest
 endif
 	hack/verify-golint.sh
 

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -24,7 +24,7 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 if ! which golint > /dev/null; then
   echo 'Can not find golint, install with:'
-  echo 'go get -u github.com/golang/lint/golint'
+  echo 'go install golang.org/x/lint/golint@latest'
   exit 1
 fi
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #1816 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
