### PR TITLE
[occm] Support specifying a sort order for node addresses

### DIFF
--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -166,6 +166,13 @@ The options in `Global` section are used for openstack-cloud-controller-manager 
   The name of Neutron external network. openstack-cloud-controller-manager uses this option when getting the external IP of the Kubernetes node. Can be specified multiple times. Specified network names will be ORed. Default: ""
 * `internal-network-name`
   The name of Neutron internal network. openstack-cloud-controller-manager uses this option when getting the internal IP of the Kubernetes node, this is useful if the node has multiple interfaces. Can be specified multiple times. Specified network names will be ORed. Default: ""
+* `address-sort-order`
+  This configuration key influences the way the provider reports the node addresses to the Kubernetes node resource. The default order depends on the hard-coded order the provider queries the addresses and what the cloud returns, which does not guarantee a specific order.
+
+  To override this behavior it is possible to specify a comma separated list of CIDRs. Essentially, this will sort and group all addresses matching a CIDR in a prioritized manner, where the first item having a higher priority than the last. All non-matching addresses will remain in the same order they are already in.
+
+  For example, this option can be useful when having multiple or dual-stack interfaces attached to a node and needing a user-controlled, deterministic way of sorting the addresses.
+  Default: ""
 
 ###  Load Balancer
 

--- a/pkg/openstack/instances.go
+++ b/pkg/openstack/instances.go
@@ -17,6 +17,7 @@ limitations under the License.
 package openstack
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net"
@@ -56,9 +57,78 @@ type Instances struct {
 const (
 	instanceShutoff       = "SHUTOFF"
 	RegionalProviderIDEnv = "OS_CCM_REGIONAL"
+	noSortPriority        = 0
 )
 
 var _ cloudprovider.Instances = &Instances{}
+
+// buildAddressSortOrderList builds a list containing only valid CIDRs based on the content of addressSortOrder.
+//
+// It will ignore and warn about invalid sort order items.
+func buildAddressSortOrderList(addressSortOrder string) []*net.IPNet {
+	var list []*net.IPNet
+	for _, item := range strings.Split(addressSortOrder, ",") {
+		item = strings.TrimSpace(item)
+
+		_, cidr, err := net.ParseCIDR(item)
+		if err != nil {
+			klog.Warningf("Ignoring invalid sort order item '%s': %v.", item, err)
+			continue
+		}
+
+		list = append(list, cidr)
+	}
+
+	return list
+}
+
+// getSortPriority returns the priority as int of an address.
+//
+// The priority depends on the index of the CIDR in the list the address is matching,
+// where the first item of the list has higher priority than the last.
+//
+// If the address does not match any CIDR or is not an IP address the function returns noSortPriority.
+func getSortPriority(list []*net.IPNet, address string) int {
+	parsedAddress := net.ParseIP(address)
+	if parsedAddress == nil {
+		return noSortPriority
+	}
+
+	for i, cidr := range list {
+		if cidr.Contains(parsedAddress) {
+			fmt.Println(i, cidr, len(list)-i)
+			return len(list) - i
+		}
+	}
+
+	return noSortPriority
+}
+
+// sortNodeAddresses sorts node addresses based on comma separated list of CIDRs represented by addressSortOrder.
+//
+// The function only sorts addresses which match the CIDR and leaves the other addresses in the same order they are in.
+// Essentially, it will also group the addresses matching a CIDR together and sort them ascending in this group,
+// whereas the inter-group sorting depends on the priority.
+//
+// The priority depends on the order of the item in addressSortOrder, where the first item has higher priority than the last.
+func sortNodeAddresses(addresses []v1.NodeAddress, addressSortOrder string) {
+	list := buildAddressSortOrderList(addressSortOrder)
+
+	sort.SliceStable(addresses, func(i int, j int) bool {
+		addressLeft := addresses[i]
+		addressRight := addresses[j]
+
+		priorityLeft := getSortPriority(list, addressLeft.Address)
+		priorityRight := getSortPriority(list, addressRight.Address)
+
+		// ignore priorities of value 0 since this means the address has noSortPriority and we need to sort by priority
+		if priorityLeft > noSortPriority && priorityLeft == priorityRight {
+			return bytes.Compare(net.ParseIP(addressLeft.Address), net.ParseIP(addressRight.Address)) < 0
+		}
+
+		return priorityLeft > priorityRight
+	})
+}
 
 // Instances returns an implementation of Instances for OpenStack.
 func (os *OpenStack) Instances() (cloudprovider.Instances, bool) {
@@ -606,6 +676,10 @@ func nodeAddresses(srv *servers.Server, interfaces []attachinterfaces.Interface,
 				)
 			}
 		}
