### PR TITLE
fix: remove leftover from bundled snapshot controller

### DIFF
--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -85,15 +85,6 @@ csi:
       nodeSelector: {}
       tolerations: []
     resources: {}
-  snapshotController:
-    enabled: false
-    image:
-      repository: k8s.gcr.io/sig-storage/snapshot-controller
-      tag: v5.0.1
-    resources: {}
-    affinity: {}
-    nodeSelector: {}
-    tolerations: []
 
 # Log verbosity level.
 # See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Remove leftover from https://github.com/kubernetes/cloud-provider-openstack/pull/1705

**Which issue this PR fixes(if applicable)**:
-

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->
-

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
