### PR TITLE
[cinder-csi-plugin] use newer base image for CSI cinder (#1994)

### DIFF
--- a/cluster/images/cinder-csi-plugin/Dockerfile
+++ b/cluster/images/cinder-csi-plugin/Dockerfile
@@ -13,7 +13,7 @@
 ARG DEBIAN_ARCH=amd64
 # We not using scratch because we need to keep the basic image information
 # from parent image
-FROM k8s.gcr.io/build-image/debian-base-${DEBIAN_ARCH}:v2.1.3
+FROM k8s.gcr.io/build-image/debian-base-${DEBIAN_ARCH}:bullseye-v1.4.2
 
 ARG ARCH=amd64
 

--- a/cluster/images/cinder-csi-plugin/Dockerfile.build
+++ b/cluster/images/cinder-csi-plugin/Dockerfile.build
@@ -1,5 +1,5 @@
 ARG DEBIAN_ARCH=amd64
-FROM k8s.gcr.io/build-image/debian-base-${DEBIAN_ARCH}:v2.1.3
+FROM k8s.gcr.io/build-image/debian-base-${DEBIAN_ARCH}:bullseye-v1.4.2
 
 ARG ARCH=amd64
 


### PR DESCRIPTION
**What this PR does / why we need it**: update base cinder image for less CVEs

**Which issue this PR fixes(if applicable)**:
fixes #1994


**Release note**:

```release-note
NONE
```
