### PR TITLE
[occm] Get occm pod logs when CI job fails

### DIFF
--- a/tests/playbooks/roles/install-cpo-occm/defaults/main.yaml
+++ b/tests/playbooks/roles/install-cpo-occm/defaults/main.yaml
@@ -8,5 +8,5 @@ build_image: false
 run_e2e: false
 # Used for access the private registry image from k8s
 remote_registry_host: "{{ ansible_default_ipv4.address }}"
-generated_image_url: "{{ remote_registry_host }}/openstack-cloud-controller-manager-amd64:{{ github_pr }}"
+generated_image_url: "{{ remote_registry_host }}/openstack-cloud-controller-manager-amd64:v0.0.{{ github_pr }}"
 image_url: "{{ generated_image_url if build_image else 'docker.io/k8scloudprovider/openstack-cloud-controller-manager:latest' }}"

--- a/tests/playbooks/roles/install-cpo-occm/tasks/main.yaml
+++ b/tests/playbooks/roles/install-cpo-occm/tasks/main.yaml
@@ -18,7 +18,7 @@
       cd $GOPATH/src/k8s.io/cloud-provider-openstack
 
       REGISTRY={{ image_registry_host }} \
-      VERSION={{ github_pr }} \
+      VERSION=v0.0.{{ github_pr }} \
       IMAGE_NAMES=openstack-cloud-controller-manager \
       make upload-image-amd64
 
@@ -136,7 +136,7 @@
   register: check_occm
   until: check_occm.rc == 0
   retries: 24
-  delay: 5  
+  delay: 5
   ignore_errors: true
 
 - name: Gather additional evidence if openstack-cloud-controller-manager failed to come up
@@ -153,6 +153,12 @@
     - name: Log failed openstack-cloud-controller-manager deployment
       debug:
         var: describe_occm.stdout_lines
+
+    - name: Show openstack-cloud-controller-manager pod logs
+      shell:
+        executable: /bin/bash
+        cmd: |
+          kubectl -n kube-system logs deployment/openstack-cloud-controller-manager
 
     - name: &failmsg Stop due to prior failure of openstack-cloud-controller-manager
       fail:


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Currently when the CI job fails, we can't see the pod logs, making it hard for troubleshooting.

This PR also fixes the image tag issue.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
