### PR TITLE
[occm] Option to configure member-subnet-id for Load Balancer

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -114,6 +114,10 @@ Request Body:
 
   VIP subnet ID of load balancer created.
 
+- `loadbalancer.openstack.org/member-subnet-id`
+
+  Member subnet ID of the load balancer created.
+
 - `loadbalancer.openstack.org/network-id`
 
   The network ID which will allocate virtual IP for loadbalancer.

--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -200,7 +200,10 @@ Although the openstack-cloud-controller-manager was initially implemented with N
   Optional. If specified, only "v2" is supported.
 
 * `subnet-id`
-  ID of the Neutron subnet on which to create load balancer VIP, this ID is also used to create pool members.
+  ID of the Neutron subnet on which to create load balancer VIP. This ID is also used to create pool members, if `member-subnet-id` is not set.
+
+* `member-subnet-id`
+  ID of the Neutron network on which to create the members of the load balancer. The load balancer gets another network port on this subnet. Defaults to `subnet-id` if not set.
 
 * `network-id`
   ID of the Neutron network on which to create load balancer VIP, not needed if `subnet-id` is set.
@@ -243,6 +246,7 @@ Although the openstack-cloud-controller-manager was initially implemented with N
   * floating-subnet-tags. The same with `floating-subnet-tags` option above.
   * network-id. The same with `network-id` option above.
   * subnet-id. The same with `subnet-id` option above.
+  * member-subnet-id. The same with `member-subnet-id` option above.
 
 * `enable-ingress-hostname`
 

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -80,6 +80,7 @@ type LoadBalancerOpts struct {
 	LBVersion             string              `gcfg:"lb-version"`           // overrides autodetection. Only support v2.
 	UseOctavia            bool                `gcfg:"use-octavia"`          // uses Octavia V2 service catalog endpoint
 	SubnetID              string              `gcfg:"subnet-id"`            // overrides autodetection.
+	MemberSubnetID        string              `gcfg:"member-subnet-id"`     // overrides autodetection.
 	NetworkID             string              `gcfg:"network-id"`           // If specified, will create virtual ip from a subnet in network which has available IP addresses
 	FloatingNetworkID     string              `gcfg:"floating-network-id"`  // If specified, will create floating ip for loadbalancer, or do not create floating ip.
 	FloatingSubnetID      string              `gcfg:"floating-subnet-id"`   // If specified, will create floating ip for loadbalancer in this particular floating pool subnetwork.
@@ -115,6 +116,7 @@ type LBClass struct {
 	FloatingSubnetTags string `gcfg:"floating-subnet-tags,omitempty"`
 	NetworkID          string `gcfg:"network-id,omitempty"`
 	SubnetID           string `gcfg:"subnet-id,omitempty"`
+	MemberSubnetID     string `gcfg:"member-subnet-id,omitempty"`
 }
 
 // NetworkingOpts is used for networking settings


### PR DESCRIPTION
This patch introduces the possibility to configure the member-subnet-id
independent from the subnet-id.

This way it is possible to create load balancer with several network ports in
different subnet. For example to create load balancer with IPv6 frontend and
IPv4 backend.

Signed-off-by: Sven Haardiek <sven.haardiek@uni-muenster.de>

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This patch introduces the possibility to configure the member-subnet-id
independent from the subnet-id.

This way it is possible to create load balancer with several network ports in
different subnet. For example to create load balancer with IPv6 frontend and
IPv4 backend.

It was already possible in a hacky way by using different `subnet-id`s in the
class configuration and the annotation. This way the annotation only overrides
the member-subnet-id, but not the subnet-id as described in
https://github.com/kubernetes/cloud-provider-openstack/issues/1086#issuecomment-650176521.
Unfortunately this hack does not work anymore, because in the current version
* only floating* configuration can be set via the class.
* classes are ignored in for internal load balancer.

See also #1961.

**Which issue this PR fixes(if applicable)**:
fixes #1855

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

the `loadbalancer.go` is a little bit complicated and IMHO needs a little bit of cleanup and refactoring. Therefore it feels quite complicated to introduce new code. We are pretty interested in this feature and in the loadbalancers itself. So we are willing to help to make the situation better. Also outside of the scope of this PR.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add option to configure `member-subnet-id` for Load Balancer.
```
