### PR TITLE
[occm] Remove finalizer from Service

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -359,7 +359,7 @@ func getLoadbalancerByName(client *gophercloud.ServiceClient, name string, legac
 		Name: name,
 	}
 	allLoadbalancers, err := openstackutil.GetLoadBalancers(client, opts)
-	if err != nil {
+	if err != nil && !cpoerrors.IsNotFound(err) {
 		return nil, err
 	}
 
@@ -370,7 +370,7 @@ func getLoadbalancerByName(client *gophercloud.ServiceClient, name string, legac
 				Name: legacyName,
 			}
 			allLoadbalancers, err = openstackutil.GetLoadBalancers(client, opts)
-			if err != nil {
+			if err != nil && !cpoerrors.IsNotFound(err) {
 				return nil, err
 			}
 		} else {


### PR DESCRIPTION
When the load-balancer creation is not handled
by the CCM, the Service still gets a finalizer
named "service.kubernetes.io/load-balancer-cleanup"
added to it. The finalizer existence is blocking
Services from being deleted as the finalizer is not
cleaned up when an exception is raised of load-balancer
not found. This commit fixes the issue by ensuring not
found exceptions are ignored and allowing the
finalizer to be removed.

