### PR TITLE
[occm] Rename WaitLoadbalancerActive

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -549,7 +549,7 @@ func (lbaas *LbaasV2) createFullyPopulatedOctaviaLoadBalancer(name, clusterName 
 		svcConf.lbMemberSubnetID = loadbalancer.VipSubnetID
 	}
 
-	if loadbalancer, err = openstackutil.WaitLoadbalancerActive(lbaas.lb, loadbalancer.ID); err != nil {
+	if loadbalancer, err = openstackutil.WaitLoadBalancerActiveAndGetLB(lbaas.lb, loadbalancer.ID); err != nil {
 		return nil, err
 	}
 

--- a/pkg/util/openstack/loadbalancer.go
+++ b/pkg/util/openstack/loadbalancer.go
@@ -159,7 +159,7 @@ func IsOctaviaFeatureSupported(client *gophercloud.ServiceClient, feature int, l
 	return false
 }
 
-func WaitLoadbalancerActive(client *gophercloud.ServiceClient, loadbalancerID string) (*loadbalancers.LoadBalancer, error) {
+func WaitLoadBalancerActiveAndGetLB(client *gophercloud.ServiceClient, loadbalancerID string) (*loadbalancers.LoadBalancer, error) {
 	klog.InfoS("Waiting for load balancer ACTIVE", "lbID", loadbalancerID)
 	backoff := wait.Backoff{
 		Duration: waitLoadbalancerInitDelay,
@@ -256,7 +256,7 @@ func UpdateLoadBalancerTags(client *gophercloud.ServiceClient, lbID string, tags
 		return err
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitLoadBalancerActiveAndGetLB(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after updating: %v", lbID, err)
 	}
 
@@ -320,7 +320,7 @@ func UpdateListener(client *gophercloud.ServiceClient, lbID string, listenerID s
 		return err
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitLoadBalancerActiveAndGetLB(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after updating listener: %v", lbID, err)
 	}
 
@@ -335,7 +335,7 @@ func CreateListener(client *gophercloud.ServiceClient, lbID string, opts listene
 		return nil, err
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitLoadBalancerActiveAndGetLB(client, lbID); err != nil {
 		return nil, fmt.Errorf("failed to wait for load balancer %s ACTIVE after creating listener: %v", lbID, err)
 	}
 
@@ -354,7 +354,7 @@ func DeleteListener(client *gophercloud.ServiceClient, listenerID string, lbID s
 		}
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitLoadBalancerActiveAndGetLB(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after deleting listener: %v", lbID, err)
 	}
 
@@ -421,7 +421,7 @@ func CreatePool(client *gophercloud.ServiceClient, opts pools.CreateOptsBuilder,
 		return nil, err
 	}
 
-	if _, err = WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err = WaitLoadBalancerActiveAndGetLB(client, lbID); err != nil {
 		return nil, fmt.Errorf("failed to wait for load balancer ACTIVE after creating pool: %v", err)
 	}
 
@@ -551,7 +551,7 @@ func DeletePool(client *gophercloud.ServiceClient, poolID string, lbID string) e
 			return fmt.Errorf("error deleting pool %s for load balancer %s: %v", poolID, lbID, err)
 		}
 	}
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitLoadBalancerActiveAndGetLB(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after deleting pool: %v", lbID, err)
 	}
 
@@ -566,7 +566,7 @@ func BatchUpdatePoolMembers(client *gophercloud.ServiceClient, lbID string, pool
 		return err
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitLoadBalancerActiveAndGetLB(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after updating pool members for %s: %v", lbID, poolID, err)
 	}
 
@@ -602,7 +602,7 @@ func CreateL7Policy(client *gophercloud.ServiceClient, opts l7policies.CreateOpt
 		return nil, err
 	}
 
-	if _, err = WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err = WaitLoadBalancerActiveAndGetLB(client, lbID); err != nil {
 		return nil, fmt.Errorf("failed to wait for load balancer ACTIVE after creating l7policy: %v", err)
 	}
 
@@ -616,7 +616,7 @@ func DeleteL7policy(client *gophercloud.ServiceClient, policyID string, lbID str
 		return err
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitLoadBalancerActiveAndGetLB(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after deleting l7policy: %v", lbID, err)
 	}
 
@@ -646,7 +646,7 @@ func CreateL7Rule(client *gophercloud.ServiceClient, policyID string, opts l7pol
 		return err
 	}
 
-	if _, err = WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err = WaitLoadBalancerActiveAndGetLB(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer ACTIVE after creating l7policy rule: %v", err)
 	}
 
@@ -672,7 +672,7 @@ func DeleteHealthMonitor(client *gophercloud.ServiceClient, monitorID string, lb
 		return mc.ObserveRequest(err)
 	}
 	_ = mc.ObserveRequest(nil)
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitLoadBalancerActiveAndGetLB(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after deleting healthmonitor: %v", lbID, err)
 	}
 
@@ -687,7 +687,7 @@ func CreateHealthMonitor(client *gophercloud.ServiceClient, opts monitors.Create
 		return nil, fmt.Errorf("failed to create healthmonitor: %v", err)
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitLoadBalancerActiveAndGetLB(client, lbID); err != nil {
 		return nil, fmt.Errorf("failed to wait for load balancer %s ACTIVE after creating healthmonitor: %v", lbID, err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As `WaitLoadbalancerActive()` function now returns the LB as well, it's renamed to `WaitLoadBalancerActiveAndGetLB()`.

```release-note
NONE
```
