### PR TITLE
Automated cherry pick of #1946: Support specifying a sort order for node addresses

### DIFF
--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -167,6 +167,13 @@ The options in `Global` section are used for openstack-cloud-controller-manager 
   The name of Neutron external network. openstack-cloud-controller-manager uses this option when getting the external IP of the Kubernetes node. Can be specified multiple times. Specified network names will be ORed. Default: ""
 * `internal-network-name`
   The name of Neutron internal network. openstack-cloud-controller-manager uses this option when getting the internal IP of the Kubernetes node, this is useful if the node has multiple interfaces. Can be specified multiple times. Specified network names will be ORed. Default: ""
+* `address-sort-order`
+  This configuration key influences the way the provider reports the node addresses to the Kubernetes node resource. The default order depends on the hard-coded order the provider queries the addresses and what the cloud returns, which does not guarantee a specific order.
+
+  To override this behavior it is possible to specify a comma separated list of CIDRs. Essentially, this will sort and group all addresses matching a CIDR in a prioritized manner, where the first item having a higher priority than the last. All non-matching addresses will remain in the same order they are already in.
+
+  For example, this option can be useful when having multiple or dual-stack interfaces attached to a node and needing a user-controlled, deterministic way of sorting the addresses.
+  Default: ""
 
 ###  Load Balancer
 

--- a/pkg/autohealing/cloudprovider/openstack/provider.go
+++ b/pkg/autohealing/cloudprovider/openstack/provider.go
@@ -251,10 +251,11 @@ func (provider OpenStackCloudProvider) waitForServerDetachVolumes(serverID strin
 }
 
 // FirstTimeRepair Handle the first time repair for a node
