### PR TITLE
[occm] add member name as key when comparing pool members

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1285,7 +1285,7 @@ func (lbaas *LbaasV2) ensureOctaviaPool(lbID string, name string, listener *list
 		klog.Errorf("failed to get members in the pool %s: %v", pool.ID, err)
 	}
 	for _, m := range poolMembers {
-		curMembers.Insert(fmt.Sprintf("%s-%d-%d", m.Address, m.ProtocolPort, m.MonitorPort))
+		curMembers.Insert(fmt.Sprintf("%s-%s-%d-%d", m.Name, m.Address, m.ProtocolPort, m.MonitorPort))
 	}
 
 	members, newMembers, err := lbaas.buildBatchUpdateMemberOpts(port, nodes, svcConf)
@@ -1364,7 +1364,7 @@ func (lbaas *LbaasV2) buildBatchUpdateMemberOpts(port corev1.ServicePort, nodes 
 			member.MonitorPort = &svcConf.healthCheckNodePort
 		}
 		members = append(members, member)
-		newMembers.Insert(fmt.Sprintf("%s-%d-%d", addr, member.ProtocolPort, svcConf.healthCheckNodePort))
+		newMembers.Insert(fmt.Sprintf("%s-%s-%d-%d", node.Name, addr, member.ProtocolPort, svcConf.healthCheckNodePort))
 	}
 	return members, newMembers, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**: we are currently facing issue when reusing the ip address (same openstack port) with newer instance. We are using kOps for provisioning our cluster. kOps is reusing ports and the only thing that is changing is instance name. 

this leads to following situation https://gist.github.com/zetaab/4f28c515d1d1dd792d526dbd6a69e4aa (loadbalancer member names does not match to kubernetes node names and weight of pool members are 0). When we force the update if node / instance name is updated at least this got solved and names are in-sync between k8s and openstack lb members. Also operating status changes ONLINE after names are updated.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:

kops executes rolling update to machines it marks nodes as weight 0 to loadbalancer pool member (https://github.com/kubernetes/kops/blob/master/upup/pkg/fi/cloudup/openstack/instance.go#L241-L246). It is because kops is draining connections away from that machine. However, now the problem is that new machines are using same ip. It means that openstack cloudprovider does not recreate the lb pool members. When it does not do that the weight stays 0 and lb pool member names are also out-of-date.

It leads to situation that we have basically working kubernetes cluster and loadbalancer members. The main problem is that lb pool member weight is 0 and that leads to problem that whole loadbalancer is basically not working

Another way to solve this issue is that kOps does not modify member weight to 0, instead it removes the member from the lb pool. In that case there is no time to drain the connection(s)?

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Pool members are forced to update if the instance name is modified
```
