### PR TITLE
Automated cherry pick of #1793: fix listener pop during iteration

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1854,9 +1854,6 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 				return nil, err
 			}
 
-			// After all ports have been processed, remaining listeners are removed if they were created by this Service.
-			curListeners = popListener(curListeners, listener.ID)
-
 			pool, err := lbaas.ensureOctaviaPool(loadbalancer.ID, cutString(fmt.Sprintf("pool_%d_%s", portIndex, lbName)), listener, service, port, nodes, svcConf)
 			if err != nil {
 				return nil, err
@@ -1865,6 +1862,11 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 			if err := lbaas.ensureOctaviaHealthMonitor(loadbalancer.ID, cutString(fmt.Sprintf("monitor_%d_%s)", portIndex, lbName)), pool, port, svcConf); err != nil {
 				return nil, err
 			}
+
+			// After all ports have been processed, remaining listeners are removed if they were created by this Service.
+			// The remove of the listener must always happen at the end of the loop to avoid wrong assignment.
+			// Modifying the curListeners would also change the mapping.
+			curListeners = popListener(curListeners, listener.ID)
 		}
 
 		// Deal with the remaining listeners, delete the listener if it was created by this Service previously.


### PR DESCRIPTION
Cherry pick of #1793 on release-1.23.

#1793: fix listener pop during iteration

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
[openstack-cloud-controller-manager] An issue causing for Services of type LoadBalancer with multiple ports OCCM to mix up the different listeners of a loadbalancer and start assigning the members to the wrong listener/pool is now fixed.
```
