### PR TITLE
fix test gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ build-cmd-%: work $(SOURCES)
 test: unit functional
 
 check: work
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.1 run ./...
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1 run ./...
 
 unit: work
 	go test -tags=unit $(shell go list ./... | sed -e '/sanity/ { N; d; }' | sed -e '/tests/ {N; d;}') $(TESTARGS)

--- a/cmd/openstack-cloud-controller-manager/main.go
+++ b/cmd/openstack-cloud-controller-manager/main.go
@@ -44,7 +44,7 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
+	rand.NewSource(time.Now().UnixNano())
 
 	ccmOptions, err := options.NewCloudControllerManagerOptions()
 	if err != nil {

--- a/pkg/identity/keystone/token_getter.go
+++ b/pkg/identity/keystone/token_getter.go
@@ -19,6 +19,7 @@ package keystone
 import (
 	"crypto/tls"
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/gophercloud/gophercloud"
@@ -29,7 +30,6 @@ import (
 	osClient "k8s.io/cloud-provider-openstack/pkg/client"
 	"k8s.io/cloud-provider-openstack/pkg/version"
 	"k8s.io/klog/v2"
-	"net/http"
 )
 
 type Options struct {
@@ -76,7 +76,6 @@ func GetToken(options Options) (*tokens3.Token, error) {
 			return token, msg
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
-		tlsConfig.BuildNameToCertificate()
 		setTransport = true
 	}
 

--- a/tests/playbooks/roles/install-devstack/tasks/main.yml
+++ b/tests/playbooks/roles/install-devstack/tasks/main.yml
@@ -125,10 +125,3 @@
         cmd: |
           set -ex
           sudo -u {{ user }} -H ./stack.sh
-
-    - name: Remove openstack CLI warnings
-      shell:
-        executable: /bin/bash
-        cmd: |
-          # To avoid the warning msg: "CryptographyDeprecationWarning: int_from_bytes is deprecated, use int.from_bytes instead"
-          python3 -m pip install cryptography==3.3.2

--- a/tests/playbooks/roles/install-devstack/tasks/main.yml
+++ b/tests/playbooks/roles/install-devstack/tasks/main.yml
@@ -106,6 +106,7 @@
           python3 -m pip install --upgrade setuptools
           python3 -m pip install --upgrade python-debian
           python3 -m pip install --upgrade distro-info
+          python3 -m pip install --upgrade SecretStorage
 
     - name: Change devstack directory owner
       file:

--- a/tests/playbooks/roles/install-devstack/tasks/main.yml
+++ b/tests/playbooks/roles/install-devstack/tasks/main.yml
@@ -101,7 +101,11 @@
           rm -rf /usr/lib/python3/dist-packages/PyYAML-*.egg-info
           # https://bugs.launchpad.net/devstack/+bug/1906322
           sed -i 's|$cmd_pip $upgrade |$cmd_pip $upgrade --ignore-installed |g' {{ workdir }}/inc/python
-          python3 -m pip install --upgrade pip==20.2.3
+          python3 -m pip install --upgrade pip==23.0
+          python3 -m pip install --upgrade keystoneauth1==5.1.1
+          python3 -m pip install --upgrade setuptools
+          python3 -m pip install --upgrade python-debian
+          python3 -m pip install --upgrade distro-info
 
     - name: Change devstack directory owner
       file:


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
