### PR TITLE
update release procedure file

### DIFF
--- a/release-procedure.md
+++ b/release-procedure.md
@@ -22,8 +22,8 @@ $ git tag -m "Release for cloud-provider-openstack to support Kubernetes release
 $ git push upstream vX.Y.Z
 ```
 
-3. Github Actions will make the new docker images and make new draft release to repository.
+3. [Github Actions](https://github.com/kubernetes/cloud-provider-openstack/actions/workflows/release-cpo.yaml) will make the new docker images and make [new draft release](https://github.com/kubernetes/cloud-provider-openstack/releases) to repository.
 
-4. Update manifests with new release images, create a PR against release branch to update.
+4. Update manifests with new release images, create a PR against release branch to update. This will be a chicked and egg problem as we already created vX.Y.Z tag, but we recommend to do such update on the manifests file.
 
 5. Make release notes and publish the release.


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