+	}
+
+	if networkingOpts.AddressSortOrder != "" {
+		sortNodeAddresses(addrs, networkingOpts.AddressSortOrder)
 	}
 
 	return addrs, nil

--- a/pkg/openstack/instances_test.go
+++ b/pkg/openstack/instances_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestBuildAddressSortOrderList(t *testing.T) {
+	var emptyList []*net.IPNet
+
+	_, cidrIPv4, _ := net.ParseCIDR("192.168.0.0/16")
+	_, cidrIPv6, _ := net.ParseCIDR("2001:4800:790e::/64")
+
+	emptyOption := ""
+	multipleInvalidOptions := "InvalidOption, AnotherInvalidOption"
+	multipleOptionsWithInvalidOption := fmt.Sprintf("%s, %s, %s", cidrIPv4, multipleInvalidOptions, cidrIPv6)
+
+	tests := map[string][]*net.IPNet{
+		emptyOption:                      emptyList,
+		multipleInvalidOptions:           emptyList,
+		multipleOptionsWithInvalidOption: {cidrIPv4, cidrIPv6},
+	}
+
+	for option, want := range tests {
+		actual := buildAddressSortOrderList(option)
+		if !reflect.DeepEqual(want, actual) {
+			t.Errorf("assignSortOrderPriorities returned incorrect value for '%v', want %+v but got %+v", option, want, actual)
+		}
+	}
+}
+
+func TestGetSortPriority(t *testing.T) {
+	_, cidrIPv4, _ := net.ParseCIDR("192.168.100.0/24")
+	_, cidrIPv6, _ := net.ParseCIDR("2001:4800:790e::/64")
+
+	list := []*net.IPNet{cidrIPv4, cidrIPv6}
+	t.Log(list)
+	tests := map[string]int{
+		"":                     noSortPriority,
+		"some-host.exam.ple":   noSortPriority,
+		"2001:4800:790e::82a8": 1,
+		"2001:cafe:babe::82a8": noSortPriority,
+		"192.168.100.200":      2,
+		"192.168.101.123":      noSortPriority,
+	}
+
+	for option, want := range tests {
+		actual := getSortPriority(list, option)
+		if !reflect.DeepEqual(want, actual) {
+			t.Errorf("assignSortOrderPriorities returned incorrect value for '%v', want %+v but got %+v", option, want, actual)
+		}
+	}
+}
+
+func executeSortNodeAddressesTest(t *testing.T, addressSortOrder string, want []v1.NodeAddress) {
+	addresses := []v1.NodeAddress{
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "192.168.0.1"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
+		{Type: v1.NodeInternalIP, Address: "172.16.0.1"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeInternalIP, Address: "50.56.176.37"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.exam.ple"},
+	}
+
+	sortNodeAddresses(addresses, addressSortOrder)
+
+	t.Logf("addresses are %v", addresses)
+	if !reflect.DeepEqual(want, addresses) {
+		t.Fatalf("sortNodeAddresses returned incorrect value, want %v", want)
+	}
+}
+
+func TestSortNodeAddressesWithAnInvalidCIDR(t *testing.T) {
+	addressSortOrder := "10.0.0.0/244"
+
+	want := []v1.NodeAddress{
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "192.168.0.1"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
+		{Type: v1.NodeInternalIP, Address: "172.16.0.1"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeInternalIP, Address: "50.56.176.37"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.exam.ple"},
+	}
+
+	executeSortNodeAddressesTest(t, addressSortOrder, want)
+}
+
+func TestSortNodeAddressesWithOneIPv4CIDR(t *testing.T) {
+	addressSortOrder := "10.0.0.0/8"
+
+	want := []v1.NodeAddress{
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "192.168.0.1"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "172.16.0.1"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "50.56.176.37"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.exam.ple"},
+	}
+
+	executeSortNodeAddressesTest(t, addressSortOrder, want)
+}
+
+func TestSortNodeAddressesWithOneIPv6CIDR(t *testing.T) {
+	addressSortOrder := "fd08:1374:fcee:916b::/64"
+
+	want := []v1.NodeAddress{
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "192.168.0.1"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
+		{Type: v1.NodeInternalIP, Address: "172.16.0.1"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeInternalIP, Address: "50.56.176.37"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.exam.ple"},
+	}
+
+	executeSortNodeAddressesTest(t, addressSortOrder, want)
+}
+
+func TestSortNodeAddressesWithMultipleCIDRs(t *testing.T) {
+	addressSortOrder := "10.0.0.0/8, 172.16.0.0/16, 192.168.0.0/24, fd08:1374:fcee:916b::/64, 50.56.176.0/24, 2001:cafe:babe::/64"
+
+	want := []v1.NodeAddress{
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
+		{Type: v1.NodeInternalIP, Address: "172.16.0.1"},
+		{Type: v1.NodeInternalIP, Address: "192.168.0.1"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeInternalIP, Address: "50.56.176.37"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.exam.ple"},
+	}
+
+	executeSortNodeAddressesTest(t, addressSortOrder, want)
+}

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -124,6 +124,7 @@ type NetworkingOpts struct {
 	IPv6SupportDisabled bool     `gcfg:"ipv6-support-disabled"`
 	PublicNetworkName   []string `gcfg:"public-network-name"`
 	InternalNetworkName []string `gcfg:"internal-network-name"`
+	AddressSortOrder    string   `gcfg:"address-sort-order"`
 }
 
 // RouterOpts is used for Neutron routes

--- a/pkg/openstack/openstack_test.go
+++ b/pkg/openstack/openstack_test.go
@@ -794,6 +794,90 @@ func TestNodeAddressesIPv6Disabled(t *testing.T) {
 	}
 }
 
+func TestNodeAddressesWithAddressSortOrderOptions(t *testing.T) {
+	srv := servers.Server{
+		Status:     "ACTIVE",
+		HostID:     "29d3c8c896a45aa4c34e52247875d7fefc3d94bbcc9f622b5d204362",
+		AccessIPv4: "50.56.176.99",
+		AccessIPv6: "2001:4800:790e:510:be76:4eff:fe04:82a8",
+		Addresses: map[string]interface{}{
+			"private": []interface{}{
+				map[string]interface{}{
+					"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:7c:1b:2b",
+					"version":                 float64(4),
+					"addr":                    "10.0.0.32",
+					"OS-EXT-IPS:type":         "fixed",
+				},
+				map[string]interface{}{
+					"version":         float64(4),
+					"addr":            "50.56.176.36",
+					"OS-EXT-IPS:type": "floating",
+				},
+				map[string]interface{}{
+					"version": float64(4),
+					"addr":    "10.0.0.31",
+					// No OS-EXT-IPS:type
+				},
+			},
+			"public": []interface{}{
+				map[string]interface{}{
+					"version": float64(4),
+					"addr":    "50.56.176.35",
+				},
+				map[string]interface{}{
+					"version": float64(6),
+					"addr":    "2001:4800:780e:510:be76:4eff:fe04:84a8",
+				},
+			},
+		},
+		Metadata: map[string]string{
+			"name":       "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy",
+			TypeHostName: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal",
+		},
+	}
+
+	networkingOpts := NetworkingOpts{
+		PublicNetworkName: []string{"public"},
+		AddressSortOrder:  "10.0.0.0/8, 50.56.176.0/24, 2001:4800::/32",
+	}
+
+	interfaces := []attachinterfaces.Interface{
+		{
+			PortState: "ACTIVE",
+			FixedIPs: []attachinterfaces.FixedIP{
+				{
+					IPAddress: "10.0.0.32",
+				},
+				{
+					IPAddress: "10.0.0.31",
+				},
+			},
+		},
+	}
+
+	addrs, err := nodeAddresses(&srv, interfaces, networkingOpts)
+	if err != nil {
+		t.Fatalf("nodeAddresses returned error: %v", err)
+	}
+
+	t.Logf("addresses are %v", addrs)
+
+	want := []v1.NodeAddress{
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
+	}
+
+	if !reflect.DeepEqual(want, addrs) {
+		t.Errorf("nodeAddresses returned incorrect value, want %v", want)
+	}
+}
+
 func TestNewOpenStack(t *testing.T) {
 	cfg := ConfigFromEnv()
 	testConfigFromEnv(t, &cfg)


### PR DESCRIPTION
**What this PR does / why we need it**:
This introduces a configuration key which influences the way the provider reports the node addresses to the Kubernetes node resource.

The default order depends on the hard-coded order the provider queries the addresses and what the cloud returns, which does not guarantee a specific order.

To override this behavior it is possible to specify a comma separated list of CIDRs. Essentially, this will sort and group all addresses matching a CIDR in a prioritized manner, where the first item having a higher priority than the last. All non-matching addresses will remain in the same order they are already in.

For example, this option can be useful when having multiple or dual-stack interfaces attached to a node and needing a user-controlled, deterministic way of sorting the addresses.

**Which issue this PR fixes(if applicable)**:
Fixes at least my issue with occm reporting either IPv6 or IPv4 when trying to access Pods and not needing to deactivate IPv6 reporting or specifying the IPv6 network as an external network (which is only possible if the IPv6 is from a different network anyhow).

**Special notes for reviewers**:
None so far.

**Release note**:
```release-note
[openstack-cloud-controller-manager] Support specifying a sort order for node addresses
```
