### PR TITLE
[cinder-csi-plugin]add 'force-create' into tag param to support force…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ fmt:
 lint:
 ifndef HAS_LINT
 	echo "installing lint"
-	go get -u golang.org/x/lint/golint
+	go install golang.org/x/lint/golint@latest
 endif
 	hack/verify-golint.sh
 

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -365,7 +365,10 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		properties := map[string]string{cinderCSIClusterIDKey: cs.Driver.cluster}
 
 		// see https://github.com/kubernetes-csi/external-snapshotter/pull/375/
-		for _, mKey := range []string{"csi.storage.k8s.io/volumesnapshot/name", "csi.storage.k8s.io/volumesnapshot/namespace", "csi.storage.k8s.io/volumesnapshotcontent/name"} {
+		// Also, we don't want to tag every param but we still want to send the
+		// 'force-create' flag to openstack layer so that we will honor the
+		// force create functions
+		for _, mKey := range []string{"csi.storage.k8s.io/volumesnapshot/name", "csi.storage.k8s.io/volumesnapshot/namespace", "csi.storage.k8s.io/volumesnapshotcontent/name", openstack.SnapshotForceCreate} {
 			if v, ok := req.Parameters[mKey]; ok {
 				properties[mKey] = v
 			}

--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -441,6 +441,7 @@ func TestCreateSnapshotWithExtraMetadata(t *testing.T) {
 		"csi.storage.k8s.io/volumesnapshot/name":        FakeSnapshotName,
 		"csi.storage.k8s.io/volumesnapshotcontent/name": FakeSnapshotContentName,
 		"csi.storage.k8s.io/volumesnapshot/namespace":   FakeSnapshotNamespace,
+		openstack.SnapshotForceCreate:                   "true",
 	}
 
 	osmock.On("CreateSnapshot", FakeSnapshotName, FakeVolID, &properties).Return(&FakeSnapshotRes, nil)
@@ -458,6 +459,7 @@ func TestCreateSnapshotWithExtraMetadata(t *testing.T) {
 			"csi.storage.k8s.io/volumesnapshot/name":        FakeSnapshotName,
 			"csi.storage.k8s.io/volumesnapshotcontent/name": FakeSnapshotContentName,
 			"csi.storage.k8s.io/volumesnapshot/namespace":   FakeSnapshotNamespace,
+			openstack.SnapshotForceCreate:                   "true",
 		},
 	}
 

--- a/pkg/csi/cinder/openstack/openstack_snapshots.go
+++ b/pkg/csi/cinder/openstack/openstack_snapshots.go
@@ -37,7 +37,7 @@ const (
 	snapReadySteps      = 10
 
 	snapshotDescription = "Created by OpenStack Cinder CSI driver"
-	snapshotForceCreate = "force-create"
+	SnapshotForceCreate = "force-create"
 )
 
 // CreateSnapshot issues a request to take a Snapshot of the specified Volume with the corresponding ID and
@@ -47,14 +47,14 @@ func (os *OpenStack) CreateSnapshot(name, volID string, tags *map[string]string)
 	force := false
 	// if no flag given, then force will be false by default
 	// if flag it given , check it
-	if item, ok := (*tags)[snapshotForceCreate]; ok {
+	if item, ok := (*tags)[SnapshotForceCreate]; ok {
 		var err error
 		force, err = strconv.ParseBool(item)
 		if err != nil {
 			klog.V(5).Infof("Make force create flag to false due to: %v", err)
 		}
 
-		delete(*tags, snapshotForceCreate)
+		delete(*tags, SnapshotForceCreate)
 	}
 	// Force the creation of snapshot even the Volume is in in-use state
 	opts := &snapshots.CreateOpts{


### PR DESCRIPTION
… create

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

https://github.com/kubernetes/cloud-provider-openstack/pull/1813
1.23 version 

also, there is a golint issue , fixed in this PR as well

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
