### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/release-cpo.yaml
+++ b/.github/workflows/release-cpo.yaml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Get the version from ref
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
 
     - name: build & publish images
       run: |


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find .github/workflows -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
```

**TO-BE**

```yml
run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
```

**Which issue this PR fixes(if applicable)**:
fixes #2087 

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
