### PR TITLE
test: fix gate issue

### DIFF
--- a/tests/playbooks/roles/install-devstack/tasks/main.yml
+++ b/tests/playbooks/roles/install-devstack/tasks/main.yml
@@ -44,7 +44,6 @@
           - python3-pip
           - build-essential
           - python3-dev
-          - python3-setuptools
           - libffi-dev
           - libxslt1-dev
           - libxml2-dev
@@ -54,6 +53,12 @@
           - unzip
           - jq
           - net-tools
+          
+    - name: Fix localhost setuptools
+      shell:
+        executable: /bin/bash
+        cmd: |
+          python3 -m pip install --user -U pip "setuptools<66.0.0"
 
     - name: Git checkout devstack
       git:
@@ -121,6 +126,31 @@
         cmd: |
           set -ex
           sudo -u {{ user }} -H ./stack.sh
+      ignore_errors: true
+
+    - name: show logs2
+      shell:
+        executable: /bin/bash
+        cmd: |
+          set -ex
+          journalctl -u devstack@n-cpu > output
+          cat output
+          echo "---------1"
+          journalctl -u devstack@n-super-cond > output1
+          cat output1
+          echo "---------2"
+          journalctl -u devstack@n-cond-cell1 > output2
+          cat output2
+          echo "----3"
+          journalctl -u devstack@placement-api > output3
+          cat output3
+
+    - name: fail
+      shell:
+        executable: /bin/bash
+        cmd: |
+          set -ex
+          ls /dummy
 
     - name: Remove openstack CLI warnings
       shell:


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
