### PR TITLE
cinder-csi doc: update trouble shooting with volume not extended

### DIFF
--- a/docs/cinder-csi-plugin/troubleshooting.md
+++ b/docs/cinder-csi-plugin/troubleshooting.md
@@ -1,5 +1,11 @@
 # Troubleshooting
 
+## When trying to resize a Cinder Volume, PV/PVC is updated but file system not resized.
+
+Check the volume status by using `openstack volume show` command about the volume (it should have `pvc-` prefix) and see whether backend openstack need update, contact with your openstack administrator for help on the error reported.
+
+`openstack volume message list --os-volume-api-version 3.3` might also show some information about a failed resize, e.g. extend volume:Compute service failed to extend volume.
+
 ## When trying to resize a Cinder Volume based on Ceph, the VM doesn't see the new size.
 
 Chances are, the underlying OpenStack is not configured properly.


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
related to #2059 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
