### PR TITLE
[octavia-ingress-controller] Refactor ingress to improve code climate

### DIFF
--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -437,7 +437,7 @@ func (c *Controller) nodeSyncLoop() {
 		return
 	}
 
-	ings := new(nwv1.IngressList)
+	var ings *nwv1.IngressList
 	// NOTE(lingxiankong): only take ingresses without ip address into consideration
 	opts := apimetav1.ListOptions{}
 	if ings, err = c.kubeClient.NetworkingV1().Ingresses("").List(context.TODO(), opts); err != nil {

--- a/pkg/ingress/controller/openstack/neutron.go
+++ b/pkg/ingress/controller/openstack/neutron.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"k8s.io/cloud-provider-openstack/pkg/ingress/utils"
@@ -74,6 +74,9 @@ func (os *OpenStack) getPorts(listOpts ports.ListOpts) ([]ports.Port, error) {
 func (os *OpenStack) EnsureFloatingIP(needDelete bool, portID string, floatingIPNetwork string, description string) (string, error) {
 	listOpts := floatingips.ListOpts{PortID: portID}
 	fips, err := os.getFloatingIPs(listOpts)
+	if err != nil {
+		return "", fmt.Errorf("unable to get floating ips: %w", err)
+	}
 
 	// If needed, delete the floating IPs and return.
 	if needDelete {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Refactor octavia-ingress-controller to make golangci-lint happy.

**Which issue this PR fixes(if applicable)**:
Relates to #1883

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
