### PR TITLE
Automated cherry pick of #2005: Fix panic when setting fake proxy protocol LB hostname

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1937,7 +1937,7 @@ func (lbaas *LbaasV2) createLoadBalancerStatus(service *corev1.Service, svcConf 
 	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1860-kube-proxy-IP-node-binding
 	// is implemented (maybe in v1.22).
 	if svcConf.enableProxyProtocol && lbaas.opts.EnableIngressHostname {
-		fakeHostname := fmt.Sprintf("%s.%s", status.Ingress[0].IP, lbaas.opts.IngressHostnameSuffix)
+		fakeHostname := fmt.Sprintf("%s.%s", addr, lbaas.opts.IngressHostnameSuffix)
 		status.Ingress = []corev1.LoadBalancerIngress{{Hostname: fakeHostname}}
 		return status
 	}


### PR DESCRIPTION
Cherry pick of #2005 on release-1.25.

#2005: Fix panic when setting fake proxy protocol LB hostname

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```