### PR TITLE
[occm] Remove mostly broken default ca-certs mount from helm chart

### DIFF
--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -98,9 +98,6 @@ extraVolumes:
   - name: flexvolume-dir
     hostPath:
       path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-  - name: ca-certs
-    hostPath:
-      path: /etc/ssl/certs
   - name: k8s-certs
     hostPath:
       path: /etc/kubernetes/pki
@@ -108,9 +105,6 @@ extraVolumes:
 extraVolumeMounts:
   - name: flexvolume-dir
     mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-    readOnly: true
-  - name: ca-certs
-    mountPath: /etc/ssl/certs
     readOnly: true
   - name: k8s-certs
     mountPath: /etc/kubernetes/pki


### PR DESCRIPTION
**What this PR does / why we need it**:
As explained in https://github.com/kubernetes/cloud-provider-openstack/issues/1923 this mount breaks OCCM on Flatcar, and doesn't bring any value on Ubuntu.

**Which issue this PR fixes(if applicable)**:
fixes https://github.com/kubernetes/cloud-provider-openstack/issues/1923

**Special notes for reviewers**:
I tested it on Flatcar and Ubuntu.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[occm] Remove mostly broken default ca-certs mount from helm chart
```
