### PR TITLE
add sleep before starting to create things

### DIFF
--- a/tests/scripts/create-gce-vm.sh
+++ b/tests/scripts/create-gce-vm.sh
@@ -83,6 +83,9 @@ function init_networks() {
 }
 
 main() {
+  # sleep 60 seconds to ensure that GCP credentials are activated
+  sleep 60
+
   if [[ -n "${SKIP_INIT_NETWORK:-}" ]]; then
     echo "Skipping network initialization..."
   else


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

we are seeing quite lot of [https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/cloud-provider-opensta[…]openstack-cloud-controller-manager-e2e-test/1626470715391741952](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/cloud-provider-openstack/2097/openstack-cloud-controller-manager-e2e-test/1626470715391741952) items like that. It means that serviceaccounts are not yet synchronised to all places. 

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
