### PR TITLE
[occm] Support members without subnet in fully populated LB

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1222,12 +1222,17 @@ func (lbaas *LbaasV2) buildBatchUpdateMemberOpts(port corev1.ServicePort, nodes 
 			}
 		}
 
+		memberSubnetID := &svcConf.lbMemberSubnetID
+		if memberSubnetID != nil && *memberSubnetID == "" {
+			memberSubnetID = nil
+		}
+
 		if port.NodePort != 0 { // It's 0 when AllocateLoadBalancerNodePorts=False
 			member := v2pools.BatchUpdateMemberOpts{
 				Address:      addr,
 				ProtocolPort: int(port.NodePort),
 				Name:         &node.Name,
-				SubnetID:     &svcConf.lbMemberSubnetID,
+				SubnetID:     memberSubnetID,
 			}
 			if svcConf.healthCheckNodePort > 0 && lbaas.canUseHTTPMonitor(port) {
 				member.MonitorPort = &svcConf.healthCheckNodePort


### PR DESCRIPTION
[occm] Do not send the subnet-id if it is empty for members during the creation of fully populated loadbalancer.

**What this PR does / why we need it**:
Prevents sending an empty string to the Octavia API for members in creating fullyPopulatedLoadBalancer when there is no subnet-id defined.

**Which issue this PR fixes(if applicable)**:
fixes #2124

**Release note**:
```release-note
NONE
```
