### PR TITLE
Concat AZ name with volume type

### DIFF
--- a/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
+++ b/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
@@ -118,6 +118,9 @@ These configuration options pertain to block storage and should appear in the `[
   Optional. When `Topology` feature enabled, by default, PV volume node affinity is populated with volume accessible topology, which is volume AZ. But, some of the openstack users do not have compute zones named exactly the same as volume zones. This might cause pods to go in pending state as no nodes available in volume AZ. Enabling `ignore-volume-az=true`, ignores volumeAZ and schedules on any of the available node AZ. Default `false`. Check `cross_az_attach` in [nova configuration](https://docs.openstack.org/nova/latest/configuration/config.html) for further information.
 * `ignore-volume-microversion`
   Optional. Set to `true` only when your cinder microversion is older than 3.34. This might cause some features to not work as expected, but aims to allow basic operations like creating a volume.
+* `append-volume-az`
+  Optional. Set to `true`, when you have availability zone suffix in volume type. For example: volume type = nvme-disk.eu-1a where nvme-disk is name of volume type and eu-1a is name of availability zone.
+  It can be enabled for Storage Class, please see options below. Also you can change separator for volume type using setting `append-volume-az-separator`, default is `.`.
 
 ### Metadata
 These configuration options pertain to metadata and should appear in the `[Metadata]` section of the `$CLOUD_CONFIG` file.
@@ -243,6 +246,8 @@ helm install --namespace kube-system --name cinder-csi ./charts/cinder-csi-plugi
 |-------------------------   |-----------------------|-----------------|-----------------|
 | StorageClass `parameters`  | `availability`          | `nova`          | String. Volume Availability Zone |
 | StorageClass `parameters`  | `type`                  | Empty String    | String. Name/ID of Volume type. Corresponding volume type should exist in cinder     |
+| StorageClass `parameters`  | `appendAZ`                  | `false`    | Boolean. For enabling append availability zone to type of volume     |
+| StorageClass `parameters`  | `appendAZseparator`                  | `.`    | String. Set separtator for volume type     |
 | VolumeSnapshotClass `parameters` | `force-create`    | `false`         | Enable to support creating snapshot for a volume in in-use status |
 | Inline Volume `volumeAttributes`   | `capacity`              | `1Gi`       | volume size for creating inline volumes| 
 | Inline Volume `VolumeAttributes`   | `type`              | Empty String  | Name/ID of Volume type. Corresponding volume type should exist in cinder |

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -84,7 +84,24 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	}
 
 	cloud := cs.Cloud
+	appendVolumeAZ := cloud.GetBlockStorageOpts().AppendVolumeAZ
+	volumeAZseparator := cloud.GetBlockStorageOpts().AppendVolumeAZseparator
 	ignoreVolumeAZ := cloud.GetBlockStorageOpts().IgnoreVolumeAZ
+
+	appendAZ, _ := strconv.ParseBool(req.GetParameters()["appendAZ"])
+	appendAZseparator := req.GetParameters()["appendAZseparator"]
+
+	if len(volumeAZseparator) == 0 {
+		volumeAZseparator = "."
+	}
+
+	if len(appendAZseparator) != 0 {
+		volumeAZseparator = appendAZseparator
+	}
+
+	if (appendVolumeAZ || appendAZ) && len(volAvailability) != 0 {
+		volType = fmt.Sprintf("%s%s%s", volType, volumeAZseparator, volAvailability)
+	}
 
 	// Verify a volume with the provided name doesn't already exist for this tenant
 	volumes, err := cloud.GetVolumesByName(volName)

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -73,10 +73,12 @@ type OpenStack struct {
 }
 
 type BlockStorageOpts struct {
-	NodeVolumeAttachLimit    int64 `gcfg:"node-volume-attach-limit"`
-	RescanOnResize           bool  `gcfg:"rescan-on-resize"`
-	IgnoreVolumeAZ           bool  `gcfg:"ignore-volume-az"`
-	IgnoreVolumeMicroversion bool  `gcfg:"ignore-volume-microversion"`
+	NodeVolumeAttachLimit    int64  `gcfg:"node-volume-attach-limit"`
+	RescanOnResize           bool   `gcfg:"rescan-on-resize"`
+	AppendVolumeAZ           bool   `gcfg:"append-volume-az"`
+	AppendVolumeAZseparator  string `gcfg:"append-volume-az-separator"`
+	IgnoreVolumeAZ           bool   `gcfg:"ignore-volume-az"`
+	IgnoreVolumeMicroversion bool   `gcfg:"ignore-volume-microversion"`
 }
 
 type Config struct {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
--> cinder-csi-plugin

**What this PR does / why we need it**:
This PR gives opportuinity to concatenate availability zone name with type of volume.
Motivation:
We have kubernetes cluster on the cloud that use openstack under the hood.
This cloud has few availability zones. For every AZ we have volume type with AZ suffix.
For example:
We has k8s at AZs called: eu1a, eu1b, eu1c. For every zone we have volume types: fastssd.eu1a, fastssd.eu1b, etc.
To be able to have disks in every zone we need to concat type of volume and AZ name together and pass to openstack server.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
