### PR TITLE
[occm] Remove trailing bracket from healthmonitor

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -2253,7 +2253,7 @@ func (lbaas *LbaasV2) ensureLoadBalancer(ctx context.Context, clusterName string
 				monitorProtocol = "UDP-CONNECT"
 			}
 			createOpts := v2monitors.CreateOpts{
-				Name:       cutString(fmt.Sprintf("monitor_%d_%s)", portIndex, name)),
+				Name:       cutString(fmt.Sprintf("monitor_%d_%s", portIndex, name)),
 				PoolID:     pool.ID,
 				Type:       monitorProtocol,
 				Delay:      int(lbaas.opts.MonitorDelay.Duration.Seconds()),


### PR DESCRIPTION


<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

I noticed that OCCM would create healthmonitors named like this (note the trailing bracket)
> monitor_1_kube_service_CLUSTER_NAMESPACE_SERVICE)

It turns out there is minor typo in the code, fixed with this patch.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
