### PR TITLE
[occm] Fix minor Inconsistency in `getMemberSubnetID`

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1503,9 +1503,9 @@ func (lbaas *LbaasV2) getMemberSubnetID(service *corev1.Service, svcConf *servic
 	// Get Member Subnet from Config Class
 	configClassName := getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerClass, "")
 	if configClassName != "" {
-		lbClass := lbaas.opts.LBClasses[svcConf.configClassName]
+		lbClass := lbaas.opts.LBClasses[configClassName]
 		if lbClass == nil {
-			return "", fmt.Errorf("invalid loadbalancer class %q", svcConf.configClassName)
+			return "", fmt.Errorf("invalid loadbalancer class %q", configClassName)
 		}
 		if lbClass.MemberSubnetID != "" {
 			return lbClass.MemberSubnetID, nil


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This patches fixes a small inconsistency in `getMemberSubnetID` where
`svcConf.configClassName` is used instead of `configClassName`.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
