### PR TITLE
Update release process

### DIFF
--- a/release-procedure.md
+++ b/release-procedure.md
@@ -15,15 +15,15 @@ $ git fetch upstream
 $ git checkout -b release-X.Y upstream/release-X.Y
 ```
 
-2. Make tag and push to upstream repo.
+2. Update manifests with new release images, create a PR against release branch to update.
+
+3. Make tag and push to upstream repo.
 
 ```
 $ git tag -m "Release for cloud-provider-openstack to support Kubernetes release x" vX.Y.Z
 $ git push upstream vX.Y.Z
 ```
 
-3. [Github Actions](https://github.com/kubernetes/cloud-provider-openstack/actions/workflows/release-cpo.yaml) will make the new docker images and make [new draft release](https://github.com/kubernetes/cloud-provider-openstack/releases) to repository.
-
-4. Update manifests with new release images, create a PR against release branch to update. This will be a chicked and egg problem as we already created vX.Y.Z tag, but we recommend to do such update on the manifests file.
+4. [Github Actions](https://github.com/kubernetes/cloud-provider-openstack/actions/workflows/release-cpo.yaml) will make the new docker images and make [new draft release](https://github.com/kubernetes/cloud-provider-openstack/releases) to repository.
 
 5. Make release notes and publish the release.


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

see https://github.com/kubernetes/cloud-provider-openstack/issues/2085 and https://github.com/kubernetes/cloud-provider-openstack/issues/2094

so we need to update manifests before making the tag

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
