### PR TITLE
[manila-csi-plugin] Add csi-provisioner's --extra-create-metadata as share metadata

### DIFF
--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -26,6 +26,9 @@ spec:
             {{- if $.Values.csimanila.topologyAwarenessEnabled }}
             - "--feature-gates=Topology=true"
             {{- end }}
+            {{- if $.Values.controllerplugin.provisioner.extraCreateMetadata }}
+            - "--extra-create-metadata"
+            {{- end }}
           env:
             - name: ADDRESS
               value: "unix:///var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}/csi-controllerplugin.sock"

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -79,6 +79,8 @@ controllerplugin:
       tag: v3.0.0
       pullPolicy: IfNotPresent
     resources: {}
+    # Whether to pass --extra-create-metadata flag to csi-provisioner.
+    extraCreateMetadata: false
   # CSI external-snapshotter container spec
   snapshotter:
     image:


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This PR adds support for recognizing volume parameters when csi-provisioner sidecar is run with `--extra-create-metadata`, and adds those as share metadata.

```
$ kubectl get pvc
NAME                   STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS            AGE
new-cephfs-share-pvc   Bound    pvc-755d6df7-b29c-40c6-9df6-9008c8db5339   1Gi        RWX            geneva-cephfs-testing   56s

$ openstack share show pvc-755d6df7-b29c-40c6-9df6-9008c8db5339 -c properties -f value
{'csi.storage.k8s.io/pv/name': 'pvc-755d6df7-b29c-40c6-9df6-9008c8db5339', 'csi.storage.k8s.io/pvc/name': 'new-cephfs-share-pvc', 'csi.storage.k8s.io/pvc/namespace': 'default', 'manila.csi.openstack.org/cluster': '968241dc-0820-44b0-9f6c-3c78cf0dd0b7'}
```

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
manila-csi-plugin: Add csi-provisioner's --extra-create-metadata as share metadata. Disabled by default.
```
