### PR TITLE
[occm] network-id and subnet-id in class settings

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -108,7 +108,7 @@ Request Body:
 
 - `loadbalancer.openstack.org/class`
 
-  The name of a preconfigured class in the config file. If provided, this config options included in the class section take precedence over the annotations of floating-subnet-id and floating-network-id. See the section below for how it works.
+  The name of a preconfigured class in the config file. If provided, this config options included in the class section take precedence over the annotations of floating-subnet-id, floating-network-id, network-id, subnet-id and member-subnet-id . See the section below for how it works.
 
 - `loadbalancer.openstack.org/subnet-id`
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This patch make the `EnsureLoadbalancer` honor the settings for network-id and subnet-id made in the load balancer classes.
Otherwise subnet-id and network-id are not settable from the class and only from annotations, but according to the docs (at least part of the docs) this should work:

![image](https://user-images.githubusercontent.com/5557272/187695953-9bdafcfc-63ba-459b-8bcb-db300aa04324.png)


**Which issue this PR fixes(if applicable)**:
fixes #1961

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

I only fixed this for the octavia load balancer not for the legacy ones.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Honor network-id and subnet-id in load balancer classes
```
