### PR TITLE
[occm] Implement `container-store` configuration setting

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -207,11 +207,13 @@ Request Body:
   Reference to a tls container. This option works with Octavia, when this option is set then the cloud provider will create an Octavia Listener of type `TERMINATED_HTTPS` for a TLS Terminated loadbalancer.
   Format for tls container ref: `https://{keymanager_host}/v1/containers/{uuid}`
 
+  When `container-store` parameter is set to `external` format for `default-tls-container-ref` could be any string.
+
   Not supported when `lb-provider=ovn` is configured in openstack-cloud-controller-manager.
 
 - `loadbalancer.openstack.org/load-balancer-id`
 
-  This annotation is automatically added to the Service if it's not specified when creating. After the Service is created successfully it shouldn't be changed, otherwise the Service won't behave as expected.  
+  This annotation is automatically added to the Service if it's not specified when creating. After the Service is created successfully it shouldn't be changed, otherwise the Service won't behave as expected.
 
   If this annotation is specified with a valid cloud load balancer ID when creating Service, the Service is reusing this load balancer rather than creating another one. Again, it shouldn't be changed after the Service is created.
 
@@ -413,9 +415,9 @@ To enable PROXY protocol support, the openstack-cloud-controller-manager config 
            ports:
              - containerPort: 8080
    EOF
-   
+
    $ kubectl expose deployment echoserver --type=ClusterIP --target-port=8080
-   
+
    $ cat <<EOF | kubectl apply -f -
    apiVersion: networking.k8s.io/v1
    kind: Ingress
@@ -437,7 +439,7 @@ To enable PROXY protocol support, the openstack-cloud-controller-manager config 
                  port:
                    number: 80
    EOF
-   
+
    $ kubectl get ing
    NAME                   CLASS    HOSTS      ADDRESS                 PORTS   AGE
    test-proxy-protocol    <none>   test.com   103.250.240.24.nip.io   80      58m
@@ -580,7 +582,7 @@ $ openstack loadbalancer listener list --loadbalancer 2b224530-9414-4302-8163-5a
 +--------------------------------------+----------+---------------+
 ```
 
-The load balancer will be deleted after `service-2` is deleted. 
+The load balancer will be deleted after `service-2` is deleted.
 
 ### IPv4 / IPv6 dual-stack services
 Since Kubernetes 1.20, Kubernetes clusters can run in dual-stack mode,

--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -177,7 +177,7 @@ Although the openstack-cloud-controller-manager was initially implemented with N
 
 * `use-octavia`
   Whether or not to use Octavia for LoadBalancer type of Service implementation instead of using Neutron-LBaaS. Default: true
-  
+
 * `floating-network-id`
   Optional. The external network used to create floating IP for the load balancer VIP. If there are multiple external networks in the cloud, either this option must be set or user must specify `loadbalancer.openstack.org/floating-network-id` in the Service annotation.
 
@@ -185,10 +185,10 @@ Although the openstack-cloud-controller-manager was initially implemented with N
   Optional. The external network subnet used to create floating IP for the load balancer VIP. Can be overridden by the Service annotation `loadbalancer.openstack.org/floating-subnet-id`.
 
 * `floating-subnet`
-  Optional. A name pattern (glob or regexp if starting with `~`) for the external network subnet used to create floating IP for the load balancer VIP. Can be overridden by the Service annotation `loadbalancer.openstack.org/floating-subnet`. If multiple subnets match the first one with still available IPs is used. 
+  Optional. A name pattern (glob or regexp if starting with `~`) for the external network subnet used to create floating IP for the load balancer VIP. Can be overridden by the Service annotation `loadbalancer.openstack.org/floating-subnet`. If multiple subnets match the first one with still available IPs is used.
 
 * `floating-subnet-tags`
-  Optional. Tags for the external network subnet used to create floating IP for the load balancer VIP. Can be overridden by the Service annotation `loadbalancer.openstack.org/floating-subnet-tags`. If multiple subnets match the first one with still available IPs is used. 
+  Optional. Tags for the external network subnet used to create floating IP for the load balancer VIP. Can be overridden by the Service annotation `loadbalancer.openstack.org/floating-subnet-tags`. If multiple subnets match the first one with still available IPs is used.
 
 * `lb-method`
   The load balancing algorithm used to create the load balancer pool. The value can be `ROUND_ROBIN`, `LEAST_CONNECTIONS`, or `SOURCE_IP`. Default: `ROUND_ROBIN`
@@ -227,7 +227,7 @@ Although the openstack-cloud-controller-manager was initially implemented with N
 
 * `cascade-delete`
   Determines whether or not to perform cascade deletion of load balancers. Default: true.
-  
+
 * `flavor-id`
   The id of the loadbalancer flavor to use. Uses octavia default if not set.
 
@@ -243,7 +243,7 @@ Although the openstack-cloud-controller-manager was initially implemented with N
   * floating-subnet-tags. The same with `floating-subnet-tags` option above.
   * network-id. The same with `network-id` option above.
   * subnet-id. The same with `subnet-id` option above.
-  
+
 * `enable-ingress-hostname`
 
   Used with proxy protocol (set by annotation `loadbalancer.openstack.org/proxy-protocol: "true"`) by adding a dns suffix (nip.io) to the load balancer IP address. Default false.
@@ -260,6 +260,13 @@ Although the openstack-cloud-controller-manager was initially implemented with N
   Reference to a tls container. This option works with Octavia, when this option is set then the cloud provider will create an Octavia Listener of type TERMINATED_HTTPS for a TLS Terminated loadbalancer.
 
   Format for tls container ref: `https://{keymanager_host}/v1/containers/{uuid}`
