### PR TITLE
Update k3s and test image to ubuntu 22

### DIFF
--- a/tests/playbooks/roles/install-k3s/defaults/main.yaml
+++ b/tests/playbooks/roles/install-k3s/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-k3s_release: "v1.23.6+k3s1"
+k3s_release: v1.26.1+k3s1
 worker_node_count: 1
 cluster_token: "9a08jv.c0izixklcxtmnze7"
 devstack_workdir: "{{ ansible_user_dir }}/devstack"

--- a/tests/playbooks/test-csi-cinder-e2e.yaml
+++ b/tests/playbooks/test-csi-cinder-e2e.yaml
@@ -20,7 +20,7 @@
         - cinder
     - role: install-k3s
       worker_node_count: 0
-      k3s_release: v1.23.6+k3s1
+      k3s_release: v1.26.1+k3s1
     - role: install-docker
     - role: install-docker-registry
       cert_hosts: ' ["{{ ansible_default_ipv4.address }}"]'

--- a/tests/playbooks/test-csi-manila-e2e.yaml
+++ b/tests/playbooks/test-csi-manila-e2e.yaml
@@ -19,7 +19,7 @@
         - manila
     - role: install-k3s
       worker_node_count: 0
-      k3s_release: v1.23.6+k3s1
+      k3s_release: v1.26.1+k3s1
     - role: install-docker
     - role: install-docker-registry
       cert_hosts: ' ["{{ ansible_default_ipv4.address }}"]'

--- a/tests/playbooks/test-occm-e2e.yaml
+++ b/tests/playbooks/test-occm-e2e.yaml
@@ -21,7 +21,7 @@
         - barbican
     - role: install-k3s
       worker_node_count: 0
-      k3s_release: v1.23.6+k3s1
+      k3s_release: v1.26.1+k3s1
     - role: install-docker
     - role: install-docker-registry
       cert_hosts: ' ["{{ ansible_default_ipv4.address }}"]'

--- a/tests/scripts/create-gce-vm.sh
+++ b/tests/scripts/create-gce-vm.sh
@@ -94,7 +94,7 @@ main() {
     if ! gcloud compute disks describe devstack-${FLAVOR} --zone "${GCP_ZONE}" > /dev/null 2>&1;
     then
       gcloud compute disks create devstack-${FLAVOR} \
-        --image-project ubuntu-os-cloud --image-family ubuntu-2004-lts \
+        --image-project ubuntu-os-cloud --image-family ubuntu-2204-lts \
         --zone "${GCP_ZONE}"
     fi
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
