### PR TITLE
[occm] Fix panic when setting fake proxy protocol LB hostname

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1951,7 +1951,7 @@ func (lbaas *LbaasV2) createLoadBalancerStatus(service *corev1.Service, svcConf 
 	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1860-kube-proxy-IP-node-binding
 	// is implemented (maybe in v1.22).
 	if svcConf.enableProxyProtocol && lbaas.opts.EnableIngressHostname {
-		fakeHostname := fmt.Sprintf("%s.%s", status.Ingress[0].IP, lbaas.opts.IngressHostnameSuffix)
+		fakeHostname := fmt.Sprintf("%s.%s", addr, lbaas.opts.IngressHostnameSuffix)
 		status.Ingress = []corev1.LoadBalancerIngress{{Hostname: fakeHostname}}
 		return status
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

With #1968 the execution order changed such that `status.Ingress` is `nil` leading to a panic. Instead, `addr` can be used directly.

**Which issue this PR fixes(if applicable)**:

**Special notes for reviewers**:

**Release note**:

```release-note
NONE
```
