### PR TITLE
[occm] Allow user to specify common annotations

### DIFF
--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 1.4.0
+version: 1.5.0
 maintainers:
   - name: morremeyer
     email: kubernetes@maurice-meyer.de

--- a/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
@@ -2,6 +2,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: system:openstack-cloud-controller-manager
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/charts/openstack-cloud-controller-manager/templates/clusterrolebinding-sm.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrolebinding-sm.yaml
@@ -3,6 +3,10 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: system:{{ include "occm.name" . }}:auth-delegate
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 subjects:
 - kind: User
   name: system:serviceaccount:{{ .Release.Namespace }}:{{ include "occm.name" . }}

--- a/charts/openstack-cloud-controller-manager/templates/clusterrolebinding.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrolebinding.yaml
@@ -2,6 +2,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:openstack-cloud-controller-manager
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "occm.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -17,6 +21,10 @@ spec:
          checksum/config: {{ include "cloudConfig" . | sha256sum }}
       labels:
         {{- include "occm.controllermanager.labels" . | nindent 8 }}
+      annotations:
+        {{- with .Values.commonAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/openstack-cloud-controller-manager/templates/secret.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/secret.yaml
@@ -2,14 +2,18 @@
 apiVersion: v1
 kind: Secret
 metadata:
- name: {{ .Values.secret.name | default "cloud-config" }}
- namespace: {{ .Release.Namespace }}
+  name: {{ .Values.secret.name | default "cloud-config" }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 type: Opaque
 data:
- {{ if .Values.cloudConfigContents -}}
- cloud.conf: |
-  {{ .Values.cloudConfigContents | b64enc }}
- {{ else -}}
- cloud.conf: {{ include "cloudConfig" . | b64enc }}
- {{ end -}}
+  {{ if .Values.cloudConfigContents -}}
+  cloud.conf: |
+    {{ .Values.cloudConfigContents | b64enc }}
+  {{ else -}}
+  cloud.conf: {{ include "cloudConfig" . | b64enc }}
+  {{ end -}}
 {{- end }}

--- a/charts/openstack-cloud-controller-manager/templates/service-sm.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/service-sm.yaml
@@ -6,6 +6,10 @@ metadata:
     {{- include "occm.labels" . | nindent 4 }}
   name: {{ include "occm.name" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   ports:
   - name: http

--- a/charts/openstack-cloud-controller-manager/templates/serviceaccount.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/serviceaccount.yaml
@@ -3,3 +3,7 @@ kind: ServiceAccount
 metadata:
   name: openstack-cloud-controller-manager
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}

--- a/charts/openstack-cloud-controller-manager/templates/servicemonitor.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/servicemonitor.yaml
@@ -6,6 +6,10 @@ metadata:
     {{- include "occm.labels" . | nindent 4 }}
   name: {{ include "occm.name" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -2,6 +2,13 @@
 #
 # Define deployment mode for the controller and provide cloud credentials in cloudConfig at the end of the file
 #
+## Annotations to apply to all resources
+commonAnnotations: {}
+# commonAnnotations:
+#   "helm.sh/hook": pre-install,pre-upgrade
+#   "helm.sh/hook-weight": "-100"
+#   "helm.sh/hook-delete-policy": before-hook-creation
+
 # Image repository name and tag
 image:
   repository: docker.io/k8scloudprovider/openstack-cloud-controller-manager


### PR DESCRIPTION
**What this PR does / why we need it**:

When deploying all the services from one cluster with a central chart, it might be that applications can alter the lifecicle deployment of helm  due to the use of helm hooks. 

Some examples of this applications include:
- kube-prometheus-stack
- ingress-nginx

A chart cannot change it's subcharts hook implementations. Because occm is required to untaint nodes from `node.cloudprovider.kubernetes.io/uninitialized`, the other applications will stall helm deployment and eventually deployment will fail due to timeout (race condition)

One way to circunvent this, is by making occm be deployed as a critical component, previous to all other components by using a hook with higher priority. See [upstream docs](https://helm.sh/docs/topics/charts_hooks/#hooks-and-the-release-lifecycle)

To do this, all the components required for the occm app to work need to be launched as a helm hook resource and thus need to be annotated.

This patch allows a user to add commonAnnotations into all manifests. 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
