### PR TITLE
[magnum-auto-healer] Refactor autohealing to improve code climate

### DIFF
--- a/pkg/autohealing/cloudprovider/register/register.go
+++ b/pkg/autohealing/cloudprovider/register/register.go
@@ -70,8 +70,7 @@ func registerOpenStack(cfg config.Config, kubeClient kubernetes.Interface) (clou
 		return nil, fmt.Errorf("failed to find Cinder service endpoint in the region %s: %v", cfg.OpenStack.Region, err)
 	}
 
-	var p cloudprovider.CloudProvider
-	p = openstack.OpenStackCloudProvider{
+	p := openstack.CloudProvider{
 		KubeClient: kubeClient,
 		Nova:       novaClient,
 		Heat:       heatClient,

--- a/pkg/autohealing/cmd/root.go
+++ b/pkg/autohealing/cmd/root.go
@@ -96,7 +96,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.kube_autohealer_config.yaml)")
 
 	log.InitFlags(nil)
-	goflag.CommandLine.Parse(nil)
+	_ = goflag.CommandLine.Parse(nil)
 	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 }
 

--- a/pkg/autohealing/healthcheck/plugin_nodecondition.go
+++ b/pkg/autohealing/healthcheck/plugin_nodecondition.go
@@ -50,7 +50,7 @@ func (check *NodeConditionCheck) Check(node NodeInfo, controller NodeController)
 
 	for _, cond := range node.KubeNode.Status.Conditions {
 		if utils.Contains(check.Types, string(cond.Type)) {
-			unhealthyDuration := time.Now().Sub(cond.LastTransitionTime.Time)
+			unhealthyDuration := time.Since(cond.LastTransitionTime.Time)
 
 			if len(check.ErrorValues) > 0 {
 				if utils.Contains(check.ErrorValues, string(cond.Status)) {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Refactor magnum-auto-healer to make golangci-lint happy.

**Which issue this PR fixes(if applicable)**:
Relates to #1883

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
