### PR TITLE
OpenSSL PEM generates PKCS #8 keys

### DIFF
--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -1025,8 +1025,8 @@ func privateKeyFromPEM(pemData []byte) (crypto.PrivateKey, error) {
 			return x509.ParsePKCS1PrivateKey(result.Bytes)
 		case "EC PRIVATE KEY":
 			return x509.ParseECPrivateKey(result.Bytes)
-                case "PRIVATE KEY":
-                        return x509.ParsePKCS8PrivateKey(result.Bytes)
+		case "PRIVATE KEY":
+			return x509.ParsePKCS8PrivateKey(result.Bytes)
 		}
 	}
 }

--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -1025,6 +1025,8 @@ func privateKeyFromPEM(pemData []byte) (crypto.PrivateKey, error) {
 			return x509.ParsePKCS1PrivateKey(result.Bytes)
 		case "EC PRIVATE KEY":
 			return x509.ParseECPrivateKey(result.Bytes)
+                case "PRIVATE KEY":
+                        return x509.ParsePKCS8PrivateKey(result.Bytes)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->
[octavia-ingress-controller] PKCS8 keys

**What this PR does / why we need it**:
#1910 

**Which issue this PR fixes(if applicable)**:
#1910 (I am not suggesting you use this code)

This is probably more relevant:
https://github.com/golang/go/blob/master/src/crypto/tls/tls.go#L336

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
