### PR TITLE
[manila-csi-plugin] Fix fake csi and manila clients for sanity-csi test

### DIFF
--- a/tests/sanity/manila/fakecsiclient.go
+++ b/tests/sanity/manila/fakecsiclient.go
@@ -18,6 +18,7 @@ package sanity
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -76,11 +77,21 @@ func (c fakeNodeSvcClient) UnstageVolume(context.Context, *csi.NodeUnstageVolume
 	return &csi.NodeUnstageVolumeResponse{}, nil
 }
 
-func (c fakeNodeSvcClient) PublishVolume(context.Context, *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+func (c fakeNodeSvcClient) PublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+	// sanity-csi test checks for existence of target_path directory.
+	if err := os.MkdirAll(req.GetTargetPath(), 0700); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 
-func (c fakeNodeSvcClient) UnpublishVolume(context.Context, *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+func (c fakeNodeSvcClient) UnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+	// sanity-csi test checks that target_path directory no longer exists.
+	if err := os.RemoveAll(req.GetTargetPath()); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 }
 

--- a/tests/sanity/manila/fakemanilaclient.go
+++ b/tests/sanity/manila/fakemanilaclient.go
@@ -102,6 +102,9 @@ func (c fakeManilaClient) CreateShare(opts shares.CreateOptsBuilder) (*shares.Sh
 
 	share.ID = intToStr(fakeShareID)
 	share.Status = "available"
+	share.SnapshotSupport = true
+	share.CreateShareFromSnapshotSupport = true
+
 	fakeShares[fakeShareID] = share
 	fakeShareID++
 
@@ -135,6 +138,8 @@ func (c fakeManilaClient) ExtendShare(shareID string, opts shares.ExtendOptsBuil
 	if extendOpts.NewSize < share.Size {
 		return fmt.Errorf("new size is smaller than old size: %d < %d", extendOpts.NewSize, share.Size)
 	}
+
+	share.Size = extendOpts.NewSize
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a couple of missing things in fakecsiclient and fakemanilaclient used in sanity CSI tests.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
