### PR TITLE
cherry pick support mounting btrfs volumes by the cinder-csi-plugin (#1941) to 1.24

### DIFF
--- a/cluster/images/cinder-csi-plugin/Dockerfile.build
+++ b/cluster/images/cinder-csi-plugin/Dockerfile.build
@@ -4,6 +4,6 @@ FROM k8s.gcr.io/build-image/debian-base-${DEBIAN_ARCH}:v2.1.3
 ARG ARCH=amd64
 
 # Install e4fsprogs for format
-RUN clean-install ca-certificates e2fsprogs mount xfsprogs udev
+RUN clean-install btrfs-progs ca-certificates e2fsprogs mount udev xfsprogs
 
 ADD cinder-csi-plugin-${ARCH} /bin/cinder-csi-plugin

--- a/pkg/autohealing/cloudprovider/openstack/provider.go
+++ b/pkg/autohealing/cloudprovider/openstack/provider.go
@@ -251,10 +251,11 @@ func (provider OpenStackCloudProvider) waitForServerDetachVolumes(serverID strin
 }
 
 // FirstTimeRepair Handle the first time repair for a node
-// 1) If the node is the first time in error, reboot and uncordon it
-// 2) If the node is not the first time in error, check if the last reboot time is in provider.Config.RebuildDelayAfterReboot
-//    That said, if the node has been found in broken status before but has been long time since then, the processed variable
-//    will be kept as False, which means the node need to be rebuilt to fix it, otherwise it means the has been processed.
+//  1. If the node is the first time in error, reboot and uncordon it
+//  2. If the node is not the first time in error, check if the last reboot time is in provider.Config.RebuildDelayAfterReboot
+//     That said, if the node has been found in broken status before but has been long time since then, the processed variable
+//     will be kept as False, which means the node need to be rebuilt to fix it, otherwise it means the has been processed.
+//
 // The bool type return value means that if the node has been processed from a first time repair PoV
 func (provider OpenStackCloudProvider) firstTimeRepair(n healthcheck.NodeInfo, serverID string, firstTimeRebootNodes map[string]healthcheck.NodeInfo) (bool, error) {
 	var firstTimeUnhealthy = true
@@ -312,12 +313,14 @@ func (provider OpenStackCloudProvider) firstTimeRepair(n healthcheck.NodeInfo, s
 }
 
 // Repair  For master nodes: detach etcd and docker volumes, find the root
-//         volume, then shutdown the VM, marks the both the VM and the root
-//         volume (heat resource) as "unhealthy" then trigger Heat stack update
-//         in order to rebuild the node. The information this function needs:
-//         - Nova VM ID
-//         - Root volume ID
-// 	       - Heat stack ID and resource ID.
+//
+//	        volume, then shutdown the VM, marks the both the VM and the root
+//	        volume (heat resource) as "unhealthy" then trigger Heat stack update
+//	        in order to rebuild the node. The information this function needs:
+//	        - Nova VM ID
+//	        - Root volume ID
+//		       - Heat stack ID and resource ID.
+//
 // For worker nodes: Call Magnum resize API directly.
 func (provider OpenStackCloudProvider) Repair(nodes []healthcheck.NodeInfo) error {
 	if len(nodes) == 0 {

--- a/pkg/csi/cinder/openstack/openstack_snapshots.go
+++ b/pkg/csi/cinder/openstack/openstack_snapshots.go
@@ -142,7 +142,7 @@ func (os *OpenStack) DeleteSnapshot(snapID string) error {
 	return err
 }
 
-//GetSnapshotByID returns snapshot details by id
+// GetSnapshotByID returns snapshot details by id
 func (os *OpenStack) GetSnapshotByID(snapshotID string) (*snapshots.Snapshot, error) {
 	s, err := snapshots.Get(os.blockstorage, snapshotID).Extract()
 	if err != nil {

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -223,7 +223,7 @@ func (os *OpenStack) WaitDiskAttached(instanceID string, volumeID string) error 
 	return err
 }
 
-//WaitVolumeTargetStatus waits for volume to be in target state
+// WaitVolumeTargetStatus waits for volume to be in target state
 func (os *OpenStack) WaitVolumeTargetStatus(volumeID string, tStatus []string) error {
 	backoff := wait.Backoff{
 		Duration: operationFinishInitDelay,
@@ -358,7 +358,7 @@ func (os *OpenStack) ExpandVolume(volumeID string, status string, newSize int) e
 	return fmt.Errorf("volume cannot be resized, when status is %s", status)
 }
 
-//GetMaxVolLimit returns max vol limit
+// GetMaxVolLimit returns max vol limit
 func (os *OpenStack) GetMaxVolLimit() int64 {
 	if os.bsOpts.NodeVolumeAttachLimit > 0 && os.bsOpts.NodeVolumeAttachLimit <= 256 {
 		return os.bsOpts.NodeVolumeAttachLimit

--- a/pkg/csi/manila/validator/validator.go
+++ b/pkg/csi/manila/validator/validator.go
@@ -28,20 +28,20 @@ import (
 // By default, the input data has to contain a value for each struct field.
 //
 // Available tags:
-// * name:"FIELD-NAME" : key of the value in the input map
-// * value: modifies value requirements:
-//   value:"required" : field is required
-//   value:"optional" : field is optional
-//   value:"requiredIf:FIELD-NAME=REGEXP-PATTERN" : field is required if the value of FIELD-NAME matches REGEXP-PATTERN
-//   value:"optionalIf:FIELD-NAME=REGEXP-PATTERN" : field is optional if the value of FIELD-NAME matches REGEXP-PATTERN
-//   value:"default:VALUE" : field value defaults to VALUE
-// * dependsOn:"FIELD-NAMES|,..." : if this field is not empty, the specified fields are required to be present
-//   operator ',' acts as AND
-//   operator '|' acts as XOR
-//   e.g.: dependsOn:"f1|f2|f3,f4,f5" : if this field is not empty, exactly one of {f1,f2,f3} is required to be present,
-//         and f4 and f5 is required to be present
-// * precludes:"FIELD-NAMES,..." : if this field is not empty, all specified fields are required to be empty
-// * matches:"REGEXP-PATTERN" : if this field is not empty, it's required to match REGEXP-PATTERN
+//   - name:"FIELD-NAME" : key of the value in the input map
+//   - value: modifies value requirements:
+//     value:"required" : field is required
+//     value:"optional" : field is optional
+//     value:"requiredIf:FIELD-NAME=REGEXP-PATTERN" : field is required if the value of FIELD-NAME matches REGEXP-PATTERN
+//     value:"optionalIf:FIELD-NAME=REGEXP-PATTERN" : field is optional if the value of FIELD-NAME matches REGEXP-PATTERN
+//     value:"default:VALUE" : field value defaults to VALUE
+//   - dependsOn:"FIELD-NAMES|,..." : if this field is not empty, the specified fields are required to be present
+//     operator ',' acts as AND
+//     operator '|' acts as XOR
+//     e.g.: dependsOn:"f1|f2|f3,f4,f5" : if this field is not empty, exactly one of {f1,f2,f3} is required to be present,
+//     and f4 and f5 is required to be present
+//   - precludes:"FIELD-NAMES,..." : if this field is not empty, all specified fields are required to be empty
+//   - matches:"REGEXP-PATTERN" : if this field is not empty, it's required to match REGEXP-PATTERN
 type Validator struct {
 	t reflect.Type
 

--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -1033,7 +1033,6 @@ func privateKeyFromPEM(pemData []byte) (crypto.PrivateKey, error) {
 
 // parsePEMBundle parses a certificate bundle from top to bottom and returns
 // a slice of x509 certificates. This function will error if no certificates are found.
-//
 func parsePEMBundle(bundle []byte) ([]*x509.Certificate, error) {
 	var certificates []*x509.Certificate
 	var certDERBlock *pem.Block

--- a/pkg/kms/barbican/barbican.go
+++ b/pkg/kms/barbican/barbican.go
@@ -15,7 +15,7 @@ type KMSOpts struct {
 	KeyID string `gcfg:"key-id"`
 }
 
-//Config to read config options
+// Config to read config options
 type Config struct {
 	Global     client.AuthOpts
 	KeyManager KMSOpts

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -743,7 +743,7 @@ func nodeAddressForLB(node *corev1.Node) (string, error) {
 	return "", cpoerrors.ErrNoAddressFound
 }
 
-//getStringFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's value or a specified defaultSetting
+// getStringFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's value or a specified defaultSetting
 func getStringFromServiceAnnotation(service *corev1.Service, annotationKey string, defaultSetting string) string {
 	klog.V(4).Infof("getStringFromServiceAnnotation(%s/%s, %v, %v)", service.Namespace, service.Name, annotationKey, defaultSetting)
 	if annotationValue, ok := service.Annotations[annotationKey]; ok {
@@ -760,7 +760,7 @@ func getStringFromServiceAnnotation(service *corev1.Service, annotationKey strin
 	return defaultSetting
 }
 
-//getIntFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's integer value or a specified defaultSetting
+// getIntFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's integer value or a specified defaultSetting
 func getIntFromServiceAnnotation(service *corev1.Service, annotationKey string, defaultSetting int) int {
 	klog.V(4).Infof("getIntFromServiceAnnotation(%s/%s, %v, %v)", service.Namespace, service.Name, annotationKey, defaultSetting)
 	if annotationValue, ok := service.Annotations[annotationKey]; ok {
@@ -777,7 +777,7 @@ func getIntFromServiceAnnotation(service *corev1.Service, annotationKey string, 
 	return defaultSetting
 }
 
-//getBoolFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's boolean value or a specified defaultSetting
+// getBoolFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's boolean value or a specified defaultSetting
 func getBoolFromServiceAnnotation(service *corev1.Service, annotationKey string, defaultSetting bool) bool {
 	klog.V(4).Infof("getBoolFromServiceAnnotation(%s/%s, %v, %v)", service.Namespace, service.Name, annotationKey, defaultSetting)
 	if annotationValue, ok := service.Annotations[annotationKey]; ok {
@@ -1187,7 +1187,7 @@ func (lbaas *LbaasV2) ensureOctaviaHealthMonitor(lbID string, name string, pool 
 	return nil
 }
 
-//buildMonitorCreateOpts returns a v2monitors.CreateOpts without PoolID for consumption of both, fully popuplated Loadbalancers and Monitors.
+// buildMonitorCreateOpts returns a v2monitors.CreateOpts without PoolID for consumption of both, fully popuplated Loadbalancers and Monitors.
 func (lbaas *LbaasV2) buildMonitorCreateOpts(svcConf *serviceConfig, port corev1.ServicePort) v2monitors.CreateOpts {
 	monitorProtocol := string(port.Protocol)
 	if port.Protocol == corev1.ProtocolUDP {
@@ -1301,7 +1301,7 @@ func (lbaas *LbaasV2) buildPoolCreateOpt(listenerProtocol string, service *corev
 	}
 }
 
-//buildBatchUpdateMemberOpts returns v2pools.BatchUpdateMemberOpts array for Services and Nodes alongside a list of member names
+// buildBatchUpdateMemberOpts returns v2pools.BatchUpdateMemberOpts array for Services and Nodes alongside a list of member names
 func (lbaas *LbaasV2) buildBatchUpdateMemberOpts(port corev1.ServicePort, nodes []*corev1.Node, svcConf *serviceConfig) ([]v2pools.BatchUpdateMemberOpts, sets.String, error) {
 	var members []v2pools.BatchUpdateMemberOpts
 	newMembers := sets.NewString()
@@ -1426,7 +1426,7 @@ func (lbaas *LbaasV2) ensureOctaviaListener(lbID string, name string, curListene
 	return listener, nil
 }
 
-//buildListenerCreateOpt returns listeners.CreateOpts for a specific Service port and configuration
+// buildListenerCreateOpt returns listeners.CreateOpts for a specific Service port and configuration
 func (lbaas *LbaasV2) buildListenerCreateOpt(port corev1.ServicePort, svcConf *serviceConfig) listeners.CreateOpts {
 	listenerProtocol := listeners.Protocol(port.Protocol)
 

--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -36,7 +36,7 @@ var ErrNoAddressFound = errors.New("no address found for host")
 // IPv6 support is disabled by config
 var ErrIPv6SupportDisabled = errors.New("IPv6 support is disabled")
 
-//ErrNoRouterID is used when router-id is not set
+// ErrNoRouterID is used when router-id is not set
 var ErrNoRouterID = errors.New("router-id not set in cloud provider config")
 
 func IsNotFound(err error) bool {

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -81,7 +81,7 @@ func getBaseMounter() *mount.SafeFormatAndMount {
 	}
 }
 
-//GetMountProvider returns instance of Mounter
+// GetMountProvider returns instance of Mounter
 func GetMountProvider() IMount {
 	if MInstance == nil {
 		MInstance = &Mount{BaseMounter: getBaseMounter()}

--- a/tests/sanity/cinder/fakemount.go
+++ b/tests/sanity/cinder/fakemount.go
@@ -18,7 +18,7 @@ var (
 	mounter     = &cpomount.Mount{BaseMounter: newFakeSafeFormatAndMounter()}
 )
 
-//GetFakeMountProvider returns fake instance of Mounter
+// GetFakeMountProvider returns fake instance of Mounter
 func GetFakeMountProvider() cpomount.IMount {
 	return &fakemount{BaseMounter: newFakeSafeFormatAndMounter()}
 }


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

cherry pick #1941
update go fmt with all files

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
