### PR TITLE
[octavia-ingress-controller] Add octavia.flavor-id option

### DIFF
--- a/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
+++ b/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
@@ -145,6 +145,13 @@ Here are several other config options are not included in the example configurat
     - The security group has tags: `["octavia.ingress.kubernetes.io", "<ingress-namespace>_<ingress-name>"]`
     - The security group is associated with all the Neutron ports of the Kubernetes worker nodes. 
 
+- Options to select a flavor id. The octavia-ingress-controller will use that flavor to create the Octavia load balancer. If not specified, the default flavor will be used.
+
+    ```yaml
+    octavia:
+      flavor-id: a07528cf-4a99-4f8a-94de-691e0b3e2076
+    ```
+
 ### Deploy octavia-ingress-controller
 
 ```shell

--- a/pkg/ingress/config/config.go
+++ b/pkg/ingress/config/config.go
@@ -53,4 +53,8 @@ type octaviaConfig struct {
 	// (Optional) If the ingress controller should manage the security groups attached to the cluster nodes.
 	// Default is false.
 	ManageSecurityGroups bool `mapstructure:"manage-security-groups"`
+
+	// (Optional) Flavor ID to create the load balancer.
+	// If empty, the default flavor will be used.
+	FlavorID string `mapstructure:"flavor-id"`
 }

--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -680,7 +680,7 @@ func (c *Controller) ensureIngress(ing *nwv1.Ingress) error {
 		return fmt.Errorf("TLS Ingress not supported because of Key Manager service unavailable")
 	}
 
-	lb, err := c.osClient.EnsureLoadBalancer(resName, c.config.Octavia.SubnetID, ingNamespace, ingName, clusterName)
+	lb, err := c.osClient.EnsureLoadBalancer(resName, c.config.Octavia.SubnetID, ingNamespace, ingName, clusterName, c.config.Octavia.FlavorID)
 	if err != nil {
 		return err
 	}

--- a/pkg/ingress/controller/openstack/octavia.go
+++ b/pkg/ingress/controller/openstack/octavia.go
@@ -282,7 +282,7 @@ func (os *OpenStack) waitLoadbalancerActiveProvisioningStatus(loadbalancerID str
 }
 
 // EnsureLoadBalancer creates a loadbalancer in octavia if it does not exist, wait for the loadbalancer to be ACTIVE.
-func (os *OpenStack) EnsureLoadBalancer(name string, subnetID string, ingNamespace string, ingName string, clusterName string) (*loadbalancers.LoadBalancer, error) {
+func (os *OpenStack) EnsureLoadBalancer(name string, subnetID string, ingNamespace string, ingName string, clusterName string, flavorId string) (*loadbalancers.LoadBalancer, error) {
 	logger := log.WithFields(log.Fields{"ingress": fmt.Sprintf("%s/%s", ingNamespace, ingName)})
 
 	loadbalancer, err := openstackutil.GetLoadbalancerByName(os.Octavia, name)
@@ -303,6 +303,7 @@ func (os *OpenStack) EnsureLoadBalancer(name string, subnetID string, ingNamespa
 			Description: fmt.Sprintf("Kubernetes ingress %s in namespace %s from cluster %s", ingName, ingNamespace, clusterName),
 			VipSubnetID: subnetID,
 			Provider:    provider,
+			FlavorID:    flavorId,
 		}
 		loadbalancer, err = loadbalancers.Create(os.Octavia, createOpts).Extract()
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a new `octavia.flavor-id` option. It uses the given flavor id to create the LB rather than auto-selecting the default. Especially useful for Openstack installations where multiple Octavia flavors exist.

**Special notes for reviewers**:
Add the flavor id of the load-balancer to be created in octavia-ingress-controller configuration
```
octavia:
    flavor-id: XXX
```

**Release note**:
```release-note
NONE
```
