### PR TITLE
[barbican-kms-plugin] Refactor barbican-kms-plugin to improve code climate

### DIFF
--- a/pkg/kms/barbican/barbican.go
+++ b/pkg/kms/barbican/barbican.go
@@ -7,10 +7,6 @@ import (
 	"k8s.io/cloud-provider-openstack/pkg/client"
 )
 
-type BarbicanService interface {
-	GetSecret(keyID string) ([]byte, error)
-}
-
 type KMSOpts struct {
 	KeyID string `gcfg:"key-id"`
 }

--- a/pkg/kms/client/client.go
+++ b/pkg/kms/client/client.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"os"
+
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	pb "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1"
-	"os"
 )
 
 //This client is for test purpose only, Kubernetes api server will call to kms plugin grpc server
@@ -13,7 +15,7 @@ import (
 func main() {
 
 	connection, err := grpc.Dial("unix:///var/lib/kms/kms.sock", grpc.WithInsecure())
-	defer connection.Close()
+	defer func() { _ = connection.Close() }()
 	if err != nil {
 		fmt.Printf("\nConnection to KMS plugin failed, error: %v", err)
 	}
@@ -49,6 +51,9 @@ func main() {
 	}
 
 	decResponse, err := kmsClient.Decrypt(context.TODO(), decRequest)
+	if err != nil {
+		log.Fatalf("Unable to decrypt response: %v", err)
+	}
 
 	fmt.Printf("\n\ndecryption response %v", decResponse)
 }

--- a/pkg/kms/encryption/aescbc/aescbc_test.go
+++ b/pkg/kms/encryption/aescbc/aescbc_test.go
@@ -26,6 +26,9 @@ func TestEncryptDecrypt(t *testing.T) {
 func TestEncryptDecryptInvalidData(t *testing.T) {
 	data := []byte("mypassword")
 	cipher, err := Encrypt(data, key)
+	if err != nil {
+		t.FailNow()
+	}
 	_, err = Decrypt(cipher[1:], key)
 	if err == nil {
 		t.FailNow()


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Refactor barbican-kms-plugin to make golangci-lint happy.

**Which issue this PR fixes(if applicable)**:
Relates to #1883

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
