### PR TITLE
[manila-csi-plugin] Refactor csi-manila to improve code climate

### DIFF
--- a/pkg/csi/manila/csiclient/builder.go
+++ b/pkg/csi/manila/csiclient/builder.go
@@ -18,12 +18,14 @@ package csiclient
 
 import (
 	"context"
+	"sync/atomic"
+	"time"
+
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
 	"k8s.io/klog/v2"
-	"sync/atomic"
-	"time"
 )
 
 var (
@@ -31,7 +33,11 @@ var (
 
 	dialOptions = []grpc.DialOption{
 		grpc.WithInsecure(),
-		grpc.WithBackoffMaxDelay(time.Second),
+		grpc.WithConnectParams(grpc.ConnectParams{
+			Backoff: backoff.Config{
+				MaxDelay: time.Second,
+			},
+		}),
 		grpc.WithBlock(),
 		// CSI connections use unix:// so should ignore proxy settings
 		// WithNoProxy can be removed when we update to gRPC >= v1.34,

--- a/pkg/csi/manila/csiclient/builder.go
+++ b/pkg/csi/manila/csiclient/builder.go
@@ -35,7 +35,10 @@ var (
 		grpc.WithInsecure(),
 		grpc.WithConnectParams(grpc.ConnectParams{
 			Backoff: backoff.Config{
-				MaxDelay: time.Second,
+				BaseDelay:  1.0 * time.Second,
+				Multiplier: 1.6,
+				Jitter:     0.2,
+				MaxDelay:   time.Second,
 			},
 		}),
 		grpc.WithBlock(),

--- a/pkg/csi/manila/driver.go
+++ b/pkg/csi/manila/driver.go
@@ -283,14 +283,6 @@ func (s *nonBlockingGRPCServer) wait() {
 	s.wg.Wait()
 }
 
-func (s *nonBlockingGRPCServer) stop() {
-	s.server.GracefulStop()
-}
-
-func (s *nonBlockingGRPCServer) forceStop() {
-	s.server.Stop()
-}
-
 func (s *nonBlockingGRPCServer) serve(endpoint string, ids *identityServer, cs *controllerServer, ns *nodeServer) {
 	proto, addr, err := parseGRPCEndpoint(endpoint)
 	if err != nil {

--- a/pkg/csi/manila/nodeserver.go
+++ b/pkg/csi/manila/nodeserver.go
@@ -83,7 +83,7 @@ func (ns *nodeServer) buildVolumeContext(volID volumeID, shareOpts *options.Node
 
 	// Verify the plugin supports this share
 
-	if strings.ToLower(share.ShareProto) != strings.ToLower(ns.d.shareProto) {
+	if !strings.EqualFold(share.ShareProto, ns.d.shareProto) {
 		return nil, nil, status.Errorf(codes.InvalidArgument,
 			"wrong share protocol %s for volume %s, the plugin is set to operate in %s",
 			share.ShareProto, volID, ns.d.shareProto)

--- a/pkg/csi/manila/share.go
+++ b/pkg/csi/manila/share.go
@@ -137,7 +137,7 @@ func extendShare(shareID string, newSizeInGiB int, manilaClient manilaclient.Int
 			return nil, status.Errorf(codes.DeadlineExceeded, "deadline exceeded while waiting for volume ID %s to become available", share.Name)
 		}
 
-		return nil, status.Errorf(manilaErrCode.toRpcErrorCode(), "failed to resize volume %s: %v", share.Name, err)
+		return nil, status.Errorf(manilaErrCode.toRPCErrorCode(), "failed to resize volume %s: %v", share.Name, err)
 	}
 
 	return share, nil

--- a/pkg/csi/manila/snapshot.go
+++ b/pkg/csi/manila/snapshot.go
@@ -28,11 +28,10 @@ import (
 )
 
 const (
-	snapshotCreating      = "creating"
-	snapshotDeleting      = "deleting"
-	snapshotError         = "error"
-	snapshotErrorDeleting = "error_deleting"
-	snapshotAvailable     = "available"
+	snapshotCreating  = "creating"
+	snapshotDeleting  = "deleting"
+	snapshotError     = "error"
+	snapshotAvailable = "available"
 
 	snapshotDescription = "snapshotted-by=manila.csi.openstack.org"
 )

--- a/pkg/csi/manila/util.go
+++ b/pkg/csi/manila/util.go
@@ -33,8 +33,7 @@ import (
 )
 
 type (
-	volumeID   string
-	snapshotID string
+	volumeID string
 )
 
 const (
@@ -43,7 +42,7 @@ const (
 
 type manilaError int
 
-func (c manilaError) toRpcErrorCode() codes.Code {
+func (c manilaError) toRPCErrorCode() codes.Code {
 	switch c {
 	case manilaErrNoValidHost:
 		return codes.OutOfRange
@@ -143,7 +142,7 @@ func lastResourceError(resourceID string, manilaClient manilaclient.Interface) (
 		return manilaErrorMessage{}, err
 	}
 
-	if msgs != nil && len(msgs) == 1 {
+	if len(msgs) == 1 {
 		return manilaErrorMessage{errCode: manilaErrorCodesMap[msgs[0].DetailID], message: msgs[0].UserMessage}, nil
 	}
 
@@ -151,7 +150,7 @@ func lastResourceError(resourceID string, manilaClient manilaclient.Interface) (
 }
 
 func compareProtocol(protoA, protoB string) bool {
-	return strings.ToUpper(protoA) == strings.ToUpper(protoB)
+	return strings.EqualFold(protoA, protoB)
 }
 
 //

--- a/pkg/csi/manila/validator/valueexpr.go
+++ b/pkg/csi/manila/validator/valueexpr.go
@@ -29,7 +29,6 @@ const (
 	valueOptionalTag   = "optional"
 	valueOptionalIfTag = "optionalIf:"
 	valueDefaultTag    = "default:"
-	valueCoalesceTag   = "coalesce:"
 
 	valueExprDelim = '='
 )
@@ -122,7 +121,7 @@ func parseValueExpr(value string, selfStructName string, fName fieldName, nameId
 		expr.exprType = valueOptionalIf
 		expr.fName, expr.arg = parseCondValueExpr(value, valueOptionalIfTag, selfStructName, nameIdxMap, fName)
 	} else {
-		panic(invalidValueExprError(fmt.Sprintf("unrecognized value expression"), value, selfStructName, fName))
+		panic(invalidValueExprError("unrecognized value expression", value, selfStructName, fName))
 	}
 
 	return expr

--- a/pkg/csi/manila/volumesource.go
+++ b/pkg/csi/manila/volumesource.go
@@ -56,7 +56,7 @@ func (blankVolume) create(req *csi.CreateVolumeRequest, shareName string, sizeIn
 			tryDeleteShare(share, manilaClient)
 		}
 
-		return nil, status.Errorf(manilaErrCode.toRpcErrorCode(), "failed to create volume %s: %v", shareName, err)
+		return nil, status.Errorf(manilaErrCode.toRPCErrorCode(), "failed to create volume %s: %v", shareName, err)
 	}
 
 	return share, err
@@ -111,7 +111,7 @@ func (volumeFromSnapshot) create(req *csi.CreateVolumeRequest, shareName string,
 			tryDeleteShare(share, manilaClient)
 		}
 
-		return nil, status.Errorf(manilaErrCode.toRpcErrorCode(), "failed to restore snapshot %s into volume %s: %v", snapshotSource.GetSnapshotId(), shareName, err)
+		return nil, status.Errorf(manilaErrCode.toRPCErrorCode(), "failed to restore snapshot %s into volume %s: %v", snapshotSource.GetSnapshotId(), shareName, err)
 	}
 
 	return share, err

--- a/tests/ci-csi-manila-e2e.sh
+++ b/tests/ci-csi-manila-e2e.sh
@@ -109,10 +109,10 @@ ansible-playbook -v \
   -e github_pr_branch=${PR_BRANCH}
 exit_code=$?
 
-# Fetch devstack logs for debugging purpose
-#scp -i ~/.ssh/google_compute_engine \
-#  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-#  -r ${USERNAME}@${PUBLIC_IP}:/opt/stack/logs $ARTIFACTS/logs/devstack || true
+# Fetch manila-csi tests results
+scp -i ~/.ssh/google_compute_engine \
+  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+  -r ${USERNAME}@${PUBLIC_IP}:/var/log/csi-pod/* $ARTIFACTS/logs/ || true
 
 # If Boskos is being used then release the resource back to Boskos.
 [ -z "${BOSKOS_HOST:-}" ] || python3 tests/scripts/boskos.py --release >> "$ARTIFACTS/logs/boskos.log" 2>&1

--- a/tests/e2e/csi/manila/manilavolume.go
+++ b/tests/e2e/csi/manila/manilavolume.go
@@ -31,7 +31,6 @@ func runCmd(name string, args ...string) ([]byte, error) {
 // are accessible from $PATH on the node.
 
 type manilaVolume struct {
-	proto    string
 	shareID  string
 	accessID string
 }

--- a/tests/e2e/csi/manila/testsuite.go
+++ b/tests/e2e/csi/manila/testsuite.go
@@ -7,11 +7,12 @@ import (
 	// revive:disable:blank-imports
 	_ "github.com/onsi/gomega"
 	// revive:enable:blank-imports
-	"k8s.io/kubernetes/test/e2e/framework"
+
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
+	e2etestingmanifests "k8s.io/kubernetes/test/e2e/testing-manifests"
 )
 
 var CSITestSuites = []func() storageframework.TestSuite{
@@ -25,7 +26,7 @@ var CSITestSuites = []func() storageframework.TestSuite{
 }
 
 var _ = utils.SIGDescribe("[manila-csi-e2e] CSI Volumes", func() {
-	testfiles.AddFileSource(testfiles.RootFileSource{Root: framework.TestContext.RepoRoot})
+	testfiles.AddFileSource(e2etestingmanifests.GetE2ETestingManifestsFS())
 
 	testDriver := newManilaTestDriver()
 

--- a/tests/e2e/csi/manila/testsuite.go
+++ b/tests/e2e/csi/manila/testsuite.go
@@ -1,8 +1,12 @@
 package test
 
 import (
+	// revive:disable:dot-imports
 	. "github.com/onsi/ginkgo"
+	// revive:enable:dot-imports
+	// revive:disable:blank-imports
 	_ "github.com/onsi/gomega"
+	// revive:enable:blank-imports
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"

--- a/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
@@ -216,6 +216,30 @@
       cd {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack
 
       # GATEWAY_IP is the default value in devstack
+      mkdir -p /var/log/csi-pod
       GATEWAY_IP=172.24.5.1 \
       OS_RC={{ devstack_workdir }}/openrc \
-      go test -v ./cmd/tests/manila-csi-e2e-suite/manila_csi_e2e_suite_test.go -ginkgo.v -ginkgo.progress -ginkgo.skip="\[Disruptive\]" -ginkgo.focus="\[manila-csi-e2e\]" -ginkgo.noColor -timeout=0
+      go test -v ./cmd/tests/manila-csi-e2e-suite/manila_csi_e2e_suite_test.go \
+        -ginkgo.v \
+        -ginkgo.progress \
+        -ginkgo.skip="\[Disruptive\]|\[sig-storage\]\s+\[manila-csi-e2e\]\s+CSI\s+Volumes\s+\[Driver:\s+nfs.manila.csi.openstack.org\]\s+\[Testpattern:\s+Dynamic\s+PV\s+\(default\s+fs\)\]\s+provisioning\s+should\s+provision\s+storage\s+with\s+any\s+volume\s+data\s+source\s+\[Serial\]" \
+        -ginkgo.focus="\[manila-csi-e2e\]" \
+        -ginkgo.noColor \
+        -report-dir /var/log/csi-pod \
+        -timeout=0 | tee "/var/log/csi-pod/manila-csi-e2e.log"
+  register: functional_test_result
+  ignore_errors: true
+
+- name: Collect pod logs for debug purpose
+  shell:
+    executable: /bin/bash
+    cmd: |
+      set -x
+      set -e
+
+      kubectl logs statefulset/manila-openstack-manila-csi-controllerplugin -n default -c nfs-nodeplugin > /var/log/csi-pod/csi-manila-controllerplugin.log
+      kubectl logs daemonset/manila-openstack-manila-csi-nodeplugin -n default -c nfs-nodeplugin > /var/log/csi-pod/csi-manila-nodeplugin.log
+  ignore_errors: true
+
+- fail: msg="The execution has failed because of errors."
+  when: functional_test_result.failed


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Refactor manila-csi-plugin to make golangci-lint happy.

**Which issue this PR fixes(if applicable)**:
Relates to #1883

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
