### PR TITLE
wip: cache devstack

### DIFF
--- a/tests/ci-cache-devstack.sh
+++ b/tests/ci-cache-devstack.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+########################################################################
+#
+# Desc: Entrypoint cache devstack
+#
+# This script may be invoked for different branches (first added in
+# release-1.23). It is getting GCP credentials from boskos and provision
+# a GCP VM, then run ansible for the rest tasks.
+#
+########################################################################
+
+set -x
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${REPO_ROOT}" || exit 1
+# PULL_NUMBER and PULL_BASE_REF are Prow job environment variables
+PR_NUMBER="${PULL_NUMBER:-}"
+[[ -z $PR_NUMBER ]] && echo "PR_NUMBER is required" && exit 1
+PR_BRANCH="${PULL_BASE_REF:-master}"
+CONFIG_ANSIBLE="${CONFIG_ANSIBLE:-"true"}"
+RESOURCE_TYPE="${RESOURCE_TYPE:-"gce-project"}"
+ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
+mkdir -p "${ARTIFACTS}/logs"
+
+cleanup() {
+  # stop boskos heartbeat
+  [[ -z ${HEART_BEAT_PID:-} ]] || kill -9 "${HEART_BEAT_PID}"
+}
+trap cleanup EXIT
+
+python3 -m pip install requests ansible
+
+# If BOSKOS_HOST is set then acquire a resource of type ${RESOURCE_TYPE} from Boskos.
+if [ -n "${BOSKOS_HOST:-}" ]; then
+  # Check out the account from Boskos and store the produced environment
+  # variables in a temporary file.
+  account_env_var_file="$(mktemp)"
+  python3 tests/scripts/boskos.py --get --resource-type="${RESOURCE_TYPE}" 1>"${account_env_var_file}"
+  checkout_account_status="${?}"
+
+  # If the checkout process was a success then load the account's
+  # environment variables into this process.
+  # shellcheck disable=SC1090
+  [ "${checkout_account_status}" = "0" ] && . "${account_env_var_file}"
+
+  # Always remove the account environment variable file. It contains
+  # sensitive information.
+  rm -f "${account_env_var_file}"
+
+  if [ ! "${checkout_account_status}" = "0" ]; then
+    echo "Failed to get account from boskos, type: ${RESOURCE_TYPE}" 1>&2
+    exit "${checkout_account_status}"
+  fi
+
+  # run the heart beat process to tell boskos that we are still
+  # using the checked out account periodically
+  python3 -u tests/scripts/boskos.py --heartbeat >> "${ARTIFACTS}/logs/boskos.log" 2>&1 &
+  HEART_BEAT_PID=$!
+fi
+
+case "${RESOURCE_TYPE}" in
+"gce-project")
+    . tests/scripts/create-gce-vm.sh
+    ;;
+*)
+    echo "Unsupported resource type: ${RESOURCE_TYPE}"
+    exit 1
+    ;;
+esac
+
+# Config ansible. If Ansible is installed from pip or from source,
+# we need to create the config file manually.
+if [[ "$CONFIG_ANSIBLE" == "true" ]]; then
+  mkdir -p /etc/ansible
+  cat <<EOF > /etc/ansible/ansible.cfg
+[defaults]
+private_key_file = ~/.ssh/google_compute_engine
+host_key_checking = False
+timeout = 30
+stdout_callback = debug
+EOF
+fi
+
+# Run ansible playbook on the CI host, e.g. a VM in GCP
+# USERNAME and PUBLIC_IP are global env variables set after creating the CI host.
+ansible-playbook -v \
+  --user ${USERNAME} \
+  --private-key ~/.ssh/google_compute_engine \
+  --inventory ${PUBLIC_IP}, \
+  --ssh-common-args "-o StrictHostKeyChecking=no" \
+  tests/playbooks/cache-devstack.yaml \
+exit_code=$?
+
+# Fetch devstack logs for debugging purpose
+#scp -i ~/.ssh/google_compute_engine \
+#  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+#  -r ${USERNAME}@${PUBLIC_IP}:/opt/stack/logs $ARTIFACTS/logs/devstack || true
+
+# Fetch octavia amphora image build logs for debugging purpose
+# scp -i ~/.ssh/google_compute_engine \
+#    -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+#    -r ${USERNAME}@${PUBLIC_IP}:/var/log/dib-build/amphora-x64-haproxy.qcow2.log $ARTIFACTS/logs/octavia-image-build.log || true
+
+gcloud compute machine-images create devstack-preinstalled --source-instance=devstack
+
+# TODO which bucket we should use?
+gcloud compute images export --destination-uri gs://whichbucket/devstack/latest/devstack.raw.tar.gz --image devstack-preinstalled
+
+# If Boskos is being used then release the resource back to Boskos.
+[ -z "${BOSKOS_HOST:-}" ] || python3 tests/scripts/boskos.py --release >> "$ARTIFACTS/logs/boskos.log" 2>&1
+
+exit ${exit_code}

--- a/tests/playbooks/cache-devstack.yaml
+++ b/tests/playbooks/cache-devstack.yaml
@@ -1,0 +1,19 @@
+- hosts: all
+  become: true
+  become_method: sudo
+  gather_facts: true
+
+  vars:
+    user: stack
+    global_env: {}
+
+  roles:
+    - role: install-golang
+    - role: install-devstack
+      enable_services:
+        - nova
+        - glance
+        - cinder
+        - neutron
+        - octavia
+        - barbican

--- a/tests/playbooks/roles/install-devstack/tasks/main.yml
+++ b/tests/playbooks/roles/install-devstack/tasks/main.yml
@@ -126,3 +126,20 @@
         cmd: |
           set -ex
           sudo -u {{ user }} -H ./stack.sh
+
+    - name: devstack resources
+      shell:
+        executable: /bin/bash
+        chdir: "{{ workdir }}"
+        cmd: |
+          openstack --os-cloud devstack-admin hypervisor stats show
+          openstack --os-cloud devstack-admin host list
+          openstack --os-cloud devstack-admin usage list
+          openstack --os-cloud devstack-admin project list
+          openstack --os-cloud devstack-admin network list
+          openstack --os-cloud devstack-admin subnet list
+          openstack --os-cloud devstack-admin image list
+          openstack --os-cloud devstack-admin flavor list
+          openstack --os-cloud devstack-admin server list
+          openstack --os-cloud devstack-admin availability zone list
+          openstack --os-cloud devstack-admin domain list


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

currently it takes something like 25-30 minutes to install devstack. We could think of caching the devstack installation, and update the devstack like once a week.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
