### PR TITLE
[cinder-csi-plugin] add support for openstack api metrics

### DIFF
--- a/cmd/cinder-csi-plugin/main.go
+++ b/cmd/cinder-csi-plugin/main.go
@@ -31,10 +31,11 @@ import (
 )
 
 var (
-	endpoint    string
-	nodeID      string
-	cloudconfig []string
-	cluster     string
+	endpoint     string
+	nodeID       string
+	cloudconfig  []string
+	cluster      string
+	httpEndpoint string
 )
 
 func init() {
@@ -83,7 +84,7 @@ func main() {
 	cmd.MarkPersistentFlagRequired("cloud-config")
 
 	cmd.PersistentFlags().StringVar(&cluster, "cluster", "", "The identifier of the cluster that the plugin is running in.")
-
+	cmd.PersistentFlags().StringVar(&httpEndpoint, "http-endpoint", "", "The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080`). The default is empty string, which means the server is disabled.")
 	openstack.AddExtraFlags(pflag.CommandLine)
 
 	code := cli.Run(cmd)
@@ -94,7 +95,7 @@ func handle() {
 
 	// Initialize cloud
 	d := cinder.NewDriver(endpoint, cluster)
-	openstack.InitOpenStackProvider(cloudconfig)
+	openstack.InitOpenStackProvider(cloudconfig, httpEndpoint)
 	cloud, err := openstack.GetOpenStackProvider()
 	if err != nil {
 		klog.Warningf("Failed to GetOpenStackProvider: %v", err)

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -18,6 +18,7 @@ package openstack
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/gophercloud/gophercloud"
@@ -28,7 +29,9 @@ import (
 	"github.com/spf13/pflag"
 	gcfg "gopkg.in/gcfg.v1"
 	"k8s.io/cloud-provider-openstack/pkg/client"
+	"k8s.io/cloud-provider-openstack/pkg/metrics"
 	"k8s.io/cloud-provider-openstack/pkg/util/metadata"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
 )
 
@@ -132,7 +135,20 @@ var OsInstance IOpenStack = nil
 var configFiles = []string{"/etc/cloud.conf"}
 var cfg Config
 
-func InitOpenStackProvider(cfgFiles []string) {
+func InitOpenStackProvider(cfgFiles []string, httpEndpoint string) {
+	metrics.RegisterMetrics("cinder-csi")
+	if httpEndpoint != "" {
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", legacyregistry.HandlerWithReset())
+		go func() {
+			err := http.ListenAndServe(httpEndpoint, mux)
+			if err != nil {
+				klog.Fatalf("failed to listen & serve metrics from %q: %v", httpEndpoint, err)
+			}
+			klog.Infof("metrics available in %q", httpEndpoint)
+		}()
+	}
+
 	configFiles = cfgFiles
 	klog.V(2).Infof("InitOpenStackProvider configFiles: %s", configFiles)
 }

--- a/pkg/csi/cinder/openstack/openstack_instances.go
+++ b/pkg/csi/cinder/openstack/openstack_instances.go
@@ -2,12 +2,14 @@ package openstack
 
 import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"k8s.io/cloud-provider-openstack/pkg/metrics"
 )
 
 // GetInstanceByID returns server with specified instanceID
 func (os *OpenStack) GetInstanceByID(instanceID string) (*servers.Server, error) {
+	mc := metrics.NewMetricContext("server", "get")
 	server, err := servers.Get(os.compute, instanceID).Extract()
-	if err != nil {
+	if mc.ObserveRequest(err) != nil {
 		return nil, err
 	}
 	return server, nil

--- a/pkg/csi/cinder/openstack/openstack_snapshots.go
+++ b/pkg/csi/cinder/openstack/openstack_snapshots.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
 	"github.com/gophercloud/gophercloud/pagination"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/cloud-provider-openstack/pkg/metrics"
 	"k8s.io/klog/v2"
 )
 
@@ -67,9 +68,9 @@ func (os *OpenStack) CreateSnapshot(name, volID string, tags *map[string]string)
 		opts.Metadata = *tags
 	}
 	// TODO: Do some check before really call openstack API on the input
-
+	mc := metrics.NewMetricContext("snapshot", "create")
 	snap, err := snapshots.Create(os.blockstorage, opts).Extract()
-	if err != nil {
+	if mc.ObserveRequest(err) != nil {
 		return &snapshots.Snapshot{}, err
 	}
 	// There's little value in rewrapping these gophercloud types into yet another abstraction/type, instead just
@@ -103,6 +104,7 @@ func (os *OpenStack) ListSnapshots(filters map[string]string) ([]snapshots.Snaps
 			klog.V(3).Infof("Not a valid filter key %s", key)
 		}
 	}
+	mc := metrics.NewMetricContext("snapshot", "list")
 	err := snapshots.List(os.blockstorage, opts).EachPage(func(page pagination.Page) (bool, error) {
 		var err error
 
@@ -126,7 +128,7 @@ func (os *OpenStack) ListSnapshots(filters map[string]string) ([]snapshots.Snaps
 
 		return false, nil
 	})
-	if err != nil {
+	if mc.ObserveRequest(err) != nil {
 		return nil, nextPageToken, err
 	}
 
@@ -135,8 +137,9 @@ func (os *OpenStack) ListSnapshots(filters map[string]string) ([]snapshots.Snaps
 
 // DeleteSnapshot issues a request to delete the Snapshot with the specified ID from the Cinder backend
 func (os *OpenStack) DeleteSnapshot(snapID string) error {
+	mc := metrics.NewMetricContext("snapshot", "delete")
 	err := snapshots.Delete(os.blockstorage, snapID).ExtractErr()
-	if err != nil {
+	if mc.ObserveRequest(err) != nil {
 		klog.Errorf("Failed to delete snapshot: %v", err)
 	}
 	return err
@@ -144,8 +147,9 @@ func (os *OpenStack) DeleteSnapshot(snapID string) error {
 
 //GetSnapshotByID returns snapshot details by id
 func (os *OpenStack) GetSnapshotByID(snapshotID string) (*snapshots.Snapshot, error) {
+	mc := metrics.NewMetricContext("snapshot", "get")
 	s, err := snapshots.Get(os.blockstorage, snapshotID).Extract()
-	if err != nil {
+	if mc.ObserveRequest(err) != nil {
 		klog.Errorf("Failed to get snapshot: %v", err)
 		return nil, err
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -59,7 +59,9 @@ func (mc *MetricContext) Observe(om *OpenstackMetrics, err error) error {
 	return err
 }
 
-func RegisterMetrics() {
+func RegisterMetrics(component string) {
 	doRegisterAPIMetrics()
-	doRegisterOccmMetrics()
+	if component == "occm" {
+		doRegisterOccmMetrics()
+	}
 }

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -154,7 +154,7 @@ type Config struct {
 }
 
 func init() {
-	metrics.RegisterMetrics()
+	metrics.RegisterMetrics("occm")
 
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
 		cfg, err := ReadConfig(config)


### PR DESCRIPTION
**What this PR does / why we need it**:

see comment
https://github.com/kubernetes/cloud-provider-openstack/pull/1398#issuecomment-1141721027
https://github.com/kubernetes/cloud-provider-openstack/pull/1398#issuecomment-1141752625



**Which issue this PR fixes(if applicable)**:
fixes #913

**Special notes for reviewers**:



**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[cinder-csi-plugin] expose csi & openstack metrics by providing new flag `--http-endpoint`
```
