### PR TITLE
[all] Add k8s.io/dynamic-resource-allocation to replaced deps 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -166,6 +166,7 @@ replace (
 	k8s.io/controller-manager => k8s.io/controller-manager v0.26.0
 	k8s.io/cri-api => k8s.io/cri-api v0.26.0
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.26.0
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.26.0
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.26.0
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.26.0
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.26.0


### PR DESCRIPTION
**What this PR does / why we need it**:
After #2052 we see build failures like these:

```
mdulko:cloud-provider-openstack/ (master) $ go list -v -mod readonly -m all                                               
get "k8s.io/dynamic-resource-allocation": found meta tag vcs.metaImport{Prefix:"k8s.io/dynamic-resource-allocation", VCS:"git", RepoRoot:"https://github.com/kubernetes/dynamic-resource-allocation"} at //k8s.io/dyn
amic-resource-allocation?go-get=1
go: k8s.io/dynamic-resource-allocation@v0.0.0: invalid version: unknown revision v0.0.0
```

This comes from https://github.com/kubernetes/kubernetes/blob/master/go.mod#L109 and by comparison of other v0.0.0 modules we replace I added dynamic-resource-allocation as well. I'm not 100% sure this is the correct way to go, please advise if not.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
```
NONE
```
