### PR TITLE
[release-1.26][occm] Reintroduce seeding of math/rand source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ build-cmd-%: work $(SOURCES)
 test: unit functional
 
 check: work
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1 run ./...
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2 run ./...
 
 unit: work
 	go test -tags=unit $(shell go list ./... | sed -e '/sanity/ { N; d; }' | sed -e '/tests/ {N; d;}') $(TESTARGS)

--- a/cmd/openstack-cloud-controller-manager/main.go
+++ b/cmd/openstack-cloud-controller-manager/main.go
@@ -44,7 +44,7 @@ import (
 )
 
 func main() {
-	rand.NewSource(time.Now().UnixNano())
+	rand.Seed(time.Now().UnixNano())
 
 	ccmOptions, err := options.NewCloudControllerManagerOptions()
 	if err != nil {


### PR DESCRIPTION
In Go v1.20, `rand.Seed` is deprecated and `math/rand`'s is automatically seeded. However, that doesn't happen in Go v1.19 that is used to build this branch.

With this change, the global source for `math/rand` is seeded again in `main.go`.

In a separate commit, this PR bumps `golangci-lint` to v1.51.2, which handles the deprecation more gracefully.

**What this PR does / why we need it**:
rand.Seed was prematurely removed in a previous commit.

Cherry-pick of https://github.com/kubernetes/cloud-provider-openstack/pull/2121

**Release note**:
```release-note
NONE
```