### PR TITLE
Update sanity_test.go

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,17 @@
 # Contributing Guidelines
 
-The **kubernetes/cloud-provider-openstack** project accepts contribution via github [pull request](https://help.github.com/articles/about-pull-requests/). This document outlines the process to help get your contribution accepted. Please also read the [Kubernetes contributor guide](https://github.com/kubernetes/community/blob/master/contributors/guide/README.md)
+The **kubernetes/cloud-provider-openstack** project accepts contribution via GitHub [pull request](https://help.github.com/articles/about-pull-requests/). This document outlines the process to help get your contribution accepted. Please also read the [Kubernetes contributor guide](https://github.com/kubernetes/community/blob/master/contributors/guide/README.md)
 
 ## Sign the Contributor License Agreement
 We'd love to accept your patches! Before we can accept them you need to sign Cloud Native Computing Foundation (CNCF) [CLA](https://github.com/kubernetes/community/blob/master/CLA.md).
 
 ## Reporting an issue
-If you find a bug or a feature request related to cloud-provider-openstack you can create a new github issue in this repo @[kubernetes/cloud-provider-openstack](https://github.com/kubernetes/cloud-provider-openstack/issues).
+If you find a bug or a feature request related to cloud-provider-openstack you can create a new GitHub issue in this repo @[kubernetes/cloud-provider-openstack](https://github.com/kubernetes/cloud-provider-openstack/issues).
 
-## Submiting a Pull Request
+## Submitting a Pull Request
 * Fork the cloud-provider-openstack repo, develop and test your code changes.
 * Submit a pull request.
-* The bot will automatically assigns someone to review your PR.
+* The bot will automatically assign someone to review your PR.
 
 ## Contact
 * [Slack](https://kubernetes.slack.com/messages/provider-openstack).

--- a/tests/sanity/manila/sanity_test.go
+++ b/tests/sanity/manila/sanity_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestDriver(t *testing.T) {
-	basePath, err := ioutil.TempDir("", "manila.csi.openstack.org")
+	basePath, err := os.MkdirTemp("", "manila.csi.openstack.org")
 	if err != nil {
 		t.Fatalf("failed create base path in %s: %v", basePath, err)
 	}


### PR DESCRIPTION
ioutil.TempDir -->os.MkdirTemp,because ioutil.TempDir is deprecated 

Signed-off-by: lixin18 <68135097+lixin963@users.noreply.github.com>

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
