### PR TITLE
[cinder-csi-plugin] btrfs-volumes not mountable by cinder-csi-plugin

### DIFF
--- a/cluster/images/cinder-csi-plugin/Dockerfile.build
+++ b/cluster/images/cinder-csi-plugin/Dockerfile.build
@@ -4,6 +4,6 @@ FROM k8s.gcr.io/build-image/debian-base-${DEBIAN_ARCH}:v2.1.3
 ARG ARCH=amd64
 
 # Install e4fsprogs for format
-RUN clean-install ca-certificates e2fsprogs mount xfsprogs udev
+RUN clean-install btrfs-progs ca-certificates e2fsprogs mount udev xfsprogs
 
 ADD cinder-csi-plugin-${ARCH} /bin/cinder-csi-plugin


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the necessary binaries (via the corresponding deb-package) to be able to mount volumes containing btrfs. ( see [issue #1934](https://github.com/kubernetes/cloud-provider-openstack/issues/1934) and [this comment](https://github.com/kubernetes/cloud-provider-openstack/issues/1934#issuecomment-1186910206) ).

**Which issue this PR fixes(if applicable)**:
fixes #1934 

**Release note**:
```release-note
[cinder-csi-plugin] added capability to mount btrfs volumes.
```
