### PR TITLE
[cinder-csi-plugin] Remove downstream from probe (#1904)

### DIFF
--- a/pkg/csi/cinder/identityserver.go
+++ b/pkg/csi/cinder/identityserver.go
@@ -21,7 +21,6 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack"
 	"k8s.io/klog/v2"
 )
 
@@ -47,15 +46,6 @@ func (ids *identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPlugin
 }
 
 func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
-	oProvider, err := openstack.GetOpenStackProvider()
-	if err != nil {
-		klog.Errorf("Failed to GetOpenStackProvider: %v", err)
-		return nil, status.Error(codes.FailedPrecondition, "Failed to retrieve openstack provider")
-	}
-	if err := oProvider.CheckBlockStorageAPI(); err != nil {
-		klog.Errorf("Failed to query blockstorage API: %v", err)
-		return nil, status.Error(codes.FailedPrecondition, "Failed to communicate with OpenStack BlockStorage API")
-	}
 	return &csi.ProbeResponse{}, nil
 }
 

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -41,7 +41,6 @@ func AddExtraFlags(fs *pflag.FlagSet) {
 }
 
 type IOpenStack interface {
-	CheckBlockStorageAPI() error
 	CreateVolume(name string, size int, vtype, availability string, snapshotID string, sourcevolID string, tags *map[string]string) (*volumes.Volume, error)
 	DeleteVolume(volumeID string) error
 	AttachVolume(instanceID, volumeID string) (string, error)

--- a/pkg/csi/cinder/openstack/openstack_mock.go
+++ b/pkg/csi/cinder/openstack/openstack_mock.go
@@ -116,11 +116,6 @@ func (_m *OpenStackMock) GetVolume(volumeID string) (*volumes.Volume, error) {
 	return &fakeVol1, nil
 }
 
-// CheckBlockStorageAPI
-func (_m *OpenStackMock) CheckBlockStorageAPI() error {
-	return nil
-}
-
 // DetachVolume provides a mock function with given fields: instanceID, volumeID
 func (_m *OpenStackMock) DetachVolume(instanceID string, volumeID string) error {
 	ret := _m.Called(instanceID, volumeID)

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack"
-	"github.com/gophercloud/gophercloud/openstack/blockstorage/apiversions"
 	volumeexpand "github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach"
@@ -49,14 +48,6 @@ const (
 )
 
 var volumeErrorStates = [...]string{"error", "error_extending", "error_deleting"}
-
-func (os *OpenStack) CheckBlockStorageAPI() error {
-	_, err := apiversions.List(os.blockstorage).AllPages()
-	if err != nil {
-		return err
-	}
-	return nil
-}
 
 // CreateVolume creates a volume of given size
 func (os *OpenStack) CreateVolume(name string, size int, vtype, availability string, snapshotID string, sourcevolID string, tags *map[string]string) (*volumes.Volume, error) {

--- a/tests/sanity/cinder/fakecloud.go
+++ b/tests/sanity/cinder/fakecloud.go
@@ -56,10 +56,6 @@ func (cloud *cloud) DeleteVolume(volumeID string) error {
 	return nil
 }
 
-func (cloud *cloud) CheckBlockStorageAPI() error {
-	return nil
-}
-
 func (cloud *cloud) AttachVolume(instanceID, volumeID string) (string, error) {
 	// update the volume with attachement
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove all sorts of downstream dependency on cinder from probe. Probe is
the one called by the liveness sidecar to determine the health of the
csi plugin. Including downstream services in a health check can result
in unfortunate behavior in cluster. For example, over and over restarts
of daemonsets/deployments just because the downstream api is not
available at the moment... e.g. because of a maintenance.

On the other hand, just because the downstream api is available doesn't
tell us anything about whether or not the downstream works as expected.
Therefore there are facilities in place that reports errors when they
happen all over the place.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[cinder-csi-plugin] Remove dependency on openstack api from csi Probes
```
