### PR TITLE
[occm] add annotation for real loadbalancer address cherry pick to 1.25

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -227,6 +227,11 @@ Request Body:
 
   This annotations explicitly sets a hostname in the status of the load balancer service.
 
+- `loadbalancer.openstack.org/load-balancer-address`
+  
+  This annotation is automatically added and it contains the floating ip address of the load balancer service.
+  When using `loadbalancer.openstack.org/hostname` annotation it is the only place to see the real address of the load balancer.
+
 ### Switching between Floating Subnets by using preconfigured Classes
 
 If you have multiple `FloatingIPPools` and/or `FloatingIPSubnets` it might be desirable to offer the user logical meanings for `LoadBalancers` like `internetFacing` or `DMZ` instead of requiring the user to select a dedicated network or subnet ID at the service object level as an annotation.

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -93,6 +93,7 @@ const (
 	ServiceAnnotationLoadBalancerHealthMonitorTimeout    = "loadbalancer.openstack.org/health-monitor-timeout"
 	ServiceAnnotationLoadBalancerHealthMonitorMaxRetries = "loadbalancer.openstack.org/health-monitor-max-retries"
 	ServiceAnnotationLoadBalancerLoadbalancerHostname    = "loadbalancer.openstack.org/hostname"
+	ServiceAnnotationLoadBalancerAddress                 = "loadbalancer.openstack.org/load-balancer-address"
 	// revive:disable:var-naming
 	ServiceAnnotationTlsContainerRef = "loadbalancer.openstack.org/default-tls-container-ref"
 	// revive:enable:var-naming
@@ -1916,11 +1917,13 @@ func (sp *servicePatcher) Patch(ctx context.Context, err error) error {
 	return utilerrors.NewAggregate([]error{err, perr})
 }
 
-func (lbaas *LbaasV2) updateServiceAnnotation(service *corev1.Service, annotName, annotValue string) {
+func (lbaas *LbaasV2) updateServiceAnnotations(service *corev1.Service, annotations map[string]string) {
 	if service.ObjectMeta.Annotations == nil {
 		service.ObjectMeta.Annotations = map[string]string{}
 	}
-	service.ObjectMeta.Annotations[annotName] = annotValue
+	for key, value := range annotations {
+		service.ObjectMeta.Annotations[key] = value
+	}
 }
 
 // createLoadBalancerStatus creates the loadbalancer status from the different possible sources
@@ -2075,7 +2078,11 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 	}
 
 	// Add annotation to Service and add LB name to load balancer tags.
-	lbaas.updateServiceAnnotation(service, ServiceAnnotationLoadBalancerID, loadbalancer.ID)
+	annotationUpdate := map[string]string{
+		ServiceAnnotationLoadBalancerID:      loadbalancer.ID,
+		ServiceAnnotationLoadBalancerAddress: addr,
+	}
+	lbaas.updateServiceAnnotations(service, annotationUpdate)
 	if svcConf.supportLBTags {
 		lbTags := loadbalancer.Tags
 		if !cpoutil.Contains(lbTags, lbName) {


### PR DESCRIPTION
Cherry pick of #2097 on release-1.25.

#2097: add annotation for real address
#2110: add load-balancer-address annotation doc

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```