+  Check `container-store` parameter if you want to disable validation.
+
+* `container-store`
+  Optional. Used to specify the store of the tls-container-ref, e.g. "barbican" or "external" - other store will cause a warning log.
+  Default value - `barbican` - existence of tls container ref would always be performed.
+
+  If set to `external` format for tls container ref will not be validated.
 
 * `max-shared-lb`
   The maximum number of Services that share a load balancer. Default: 2

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -341,7 +341,6 @@ type serviceConfig struct {
 	flavorID                string
 	availabilityZone        string
 	tlsContainerRef         string
-	containerStore          string
 	lbID                    string
 	lbName                  string
 	supportLBTags           bool

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -341,6 +341,7 @@ type serviceConfig struct {
 	flavorID                string
 	availabilityZone        string
 	tlsContainerRef         string
+	containerStore          string
 	lbID                    string
 	lbName                  string
 	supportLBTags           bool
@@ -1598,15 +1599,17 @@ func (lbaas *LbaasV2) checkService(service *corev1.Service, nodes []*corev1.Node
 				"initialized and default-tls-container-ref %q is set", svcConf.tlsContainerRef)
 		}
 
-		// check if container exists
+		// check if container exists for 'barbican' container store
 		// tls container ref has the format: https://{keymanager_host}/v1/containers/{uuid}
-		slice := strings.Split(svcConf.tlsContainerRef, "/")
-		containerID := slice[len(slice)-1]
-		container, err := containers.Get(lbaas.secret, containerID).Extract()
-		if err != nil {
-			return fmt.Errorf("failed to get tls container %q: %v", svcConf.tlsContainerRef, err)
+		if lbaas.opts.ContainerStore == "barbican" {
+			slice := strings.Split(svcConf.tlsContainerRef, "/")
+			containerID := slice[len(slice)-1]
+			container, err := containers.Get(lbaas.secret, containerID).Extract()
+			if err != nil {
+				return fmt.Errorf("failed to get tls container %q: %v", svcConf.tlsContainerRef, err)
+			}
+			klog.V(4).Infof("Default TLS container %q found", container.ContainerRef)
 		}
-		klog.V(4).Infof("Default TLS container %q found", container.ContainerRef)
 	}
 
 	svcConf.connLimit = getIntFromServiceAnnotation(service, ServiceAnnotationLoadBalancerConnLimit, -1)

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -56,6 +56,9 @@ var userAgentData []string
 // supportedLBProvider map is used to define LoadBalancer providers that we support
 var supportedLBProvider = []string{"amphora", "octavia", "ovn"}
 
+// supportedContainerStore map is used to define supported tls-container-ref store
+var supportedContainerStore = []string{"barbican", "external"}
+
 // AddExtraFlags is called by the main package to add component specific command line flags
 func AddExtraFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVar(&userAgentData, "user-agent", nil, "Extra data to add to gophercloud user-agent. Use multiple times to add more than one component.")
@@ -98,6 +101,7 @@ type LoadBalancerOpts struct {
 	EnableIngressHostname bool                `gcfg:"enable-ingress-hostname"` // Used with proxy protocol by adding a dns suffix to the load balancer IP address. Default false.
 	IngressHostnameSuffix string              `gcfg:"ingress-hostname-suffix"` // Used with proxy protocol by adding a dns suffix to the load balancer IP address. Default nip.io.
 	MaxSharedLB           int                 `gcfg:"max-shared-lb"`           //  Number of Services in maximum can share a single load balancer. Default 2
+	ContainerStore        string              `gcfg:"container-store"`         // Used to specify the store of the tls-container-ref
 	// revive:disable:var-naming
 	TlsContainerRef string `gcfg:"default-tls-container-ref"` //  reference to a tls container
 	// revive:enable:var-naming
@@ -198,6 +202,7 @@ func ReadConfig(config io.Reader) (Config, error) {
 	cfg.LoadBalancer.EnableIngressHostname = false
 	cfg.LoadBalancer.IngressHostnameSuffix = defaultProxyHostnameSuffix
 	cfg.LoadBalancer.TlsContainerRef = ""
+	cfg.LoadBalancer.ContainerStore = "barbican"
 	cfg.LoadBalancer.MaxSharedLB = 2
 
 	err := gcfg.FatalOnly(gcfg.ReadInto(&cfg, config))
@@ -226,6 +231,10 @@ func ReadConfig(config io.Reader) (Config, error) {
 
 	if !util.Contains(supportedLBProvider, cfg.LoadBalancer.LBProvider) {
 		klog.Warningf("Unsupported LoadBalancer Provider: %s", cfg.LoadBalancer.LBProvider)
+	}
+
+	if !util.Contains(supportedContainerStore, cfg.LoadBalancer.ContainerStore) {
+		klog.Warningf("Unsupported Container Store: %s", cfg.LoadBalancer.ContainerStore)
 	}
 
 	return cfg, err


### PR DESCRIPTION
**What this PR does / why we need it**:
For heavely customized Openstack installation it may be helpful to disable `tls-container-ref` format validation.

Official [terraform-provider-openstack](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/lb_listener_v2#default_tls_container_ref) and [python-octaviaclient](https://docs.openstack.org/python-octaviaclient/pike/usage/osc/v2/load-balancer.html#cmdoption-loadbalancer-listener-create-default-tls-container-ref) do not have such validation mechanism

Now we have `container-store` parameter in `cloud.conf` which can be one of two values:
- `barbican` - Default. `tls-container-ref` format validation **enabled**
- `external` - `tls-container-ref` format validation **disabled**

**Which issue this PR fixes(if applicable)**:
fixes #1929

**Special notes for reviewers**:
If `container-store` set to `external` content of `tls-container-ref` parameter or annotation can be any string.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
