### PR TITLE
[CI] bump golang version to 1.19 in install-golang role

### DIFF
--- a/tests/playbooks/roles/install-golang/defaults/main.yml
+++ b/tests/playbooks/roles/install-golang/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-go_version: '1.17.4'
+go_version: '1.19'
 arch: 'amd64'
 go_tarball: 'go{{ go_version }}.linux-{{ arch }}.tar.gz'
-go_download_location: 'https://storage.googleapis.com/golang/{{ go_tarball }}'
+go_download_location: 'https://go.dev/dl/{{ go_tarball }}'


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This PR sets golang version to 1.19 in install-golang role. The download location was also changed because 1.19 doesn't seem to be available in https://storage.googleapis.com/golang.

We need 1.19 golang toolchain because k/k 1.25 dependencies are already using some parts of its std lib which are not available in previous verisions (see https://github.com/kubernetes/cloud-provider-openstack/pull/1975#issuecomment-1232711142).

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:

This PR contains a fixed version of https://github.com/kubernetes/cloud-provider-openstack/pull/1981. There was a typo in the download URL.

This is the URL that gets generated + wget call to test

```
wget https://go.dev/dl/go1.19.linux-amd64.tar.gz
```

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
