### PR TITLE
[OCCM]nit: rename function WaitLoadbalancerActive

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -550,7 +550,7 @@ func (lbaas *LbaasV2) createFullyPopulatedOctaviaLoadBalancer(name, clusterName 
 		svcConf.lbMemberSubnetID = loadbalancer.VipSubnetID
 	}
 
-	if loadbalancer, err = openstackutil.WaitLoadbalancerActive(lbaas.lb, loadbalancer.ID); err != nil {
+	if loadbalancer, err = openstackutil.WaitActiveAndGetLoadBalancer(lbaas.lb, loadbalancer.ID); err != nil {
 		return nil, err
 	}
 

--- a/pkg/util/openstack/loadbalancer.go
+++ b/pkg/util/openstack/loadbalancer.go
@@ -159,7 +159,8 @@ func IsOctaviaFeatureSupported(client *gophercloud.ServiceClient, feature int, l
 	return false
 }
 
-func WaitLoadbalancerActive(client *gophercloud.ServiceClient, loadbalancerID string) (*loadbalancers.LoadBalancer, error) {
+// WaitActiveAndGetLoadBalancer wait for LB active then return the LB object for further usage
+func WaitActiveAndGetLoadBalancer(client *gophercloud.ServiceClient, loadbalancerID string) (*loadbalancers.LoadBalancer, error) {
 	klog.InfoS("Waiting for load balancer ACTIVE", "lbID", loadbalancerID)
 	backoff := wait.Backoff{
 		Duration: waitLoadbalancerInitDelay,
@@ -256,7 +257,7 @@ func UpdateLoadBalancerTags(client *gophercloud.ServiceClient, lbID string, tags
 		return err
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after updating: %v", lbID, err)
 	}
 
@@ -320,7 +321,7 @@ func UpdateListener(client *gophercloud.ServiceClient, lbID string, listenerID s
 		return err
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after updating listener: %v", lbID, err)
 	}
 
@@ -335,7 +336,7 @@ func CreateListener(client *gophercloud.ServiceClient, lbID string, opts listene
 		return nil, err
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return nil, fmt.Errorf("failed to wait for load balancer %s ACTIVE after creating listener: %v", lbID, err)
 	}
 
@@ -354,7 +355,7 @@ func DeleteListener(client *gophercloud.ServiceClient, listenerID string, lbID s
 		}
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after deleting listener: %v", lbID, err)
 	}
 
@@ -421,7 +422,7 @@ func CreatePool(client *gophercloud.ServiceClient, opts pools.CreateOptsBuilder,
 		return nil, err
 	}
 
-	if _, err = WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err = WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return nil, fmt.Errorf("failed to wait for load balancer ACTIVE after creating pool: %v", err)
 	}
 
@@ -551,7 +552,7 @@ func DeletePool(client *gophercloud.ServiceClient, poolID string, lbID string) e
 			return fmt.Errorf("error deleting pool %s for load balancer %s: %v", poolID, lbID, err)
 		}
 	}
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after deleting pool: %v", lbID, err)
 	}
 
@@ -566,7 +567,7 @@ func BatchUpdatePoolMembers(client *gophercloud.ServiceClient, lbID string, pool
 		return err
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after updating pool members for %s: %v", lbID, poolID, err)
 	}
 
@@ -602,7 +603,7 @@ func CreateL7Policy(client *gophercloud.ServiceClient, opts l7policies.CreateOpt
 		return nil, err
 	}
 
-	if _, err = WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err = WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return nil, fmt.Errorf("failed to wait for load balancer ACTIVE after creating l7policy: %v", err)
 	}
 
@@ -616,7 +617,7 @@ func DeleteL7policy(client *gophercloud.ServiceClient, policyID string, lbID str
 		return err
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after deleting l7policy: %v", lbID, err)
 	}
 
@@ -646,7 +647,7 @@ func CreateL7Rule(client *gophercloud.ServiceClient, policyID string, opts l7pol
 		return err
 	}
 
-	if _, err = WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err = WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer ACTIVE after creating l7policy rule: %v", err)
 	}
 
@@ -672,7 +673,7 @@ func DeleteHealthMonitor(client *gophercloud.ServiceClient, monitorID string, lb
 		return mc.ObserveRequest(err)
 	}
 	_ = mc.ObserveRequest(nil)
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after deleting healthmonitor: %v", lbID, err)
 	}
 
@@ -687,7 +688,7 @@ func CreateHealthMonitor(client *gophercloud.ServiceClient, opts monitors.Create
 		return nil, fmt.Errorf("failed to create healthmonitor: %v", err)
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return nil, fmt.Errorf("failed to wait for load balancer %s ACTIVE after creating healthmonitor: %v", lbID, err)
 	}
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
