### PR TITLE
Improve manila csi driver chart adding fsGroupPolicy

### DIFF
--- a/charts/manila-csi-plugin/templates/csidriver.yaml
+++ b/charts/manila-csi-plugin/templates/csidriver.yaml
@@ -6,5 +6,6 @@ metadata:
 spec:
   attachRequired: false
   podInfoOnMount: false
+  fsGroupPolicy: {{ printf "%s" .fsGroupPolicy }}
 ---
 {{- end }}

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -7,6 +7,7 @@ driverName: manila.csi.openstack.org
 # Enabled Manila share protocols
 shareProtocols:
   - protocolSelector: NFS
+    fsGroupPolicy: None
     fwdNodePluginEndpoint:
       dir: /var/lib/kubelet/plugins/csi-nfsplugin
       sockFile: csi.sock

--- a/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
@@ -126,6 +126,7 @@
           tag: {{ github_pr }}
       shareProtocols:
         - protocolSelector: NFS
+          fsGroupPolicy: None
           fwdNodePluginEndpoint:
             dir: /var/lib/kubelet/plugins/csi-nfsplugin
             sockFile: csi.sock


### PR DESCRIPTION
The fsGroupPolicy option can now be defined per protocol,
enforcing a different behavior to the driver [1]

[1] https://kubernetes-csi.github.io/docs/support-fsgroup.html

Signed-off-by: Francesco Pantano <fpantano@redhat.com>

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**Which issue this PR fixes(if applicable)**:
fixes #1893


**Release note**:

```release-note
Set fsGroupPolicy (None by default) for the CSIDriver object
```
