### PR TITLE
Add region to providerID magic string.

### DIFF
--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -285,6 +285,10 @@ NOTE:
 
   Not all OpenStack clouds provide both configuration drive and metadata service though and only one or the other may be available which is why the default is to check both. Especially, the metadata on the config drive may grow stale over time, whereas the metadata service always provides the most up to date data.
 
+### Multi region support (alpha)
+
+* environment variable `OS_CCM_REGIONAL` is set to `true` - allow CCM to set ProviderID with region name `${ProviderName}://${REGION}/${instance-id}`. Default: false.
+
 ## Exposing applications using services of LoadBalancer type
 
 Refer to [Exposing applications using services of LoadBalancer type](./expose-applications-using-loadbalancer-type-service.md)

--- a/pkg/ingress/utils/utils.go
+++ b/pkg/ingress/utils/utils.go
@@ -74,14 +74,17 @@ func stringSlicesEqual(x, y []string) bool {
 
 // GetNodeID get instance ID from the Node spec.
 func GetNodeID(node *apiv1.Node) (string, error) {
-	var providerIDRegexp = regexp.MustCompile(`^openstack:///([^/]+)$`)
+	var providerIDRegexp = regexp.MustCompile(`^openstack://([^/]*)/([^/]+)$`)
 
 	matches := providerIDRegexp.FindStringSubmatch(node.Spec.ProviderID)
-	if len(matches) != 2 {
+	switch len(matches) {
+	case 2:
+		return matches[1], nil
+	case 3:
+		return matches[2], nil
+	default:
 		return "", fmt.Errorf("failed to find instance ID from node provider ID %s", node.Spec.ProviderID)
 	}
-
-	return matches[1], nil
 }
 
 // Convert2Set converts a string list to string set.

--- a/pkg/openstack/instances.go
+++ b/pkg/openstack/instances.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
+	sysos "os"
 	"regexp"
 	"sort"
 	"strings"
@@ -46,13 +46,16 @@ import (
 
 // Instances encapsulates an implementation of Instances for OpenStack.
 type Instances struct {
-	compute        *gophercloud.ServiceClient
-	opts           metadata.Opts
-	networkingOpts NetworkingOpts
+	compute          *gophercloud.ServiceClient
+	region           string
+	regionProviderID bool
+	opts             metadata.Opts
+	networkingOpts   NetworkingOpts
 }
 
 const (
-	instanceShutoff = "SHUTOFF"
+	instanceShutoff       = "SHUTOFF"
+	RegionalProviderIDEnv = "OS_CCM_REGIONAL"
 )
 
 var _ cloudprovider.Instances = &Instances{}
@@ -77,10 +80,17 @@ func (os *OpenStack) instances() (*Instances, bool) {
 		return nil, false
 	}
 
+	regionalProviderID := false
+	if isRegionalProviderID := sysos.Getenv(RegionalProviderIDEnv); isRegionalProviderID == "true" {
+		regionalProviderID = true
+	}
+
 	return &Instances{
-		compute:        compute,
-		opts:           os.metadataOpts,
-		networkingOpts: os.networkingOpts,
+		compute:          compute,
+		region:           os.epOpts.Region,
+		regionProviderID: regionalProviderID,
+		opts:             os.metadataOpts,
+		networkingOpts:   os.networkingOpts,
 	}, true
 }
 
@@ -128,12 +138,17 @@ func (i *Instances) NodeAddresses(ctx context.Context, name types.NodeName) ([]v
 // This method will not be called from the node that is requesting this ID. i.e. metadata service
 // and other local methods cannot be used here
 func (i *Instances) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]v1.NodeAddress, error) {
-	klog.V(4).Infof("NodeAddressesByProviderID (%v) called", providerID)
+	klog.V(4).Infof("NodeAddressesByProviderID(%v) called", providerID)
 
-	instanceID, err := instanceIDFromProviderID(providerID)
-
+	instanceID, instanceRegion, err := instanceIDFromProviderID(providerID)
 	if err != nil {
 		return []v1.NodeAddress{}, err
+	}
+
+	if instanceRegion != "" && instanceRegion != i.region {
+		klog.V(4).Infof("NodeAddressesByProviderID(%v) has foreign region %v, skipped", providerID, instanceRegion)
+
+		return []v1.NodeAddress{}, nil
 	}
 
 	mc := metrics.NewMetricContext("server", "get")
@@ -162,10 +177,16 @@ func (i *Instances) InstanceExists(ctx context.Context, node *v1.Node) (bool, er
 	return i.InstanceExistsByProviderID(ctx, node.Spec.ProviderID)
 }
 
-func instanceExistsByProviderID(ctx context.Context, compute *gophercloud.ServiceClient, providerID string) (bool, error) {
-	instanceID, err := instanceIDFromProviderID(providerID)
+func instanceExistsByProviderID(ctx context.Context, compute *gophercloud.ServiceClient, providerID string, region string) (bool, error) {
+	instanceID, instanceRegion, err := instanceIDFromProviderID(providerID)
 	if err != nil {
 		return false, err
+	}
+
+	if instanceRegion != "" && instanceRegion != region {
+		klog.V(4).Infof("instanceExistsByProviderID(%v) has foreign region %v, skipped", providerID, instanceRegion)
+
+		return true, nil
 	}
 
 	mc := metrics.NewMetricContext("server", "get")
@@ -183,7 +204,7 @@ func instanceExistsByProviderID(ctx context.Context, compute *gophercloud.Servic
 // InstanceExistsByProviderID returns true if the instance with the given provider id still exists.
 // If false is returned with no error, the instance will be immediately deleted by the cloud controller manager.
 func (i *Instances) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
-	return instanceExistsByProviderID(ctx, i.compute, providerID)
+	return instanceExistsByProviderID(ctx, i.compute, providerID, i.region)
 }
 
 // InstanceShutdown returns true if the instances is in safe state to detach volumes.
@@ -192,10 +213,14 @@ func (i *Instances) InstanceShutdown(ctx context.Context, node *v1.Node) (bool, 
 	return i.InstanceShutdownByProviderID(ctx, node.Spec.ProviderID)
 }
 
-func instanceShutdownByProviderID(ctx context.Context, compute *gophercloud.ServiceClient, providerID string) (bool, error) {
-	instanceID, err := instanceIDFromProviderID(providerID)
+func instanceShutdownByProviderID(ctx context.Context, compute *gophercloud.ServiceClient, providerID string, region string) (bool, error) {
+	instanceID, instanceRegion, err := instanceIDFromProviderID(providerID)
 	if err != nil {
 		return false, err
+	}
+
+	if instanceRegion != "" && instanceRegion != region {
+		return false, fmt.Errorf("ProviderID \"%s\" didn't match supported region \"%s\"", providerID, region)
 	}
 
 	mc := metrics.NewMetricContext("server", "get")
@@ -214,14 +239,18 @@ func instanceShutdownByProviderID(ctx context.Context, compute *gophercloud.Serv
 // InstanceShutdownByProviderID returns true if the instances is in safe state to detach volumes.
 // It is the only state, where volumes can be detached immediately.
 func (i *Instances) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
-	return instanceShutdownByProviderID(ctx, i.compute, providerID)
+	return instanceShutdownByProviderID(ctx, i.compute, providerID, i.region)
 }
 
 // InstanceMetadata returns metadata of the specified instance.
 func (i *Instances) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprovider.InstanceMetadata, error) {
-	instanceID, err := instanceIDFromProviderID(node.Spec.ProviderID)
+	instanceID, instanceRegion, err := instanceIDFromProviderID(node.Spec.ProviderID)
 	if err != nil {
 		return nil, err
+	}
+
+	if instanceRegion != "" && instanceRegion != i.region {
+		return nil, fmt.Errorf("ProviderID \"%s\" didn't match supported region \"%s\"", node.Spec.ProviderID, i.region)
 	}
 
 	mc := metrics.NewMetricContext("server", "get")
@@ -260,6 +289,11 @@ func (i *Instances) InstanceID(ctx context.Context, name types.NodeName) (string
 		}
 		return "", err
 	}
+
+	if i.regionProviderID {
+		return i.region + "/" + srv.ID, nil
+	}
+
 	// In the future it is possible to also return an endpoint as:
 	// <endpoint>/<instanceid>
 	return "/" + srv.ID, nil
@@ -269,10 +303,13 @@ func (i *Instances) InstanceID(ctx context.Context, name types.NodeName) (string
 // This method will not be called from the node that is requesting this ID. i.e. metadata service
 // and other local methods cannot be used here
 func (i *Instances) InstanceTypeByProviderID(ctx context.Context, providerID string) (string, error) {
-	instanceID, err := instanceIDFromProviderID(providerID)
-
+	instanceID, instanceRegion, err := instanceIDFromProviderID(providerID)
 	if err != nil {
 		return "", err
+	}
+
+	if instanceRegion != "" && instanceRegion != i.region {
+		return "", fmt.Errorf("ProviderID \"%s\" didn't match supported region \"%s\"", providerID, i.region)
 	}
 
 	mc := metrics.NewMetricContext("server", "get")
@@ -335,12 +372,13 @@ func isValidLabelValue(v string) bool {
 }
 
 // If Instances.InstanceID or cloudprovider.GetInstanceProviderID is changed, the regexp should be changed too.
-var providerIDRegexp = regexp.MustCompile(`^` + ProviderName + `:///([^/]+)$`)
+var providerIDRegexp = regexp.MustCompile(`^` + ProviderName + `://([^/]*)/([^/]+)$`)
 
 // instanceIDFromProviderID splits a provider's id and return instanceID.
-// A providerID is build out of '${ProviderName}:///${instance-id}'which contains ':///'.
+// A providerID is build out of '${ProviderName}:///${instance-id}' which contains ':///'.
+// or '${ProviderName}://${region}/${instance-id}' which contains '://'.
 // See cloudprovider.GetInstanceProviderID and Instances.InstanceID.
-func instanceIDFromProviderID(providerID string) (instanceID string, err error) {
+func instanceIDFromProviderID(providerID string) (instanceID string, region string, err error) {
 
 	// https://github.com/kubernetes/kubernetes/issues/85731
 	if providerID != "" && !strings.Contains(providerID, "://") {
@@ -348,10 +386,14 @@ func instanceIDFromProviderID(providerID string) (instanceID string, err error) 
 	}
 
 	matches := providerIDRegexp.FindStringSubmatch(providerID)
-	if len(matches) != 2 {
-		return "", fmt.Errorf("ProviderID \"%s\" didn't match expected format \"openstack:///InstanceID\"", providerID)
+	switch len(matches) {
+	case 2:
+		return matches[1], "", nil
+	case 3:
+		return matches[2], matches[1], nil
+	default:
+		return "", "", fmt.Errorf("ProviderID \"%s\" didn't match expected format \"openstack://region/InstanceID\"", providerID)
 	}
-	return matches[1], nil
 }
 
 // AddToNodeAddresses appends the NodeAddresses to the passed-by-pointer slice,
@@ -414,7 +456,7 @@ func readInstanceID(searchOrder string) (string, error) {
 
 	// Try to find instance ID on the local filesystem (created by cloud-init)
 	const instanceIDFile = "/var/lib/cloud/data/instance-id"
-	idBytes, err := os.ReadFile(instanceIDFile)
+	idBytes, err := sysos.ReadFile(instanceIDFile)
 	if err == nil {
 		instanceID := string(idBytes)
 		instanceID = strings.TrimSpace(instanceID)

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -374,7 +374,7 @@ func (os *OpenStack) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
 // This is particularly useful in external cloud providers where the kubelet
 // does not initialize node data.
 func (os *OpenStack) GetZoneByProviderID(ctx context.Context, providerID string) (cloudprovider.Zone, error) {
-	instanceID, err := instanceIDFromProviderID(providerID)
+	instanceID, _, err := instanceIDFromProviderID(providerID)
 	if err != nil {
 		return cloudprovider.Zone{}, err
 	}

--- a/pkg/openstack/openstack_test.go
+++ b/pkg/openstack/openstack_test.go
@@ -877,38 +877,50 @@ func TestInstanceIDFromProviderID(t *testing.T) {
 	testCases := []struct {
 		providerID string
 		instanceID string
+		region     string
 		fail       bool
 	}{
 		{
 			providerID: ProviderName + "://" + "/" + "7b9cf879-7146-417c-abfd-cb4272f0c935",
 			instanceID: "7b9cf879-7146-417c-abfd-cb4272f0c935",
+			region:     "",
+			fail:       false,
+		},
+		{
+			providerID: ProviderName + "://RegionOne/7b9cf879-7146-417c-abfd-cb4272f0c935",
+			instanceID: "7b9cf879-7146-417c-abfd-cb4272f0c935",
+			region:     "RegionOne",
 			fail:       false,
 		},
 		{
 			// https://github.com/kubernetes/kubernetes/issues/85731
 			providerID: "/7b9cf879-7146-417c-abfd-cb4272f0c935",
 			instanceID: "7b9cf879-7146-417c-abfd-cb4272f0c935",
+			region:     "",
 			fail:       false,
 		},
 		{
 			providerID: "openstack://7b9cf879-7146-417c-abfd-cb4272f0c935",
 			instanceID: "",
+			region:     "",
 			fail:       true,
 		},
 		{
 			providerID: "7b9cf879-7146-417c-abfd-cb4272f0c935",
 			instanceID: "",
+			region:     "",
 			fail:       true,
 		},
 		{
 			providerID: "other-provider:///7b9cf879-7146-417c-abfd-cb4272f0c935",
 			instanceID: "",
+			region:     "",
 			fail:       true,
 		},
 	}
 
 	for _, test := range testCases {
-		instanceID, err := instanceIDFromProviderID(test.providerID)
+		instanceID, instanceRegion, err := instanceIDFromProviderID(test.providerID)
 		if (err != nil) != test.fail {
 			t.Errorf("expected err: %t, got err: %v", test.fail, err)
 		}
@@ -919,6 +931,10 @@ func TestInstanceIDFromProviderID(t *testing.T) {
 
 		if instanceID != test.instanceID {
 			t.Errorf("%s yielded %s. expected %q", test.providerID, instanceID, test.instanceID)
+		}
+
+		if instanceRegion != test.region {
+			t.Errorf("%s yielded region %s. expected %q", test.providerID, instanceRegion, test.region)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Change ProviderID to magic sting ```${ProviderName}://${REGION}/${instance-id}```
Which helps to find an instance in a multi-region setup.

It also support old magic string (without region). 
In this case OCCM works as before (can be used only in the one-zone cluster).

**Which issue this PR fixes(if applicable)**:
fixes #1900

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
