### PR TITLE
[magnum-auto-healer] fix for stuck nodes in Ready,SchedulingDisabled after repair by reboot 

### DIFF
--- a/pkg/autohealing/cloudprovider/openstack/provider.go
+++ b/pkg/autohealing/cloudprovider/openstack/provider.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 	log "k8s.io/klog/v2"
 
 	"k8s.io/cloud-provider-openstack/pkg/autohealing/config"
@@ -285,15 +286,42 @@ func (provider CloudProvider) firstTimeRepair(n healthcheck.NodeInfo, serverID s
 			// Uncordon the node
 			if n.IsWorker {
 				nodeName := n.KubeNode.Name
-				newNode := n.KubeNode.DeepCopy()
-				newNode.Spec.Unschedulable = false
-				if _, err := provider.KubeClient.CoreV1().Nodes().Update(context.TODO(), newNode, metav1.UpdateOptions{}); err != nil {
-					log.Errorf("Failed to cordon node %s, error: %v", nodeName, err)
-				} else {
-					log.Infof("Node %s is cordoned", nodeName)
+				// timeout for wait.Poll
+				timeout := 150 * time.Second
+				errServiceUp := wait.Poll(3*time.Second, timeout,
+					func() (bool, error) {
+						rapairedNode, getErr := provider.KubeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+						if getErr != nil {
+							log.Errorf("Failed to get node %s, error: %v in wait.Poll waiting for services to start", nodeName, getErr)
+						}
+						if getErr != nil {
+							return false, getErr
+						}
+						if strings.Contains(rapairedNode.Status.String(), "Type:Ready,Status:True") {
+							retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+								// Retrieve the latest version of Node before attempting update
+								// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
+								newNode, err := provider.KubeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+								if err != nil {
+									log.Errorf("Failed to get node %s, error: %v before update", nodeName, err)
+								}
+								newNode.Spec.Unschedulable = false
+								if _, updateErr := provider.KubeClient.CoreV1().Nodes().Update(context.TODO(), newNode, metav1.UpdateOptions{}); updateErr != nil {
+									log.Errorf("Failed to uncordon node %s, error: %v", nodeName, updateErr)
+									return updateErr
+								} else {
+									log.Infof("Node %s is uncordoned", nodeName)
+									return nil
+								}
+							})
+							return true, retryErr
+						}
+						return false, nil
+					})
+				if errServiceUp != nil {
+					log.Infof("Reboot doesn't repair Node %s error: %v", nodeName, errServiceUp)
 				}
 			}
-
 			n.RebootAt = time.Now()
 			firstTimeRebootNodes[serverID] = n
 			unHealthyNodes[serverID] = n

--- a/pkg/autohealing/controller/controller.go
+++ b/pkg/autohealing/controller/controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	log "k8s.io/klog/v2"
 
 	"k8s.io/cloud-provider-openstack/pkg/autohealing/cloudprovider"
@@ -327,17 +328,30 @@ func (c *Controller) repairNodes(unhealthyNodes []healthcheck.NodeInfo) {
 				// Cordon the nodes before repair.
 				for _, node := range unhealthyNodes {
 					nodeName := node.KubeNode.Name
-					newNode := node.KubeNode.DeepCopy()
-					newNode.Spec.Unschedulable = true
 
 					// Skip cordon for master node
 					if !node.IsWorker {
 						continue
 					}
-					if _, err := c.kubeClient.CoreV1().Nodes().Update(context.TODO(), newNode, metav1.UpdateOptions{}); err != nil {
-						log.Errorf("Failed to cordon node %s, error: %v", nodeName, err)
-					} else {
-						log.Infof("Node %s is cordoned", nodeName)
+					retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+						// Retrieve the latest version of Node before attempting update
+						// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
+						newNode, err := c.kubeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+						if err != nil {
+							log.Errorf("Failed to get node %s, error: %v before update", nodeName, err)
+						}
+						newNode.Spec.Unschedulable = true
+						if _, updateErr := c.kubeClient.CoreV1().Nodes().Update(context.TODO(), newNode, metav1.UpdateOptions{}); updateErr != nil {
+							log.Errorf("Failed in retry to cordon node %s, error: %v", nodeName, updateErr)
+							return updateErr
+						} else {
+							log.Infof("Node %s is cordoned", nodeName)
+							return nil
+						}
+					})
+					if retryErr != nil {
+						log.Errorf("Failed to cordon node %s, error: %v", nodeName, retryErr)
+
 					}
 				}
 


### PR DESCRIPTION
<!--
[magnum-auto-healer] fix for stuck nodes in Ready,SchedulingDisabled after repair by reboot 
-->

**What this PR does / why we need it**: 
is a proposal to solve the problem with worker nodes getting stuck in Ready,SchedulingDisabled after repair by reboot 

**Which issue this PR fixes(if applicable)**:
fixes #2053

**Special notes for reviewers**:
Build an image for magnum-auto-healer from the code with these changes, use this image in the magnum k8s cluster and simulate a failure on one of the cluster's working nodes, as follows:
`sudo systemctl stop kubelet`
and confirm that repair by reboot now works fine, and the problems described in issue [#2053](https://github.com/kubernetes/cloud-provider-openstack/issues/2053)    

**Release note**:
```release-note
NONE
```
