### PR TITLE
[cinder-csi-plugin] Add doc for volume expansion

### DIFF
--- a/docs/cinder-csi-plugin/troubleshooting.md
+++ b/docs/cinder-csi-plugin/troubleshooting.md
@@ -1,0 +1,13 @@
+# Troubleshooting
+
+## When trying to resize a Cinder Volume based on Ceph, the VM doesn't see the new size.
+
+Chances are, the underlying OpenStack is not configured properly.
+This could be tested by manually creating a VM and Volume, attaching and resizing the Volume.
+If you see the same behaviour, no change of the Volume in the VM, try to get in contact with the Admin-Team of the OpenStack you are using.
+
+Chances are, Cinder is not allowed to send the `volume-extended` event to [Nova API](https://docs.openstack.org/api-ref/compute/?expanded=run-events-detail#run-events).
+The error likely can be spotted as a 403 in the logs.
+
+In that case. The section `nova` in [`cinder.conf`](https://docs.openstack.org/cinder/latest/configuration/block-storage/samples/cinder.conf.html)
+must be configured properly, and with a user with sufficient privileges.


### PR DESCRIPTION
**What this PR does / why we need it**:

In the past I saw this question bubbling up several times and it is hard
to find an good answer on the internet.


<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
