### PR TITLE
Backport to v1.24 [ci] Pin k3s to v1.23.6+k3s1 (#1907)

### DIFF
--- a/tests/playbooks/roles/install-k3s/defaults/main.yaml
+++ b/tests/playbooks/roles/install-k3s/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-k8s_branch: "master"
+k3s_release: "v1.23.6+k3s1"
 worker_node_count: 1
 cluster_token: "9a08jv.c0izixklcxtmnze7"
 devstack_workdir: "{{ ansible_user_dir }}/devstack"

--- a/tests/playbooks/roles/install-k3s/tasks/main.yaml
+++ b/tests/playbooks/roles/install-k3s/tasks/main.yaml
@@ -7,23 +7,6 @@
     packages:
       - jq
 
-- name: Get k3s release
-  shell:
-    executable: /bin/bash
-    cmd: |
-      # Get k3s release based on the given k8s branch.
-      branch={{ k8s_branch }}
-      if [[ "$branch" = "master" ]]; then
-        k3s_release=$(curl -s "https://api.github.com/repos/k3s-io/k3s/tags" | jq -r '.[0].name')
-      else
-        # release-1.20 --> 1.20
-        k8s_minor=${branch##*-}
-        # 1.20 --> v1.20.x+k3s1 or v1.20.1-rc1+k3s1
-        k3s_release=$(curl -s "https://api.github.com/repos/k3s-io/k3s/tags" | jq -r '.[].name' | grep -E "^v${k8s_minor}.[0-9a-z\+\-]+\+k3s1$" | awk 'NR==1 {print}')
-      fi
-      echo $k3s_release
-  register: release
-
 - name: Create openstack resources
   shell:
     executable: /bin/bash
@@ -98,8 +81,8 @@
         runcmd:
           - curl -sSL https://get.docker.com/ | sh
           - mkdir -p /var/lib/rancher/k3s/agent/images/
-          - curl -sSL https://github.com/k3s-io/k3s/releases/download/{{ release.stdout }}/k3s-airgap-images-amd64.tar -o /var/lib/rancher/k3s/agent/images/k3s-airgap-images.tar
-          - curl -sSL https://github.com/k3s-io/k3s/releases/download/{{ release.stdout }}/k3s -o /usr/local/bin/k3s
+          - curl -sSL https://github.com/k3s-io/k3s/releases/download/{{ k3s_release }}/k3s-airgap-images-amd64.tar -o /var/lib/rancher/k3s/agent/images/k3s-airgap-images.tar
+          - curl -sSL https://github.com/k3s-io/k3s/releases/download/{{ k3s_release }}/k3s -o /usr/local/bin/k3s
           - curl -sSL https://get.k3s.io -o /var/lib/rancher/k3s/install.sh
           - chmod u+x /var/lib/rancher/k3s/install.sh /usr/local/bin/k3s
           - INSTALL_K3S_SKIP_DOWNLOAD=true /var/lib/rancher/k3s/install.sh --docker --disable traefik --disable metrics-server --disable servicelb --disable-cloud-controller --kubelet-arg="cloud-provider=external" --tls-san {{ k3s_fip }} --token {{ cluster_token }}

--- a/tests/playbooks/test-csi-cinder-e2e.yaml
+++ b/tests/playbooks/test-csi-cinder-e2e.yaml
@@ -20,7 +20,7 @@
         - cinder
     - role: install-k3s
       worker_node_count: 0
-      k8s_branch: release-1.23
+      k3s_release: v1.23.6+k3s1
     - role: install-docker
     - role: install-docker-registry
       cert_hosts: ' ["{{ ansible_default_ipv4.address }}"]'

--- a/tests/playbooks/test-csi-manila-e2e.yaml
+++ b/tests/playbooks/test-csi-manila-e2e.yaml
@@ -19,7 +19,7 @@
         - manila
     - role: install-k3s
       worker_node_count: 0
-      k8s_branch: release-1.23
+      k3s_release: v1.23.6+k3s1
     - role: install-docker
     - role: install-docker-registry
       cert_hosts: ' ["{{ ansible_default_ipv4.address }}"]'

--- a/tests/playbooks/test-occm-e2e.yaml
+++ b/tests/playbooks/test-occm-e2e.yaml
@@ -21,7 +21,7 @@
         - barbican
     - role: install-k3s
       worker_node_count: 0
-      k8s_branch: release-1.23
+      k3s_release: v1.23.6+k3s1
     - role: install-docker
     - role: install-docker-registry
       cert_hosts: ' ["{{ ansible_default_ipv4.address }}"]'


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Backport pinning of k3s version in our ci, to un-block test runs.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
