### PR TITLE
Add Github Actions release pipeline

### DIFF
--- a/.github/workflows/release-cpo.yaml
+++ b/.github/workflows/release-cpo.yaml
@@ -1,4 +1,4 @@
-name: Release
+name: Release CPO
 
 on:
   push:

--- a/.github/workflows/release-occm.yaml
+++ b/.github/workflows/release-occm.yaml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-    - 'v[0-9]+.[0-9]+.[0-9]+'
+    - 'v[0-9]+.[0-9]+.[0-9]+.*'
 
 jobs:
   release:
@@ -31,10 +31,6 @@ jobs:
       run: |
         REGISTRY=docker.io/k8scloudprovider ARCHS='amd64 arm arm64 ppc64le s390x' GOOS=linux VERSION=${{ github.event.release.tag_name }} make upload-images
 
-    - name: build dist
-      run: |
-        VERSION=${{ github.event.release.tag_name }} make dist
-
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1
@@ -47,10 +43,3 @@ jobs:
           todo
         draft: true
         prerelease: false
-
-    - name: upload assets
-      uses: softprops/action-gh-release@v1
-      with:
-        files: |
-          _dist/*.tar.gz
-          _dist/*.zip

--- a/.github/workflows/release-occm.yaml
+++ b/.github/workflows/release-occm.yaml
@@ -1,0 +1,56 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - uses: actions/setup-go@v3
+      with:
+        go-version: 1.17
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to docker hub
+      uses: docker/login-action@v1
+      with:
+        registry: docker.io
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: build & publish images
+      run: |
+        REGISTRY=docker.io/k8scloudprovider ARCHS='amd64 arm arm64 ppc64le s390x' GOOS=linux VERSION=${{ github.event.release.tag_name }} make upload-images
+
+    - name: build dist
+      run: |
+        VERSION=${{ github.event.release.tag_name }} make dist
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        body: |
+          todo
+        draft: true
+        prerelease: false
+
+    - name: upload assets
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          _dist/*.tar.gz
+          _dist/*.zip

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ manila-csi-plugin: work $(SOURCES)
 # Remove this individual go build target, once we remove
 # image-controller-manager below.
 openstack-cloud-controller-manager: work $(SOURCES)
-	CGO_ENABLED=0 GOOS=$(GOOS) go build \
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build \
 		-ldflags $(LDFLAGS) \
 		-o openstack-cloud-controller-manager-$(ARCH) \
 		cmd/openstack-cloud-controller-manager/main.go
@@ -305,7 +305,7 @@ version:
 build-cross: work
 ifndef HAS_GOX
 	echo "installing gox"
-	go get -u github.com/mitchellh/gox
+	go install github.com/mitchellh/gox
 endif
 	CGO_ENABLED=0 gox -parallel=$(GOX_PARALLEL) -output="_dist/{{.OS}}-{{.Arch}}/{{.Dir}}" -osarch='$(TARGETS)' $(GOFLAGS) $(if $(TAGS),-tags '$(TAGS)',) -ldflags '$(GOX_LDFLAGS)' $(GIT_HOST)/$(BASE_DIR)/cmd/openstack-cloud-controller-manager/
 	CGO_ENABLED=0 gox -parallel=$(GOX_PARALLEL) -output="_dist/{{.OS}}-{{.Arch}}/{{.Dir}}" -osarch='$(TARGETS)' $(GOFLAGS) $(if $(TAGS),-tags '$(TAGS)',) -ldflags '$(GOX_LDFLAGS)' $(GIT_HOST)/$(BASE_DIR)/cmd/cinder-csi-plugin/

--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,8 @@ require (
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mgutz/str v1.2.0 // indirect
+	github.com/mitchellh/gox v1.0.1 // indirect
+	github.com/mitchellh/iochan v1.0.0 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -368,6 +368,7 @@ github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdv
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.4.0 h1:aAQzgqIrRKRa7w75CKpbBxYsmUoPjzVm1W59ca1L0J4=
 github.com/hashicorp/go-version v1.4.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
@@ -466,6 +467,9 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
+github.com/mitchellh/gox v1.0.1 h1:x0jD3dcHk9a9xPSDN6YEL4xL6Qz0dvNYm8yZqui5chI=
+github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
+github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/release-procedure.md
+++ b/release-procedure.md
@@ -22,7 +22,7 @@ $ git tag -m "Release for cloud-provider-openstack to support Kubernetes release
 $ git push upstream vX.Y.Z
 ```
 
-3. Github Actions will make the new docker images, build the binary packages and make new draft release to repository.
+3. Github Actions will make the new docker images and make new draft release to repository.
 
 4. Update manifests with new release images, create a PR against release branch to update.
 

--- a/release-procedure.md
+++ b/release-procedure.md
@@ -15,39 +15,15 @@ $ git fetch upstream
 $ git checkout -b release-X.Y upstream/release-X.Y
 ```
 
-2. Sign tag and push to upstream repo. You will need your GPG pass phrase. Check if you have a key using `gpg --list-secret-keys --keyid-format LONG`
+2. Make tag and push to upstream repo.
 
 ```
-$ git tag -s -m "Release for cloud-provider-openstack to support Kubernetes release x" vX.Y.Z
+$ git tag -m "Release for cloud-provider-openstack to support Kubernetes release x" vX.Y.Z
 $ git push upstream vX.Y.Z
 ```
-3. Build and push images to dockerhub. Provide `ARCHS` if needs to push only for specific types of architecture (for example `ARCHS='arm64 amd64'` or `ARCHS='amd64'`).
-Don't need to provide `DOCKER_USERNAME` and `DOCKER_PASSWORD` if you already logged in.
 
-```
-GOOS=linux DOCKER_USERNAME=user DOCKER_PASSWORD=my_password REGISTRY=docker.io/k8scloudprovider VERSION=vX.Y.Z make upload-images
-```
+3. Github Actions will make the new docker images, build the binary packages and make new draft release to repository.
 
 4. Update manifests with new release images, create a PR against release branch to update.
 
-5. Create entry in GitHub
-```
-https://github.com/kubernetes/cloud-provider-openstack/releases
-```
-Click on "Draft a new release", fill out the tag, title and description field and click on "Publish release"
-
-4. Sign the tarball with your key and upload vX.Y.Z.tar.gz.asc and vX.Y.Z.zip.asc
-
-```
-gpg --armor --detach-sign vX.Y.Z.tar.gz
-gpg --armor --detach-sign vX.Y.Z.zip
-```
-
-6 Make the binaries, sign them and upload them
-
-```
-VERSION=vX.Y.Z make dist
-cd _dist
-find . -name "*.tar.gz" -exec gpg --armor --detach-sign {} \;
-find . -name "*.zip" -exec gpg --armor --detach-sign {} \;
-```
+5. Make release notes and publish the release.


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
