### PR TITLE
fix gate issue

### DIFF
--- a/pkg/autohealing/cloudprovider/openstack/provider.go
+++ b/pkg/autohealing/cloudprovider/openstack/provider.go
@@ -253,10 +253,11 @@ func (provider CloudProvider) waitForServerDetachVolumes(serverID string, timeou
 }
 
 // FirstTimeRepair Handle the first time repair for a node
-// 1) If the node is the first time in error, reboot and uncordon it
-// 2) If the node is not the first time in error, check if the last reboot time is in provider.Config.RebuildDelayAfterReboot
-//    That said, if the node has been found in broken status before but has been long time since then, the processed variable
-//    will be kept as False, which means the node need to be rebuilt to fix it, otherwise it means the has been processed.
+//  1. If the node is the first time in error, reboot and uncordon it
+//  2. If the node is not the first time in error, check if the last reboot time is in provider.Config.RebuildDelayAfterReboot
+//     That said, if the node has been found in broken status before but has been long time since then, the processed variable
+//     will be kept as False, which means the node need to be rebuilt to fix it, otherwise it means the has been processed.
+//
 // The bool type return value means that if the node has been processed from a first time repair PoV
 func (provider CloudProvider) firstTimeRepair(n healthcheck.NodeInfo, serverID string, firstTimeRebootNodes map[string]healthcheck.NodeInfo) (bool, error) {
 	var firstTimeUnhealthy = true
@@ -313,12 +314,14 @@ func (provider CloudProvider) firstTimeRepair(n healthcheck.NodeInfo, serverID s
 }
 
 // Repair  For master nodes: detach etcd and docker volumes, find the root
-//         volume, then shutdown the VM, marks the both the VM and the root
-//         volume (heat resource) as "unhealthy" then trigger Heat stack update
-//         in order to rebuild the node. The information this function needs:
-//         - Nova VM ID
-//         - Root volume ID
-// 	       - Heat stack ID and resource ID.
+//
+//	        volume, then shutdown the VM, marks the both the VM and the root
+//	        volume (heat resource) as "unhealthy" then trigger Heat stack update
+//	        in order to rebuild the node. The information this function needs:
+//	        - Nova VM ID
+//	        - Root volume ID
+//		       - Heat stack ID and resource ID.
+//
 // For worker nodes: Call Magnum resize API directly.
 func (provider CloudProvider) Repair(nodes []healthcheck.NodeInfo) error {
 	if len(nodes) == 0 {

--- a/pkg/autohealing/healthcheck/plugin_endpoint.go
+++ b/pkg/autohealing/healthcheck/plugin_endpoint.go
@@ -19,8 +19,8 @@ package healthcheck
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -157,7 +157,7 @@ func (check *EndpointCheck) Check(node NodeInfo, controller NodeController) bool
 
 		if check.RequireToken {
 			if check.Token == "" {
-				b, err := ioutil.ReadFile(TokenPath)
+				b, err := os.ReadFile(TokenPath)
 				if err != nil {
 					log.Warningf("Node %s, failed to get token from %s, skip the check", nodeName, TokenPath)
 					return true

--- a/pkg/csi/cinder/driver.go
+++ b/pkg/csi/cinder/driver.go
@@ -48,8 +48,9 @@ var (
 	Version = "2.0.0"
 )
 
-//revive:disable:exported
 // Deprecated: use Driver instead
+//
+//revive:disable:exported
 type CinderDriver = Driver
 
 //revive:enable:exported

--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -18,7 +18,6 @@ package cinder
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -379,13 +378,10 @@ func TestNodeGetVolumeStatsBlock(t *testing.T) {
 	mmock.ExpectedCalls = nil
 
 	// setup for test
-	tempDir, err := ioutil.TempDir("", "cpo-test")
-	if err != nil {
-		t.Fatalf("Failed to set up temp dir: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := os.TempDir()
+	defer os.Remove(tempDir)
 	volumePath := filepath.Join(tempDir, FakeTargetPath)
-	err = os.MkdirAll(volumePath, 0750)
+	err := os.MkdirAll(volumePath, 0750)
 	if err != nil {
 		t.Fatalf("Failed to set up volumepath: %v", err)
 	}
@@ -417,13 +413,10 @@ func TestNodeGetVolumeStatsFs(t *testing.T) {
 	mmock.ExpectedCalls = nil
 
 	// setup for test
-	tempDir, err := ioutil.TempDir("", "cpo-test")
-	if err != nil {
-		t.Fatalf("Failed to set up temp dir: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := os.TempDir()
+	defer os.Remove(tempDir)
 	volumePath := filepath.Join(tempDir, FakeTargetPath)
-	err = os.MkdirAll(volumePath, 0750)
+	err := os.MkdirAll(volumePath, 0750)
 	if err != nil {
 		t.Fatalf("Failed to set up volumepath: %v", err)
 	}

--- a/pkg/csi/cinder/openstack/openstack_snapshots.go
+++ b/pkg/csi/cinder/openstack/openstack_snapshots.go
@@ -142,7 +142,7 @@ func (os *OpenStack) DeleteSnapshot(snapID string) error {
 	return err
 }
 
-//GetSnapshotByID returns snapshot details by id
+// GetSnapshotByID returns snapshot details by id
 func (os *OpenStack) GetSnapshotByID(snapshotID string) (*snapshots.Snapshot, error) {
 	s, err := snapshots.Get(os.blockstorage, snapshotID).Extract()
 	if err != nil {

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -223,7 +223,7 @@ func (os *OpenStack) WaitDiskAttached(instanceID string, volumeID string) error 
 	return err
 }
 
-//WaitVolumeTargetStatus waits for volume to be in target state
+// WaitVolumeTargetStatus waits for volume to be in target state
 func (os *OpenStack) WaitVolumeTargetStatus(volumeID string, tStatus []string) error {
 	backoff := wait.Backoff{
 		Duration: operationFinishInitDelay,
@@ -358,7 +358,7 @@ func (os *OpenStack) ExpandVolume(volumeID string, status string, newSize int) e
 	return fmt.Errorf("volume cannot be resized, when status is %s", status)
 }
 
-//GetMaxVolLimit returns max vol limit
+// GetMaxVolLimit returns max vol limit
 func (os *OpenStack) GetMaxVolLimit() int64 {
 	if os.bsOpts.NodeVolumeAttachLimit > 0 && os.bsOpts.NodeVolumeAttachLimit <= 256 {
 		return os.bsOpts.NodeVolumeAttachLimit

--- a/pkg/csi/manila/runtimeconfig/runtimeconfig.go
+++ b/pkg/csi/manila/runtimeconfig/runtimeconfig.go
@@ -18,7 +18,6 @@ package runtimeconfig
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 )
 
@@ -34,7 +33,7 @@ type RuntimeConfig struct {
 func Get() (*RuntimeConfig, error) {
 	// File contents are deliberately not cached
 	// as they may change over time.
-	data, err := ioutil.ReadFile(RuntimeConfigFilename)
+	data, err := os.ReadFile(RuntimeConfigFilename)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil

--- a/pkg/csi/manila/validator/validator.go
+++ b/pkg/csi/manila/validator/validator.go
@@ -28,20 +28,20 @@ import (
 // By default, the input data has to contain a value for each struct field.
 //
 // Available tags:
-// * name:"FIELD-NAME" : key of the value in the input map
-// * value: modifies value requirements:
-//   value:"required" : field is required
-//   value:"optional" : field is optional
-//   value:"requiredIf:FIELD-NAME=REGEXP-PATTERN" : field is required if the value of FIELD-NAME matches REGEXP-PATTERN
-//   value:"optionalIf:FIELD-NAME=REGEXP-PATTERN" : field is optional if the value of FIELD-NAME matches REGEXP-PATTERN
-//   value:"default:VALUE" : field value defaults to VALUE
-// * dependsOn:"FIELD-NAMES|,..." : if this field is not empty, the specified fields are required to be present
-//   operator ',' acts as AND
-//   operator '|' acts as XOR
-//   e.g.: dependsOn:"f1|f2|f3,f4,f5" : if this field is not empty, exactly one of {f1,f2,f3} is required to be present,
-//         and f4 and f5 is required to be present
-// * precludes:"FIELD-NAMES,..." : if this field is not empty, all specified fields are required to be empty
-// * matches:"REGEXP-PATTERN" : if this field is not empty, it's required to match REGEXP-PATTERN
+//   - name:"FIELD-NAME" : key of the value in the input map
+//   - value: modifies value requirements:
+//     value:"required" : field is required
+//     value:"optional" : field is optional
+//     value:"requiredIf:FIELD-NAME=REGEXP-PATTERN" : field is required if the value of FIELD-NAME matches REGEXP-PATTERN
+//     value:"optionalIf:FIELD-NAME=REGEXP-PATTERN" : field is optional if the value of FIELD-NAME matches REGEXP-PATTERN
+//     value:"default:VALUE" : field value defaults to VALUE
+//   - dependsOn:"FIELD-NAMES|,..." : if this field is not empty, the specified fields are required to be present
+//     operator ',' acts as AND
+//     operator '|' acts as XOR
+//     e.g.: dependsOn:"f1|f2|f3,f4,f5" : if this field is not empty, exactly one of {f1,f2,f3} is required to be present,
+//     and f4 and f5 is required to be present
+//   - precludes:"FIELD-NAMES,..." : if this field is not empty, all specified fields are required to be empty
+//   - matches:"REGEXP-PATTERN" : if this field is not empty, it's required to match REGEXP-PATTERN
 type Validator struct {
 	t reflect.Type
 

--- a/pkg/identity/keystone/sync.go
+++ b/pkg/identity/keystone/sync.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -134,7 +134,7 @@ func newSyncConfig() syncConfig {
 func newSyncConfigFromFile(path string) (*syncConfig, error) {
 	sc := newSyncConfig()
 
-	yamlFile, err := ioutil.ReadFile(path)
+	yamlFile, err := os.ReadFile(path)
 	if err != nil {
 		klog.Errorf("yamlFile get err   #%v ", err)
 		return nil, err

--- a/pkg/identity/keystone/token_getter.go
+++ b/pkg/identity/keystone/token_getter.go
@@ -19,11 +19,12 @@ package keystone
 import (
 	"crypto/tls"
 	"fmt"
+	"os"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	tokens3 "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 	"github.com/gophercloud/utils/client"
-	"io/ioutil"
 	certutil "k8s.io/client-go/util/cert"
 	osClient "k8s.io/cloud-provider-openstack/pkg/client"
 	"k8s.io/cloud-provider-openstack/pkg/version"
@@ -57,13 +58,13 @@ func GetToken(options Options) (*tokens3.Token, error) {
 	provider.UserAgent = userAgent
 
 	if options.ClientCertPath != "" && options.ClientKeyPath != "" {
-		clientCert, err := ioutil.ReadFile(options.ClientCertPath)
+		clientCert, err := os.ReadFile(options.ClientCertPath)
 		if err != nil {
 			msg := fmt.Errorf("failed: Cannot read cert file: %v", err)
 			return token, msg
 		}
 
-		clientKey, err := ioutil.ReadFile(options.ClientKeyPath)
+		clientKey, err := os.ReadFile(options.ClientKeyPath)
 		if err != nil {
 			msg := fmt.Errorf("failed: Cannot read key file: %v", err)
 			return token, msg

--- a/pkg/identity/keystone/token_getter_test.go
+++ b/pkg/identity/keystone/token_getter_test.go
@@ -16,7 +16,7 @@ package keystone
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -46,7 +46,7 @@ func TestTokenGetter(t *testing.T) {
 			}
 		}
 		var x AuthRequest
-		body, _ := ioutil.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(body, &x)
 		domainName := x.Auth.Identity.Password.User.Domain.Name
 		userName := x.Auth.Identity.Password.User.Name

--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -1033,7 +1033,6 @@ func privateKeyFromPEM(pemData []byte) (crypto.PrivateKey, error) {
 
 // parsePEMBundle parses a certificate bundle from top to bottom and returns
 // a slice of x509 certificates. This function will error if no certificates are found.
-//
 func parsePEMBundle(bundle []byte) ([]*x509.Certificate, error) {
 	var certificates []*x509.Certificate
 	var certDERBlock *pem.Block

--- a/pkg/kms/barbican/barbican.go
+++ b/pkg/kms/barbican/barbican.go
@@ -11,7 +11,7 @@ type KMSOpts struct {
 	KeyID string `gcfg:"key-id"`
 }
 
-//Config to read config options
+// Config to read config options
 type Config struct {
 	Global     client.AuthOpts
 	KeyManager KMSOpts

--- a/pkg/openstack/instances.go
+++ b/pkg/openstack/instances.go
@@ -19,8 +19,8 @@ package openstack
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -414,7 +414,7 @@ func readInstanceID(searchOrder string) (string, error) {
 
 	// Try to find instance ID on the local filesystem (created by cloud-init)
 	const instanceIDFile = "/var/lib/cloud/data/instance-id"
-	idBytes, err := ioutil.ReadFile(instanceIDFile)
+	idBytes, err := os.ReadFile(instanceIDFile)
 	if err == nil {
 		instanceID := string(idBytes)
 		instanceID = strings.TrimSpace(instanceID)

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -759,7 +759,7 @@ func nodeAddressForLB(node *corev1.Node, preferredIPFamily corev1.IPFamily) (str
 	return "", cpoerrors.ErrNoAddressFound
 }
 
-//getStringFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's value or a specified defaultSetting
+// getStringFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's value or a specified defaultSetting
 func getStringFromServiceAnnotation(service *corev1.Service, annotationKey string, defaultSetting string) string {
 	klog.V(4).Infof("getStringFromServiceAnnotation(%s/%s, %v, %v)", service.Namespace, service.Name, annotationKey, defaultSetting)
 	if annotationValue, ok := service.Annotations[annotationKey]; ok {
@@ -776,7 +776,7 @@ func getStringFromServiceAnnotation(service *corev1.Service, annotationKey strin
 	return defaultSetting
 }
 
-//getIntFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's integer value or a specified defaultSetting
+// getIntFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's integer value or a specified defaultSetting
 func getIntFromServiceAnnotation(service *corev1.Service, annotationKey string, defaultSetting int) int {
 	klog.V(4).Infof("getIntFromServiceAnnotation(%s/%s, %v, %v)", service.Namespace, service.Name, annotationKey, defaultSetting)
 	if annotationValue, ok := service.Annotations[annotationKey]; ok {
@@ -793,7 +793,7 @@ func getIntFromServiceAnnotation(service *corev1.Service, annotationKey string, 
 	return defaultSetting
 }
 
-//getBoolFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's boolean value or a specified defaultSetting
+// getBoolFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's boolean value or a specified defaultSetting
 func getBoolFromServiceAnnotation(service *corev1.Service, annotationKey string, defaultSetting bool) bool {
 	klog.V(4).Infof("getBoolFromServiceAnnotation(%s/%s, %v, %v)", service.Namespace, service.Name, annotationKey, defaultSetting)
 	if annotationValue, ok := service.Annotations[annotationKey]; ok {
@@ -1202,7 +1202,7 @@ func (lbaas *LbaasV2) ensureOctaviaHealthMonitor(lbID string, name string, pool 
 	return nil
 }
 
-//buildMonitorCreateOpts returns a v2monitors.CreateOpts without PoolID for consumption of both, fully popuplated Loadbalancers and Monitors.
+// buildMonitorCreateOpts returns a v2monitors.CreateOpts without PoolID for consumption of both, fully popuplated Loadbalancers and Monitors.
 func (lbaas *LbaasV2) buildMonitorCreateOpts(svcConf *serviceConfig, port corev1.ServicePort) v2monitors.CreateOpts {
 	monitorProtocol := string(port.Protocol)
 	if port.Protocol == corev1.ProtocolUDP {
@@ -1316,7 +1316,7 @@ func (lbaas *LbaasV2) buildPoolCreateOpt(listenerProtocol string, service *corev
 	}
 }
 
-//buildBatchUpdateMemberOpts returns v2pools.BatchUpdateMemberOpts array for Services and Nodes alongside a list of member names
+// buildBatchUpdateMemberOpts returns v2pools.BatchUpdateMemberOpts array for Services and Nodes alongside a list of member names
 func (lbaas *LbaasV2) buildBatchUpdateMemberOpts(port corev1.ServicePort, nodes []*corev1.Node, svcConf *serviceConfig) ([]v2pools.BatchUpdateMemberOpts, sets.String, error) {
 	var members []v2pools.BatchUpdateMemberOpts
 	newMembers := sets.NewString()
@@ -1441,7 +1441,7 @@ func (lbaas *LbaasV2) ensureOctaviaListener(lbID string, name string, curListene
 	return listener, nil
 }
 
-//buildListenerCreateOpt returns listeners.CreateOpts for a specific Service port and configuration
+// buildListenerCreateOpt returns listeners.CreateOpts for a specific Service port and configuration
 func (lbaas *LbaasV2) buildListenerCreateOpt(port corev1.ServicePort, svcConf *serviceConfig) listeners.CreateOpts {
 	listenerProtocol := listeners.Protocol(port.Protocol)
 

--- a/pkg/openstack/openstack_test.go
+++ b/pkg/openstack/openstack_test.go
@@ -19,7 +19,6 @@ package openstack
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -171,7 +170,7 @@ clouds:
     identity_api_version: 3
 `
 	data := []byte(cloud)
-	err = ioutil.WriteFile(cloudFile, data, 0644)
+	err = os.WriteFile(cloudFile, data, 0644)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/util/blockdevice/blockdevice_linux.go
+++ b/pkg/util/blockdevice/blockdevice_linux.go
@@ -19,7 +19,6 @@ package blockdevice
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -108,7 +107,7 @@ func RescanBlockDeviceGeometry(devicePath string, deviceMountPath string, newSiz
 
 	klog.V(3).Infof("Resolved block device path from %q to %q", devicePath, blockDeviceRescanPath)
 	klog.V(4).Infof("Rescanning %q block device geometry", devicePath)
-	err = ioutil.WriteFile(blockDeviceRescanPath, []byte{'1'}, 0666)
+	err = os.WriteFile(blockDeviceRescanPath, []byte{'1'}, 0666)
 	if err != nil {
 		klog.Errorf("Error rescanning new block device geometry: %v", err)
 		// no need to run checkBlockDeviceSize second time here, return the saved error

--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -36,7 +36,7 @@ var ErrNoAddressFound = errors.New("no address found for host")
 // IPv6 support is disabled by config
 var ErrIPv6SupportDisabled = errors.New("IPv6 support is disabled")
 
-//ErrNoRouterID is used when router-id is not set
+// ErrNoRouterID is used when router-id is not set
 var ErrNoRouterID = errors.New("router-id not set in cloud provider config")
 
 func IsNotFound(err error) bool {

--- a/pkg/util/metadata/metadata.go
+++ b/pkg/util/metadata/metadata.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -162,16 +161,13 @@ func getFromConfigDrive(metadataVersion string) (*Metadata, error) {
 		dev = strings.TrimSpace(string(out))
 	}
 
-	mntdir, err := ioutil.TempDir("", "configdrive")
-	if err != nil {
-		return nil, err
-	}
+	mntdir := os.TempDir()
 	defer os.Remove(mntdir)
 
 	klog.V(4).Infof("Attempting to mount configdrive %s on %s", dev, mntdir)
 
 	mounter := mount.GetMountProvider().Mounter()
-	err = mounter.Mount(dev, mntdir, "iso9660", []string{"ro"})
+	err := mounter.Mount(dev, mntdir, "iso9660", []string{"ro"})
 	if err != nil {
 		err = mounter.Mount(dev, mntdir, "vfat", []string{"ro"})
 	}

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -18,7 +18,6 @@ package mount
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -81,7 +80,7 @@ func getBaseMounter() *mount.SafeFormatAndMount {
 	}
 }
 
-//GetMountProvider returns instance of Mounter
+// GetMountProvider returns instance of Mounter
 func GetMountProvider() IMount {
 	if MInstance == nil {
 		MInstance = &Mount{BaseMounter: getBaseMounter()}
@@ -98,11 +97,11 @@ func (m *Mount) Mounter() *mount.SafeFormatAndMount {
 func probeVolume() error {
 	// rescan scsi bus
 	scsiPath := "/sys/class/scsi_host/"
-	if dirs, err := ioutil.ReadDir(scsiPath); err == nil {
+	if dirs, err := os.ReadDir(scsiPath); err == nil {
 		for _, f := range dirs {
 			name := scsiPath + f.Name() + "/scan"
 			data := []byte("- - -")
-			if err := ioutil.WriteFile(name, data, 0666); err != nil {
+			if err := os.WriteFile(name, data, 0666); err != nil {
 				return fmt.Errorf("Unable to scan %s: %w", f.Name(), err)
 			}
 		}
@@ -166,7 +165,7 @@ func (m *Mount) getDevicePathBySerialID(volumeID string) string {
 		fmt.Sprintf("wwn-0x%s", strings.Replace(volumeID, "-", "", -1)),
 	}
 
-	files, err := ioutil.ReadDir("/dev/disk/by-id/")
+	files, err := os.ReadDir("/dev/disk/by-id/")
 	if err != nil {
 		klog.V(4).Infof("ReadDir failed with error %v", err)
 	}

--- a/tests/sanity/cinder/fakemount.go
+++ b/tests/sanity/cinder/fakemount.go
@@ -18,7 +18,7 @@ var (
 	mounter     = &cpomount.Mount{BaseMounter: newFakeSafeFormatAndMounter()}
 )
 
-//GetFakeMountProvider returns fake instance of Mounter
+// GetFakeMountProvider returns fake instance of Mounter
 func GetFakeMountProvider() cpomount.IMount {
 	return &fakemount{BaseMounter: newFakeSafeFormatAndMounter()}
 }

--- a/tests/sanity/cinder/sanity_test.go
+++ b/tests/sanity/cinder/sanity_test.go
@@ -1,7 +1,6 @@
 package sanity
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -13,12 +12,8 @@ import (
 
 // start sanity test for driver
 func TestDriver(t *testing.T) {
-	basePath, err := ioutil.TempDir("", "cinder.csi.openstack.org")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(basePath)
+	basePath := os.TempDir()
+	defer os.Remove(basePath)
 
 	socket := path.Join(basePath, "csi.sock")
 	endpoint := "unix://" + socket

--- a/tests/sanity/manila/sanity_test.go
+++ b/tests/sanity/manila/sanity_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package sanity
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -28,12 +27,8 @@ import (
 )
 
 func TestDriver(t *testing.T) {
-	basePath, err := ioutil.TempDir("", "manila.csi.openstack.org")
-	if err != nil {
-		t.Fatalf("failed create base path in %s: %v", basePath, err)
-	}
-
-	defer os.RemoveAll(basePath)
+	basePath := os.TempDir()
+	defer os.Remove(basePath)
 
 	endpoint := path.Join(basePath, "csi.sock")
 	fwdEndpoint := "unix:///fake-fwd-endpoint"


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
