### PR TITLE
Revert "[ci] bump golang version to 1.19 in install-golang role"

### DIFF
--- a/tests/playbooks/roles/install-golang/defaults/main.yml
+++ b/tests/playbooks/roles/install-golang/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-go_version: '1.19'
+go_version: '1.17.4'
 arch: 'amd64'
 go_tarball: 'go{{ go_version }}.linux-{{ arch }}.tar.gz'
-go_download_location: 'https://https://go.dev/dl/{{ go_tarball }}'
+go_download_location: 'https://storage.googleapis.com/golang/{{ go_tarball }}'


### PR DESCRIPTION
Reverts kubernetes/cloud-provider-openstack#1981

looks like this causing issue now ..

```release-note
None
```