### PR TITLE
[occm] Add quotes to values in cloud.conf file in helm chart

### DIFF
--- a/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
+++ b/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
@@ -51,27 +51,27 @@ Create cloud-config makro.
 {{- define "cloudConfig" -}}
 [Global]
 {{- range $key, $value := .Values.cloudConfig.global }}
-{{ $key }} = {{ $value }}
+{{ $key }} = {{ $value | quote }}
 {{- end }}
 
 [Networking]
 {{- range $key, $value := .Values.cloudConfig.networking }}
-{{ $key }} = {{ $value }}
+{{ $key }} = {{ $value | quote }}
 {{- end }}
 
 [LoadBalancer]
 {{- range $key, $value := .Values.cloudConfig.loadBalancer }}
-{{ $key }} = {{ $value }}
+{{ $key }} = {{ $value | quote }}
 {{- end }}
 
 [BlockStorage]
 {{- range $key, $value := .Values.cloudConfig.blockStorage }}
-{{ $key }} = {{ $value }}
+{{ $key }} = {{ $value | quote }}
 {{- end }}
 
 [Metadata]
 {{- range $key, $value := .Values.cloudConfig.metadata }}
-{{ $key }} = {{ $value }}
+{{ $key }} = {{ $value | quote }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When a value in `cloud.conf`  (e.g. password) starts with `#` character, it becomes a comment since `#` starts comment section in `.conf` files. We need to add quotes around values to have valid conf files.

**Release note**:
```release-note
Add quotes to values in cloudConfig
```
