### PR TITLE
[cinder-csi-plugin] relocate junit files from test results

### DIFF
--- a/tests/ci-csi-cinder-e2e.sh
+++ b/tests/ci-csi-cinder-e2e.sh
@@ -113,6 +113,8 @@ exit_code=$?
 scp -i ~/.ssh/google_compute_engine \
   -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
   -r ${USERNAME}@${PUBLIC_IP}:/var/log/csi-pod/* $ARTIFACTS/logs/ || true
+# Place junit files in a propper location to be picked up by testgrid
+mv $ARTIFACTS/logs/junit* $ARTIFACTS/ || true
 
 # If Boskos is being used then release the resource back to Boskos.
 [ -z "${BOSKOS_HOST:-}" ] || python3 tests/scripts/boskos.py --release >> "$ARTIFACTS/logs/boskos.log" 2>&1


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This PR relocates junit files so that they are picked up by testgrid.

See build number 1526550932089737216
* [testgrid/provider-openstack-openstack-csi-cinder](https://testgrid.k8s.io/provider-openstack-openstack-csi-cinder#presubmit-e2e-test)
* [prow/openstack-cloud-csi-cinder-e2e-test](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/directory/openstack-cloud-csi-cinder-e2e-test/1526550932089737216)

**Which issue this PR fixes(if applicable)**:
fixes #1866

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
