### PR TITLE
[occm] Ensure namespaced objects have namespace set

### DIFF
--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "occm.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "occm.labels" . | nindent 4 }}
 spec:

--- a/charts/openstack-cloud-controller-manager/templates/secret.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
  name: {{ .Values.secret.name | default "cloud-config" }}
+ namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
  {{ if .Values.cloudConfigContents -}}

--- a/charts/openstack-cloud-controller-manager/templates/service-sm.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/service-sm.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "occm.labels" . | nindent 4 }}
   name: {{ include "occm.name" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: http

--- a/charts/openstack-cloud-controller-manager/templates/serviceaccount.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/serviceaccount.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: openstack-cloud-controller-manager
+  namespace: {{ .Release.Namespace }}

--- a/charts/openstack-cloud-controller-manager/templates/servicemonitor.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/servicemonitor.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "occm.labels" . | nindent 4 }}
   name: {{ include "occm.name" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
**What this PR does / why we need it**:

Namespaced API resources should have the namespace value set explicitly.

This commit updates the OCCM Helm chart to add this field to each template, inheriting the value of `Release.Namespace`.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

Signed-off-by: Nick Jones <nick@dischord.org>