### PR TITLE
[occm] Remove duplicate errors

### DIFF
--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -57,6 +57,7 @@ import (
 	"k8s.io/cloud-provider-openstack/pkg/ingress/config"
 	"k8s.io/cloud-provider-openstack/pkg/ingress/controller/openstack"
 	"k8s.io/cloud-provider-openstack/pkg/ingress/utils"
+	cpoerrors "k8s.io/cloud-provider-openstack/pkg/util/errors"
 	openstackutil "k8s.io/cloud-provider-openstack/pkg/util/openstack"
 )
 
@@ -456,7 +457,7 @@ func (c *Controller) nodeSyncLoop() {
 		lbName := utils.GetResourceName(ing.Namespace, ing.Name, c.config.ClusterName)
 		loadbalancer, err := openstackutil.GetLoadbalancerByName(c.osClient.Octavia, lbName)
 		if err != nil {
-			if err != openstackutil.ErrNotFound {
+			if err != cpoerrors.ErrNotFound {
 				log.WithFields(log.Fields{"name": lbName}).Errorf("Failed to retrieve loadbalancer from OpenStack: %v", err)
 			}
 
@@ -564,7 +565,7 @@ func (c *Controller) deleteIngress(ing *nwv1.Ingress) error {
 	// If load balancer doesn't exist, assume it's already deleted.
 	loadbalancer, err := openstackutil.GetLoadbalancerByName(c.osClient.Octavia, lbName)
 	if err != nil {
-		if err != openstackutil.ErrNotFound {
+		if err != cpoerrors.ErrNotFound {
 			return fmt.Errorf("error getting loadbalancer %s: %v", ing.Name, err)
 		}
 

--- a/pkg/ingress/controller/openstack/octavia.go
+++ b/pkg/ingress/controller/openstack/octavia.go
@@ -287,7 +287,7 @@ func (os *OpenStack) EnsureLoadBalancer(name string, subnetID string, ingNamespa
 
 	loadbalancer, err := openstackutil.GetLoadbalancerByName(os.Octavia, name)
 	if err != nil {
-		if err != openstackutil.ErrNotFound {
+		if err != cpoerrors.ErrNotFound {
 			return nil, fmt.Errorf("error getting loadbalancer %s: %v", name, err)
 		}
 
@@ -339,7 +339,7 @@ func (os *OpenStack) UpdateLoadBalancerDescription(lbID string, newDescription s
 func (os *OpenStack) EnsureListener(name string, lbID string, secretRefs []string, listenerAllowedCIDRs []string) (*listeners.Listener, error) {
 	listener, err := openstackutil.GetListenerByName(os.Octavia, name, lbID)
 	if err != nil {
-		if err != openstackutil.ErrNotFound {
+		if err != cpoerrors.ErrNotFound {
 			return nil, fmt.Errorf("error getting listener %s: %v", name, err)
 		}
 
@@ -394,7 +394,7 @@ func (os *OpenStack) EnsurePoolMembers(deleted bool, poolName string, lbID strin
 	if deleted {
 		pool, err := openstackutil.GetPoolByName(os.Octavia, poolName, lbID)
 		if err != nil {
-			if err != openstackutil.ErrNotFound {
+			if err != cpoerrors.ErrNotFound {
 				return nil, fmt.Errorf("error getting pool %s: %v", poolName, err)
 			}
 			return nil, nil
@@ -416,7 +416,7 @@ func (os *OpenStack) EnsurePoolMembers(deleted bool, poolName string, lbID strin
 
 	pool, err := openstackutil.GetPoolByName(os.Octavia, poolName, lbID)
 	if err != nil {
-		if err != openstackutil.ErrNotFound {
+		if err != cpoerrors.ErrNotFound {
 			return nil, fmt.Errorf("error getting pool %s: %v", poolName, err)
 		}
 

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -984,7 +984,7 @@ func (lbaas *LbaasV2) deleteListeners(lbID string, listenerList []listeners.List
 		klog.InfoS("Deleting listener", "listenerID", listener.ID, "lbID", lbID)
 
 		pool, err := openstackutil.GetPoolByListener(lbaas.lb, lbID, listener.ID)
-		if err != nil && err != openstackutil.ErrNotFound {
+		if err != nil && err != cpoerrors.ErrNotFound {
 			return fmt.Errorf("error getting pool for obsolete listener %s: %v", listener.ID, err)
 		}
 		if pool != nil {
@@ -1013,7 +1013,7 @@ func (lbaas *LbaasV2) deleteOctaviaListeners(lbID string, listenerList []listene
 			klog.InfoS("Deleting listener", "listenerID", listener.ID, "lbID", lbID)
 
 			pool, err := openstackutil.GetPoolByListener(lbaas.lb, lbID, listener.ID)
-			if err != nil && err != openstackutil.ErrNotFound {
+			if err != nil && err != cpoerrors.ErrNotFound {
 				return fmt.Errorf("error getting pool for listener %s: %v", listener.ID, err)
 			}
 			if pool != nil {
@@ -1243,7 +1243,7 @@ func (lbaas *LbaasV2) buildMonitorCreateOpts(svcConf *serviceConfig, port corev1
 // Make sure the pool is created for the Service, nodes are added as pool members.
 func (lbaas *LbaasV2) ensureOctaviaPool(lbID string, name string, listener *listeners.Listener, service *corev1.Service, port corev1.ServicePort, nodes []*corev1.Node, svcConf *serviceConfig) (*v2pools.Pool, error) {
 	pool, err := openstackutil.GetPoolByListener(lbaas.lb, lbID, listener.ID)
-	if err != nil && err != openstackutil.ErrNotFound {
+	if err != nil && err != cpoerrors.ErrNotFound {
 		return nil, fmt.Errorf("error getting pool for listener %s: %v", listener.ID, err)
 	}
 
@@ -2344,7 +2344,7 @@ func (lbaas *LbaasV2) ensureLoadBalancer(ctx context.Context, clusterName string
 		oldListeners = popListener(oldListeners, listener.ID)
 
 		pool, err := openstackutil.GetPoolByListener(lbaas.lb, loadbalancer.ID, listener.ID)
-		if err != nil && err != openstackutil.ErrNotFound {
+		if err != nil && err != cpoerrors.ErrNotFound {
 			return nil, fmt.Errorf("error getting pool for listener %s: %v", listener.ID, err)
 		}
 		if pool == nil {
@@ -2460,7 +2460,7 @@ func (lbaas *LbaasV2) ensureLoadBalancer(ctx context.Context, clusterName string
 		klog.V(4).Infof("Deleting obsolete listener %s:", listener.ID)
 		// get pool for listener
 		pool, err := openstackutil.GetPoolByListener(lbaas.lb, loadbalancer.ID, listener.ID)
-		if err != nil && err != openstackutil.ErrNotFound {
+		if err != nil && err != cpoerrors.ErrNotFound {
 			return nil, fmt.Errorf("error getting pool for obsolete listener %s: %v", listener.ID, err)
 		}
 		if pool != nil {
@@ -3366,7 +3366,7 @@ func (lbaas *LbaasV2) ensureLoadBalancerDeletedLegacy(loadbalancer *loadbalancer
 	var monitorIDs []string
 	for _, listener := range listenerList {
 		pool, err := openstackutil.GetPoolByListener(lbaas.lb, loadbalancer.ID, listener.ID)
-		if err != nil && err != openstackutil.ErrNotFound {
+		if err != nil && err != cpoerrors.ErrNotFound {
 			return fmt.Errorf("error getting pool for listener %s: %v", listener.ID, err)
 		}
 		if pool != nil {
@@ -3416,7 +3416,7 @@ func (lbaas *LbaasV2) ensureLoadBalancerDeleted(ctx context.Context, clusterName
 		// This may happen when this Service creation was failed previously.
 		loadbalancer, err = getLoadbalancerByName(lbaas.lb, lbName, legacyName)
 	}
-	if err != nil && err != cpoerrors.ErrNotFound {
+	if err != nil && !cpoerrors.IsNotFound(err) {
 		return err
 	}
 	if loadbalancer == nil {
@@ -3522,7 +3522,7 @@ func (lbaas *LbaasV2) ensureLoadBalancerDeleted(ctx context.Context, clusterName
 		var monitorIDs []string
 		for _, listener := range listenerList {
 			pool, err := openstackutil.GetPoolByListener(lbaas.lb, loadbalancer.ID, listener.ID)
-			if err != nil && err != openstackutil.ErrNotFound {
+			if err != nil && err != cpoerrors.ErrNotFound {
 				return fmt.Errorf("error getting pool for listener %s: %v", listener.ID, err)
 			}
 			if pool != nil {

--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -40,6 +40,10 @@ var ErrIPv6SupportDisabled = errors.New("IPv6 support is disabled")
 var ErrNoRouterID = errors.New("router-id not set in cloud provider config")
 
 func IsNotFound(err error) bool {
+	if err == ErrNotFound {
+		return true
+	}
+
 	if _, ok := err.(gophercloud.ErrDefault404); ok {
 		return true
 	}
@@ -52,10 +56,6 @@ func IsNotFound(err error) bool {
 		if errCode.Actual == http.StatusNotFound {
 			return true
 		}
-	}
-
-	if err == ErrNotFound {
-		return true
 	}
 
 	return false

--- a/pkg/util/openstack/keymanager.go
+++ b/pkg/util/openstack/keymanager.go
@@ -23,13 +23,14 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/keymanager/v1/secrets"
 	"k8s.io/cloud-provider-openstack/pkg/metrics"
+	cpoerrors "k8s.io/cloud-provider-openstack/pkg/util/errors"
 )
 
 // EnsureSecret creates a secret if it doesn't exist.
 func EnsureSecret(client *gophercloud.ServiceClient, name string, secretType string, payload string) (string, error) {
 	secret, err := GetSecret(client, name)
 	if err != nil {
-		if err == ErrNotFound {
+		if err == cpoerrors.ErrNotFound {
 			// Create a new one
 			return CreateSecret(client, name, secretType, payload)
 		}
@@ -56,10 +57,10 @@ func GetSecret(client *gophercloud.ServiceClient, name string) (*secrets.Secret,
 	}
 
 	if len(allSecrets) == 0 {
-		return nil, ErrNotFound
+		return nil, cpoerrors.ErrNotFound
 	}
 	if len(allSecrets) > 1 {
-		return nil, ErrMultipleResults
+		return nil, cpoerrors.ErrMultipleResults
 	}
 
 	return &allSecrets[0], nil

--- a/pkg/util/openstack/loadbalancer.go
+++ b/pkg/util/openstack/loadbalancer.go
@@ -17,7 +17,6 @@ limitations under the License.
 package openstack
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -56,11 +55,15 @@ const (
 var (
 	octaviaVersion string
 
-	// ErrNotFound is used to inform that the object is missing
-	ErrNotFound = errors.New("failed to find object")
+	// ErrNotFound is used to inform that the object is missing.
+	// Deprecated: use cpoerrors.ErrNotFound instead.
+	// TODO: remove in v1.27.0.
+	ErrNotFound = cpoerrors.ErrNotFound
 
-	// ErrMultipleResults is used when we unexpectedly get back multiple results
-	ErrMultipleResults = errors.New("multiple results where only one expected")
+	// ErrMultipleResults is used when we unexpectedly get back multiple results.
+	// Deprecated: use cpoerrors.ErrMultipleResults instead.
+	// TODO: remove in v1.27.0.
+	ErrMultipleResults = cpoerrors.ErrMultipleResults
 )
 
 // getOctaviaVersion returns the current Octavia API version.
@@ -221,10 +224,10 @@ func GetLoadbalancerByName(client *gophercloud.ServiceClient, name string) (*loa
 	}
 
 	if len(loadbalancerList) > 1 {
-		return nil, ErrMultipleResults
+		return nil, cpoerrors.ErrMultipleResults
 	}
 	if len(loadbalancerList) == 0 {
-		return nil, ErrNotFound
+		return nil, cpoerrors.ErrNotFound
 	}
 
 	return &loadbalancerList[0], nil
@@ -364,19 +367,19 @@ func GetListenerByName(client *gophercloud.ServiceClient, name string, lbID stri
 		}
 		listenerList = append(listenerList, v...)
 		if len(listenerList) > 1 {
-			return false, ErrMultipleResults
+			return false, cpoerrors.ErrMultipleResults
 		}
 		return true, nil
 	})
 	if mc.ObserveRequest(err) != nil {
 		if cpoerrors.IsNotFound(err) {
-			return nil, ErrNotFound
+			return nil, cpoerrors.ErrNotFound
 		}
 		return nil, err
 	}
 
 	if len(listenerList) == 0 {
-		return nil, ErrNotFound
+		return nil, cpoerrors.ErrNotFound
 	}
 
 	return &listenerList[0], nil
@@ -430,21 +433,21 @@ func GetPoolByName(client *gophercloud.ServiceClient, name string, lbID string) 
 		}
 		listenerPools = append(listenerPools, v...)
 		if len(listenerPools) > 1 {
-			return false, ErrMultipleResults
+			return false, cpoerrors.ErrMultipleResults
 		}
 		return true, nil
 	})
 	if mc.ObserveRequest(err) != nil {
 		if cpoerrors.IsNotFound(err) {
-			return nil, ErrNotFound
+			return nil, cpoerrors.ErrNotFound
 		}
 		return nil, err
 	}
 
 	if len(listenerPools) == 0 {
-		return nil, ErrNotFound
+		return nil, cpoerrors.ErrNotFound
 	} else if len(listenerPools) > 1 {
-		return nil, ErrMultipleResults
+		return nil, cpoerrors.ErrMultipleResults
 	}
 
 	return &listenerPools[0], nil
@@ -468,19 +471,19 @@ func GetPoolByListener(client *gophercloud.ServiceClient, lbID, listenerID strin
 			}
 		}
 		if len(listenerPools) > 1 {
-			return false, ErrMultipleResults
+			return false, cpoerrors.ErrMultipleResults
 		}
 		return true, nil
 	})
 	if mc.ObserveRequest(err) != nil {
 		if cpoerrors.IsNotFound(err) {
-			return nil, ErrNotFound
+			return nil, cpoerrors.ErrNotFound
 		}
 		return nil, err
 	}
 
 	if len(listenerPools) == 0 {
-		return nil, ErrNotFound
+		return nil, cpoerrors.ErrNotFound
 	}
 
 	return &listenerPools[0], nil


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Deprecates `ErrNotFound` and `ErrMultipleResults` errors in `k8s.io/cloud-provider-openstack/pkg/util/openstack`
as the same are defined in `k8s.io/cloud-provider-openstack/pkg/util/errors`.
Fix not found check for LoadBalancers in  `k8s.io/cloud-provider-openstack/pkg/util/openstack.ensureLoadBalancerDeleted` method.

**Which issue this PR fixes(if applicable)**:
fixes #1935

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Errors `ErrNotFound` and `ErrMultipleResults` in `k8s.io/cloud-provider-openstack/pkg/util/openstack` are deprecated, please use `ErrNotFound` and `ErrMultipleResults` from `k8s.io/cloud-provider-openstack/pkg/util/errors` instead
```
