### PR TITLE
doc: cinder-csi-plugin - add general ephemeral disk usage

### DIFF
--- a/docs/cinder-csi-plugin/examples.md
+++ b/docs/cinder-csi-plugin/examples.md
@@ -101,9 +101,11 @@ $ mount /dev/vdb /mnt; ls /mnt
 index.html  lost+found
 ```
 
-## Deploy app using Inline volumes
+## Deploy app using ephemeral volumes
 
-Sample App definition on using Inline volumes can be found at [here](../../examples/cinder-csi-plugin/ephemeral/csi-ephemeral-volumes-example.yaml)
+### CSI Ephemeral Volumes
+
+Sample App definition on using CSI ephemeral volumes can be found at [here](../../examples/cinder-csi-plugin/ephemeral/csi-ephemeral-volumes-example.yaml)
 
 Prerequisites:
 * Deploy CSI Driver, with both volumeLifecycleModes enabled as specified [here](../../manifests/cinder-csi-plugin/csi-cinder-driver.yaml)
@@ -128,6 +130,43 @@ Volumes:
     SecretName:  default-token-dn78p
     Optional:    false
 
+```
+
+### Generic Ephemeral Volumes
+
+Sample App definition on using generic ephemeral volumes can be found at [here](../../examples/cinder-csi-plugin/ephemeral/generic-ephemeral-volumes.yaml)
+
+Create a pod with ephemeral volume and storage class
+
+```
+# kubectl create -f examples/cinder-csi-plugin/ephemeral/generic-ephemeral-volumes.yaml
+storageclass.storage.k8s.io/scratch-storage-class created
+pod/ephemeral-example created
+``` 
+
+```
+# kubectl get pods -A
+NAMESPACE     NAME                                                          READY   STATUS    RESTARTS   AGE
+default       ephemeral-example                                             1/1     Running   0          28s
+```
+
+we can find pv/pvc/volumes created just like general volume.
+
+```
+# kubectl get pvc
+NAME                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS            AGE
+ephemeral-example-scratch-volume   Bound    pvc-9848ed86-8aa1-439b-9839-9ceba6e6f653   1Gi        RWO            scratch-storage-class   32s
+
+# kubectl get pv
+NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                      STORAGECLASS            REASON   AGE
+pvc-9848ed86-8aa1-439b-9839-9ceba6e6f653   1Gi        RWO            Delete           Bound    default/ephemeral-example-scratch-volume   scratch-storage-class            35s
+
+# cinder list
++--------------------------------------+-----------+------------------------------------------+------+-------------+----------+--------------------------------------+
+| ID                                   | Status    | Name                                     | Size | Volume Type | Bootable | Attached to                          |
++--------------------------------------+-----------+------------------------------------------+------+-------------+----------+--------------------------------------+
+| 7f4a09de-a8a9-4b89-9b70-d01028fcb789 | in-use    | pvc-9848ed86-8aa1-439b-9839-9ceba6e6f653 | 1    | lvmdriver-1 | false    | d438644c-864e-4b36-8a6e-794d35902f97 |
++--------------------------------------+-----------+------------------------------------------+------+-------------+----------+--------------------------------------+
 ```
 
 ## Volume Expansion Example


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
