### PR TITLE
custom secret file for cloud.conf

### DIFF
--- a/charts/openstack-cloud-controller-manager/templates/secret.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/secret.yaml
@@ -5,5 +5,10 @@ metadata:
  name: {{ .Values.secret.name | default "cloud-config" }}
 type: Opaque
 data:
+ {{ if .Values.cloudConfigContents -}}
+ cloud.conf: |
+  {{ .Values.cloudConfigContents | b64enc }}
+ {{ else -}}
  cloud.conf: {{ include "cloudConfig" . | b64enc }}
+ {{ end -}}
 {{- end }}


### PR DESCRIPTION
What this PR does / why we need it:
This PR is fixing the absence of LoadBalancerClass parsing from the helm chart
This is a helm chart change only

Which issue this PR fixes(if applicable):
fixes #
Isue 1856
Special notes for reviewers:

Just pass a values.yaml containing a .Values.cloudConfigContents field

For example:

cloudConfigContents: |
   [Global]
   auth-url=""
   username=""
   user-domain-id=""
   password=""
   tenant-id=""
   project-domain-name=""
   region=""
  ca-file=""
  [Networking]
  internal-network-name=""
  [LoadBalancer]
  enable-ingress-hostname="true"
  use-octavia="true"
  create-monitor="true"
  floating-network-id=""
  subnet-id=""
  [LoadBalancerClass "testclass"]
  floating-network-id = ""
  subnet-id = ""
  [BlockStorage]
  ignore-volume-az=""

**Release note**:
```release-note
None
```