-// 1) If the node is the first time in error, reboot and uncordon it
-// 2) If the node is not the first time in error, check if the last reboot time is in provider.Config.RebuildDelayAfterReboot
-//    That said, if the node has been found in broken status before but has been long time since then, the processed variable
-//    will be kept as False, which means the node need to be rebuilt to fix it, otherwise it means the has been processed.
+//  1. If the node is the first time in error, reboot and uncordon it
+//  2. If the node is not the first time in error, check if the last reboot time is in provider.Config.RebuildDelayAfterReboot
+//     That said, if the node has been found in broken status before but has been long time since then, the processed variable
+//     will be kept as False, which means the node need to be rebuilt to fix it, otherwise it means the has been processed.
+//
 // The bool type return value means that if the node has been processed from a first time repair PoV
 func (provider OpenStackCloudProvider) firstTimeRepair(n healthcheck.NodeInfo, serverID string, firstTimeRebootNodes map[string]healthcheck.NodeInfo) (bool, error) {
 	var firstTimeUnhealthy = true
@@ -312,12 +313,14 @@ func (provider OpenStackCloudProvider) firstTimeRepair(n healthcheck.NodeInfo, s
 }
 
 // Repair  For master nodes: detach etcd and docker volumes, find the root
-//         volume, then shutdown the VM, marks the both the VM and the root
-//         volume (heat resource) as "unhealthy" then trigger Heat stack update
-//         in order to rebuild the node. The information this function needs:
-//         - Nova VM ID
-//         - Root volume ID
-// 	       - Heat stack ID and resource ID.
+//
+//	        volume, then shutdown the VM, marks the both the VM and the root
+//	        volume (heat resource) as "unhealthy" then trigger Heat stack update
+//	        in order to rebuild the node. The information this function needs:
+//	        - Nova VM ID
+//	        - Root volume ID
+//		       - Heat stack ID and resource ID.
+//
 // For worker nodes: Call Magnum resize API directly.
 func (provider OpenStackCloudProvider) Repair(nodes []healthcheck.NodeInfo) error {
 	if len(nodes) == 0 {

--- a/pkg/csi/cinder/openstack/openstack_snapshots.go
+++ b/pkg/csi/cinder/openstack/openstack_snapshots.go
@@ -142,7 +142,7 @@ func (os *OpenStack) DeleteSnapshot(snapID string) error {
 	return err
 }
 
-//GetSnapshotByID returns snapshot details by id
+// GetSnapshotByID returns snapshot details by id
 func (os *OpenStack) GetSnapshotByID(snapshotID string) (*snapshots.Snapshot, error) {
 	s, err := snapshots.Get(os.blockstorage, snapshotID).Extract()
 	if err != nil {

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -232,7 +232,7 @@ func (os *OpenStack) WaitDiskAttached(instanceID string, volumeID string) error 
 	return err
 }
 
-//WaitVolumeTargetStatus waits for volume to be in target state
+// WaitVolumeTargetStatus waits for volume to be in target state
 func (os *OpenStack) WaitVolumeTargetStatus(volumeID string, tStatus []string) error {
 	backoff := wait.Backoff{
 		Duration: operationFinishInitDelay,
@@ -367,7 +367,7 @@ func (os *OpenStack) ExpandVolume(volumeID string, status string, newSize int) e
 	return fmt.Errorf("volume cannot be resized, when status is %s", status)
 }
 
-//GetMaxVolLimit returns max vol limit
+// GetMaxVolLimit returns max vol limit
 func (os *OpenStack) GetMaxVolLimit() int64 {
 	if os.bsOpts.NodeVolumeAttachLimit > 0 && os.bsOpts.NodeVolumeAttachLimit <= 256 {
 		return os.bsOpts.NodeVolumeAttachLimit

--- a/pkg/csi/manila/validator/validator.go
+++ b/pkg/csi/manila/validator/validator.go
@@ -28,20 +28,20 @@ import (
 // By default, the input data has to contain a value for each struct field.
 //
 // Available tags:
-// * name:"FIELD-NAME" : key of the value in the input map
-// * value: modifies value requirements:
-//   value:"required" : field is required
-//   value:"optional" : field is optional
-//   value:"requiredIf:FIELD-NAME=REGEXP-PATTERN" : field is required if the value of FIELD-NAME matches REGEXP-PATTERN
-//   value:"optionalIf:FIELD-NAME=REGEXP-PATTERN" : field is optional if the value of FIELD-NAME matches REGEXP-PATTERN
-//   value:"default:VALUE" : field value defaults to VALUE
-// * dependsOn:"FIELD-NAMES|,..." : if this field is not empty, the specified fields are required to be present
-//   operator ',' acts as AND
-//   operator '|' acts as XOR
-//   e.g.: dependsOn:"f1|f2|f3,f4,f5" : if this field is not empty, exactly one of {f1,f2,f3} is required to be present,
-//         and f4 and f5 is required to be present
-// * precludes:"FIELD-NAMES,..." : if this field is not empty, all specified fields are required to be empty
-// * matches:"REGEXP-PATTERN" : if this field is not empty, it's required to match REGEXP-PATTERN
+//   - name:"FIELD-NAME" : key of the value in the input map
+//   - value: modifies value requirements:
+//     value:"required" : field is required
+//     value:"optional" : field is optional
+//     value:"requiredIf:FIELD-NAME=REGEXP-PATTERN" : field is required if the value of FIELD-NAME matches REGEXP-PATTERN
+//     value:"optionalIf:FIELD-NAME=REGEXP-PATTERN" : field is optional if the value of FIELD-NAME matches REGEXP-PATTERN
+//     value:"default:VALUE" : field value defaults to VALUE
+//   - dependsOn:"FIELD-NAMES|,..." : if this field is not empty, the specified fields are required to be present
+//     operator ',' acts as AND
+//     operator '|' acts as XOR
+//     e.g.: dependsOn:"f1|f2|f3,f4,f5" : if this field is not empty, exactly one of {f1,f2,f3} is required to be present,
+//     and f4 and f5 is required to be present
+//   - precludes:"FIELD-NAMES,..." : if this field is not empty, all specified fields are required to be empty
+//   - matches:"REGEXP-PATTERN" : if this field is not empty, it's required to match REGEXP-PATTERN
 type Validator struct {
 	t reflect.Type
 

--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -1033,7 +1033,6 @@ func privateKeyFromPEM(pemData []byte) (crypto.PrivateKey, error) {
 
 // parsePEMBundle parses a certificate bundle from top to bottom and returns
 // a slice of x509 certificates. This function will error if no certificates are found.
-//
 func parsePEMBundle(bundle []byte) ([]*x509.Certificate, error) {
 	var certificates []*x509.Certificate
 	var certDERBlock *pem.Block

--- a/pkg/kms/barbican/barbican.go
+++ b/pkg/kms/barbican/barbican.go
@@ -15,7 +15,7 @@ type KMSOpts struct {
 	KeyID string `gcfg:"key-id"`
 }
 
-//Config to read config options
+// Config to read config options
 type Config struct {
 	Global     client.AuthOpts
 	KeyManager KMSOpts

--- a/pkg/openstack/instances_test.go
+++ b/pkg/openstack/instances_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestBuildAddressSortOrderList(t *testing.T) {
+	var emptyList []*net.IPNet
+
+	_, cidrIPv4, _ := net.ParseCIDR("192.168.0.0/16")
+	_, cidrIPv6, _ := net.ParseCIDR("2001:4800:790e::/64")
+
+	emptyOption := ""
+	multipleInvalidOptions := "InvalidOption, AnotherInvalidOption"
+	multipleOptionsWithInvalidOption := fmt.Sprintf("%s, %s, %s", cidrIPv4, multipleInvalidOptions, cidrIPv6)
+
+	tests := map[string][]*net.IPNet{
+		emptyOption:                      emptyList,
+		multipleInvalidOptions:           emptyList,
+		multipleOptionsWithInvalidOption: {cidrIPv4, cidrIPv6},
+	}
+
+	for option, want := range tests {
+		actual := buildAddressSortOrderList(option)
+		if !reflect.DeepEqual(want, actual) {
+			t.Errorf("assignSortOrderPriorities returned incorrect value for '%v', want %+v but got %+v", option, want, actual)
+		}
+	}
+}
+
+func TestGetSortPriority(t *testing.T) {
+	_, cidrIPv4, _ := net.ParseCIDR("192.168.100.0/24")
+	_, cidrIPv6, _ := net.ParseCIDR("2001:4800:790e::/64")
+
+	list := []*net.IPNet{cidrIPv4, cidrIPv6}
+	t.Log(list)
+	tests := map[string]int{
+		"":                     noSortPriority,
+		"some-host.exam.ple":   noSortPriority,
+		"2001:4800:790e::82a8": 1,
+		"2001:cafe:babe::82a8": noSortPriority,
+		"192.168.100.200":      2,
+		"192.168.101.123":      noSortPriority,
+	}
+
+	for option, want := range tests {
+		actual := getSortPriority(list, option)
+		if !reflect.DeepEqual(want, actual) {
+			t.Errorf("assignSortOrderPriorities returned incorrect value for '%v', want %+v but got %+v", option, want, actual)
+		}
+	}
+}
+
+func executeSortNodeAddressesTest(t *testing.T, addressSortOrder string, want []v1.NodeAddress) {
+	addresses := []v1.NodeAddress{
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "192.168.0.1"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
+		{Type: v1.NodeInternalIP, Address: "172.16.0.1"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeInternalIP, Address: "50.56.176.37"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.exam.ple"},
+	}
+
+	sortNodeAddresses(addresses, addressSortOrder)
+
+	t.Logf("addresses are %v", addresses)
+	if !reflect.DeepEqual(want, addresses) {
+		t.Fatalf("sortNodeAddresses returned incorrect value, want %v", want)
+	}
+}
+
+func TestSortNodeAddressesWithAnInvalidCIDR(t *testing.T) {
+	addressSortOrder := "10.0.0.0/244"
+
+	want := []v1.NodeAddress{
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "192.168.0.1"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
+		{Type: v1.NodeInternalIP, Address: "172.16.0.1"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeInternalIP, Address: "50.56.176.37"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.exam.ple"},
+	}
+
+	executeSortNodeAddressesTest(t, addressSortOrder, want)
+}
+
+func TestSortNodeAddressesWithOneIPv4CIDR(t *testing.T) {
+	addressSortOrder := "10.0.0.0/8"
+
+	want := []v1.NodeAddress{
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "192.168.0.1"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "172.16.0.1"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "50.56.176.37"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.exam.ple"},
+	}
+
+	executeSortNodeAddressesTest(t, addressSortOrder, want)
+}
+
+func TestSortNodeAddressesWithOneIPv6CIDR(t *testing.T) {
+	addressSortOrder := "fd08:1374:fcee:916b::/64"
+
+	want := []v1.NodeAddress{
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeInternalIP, Address: "192.168.0.1"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
+		{Type: v1.NodeInternalIP, Address: "172.16.0.1"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeInternalIP, Address: "50.56.176.37"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.exam.ple"},
+	}
+
+	executeSortNodeAddressesTest(t, addressSortOrder, want)
+}
+
+func TestSortNodeAddressesWithMultipleCIDRs(t *testing.T) {
+	addressSortOrder := "10.0.0.0/8, 172.16.0.0/16, 192.168.0.0/24, fd08:1374:fcee:916b::/64, 50.56.176.0/24, 2001:cafe:babe::/64"
+
+	want := []v1.NodeAddress{
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
+		{Type: v1.NodeInternalIP, Address: "172.16.0.1"},
+		{Type: v1.NodeInternalIP, Address: "192.168.0.1"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeInternalIP, Address: "fd08:1374:fcee:916b:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeInternalIP, Address: "50.56.176.37"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.exam.ple"},
+	}
+
+	executeSortNodeAddressesTest(t, addressSortOrder, want)
+}

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -739,7 +739,7 @@ func nodeAddressForLB(node *corev1.Node) (string, error) {
 	return "", cpoerrors.ErrNoAddressFound
 }
 
-//getStringFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's value or a specified defaultSetting
+// getStringFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's value or a specified defaultSetting
 func getStringFromServiceAnnotation(service *corev1.Service, annotationKey string, defaultSetting string) string {
 	klog.V(4).Infof("getStringFromServiceAnnotation(%s/%s, %v, %v)", service.Namespace, service.Name, annotationKey, defaultSetting)
 	if annotationValue, ok := service.Annotations[annotationKey]; ok {
@@ -756,7 +756,7 @@ func getStringFromServiceAnnotation(service *corev1.Service, annotationKey strin
 	return defaultSetting
 }
 
-//getIntFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's integer value or a specified defaultSetting
+// getIntFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's integer value or a specified defaultSetting
 func getIntFromServiceAnnotation(service *corev1.Service, annotationKey string, defaultSetting int) int {
 	klog.V(4).Infof("getIntFromServiceAnnotation(%s/%s, %v, %v)", service.Namespace, service.Name, annotationKey, defaultSetting)
 	if annotationValue, ok := service.Annotations[annotationKey]; ok {
@@ -773,7 +773,7 @@ func getIntFromServiceAnnotation(service *corev1.Service, annotationKey string, 
 	return defaultSetting
 }
 
-//getBoolFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's boolean value or a specified defaultSetting
+// getBoolFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's boolean value or a specified defaultSetting
 func getBoolFromServiceAnnotation(service *corev1.Service, annotationKey string, defaultSetting bool) bool {
 	klog.V(4).Infof("getBoolFromServiceAnnotation(%s/%s, %v, %v)", service.Namespace, service.Name, annotationKey, defaultSetting)
 	if annotationValue, ok := service.Annotations[annotationKey]; ok {
@@ -1172,7 +1172,7 @@ func (lbaas *LbaasV2) ensureOctaviaHealthMonitor(lbID string, name string, pool 
 	return nil
 }
 
-//buildMonitorCreateOpts returns a v2monitors.CreateOpts without PoolID for consumption of both, fully popuplated Loadbalancers and Monitors.
+// buildMonitorCreateOpts returns a v2monitors.CreateOpts without PoolID for consumption of both, fully popuplated Loadbalancers and Monitors.
 func (lbaas *LbaasV2) buildMonitorCreateOpts(svcConf *serviceConfig, port corev1.ServicePort) v2monitors.CreateOpts {
 	monitorProtocol := string(port.Protocol)
 	if port.Protocol == corev1.ProtocolUDP {
@@ -1286,7 +1286,7 @@ func (lbaas *LbaasV2) buildPoolCreateOpt(listenerProtocol string, service *corev
 	}
 }
 
-//buildBatchUpdateMemberOpts returns v2pools.BatchUpdateMemberOpts array for Services and Nodes alongside a list of member names
+// buildBatchUpdateMemberOpts returns v2pools.BatchUpdateMemberOpts array for Services and Nodes alongside a list of member names
 func (lbaas *LbaasV2) buildBatchUpdateMemberOpts(port corev1.ServicePort, nodes []*corev1.Node, svcConf *serviceConfig) ([]v2pools.BatchUpdateMemberOpts, sets.String, error) {
 	var members []v2pools.BatchUpdateMemberOpts
 	newMembers := sets.NewString()
@@ -1411,7 +1411,7 @@ func (lbaas *LbaasV2) ensureOctaviaListener(lbID string, name string, curListene
 	return listener, nil
 }
 
-//buildListenerCreateOpt returns listeners.CreateOpts for a specific Service port and configuration
+// buildListenerCreateOpt returns listeners.CreateOpts for a specific Service port and configuration
 func (lbaas *LbaasV2) buildListenerCreateOpt(port corev1.ServicePort, svcConf *serviceConfig) listeners.CreateOpts {
 	listenerProtocol := listeners.Protocol(port.Protocol)
 

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -122,6 +122,7 @@ type NetworkingOpts struct {
 	IPv6SupportDisabled bool     `gcfg:"ipv6-support-disabled"`
 	PublicNetworkName   []string `gcfg:"public-network-name"`
 	InternalNetworkName []string `gcfg:"internal-network-name"`
+	AddressSortOrder    string   `gcfg:"address-sort-order"`
 }
 
 // RouterOpts is used for Neutron routes

--- a/pkg/openstack/openstack_test.go
+++ b/pkg/openstack/openstack_test.go
@@ -830,6 +830,90 @@ func TestNodeAddressesIPv6Disabled(t *testing.T) {
 	}
 }
 
+func TestNodeAddressesWithAddressSortOrderOptions(t *testing.T) {
+	srv := servers.Server{
+		Status:     "ACTIVE",
+		HostID:     "29d3c8c896a45aa4c34e52247875d7fefc3d94bbcc9f622b5d204362",
+		AccessIPv4: "50.56.176.99",
+		AccessIPv6: "2001:4800:790e:510:be76:4eff:fe04:82a8",
+		Addresses: map[string]interface{}{
+			"private": []interface{}{
+				map[string]interface{}{
+					"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:7c:1b:2b",
+					"version":                 float64(4),
+					"addr":                    "10.0.0.32",
+					"OS-EXT-IPS:type":         "fixed",
+				},
+				map[string]interface{}{
+					"version":         float64(4),
+					"addr":            "50.56.176.36",
+					"OS-EXT-IPS:type": "floating",
+				},
+				map[string]interface{}{
+					"version": float64(4),
+					"addr":    "10.0.0.31",
+					// No OS-EXT-IPS:type
+				},
+			},
+			"public": []interface{}{
+				map[string]interface{}{
+					"version": float64(4),
+					"addr":    "50.56.176.35",
+				},
+				map[string]interface{}{
+					"version": float64(6),
+					"addr":    "2001:4800:780e:510:be76:4eff:fe04:84a8",
+				},
+			},
+		},
+		Metadata: map[string]string{
+			"name":       "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy",
+			TypeHostName: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal",
+		},
+	}
+
+	networkingOpts := NetworkingOpts{
+		PublicNetworkName: []string{"public"},
+		AddressSortOrder:  "10.0.0.0/8, 50.56.176.0/24, 2001:4800::/32",
+	}
+
+	interfaces := []attachinterfaces.Interface{
+		{
+			PortState: "ACTIVE",
+			FixedIPs: []attachinterfaces.FixedIP{
+				{
+					IPAddress: "10.0.0.32",
+				},
+				{
+					IPAddress: "10.0.0.31",
+				},
+			},
+		},
+	}
+
+	addrs, err := nodeAddresses(&srv, interfaces, networkingOpts)
+	if err != nil {
+		t.Fatalf("nodeAddresses returned error: %v", err)
+	}
+
+	t.Logf("addresses are %v", addrs)
+
+	want := []v1.NodeAddress{
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
+	}
+
+	if !reflect.DeepEqual(want, addrs) {
+		t.Errorf("nodeAddresses returned incorrect value, want %v", want)
+	}
+}
+
 func TestNewOpenStack(t *testing.T) {
 	cfg := ConfigFromEnv()
 	testConfigFromEnv(t, &cfg)

--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -36,7 +36,7 @@ var ErrNoAddressFound = errors.New("no address found for host")
 // IPv6 support is disabled by config
 var ErrIPv6SupportDisabled = errors.New("IPv6 support is disabled")
 
-//ErrNoRouterID is used when router-id is not set
+// ErrNoRouterID is used when router-id is not set
 var ErrNoRouterID = errors.New("router-id not set in cloud provider config")
 
 func IsNotFound(err error) bool {

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -81,7 +81,7 @@ func getBaseMounter() *mount.SafeFormatAndMount {
 	}
 }
 
-//GetMountProvider returns instance of Mounter
+// GetMountProvider returns instance of Mounter
 func GetMountProvider() IMount {
 	if MInstance == nil {
 		MInstance = &Mount{BaseMounter: getBaseMounter()}

--- a/tests/sanity/cinder/fakemount.go
+++ b/tests/sanity/cinder/fakemount.go
@@ -18,7 +18,7 @@ var (
 	mounter     = &cpomount.Mount{BaseMounter: newFakeSafeFormatAndMounter()}
 )
 
-//GetFakeMountProvider returns fake instance of Mounter
+// GetFakeMountProvider returns fake instance of Mounter
 func GetFakeMountProvider() cpomount.IMount {
 	return &fakemount{BaseMounter: newFakeSafeFormatAndMounter()}
 }


### PR DESCRIPTION
Cherry pick of #1946 on release-1.23.

#1946: Support specifying a sort order for node addresses

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```