### PR TITLE
[occm] add annotation for real loadbalancer address cherry-pick to 1.26

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -227,6 +227,11 @@ Request Body:
 
   This annotations explicitly sets a hostname in the status of the load balancer service.
 
+- `loadbalancer.openstack.org/load-balancer-address`
+  
+  This annotation is automatically added and it contains the floating ip address of the load balancer service.
+  When using `loadbalancer.openstack.org/hostname` annotation it is the only place to see the real address of the load balancer.
+
 ### Switching between Floating Subnets by using preconfigured Classes
 
 If you have multiple `FloatingIPPools` and/or `FloatingIPSubnets` it might be desirable to offer the user logical meanings for `LoadBalancers` like `internetFacing` or `DMZ` instead of requiring the user to select a dedicated network or subnet ID at the service object level as an annotation.


### PR DESCRIPTION
Cherry pick of #2097 on release-1.26.

#2097: add annotation for real address
#2110: add load-balancer-address annotation doc

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```