### PR TITLE
Update registry k8s.gcr.io -> registry.k8s.io

### DIFF
--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -7,32 +7,32 @@ timeout: 3m
 csi:
   attacher:
     image:
-      repository: k8s.gcr.io/sig-storage/csi-attacher
+      repository: registry.k8s.io/sig-storage/csi-attacher
       tag: v4.0.0
       pullPolicy: IfNotPresent
     resources: {}
   provisioner:
     topology: "true"
     image:
-      repository: k8s.gcr.io/sig-storage/csi-provisioner
+      repository: registry.k8s.io/sig-storage/csi-provisioner
       tag: v3.4.0
       pullPolicy: IfNotPresent
     resources: {}
   snapshotter:
     image:
-      repository: k8s.gcr.io/sig-storage/csi-snapshotter
+      repository: registry.k8s.io/sig-storage/csi-snapshotter
       tag: v6.1.0
       pullPolicy: IfNotPresent
     resources: {}
   resizer:
     image:
-      repository: k8s.gcr.io/sig-storage/csi-resizer
+      repository: registry.k8s.io/sig-storage/csi-resizer
       tag: v1.6.0
       pullPolicy: IfNotPresent
     resources: {}
   livenessprobe:
     image:
-      repository: k8s.gcr.io/sig-storage/livenessprobe
+      repository: registry.k8s.io/sig-storage/livenessprobe
       tag: v2.8.0
       pullPolicy: IfNotPresent
     failureThreshold: 5
@@ -42,7 +42,7 @@ csi:
     resources: {}
   nodeDriverRegistrar:
     image:
-      repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+      repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
       tag: v2.6.2
       pullPolicy: IfNotPresent
     resources: {}

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -55,7 +55,7 @@ nodeplugin:
   # csi-node-driver-registrar
   registrar:
     image:
-      repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+      repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
       tag: v2.4.0
       pullPolicy: IfNotPresent
     resources: {}
@@ -75,7 +75,7 @@ controllerplugin:
   # CSI external-provisioner container spec
   provisioner:
     image:
-      repository: k8s.gcr.io/sig-storage/csi-provisioner
+      repository: registry.k8s.io/sig-storage/csi-provisioner
       tag: v3.0.0
       pullPolicy: IfNotPresent
     resources: {}
@@ -84,14 +84,14 @@ controllerplugin:
   # CSI external-snapshotter container spec
   snapshotter:
     image:
-      repository: k8s.gcr.io/sig-storage/csi-snapshotter
+      repository: registry.k8s.io/sig-storage/csi-snapshotter
       tag: v5.0.1
       pullPolicy: IfNotPresent
     resources: {}
   # CSI external-resizer container spec
   resizer:
     image:
-      repository: k8s.gcr.io/sig-storage/csi-resizer
+      repository: registry.k8s.io/sig-storage/csi-resizer
       tag: v1.3.0
       pullPolicy: IfNotPresent
     resources: {}

--- a/cluster/images/cinder-csi-plugin/Dockerfile
+++ b/cluster/images/cinder-csi-plugin/Dockerfile
@@ -13,7 +13,7 @@
 ARG DEBIAN_ARCH=amd64
 # We not using scratch because we need to keep the basic image information
 # from parent image
-FROM k8s.gcr.io/build-image/debian-base-${DEBIAN_ARCH}:bullseye-v1.4.2
+FROM registry.k8s.io/build-image/debian-base-${DEBIAN_ARCH}:bullseye-v1.4.2
 
 ARG ARCH=amd64
 

--- a/cluster/images/cinder-csi-plugin/Dockerfile.build
+++ b/cluster/images/cinder-csi-plugin/Dockerfile.build
@@ -1,5 +1,5 @@
 ARG DEBIAN_ARCH=amd64
-FROM k8s.gcr.io/build-image/debian-base-${DEBIAN_ARCH}:bullseye-v1.4.2
+FROM registry.k8s.io/build-image/debian-base-${DEBIAN_ARCH}:bullseye-v1.4.2
 
 ARG ARCH=amd64
 

--- a/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
+++ b/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
@@ -388,7 +388,7 @@ Ingress and enable the more secure HTTPS protocol.
             # Any image is permissible as long as:
             # 1. It serves a 404 page at /
             # 2. It serves 200 on a /healthz endpoint
-            image: k8s.gcr.io/defaultbackend-amd64:1.5
+            image: registry.k8s.io/defaultbackend-amd64:1.5
             ports:
             - containerPort: 8080
     ---

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccount: csi-cinder-controller-sa
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v4.0.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.0.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -39,7 +39,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.3.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -55,7 +55,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.1.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.1.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -69,7 +69,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -83,7 +83,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.8.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.8.0
           args:
             - "--csi-address=$(ADDRESS)"
           env:

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -21,7 +21,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.2
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.2
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
@@ -41,7 +41,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.8.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.8.0
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/manifests/manila-csi-plugin/csi-controllerplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-controllerplugin.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: openstack-manila-csi-controllerplugin
       containers:
         - name: provisioner
-          image: "k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0"
+          image: "registry.k8s.io/sig-storage/csi-provisioner:v3.0.0"
           args:
             - "--csi-address=$(ADDRESS)"
             # To enable topology awareness in csi-provisioner, uncomment the following line:
@@ -49,7 +49,7 @@ spec:
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
         - name: snapshotter
-          image: "k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1"
+          image: "registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1"
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -60,7 +60,7 @@ spec:
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
         - name: resizer
-          image: "k8s.gcr.io/sig-storage/csi-resizer:v1.3.0"
+          image: "registry.k8s.io/sig-storage/csi-resizer:v1.3.0"
           args:
             - "--csi-address=$(ADDRESS)"
             - "--handle-volume-inuse-error=false"

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -21,7 +21,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: registrar
-          image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0"
+          image: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.4.0"
           args:
             - "--csi-address=/csi/csi.sock"
             - "--kubelet-registration-path=/var/lib/kubelet/plugins/manila.csi.openstack.org/csi.sock"


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This PR will update the uses of deprecating `[k8s.gcr.io](http://k8s.gcr.io/)` registry to `[registry.k8s.io](http://registry.k8s.io/)` prior to the planned April freeze.

**Which issue this PR fixes(if applicable)**:
fixes # https://github.com/kubernetes/k8s.io/issues/4738

**Special notes for reviewers**:
Search results: https://cs.k8s.io/?q=k8s.gcr.io&i=nope&files=&excludeFiles=vendor%2F&repos=kubernetes/cloud-provider-openstack

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
