### PR TITLE
sercret disabling capabilities

### DIFF
--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -60,9 +60,11 @@ spec:
             protocol: TCP
           {{- end }}
           volumeMounts:
+            {{- if .Values.secret.enabled }}
             - mountPath: /etc/config
               name: cloud-config-volume
               readOnly: true
+            {{- end }}
           {{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
@@ -88,9 +90,11 @@ spec:
       {{- end }}
       hostNetwork: true
       volumes:
+      {{- if .Values.secret.enabled }}
       - name: cloud-config-volume
         secret:
           secretName: {{ .Values.secret.name }}
+      {{- end }}
       {{- if .Values.extraVolumes }}
         {{ toYaml .Values.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -75,6 +75,7 @@ serviceMonitor: {}
 # You can also provide your own secret (not created by the Helm chart), in this case set create to false
 # and adjust the name of the secret as necessary
 secret:
+  enabled: true
   create: true
   name: cloud-config
 


### PR DESCRIPTION
Add the capability to disable secret handling for cloud.conf file, in order to get creds from host volume