### PR TITLE
occm: Fix LoadBalancer deletion when the underlying LoadBalancer does not exist

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -676,7 +676,7 @@ func (lbaas *LbaasV2) GetLoadBalancer(ctx context.Context, clusterName string, s
 	} else {
 		loadbalancer, err = getLoadbalancerByName(lbaas.lb, name, legacyName)
 	}
-	if err == cpoerrors.ErrNotFound {
+	if err != nil && cpoerrors.IsNotFound(err) {
 		return nil, false, nil
 	}
 	if loadbalancer == nil {


### PR DESCRIPTION
/kind bug

**Which issue this PR fixes(if applicable)**:
Fixes https://github.com/kubernetes/cloud-provider-openstack/issues/1912

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] An issue preventing Service of type LoadBalancer to be deleted when the corresponding OpenStack LoadBalancer does no longer exists is now fixed.
```
