### PR TITLE
[occm] Refactor occm to improve code climate

### DIFF
--- a/pkg/openstack/instances.go
+++ b/pkg/openstack/instances.go
@@ -47,7 +47,7 @@ import (
 // Instances encapsulates an implementation of Instances for OpenStack.
 type Instances struct {
 	compute        *gophercloud.ServiceClient
-	opts           metadata.MetadataOpts
+	opts           metadata.Opts
 	networkingOpts NetworkingOpts
 }
 

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -95,10 +95,12 @@ type LoadBalancerOpts struct {
 	CascadeDelete         bool                `gcfg:"cascade-delete"` // applicable only if use-octavia is set to True
 	FlavorID              string              `gcfg:"flavor-id"`
 	AvailabilityZone      string              `gcfg:"availability-zone"`
-	EnableIngressHostname bool                `gcfg:"enable-ingress-hostname"`   // Used with proxy protocol by adding a dns suffix to the load balancer IP address. Default false.
-	IngressHostnameSuffix string              `gcfg:"ingress-hostname-suffix"`   // Used with proxy protocol by adding a dns suffix to the load balancer IP address. Default nip.io.
-	TlsContainerRef       string              `gcfg:"default-tls-container-ref"` //  reference to a tls container
-	MaxSharedLB           int                 `gcfg:"max-shared-lb"`             //  Number of Services in maximum can share a single load balancer. Default 2
+	EnableIngressHostname bool                `gcfg:"enable-ingress-hostname"` // Used with proxy protocol by adding a dns suffix to the load balancer IP address. Default false.
+	IngressHostnameSuffix string              `gcfg:"ingress-hostname-suffix"` // Used with proxy protocol by adding a dns suffix to the load balancer IP address. Default nip.io.
+	MaxSharedLB           int                 `gcfg:"max-shared-lb"`           //  Number of Services in maximum can share a single load balancer. Default 2
+	// revive:disable:var-naming
+	TlsContainerRef string `gcfg:"default-tls-container-ref"` //  reference to a tls container
+	// revive:enable:var-naming
 }
 
 // LBClass defines the corresponding floating network, floating subnet or internal subnet ID
@@ -134,7 +136,7 @@ type OpenStack struct {
 	epOpts         *gophercloud.EndpointOpts
 	lbOpts         LoadBalancerOpts
 	routeOpts      RouterOpts
-	metadataOpts   metadata.MetadataOpts
+	metadataOpts   metadata.Opts
 	networkingOpts NetworkingOpts
 	// InstanceID of the server where this OpenStack object is instantiated.
 	localInstanceID string
@@ -147,7 +149,7 @@ type Config struct {
 	LoadBalancer      LoadBalancerOpts
 	LoadBalancerClass map[string]*LBClass
 	Route             RouterOpts
-	Metadata          metadata.MetadataOpts
+	Metadata          metadata.Opts
 	Networking        NetworkingOpts
 }
 

--- a/pkg/openstack/openstack_loadbalancer_subnet_match_test.go
+++ b/pkg/openstack/openstack_loadbalancer_subnet_match_test.go
@@ -93,7 +93,7 @@ func runTag(t *testing.T, subnet *subnets.Subnet, spec floatingSubnetSpec, expec
 	spec.subnetTags = "!" + spec.subnetTags
 	runMatch(t, subnet, spec, !expected)
 
-	if strings.Index(spec.subnetTags, ",") < 0 {
+	if !strings.Contains(spec.subnetTags, ",") {
 		spec.subnetTags = "other"
 		runMatch(t, subnet, spec, !expected)
 

--- a/pkg/openstack/openstack_test.go
+++ b/pkg/openstack/openstack_test.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -40,14 +39,6 @@ import (
 
 const (
 	testClusterName = "testCluster"
-
-	// volumeStatus* is configuration of exponential backoff for
-	// waiting for specified volume status. Starting with 1
-	// seconds, multiplying by 1.2 with each step and taking 13 steps at maximum
-	// it will time out after 32s, which roughly corresponds to 30s
-	volumeStatusInitDelay = 1 * time.Second
-	volumeStatusFactor    = 1.2
-	volumeStatusSteps     = 13
 )
 
 // ConfigFromEnv allows setting up credentials etc using the
@@ -883,8 +874,6 @@ func TestZones(t *testing.T) {
 	}
 }
 
-var diskPathRegexp = regexp.MustCompile("/dev/disk/(?:by-id|by-path)/")
-
 func TestInstanceIDFromProviderID(t *testing.T) {
 	testCases := []struct {
 		providerID string
@@ -1083,27 +1072,6 @@ func TestUserAgentFlag(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-func clearEnviron(t *testing.T) []string {
-	env := os.Environ()
-	for _, pair := range env {
-		if strings.HasPrefix(pair, "OS_") {
-			i := strings.Index(pair, "=") + 1
-			os.Unsetenv(pair[:i-1])
-		}
-	}
-	return env
-}
-func resetEnviron(t *testing.T, items []string) {
-	for _, pair := range items {
-		if strings.HasPrefix(pair, "OS_") {
-			i := strings.Index(pair, "=") + 1
-			if err := os.Setenv(pair[:i-1], pair[i:]); err != nil {
-				t.Errorf("Setenv(%q, %q) failed during reset: %v", pair[:i-1], pair[i:], err)
-			}
-		}
 	}
 }
 

--- a/pkg/openstack/routes_test.go
+++ b/pkg/openstack/routes_test.go
@@ -86,6 +86,9 @@ func TestRoutes(t *testing.T) {
 
 func getServers(os *OpenStack) []servers.Server {
 	c, err := client.NewComputeV2(os.provider, os.epOpts)
+	if err != nil {
+		panic(err)
+	}
 	opts := servers.ListOpts{
 		Status: "ACTIVE",
 	}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Refactor occm to make golangci-lint happy.

**Which issue this PR fixes(if applicable)**:
Relates to #1883

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
