### PR TITLE
fix: Add region to providerID magic string

### DIFF
--- a/pkg/ingress/utils/utils.go
+++ b/pkg/ingress/utils/utils.go
@@ -74,17 +74,14 @@ func stringSlicesEqual(x, y []string) bool {
 
 // GetNodeID get instance ID from the Node spec.
 func GetNodeID(node *apiv1.Node) (string, error) {
-	var providerIDRegexp = regexp.MustCompile(`^openstack://([^/]*)/([^/]+)$`)
+	var providerIDRegexp = regexp.MustCompile(`^openstack://(?:[^/]*)/([^/]+)$`)
 
 	matches := providerIDRegexp.FindStringSubmatch(node.Spec.ProviderID)
-	switch len(matches) {
-	case 2:
-		return matches[1], nil
-	case 3:
-		return matches[2], nil
-	default:
+	if len(matches) != 2 {
 		return "", fmt.Errorf("failed to find instance ID from node provider ID %s", node.Spec.ProviderID)
 	}
+
+	return matches[1], nil
 }
 
 // Convert2Set converts a string list to string set.

--- a/pkg/openstack/instances.go
+++ b/pkg/openstack/instances.go
@@ -386,14 +386,10 @@ func instanceIDFromProviderID(providerID string) (instanceID string, region stri
 	}
 
 	matches := providerIDRegexp.FindStringSubmatch(providerID)
-	switch len(matches) {
-	case 2:
-		return matches[1], "", nil
-	case 3:
-		return matches[2], matches[1], nil
-	default:
+	if len(matches) != 3 {
 		return "", "", fmt.Errorf("ProviderID \"%s\" didn't match expected format \"openstack://region/InstanceID\"", providerID)
 	}
+	return matches[2], matches[1], nil
 }
 
 // AddToNodeAddresses appends the NodeAddresses to the passed-by-pointer slice,


### PR DESCRIPTION
Fix definition instanceID from providerID.
Revert to the previous version with small changes.

Based on the conversation #1909.
Thanks @anguslees

