### PR TITLE
[cinder-csi-plugin] use base image v1.4.3 for CSI cinder #2127 

### DIFF
--- a/.github/workflows/release-cpo.yaml
+++ b/.github/workflows/release-cpo.yaml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Get the version from ref
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
 
     - name: build & publish images
       run: |

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ build-cmd-%: work $(SOURCES)
 test: unit functional
 
 check: work
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.1 run ./...
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1 run ./...
 
 unit: work
 	go test -tags=unit $(shell go list ./... | sed -e '/sanity/ { N; d; }' | sed -e '/tests/ {N; d;}') $(TESTARGS)

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ build-cmd-%: work $(SOURCES)
 test: unit functional
 
 check: work
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1 run ./...
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2 run ./...
 
 unit: work
 	go test -tags=unit $(shell go list ./... | sed -e '/sanity/ { N; d; }' | sed -e '/tests/ {N; d;}') $(TESTARGS)

--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.3.0
+version: 2.3.1
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -154,3 +154,7 @@ spec:
     {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
     {{- end }}
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -127,3 +127,7 @@ spec:
     {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
     {{- end }}
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -7,32 +7,32 @@ timeout: 3m
 csi:
   attacher:
     image:
-      repository: k8s.gcr.io/sig-storage/csi-attacher
+      repository: registry.k8s.io/sig-storage/csi-attacher
       tag: v4.0.0
       pullPolicy: IfNotPresent
     resources: {}
   provisioner:
     topology: "true"
     image:
-      repository: k8s.gcr.io/sig-storage/csi-provisioner
+      repository: registry.k8s.io/sig-storage/csi-provisioner
       tag: v3.4.0
       pullPolicy: IfNotPresent
     resources: {}
   snapshotter:
     image:
-      repository: k8s.gcr.io/sig-storage/csi-snapshotter
+      repository: registry.k8s.io/sig-storage/csi-snapshotter
       tag: v6.1.0
       pullPolicy: IfNotPresent
     resources: {}
   resizer:
     image:
-      repository: k8s.gcr.io/sig-storage/csi-resizer
+      repository: registry.k8s.io/sig-storage/csi-resizer
       tag: v1.6.0
       pullPolicy: IfNotPresent
     resources: {}
   livenessprobe:
     image:
-      repository: k8s.gcr.io/sig-storage/livenessprobe
+      repository: registry.k8s.io/sig-storage/livenessprobe
       tag: v2.8.0
       pullPolicy: IfNotPresent
     failureThreshold: 5
@@ -42,7 +42,7 @@ csi:
     resources: {}
   nodeDriverRegistrar:
     image:
-      repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+      repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
       tag: v2.6.2
       pullPolicy: IfNotPresent
     resources: {}

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -139,3 +139,6 @@ storageClass:
 clusterID: "kubernetes"
 
 priorityClassName: ""
+
+imagePullSecrets: []
+# - name: my-imagepull-secret

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -55,7 +55,7 @@ nodeplugin:
   # csi-node-driver-registrar
   registrar:
     image:
-      repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+      repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
       tag: v2.4.0
       pullPolicy: IfNotPresent
     resources: {}
@@ -75,7 +75,7 @@ controllerplugin:
   # CSI external-provisioner container spec
   provisioner:
     image:
-      repository: k8s.gcr.io/sig-storage/csi-provisioner
+      repository: registry.k8s.io/sig-storage/csi-provisioner
       tag: v3.0.0
       pullPolicy: IfNotPresent
     resources: {}
@@ -84,14 +84,14 @@ controllerplugin:
   # CSI external-snapshotter container spec
   snapshotter:
     image:
-      repository: k8s.gcr.io/sig-storage/csi-snapshotter
+      repository: registry.k8s.io/sig-storage/csi-snapshotter
       tag: v5.0.1
       pullPolicy: IfNotPresent
     resources: {}
   # CSI external-resizer container spec
   resizer:
     image:
-      repository: k8s.gcr.io/sig-storage/csi-resizer
+      repository: registry.k8s.io/sig-storage/csi-resizer
       tag: v1.3.0
       pullPolicy: IfNotPresent
     resources: {}

--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 1.4.0
+version: 1.5.0
 maintainers:
   - name: morremeyer
     email: kubernetes@maurice-meyer.de

--- a/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
@@ -2,6 +2,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: system:openstack-cloud-controller-manager
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/charts/openstack-cloud-controller-manager/templates/clusterrolebinding-sm.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrolebinding-sm.yaml
@@ -3,6 +3,10 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: system:{{ include "occm.name" . }}:auth-delegate
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 subjects:
 - kind: User
   name: system:serviceaccount:{{ .Release.Namespace }}:{{ include "occm.name" . }}

--- a/charts/openstack-cloud-controller-manager/templates/clusterrolebinding.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrolebinding.yaml
@@ -2,6 +2,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:openstack-cloud-controller-manager
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "occm.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -17,6 +21,10 @@ spec:
          checksum/config: {{ include "cloudConfig" . | sha256sum }}
       labels:
         {{- include "occm.controllermanager.labels" . | nindent 8 }}
+      annotations:
+        {{- with .Values.commonAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/openstack-cloud-controller-manager/templates/secret.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/secret.yaml
@@ -2,14 +2,18 @@
 apiVersion: v1
 kind: Secret
 metadata:
- name: {{ .Values.secret.name | default "cloud-config" }}
- namespace: {{ .Release.Namespace }}
+  name: {{ .Values.secret.name | default "cloud-config" }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 type: Opaque
 data:
- {{ if .Values.cloudConfigContents -}}
- cloud.conf: |
-  {{ .Values.cloudConfigContents | b64enc }}
- {{ else -}}
- cloud.conf: {{ include "cloudConfig" . | b64enc }}
- {{ end -}}
+  {{ if .Values.cloudConfigContents -}}
+  cloud.conf: |
+    {{ .Values.cloudConfigContents | b64enc }}
+  {{ else -}}
+  cloud.conf: {{ include "cloudConfig" . | b64enc }}
+  {{ end -}}
 {{- end }}

--- a/charts/openstack-cloud-controller-manager/templates/service-sm.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/service-sm.yaml
@@ -6,6 +6,10 @@ metadata:
     {{- include "occm.labels" . | nindent 4 }}
   name: {{ include "occm.name" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   ports:
   - name: http

--- a/charts/openstack-cloud-controller-manager/templates/serviceaccount.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/serviceaccount.yaml
@@ -3,3 +3,7 @@ kind: ServiceAccount
 metadata:
   name: openstack-cloud-controller-manager
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}

--- a/charts/openstack-cloud-controller-manager/templates/servicemonitor.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/servicemonitor.yaml
@@ -6,6 +6,10 @@ metadata:
     {{- include "occm.labels" . | nindent 4 }}
   name: {{ include "occm.name" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -2,6 +2,13 @@
 #
 # Define deployment mode for the controller and provide cloud credentials in cloudConfig at the end of the file
 #
+## Annotations to apply to all resources
+commonAnnotations: {}
+# commonAnnotations:
+#   "helm.sh/hook": pre-install,pre-upgrade
+#   "helm.sh/hook-weight": "-100"
+#   "helm.sh/hook-delete-policy": before-hook-creation
+
 # Image repository name and tag
 image:
   repository: docker.io/k8scloudprovider/openstack-cloud-controller-manager

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,23 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+
+# this must be specified in seconds. If omitted, defaults to 600s (10 mins)
+timeout: 1200s
+# this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
+# or any new substitutions added in the future.
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220609-2e4c91eb7e
+    entrypoint: make
+    env:
+    - REGISTRY=gcr.io/k8s-staging-cloud-provider-os
+    - VERSION=$_GIT_TAG
+    args:
+    - upload-images
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form
+  # vYYYYMMDD-hash, and can be used as a substitution
+  _GIT_TAG: '12345'
+  # _PULL_BASE_REF will contain the ref that was pushed to to trigger this
+  # build - a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
+  _PULL_BASE_REF: 'master'

--- a/cluster/images/cinder-csi-plugin/Dockerfile
+++ b/cluster/images/cinder-csi-plugin/Dockerfile
@@ -13,7 +13,7 @@
 ARG DEBIAN_ARCH=amd64
 # We not using scratch because we need to keep the basic image information
 # from parent image
-FROM k8s.gcr.io/build-image/debian-base-${DEBIAN_ARCH}:bullseye-v1.4.2
+FROM registry.k8s.io/build-image/debian-base-${DEBIAN_ARCH}:bullseye-v1.4.2
 
 ARG ARCH=amd64
 

--- a/cluster/images/cinder-csi-plugin/Dockerfile
+++ b/cluster/images/cinder-csi-plugin/Dockerfile
@@ -13,7 +13,7 @@
 ARG DEBIAN_ARCH=amd64
 # We not using scratch because we need to keep the basic image information
 # from parent image
-FROM k8s.gcr.io/build-image/debian-base-${DEBIAN_ARCH}:v2.1.3
+FROM k8s.gcr.io/build-image/debian-base-${DEBIAN_ARCH}:bullseye-v1.4.2
 
 ARG ARCH=amd64
 

--- a/cluster/images/cinder-csi-plugin/Dockerfile.build
+++ b/cluster/images/cinder-csi-plugin/Dockerfile.build
@@ -1,5 +1,5 @@
 ARG DEBIAN_ARCH=amd64
-FROM k8s.gcr.io/build-image/debian-base-${DEBIAN_ARCH}:v2.1.3
+FROM k8s.gcr.io/build-image/debian-base-${DEBIAN_ARCH}:bullseye-v1.4.2
 
 ARG ARCH=amd64
 

--- a/cluster/images/cinder-csi-plugin/Dockerfile.build
+++ b/cluster/images/cinder-csi-plugin/Dockerfile.build
@@ -1,5 +1,5 @@
 ARG DEBIAN_ARCH=amd64
-FROM k8s.gcr.io/build-image/debian-base-${DEBIAN_ARCH}:bullseye-v1.4.2
+FROM registry.k8s.io/build-image/debian-base-${DEBIAN_ARCH}:bullseye-v1.4.2
 
 ARG ARCH=amd64
 

--- a/cmd/cinder-csi-plugin/main.go
+++ b/cmd/cinder-csi-plugin/main.go
@@ -32,10 +32,11 @@ import (
 )
 
 var (
-	endpoint    string
-	nodeID      string
-	cloudconfig []string
-	cluster     string
+	endpoint     string
+	nodeID       string
+	cloudconfig  []string
+	cluster      string
+	httpEndpoint string
 )
 
 func main() {
@@ -88,7 +89,7 @@ func main() {
 	}
 
 	cmd.PersistentFlags().StringVar(&cluster, "cluster", "", "The identifier of the cluster that the plugin is running in.")
-
+	cmd.PersistentFlags().StringVar(&httpEndpoint, "http-endpoint", "", "The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080`). The default is empty string, which means the server is disabled.")
 	openstack.AddExtraFlags(pflag.CommandLine)
 
 	code := cli.Run(cmd)
@@ -99,7 +100,7 @@ func handle() {
 
 	// Initialize cloud
 	d := cinder.NewDriver(endpoint, cluster)
-	openstack.InitOpenStackProvider(cloudconfig)
+	openstack.InitOpenStackProvider(cloudconfig, httpEndpoint)
 	cloud, err := openstack.GetOpenStackProvider()
 	if err != nil {
 		klog.Warningf("Failed to GetOpenStackProvider: %v", err)

--- a/cmd/openstack-cloud-controller-manager/main.go
+++ b/cmd/openstack-cloud-controller-manager/main.go
@@ -44,7 +44,7 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
+	rand.NewSource(time.Now().UnixNano())
 
 	ccmOptions, err := options.NewCloudControllerManagerOptions()
 	if err != nil {

--- a/cmd/openstack-cloud-controller-manager/main.go
+++ b/cmd/openstack-cloud-controller-manager/main.go
@@ -44,7 +44,7 @@ import (
 )
 
 func main() {
-	rand.NewSource(time.Now().UnixNano())
+	rand.Seed(time.Now().UnixNano())
 
 	ccmOptions, err := options.NewCloudControllerManagerOptions()
 	if err != nil {

--- a/docs/cinder-csi-plugin/examples.md
+++ b/docs/cinder-csi-plugin/examples.md
@@ -101,9 +101,11 @@ $ mount /dev/vdb /mnt; ls /mnt
 index.html  lost+found
 ```
 
-## Deploy app using Inline volumes
+## Deploy app using ephemeral volumes
 
-Sample App definition on using Inline volumes can be found at [here](../../examples/cinder-csi-plugin/ephemeral/csi-ephemeral-volumes-example.yaml)
+### CSI Ephemeral Volumes
+
+Sample App definition on using CSI ephemeral volumes can be found at [here](../../examples/cinder-csi-plugin/ephemeral/csi-ephemeral-volumes-example.yaml)
 
 Prerequisites:
 * Deploy CSI Driver, with both volumeLifecycleModes enabled as specified [here](../../manifests/cinder-csi-plugin/csi-cinder-driver.yaml)
@@ -128,6 +130,43 @@ Volumes:
     SecretName:  default-token-dn78p
     Optional:    false
 
+```
+
+### Generic Ephemeral Volumes
+
+Sample App definition on using generic ephemeral volumes can be found at [here](../../examples/cinder-csi-plugin/ephemeral/generic-ephemeral-volumes.yaml)
+
+Create a pod with ephemeral volume and storage class
+
+```
+# kubectl create -f examples/cinder-csi-plugin/ephemeral/generic-ephemeral-volumes.yaml
+storageclass.storage.k8s.io/scratch-storage-class created
+pod/ephemeral-example created
+``` 
+
+```
+# kubectl get pods -A
+NAMESPACE     NAME                                                          READY   STATUS    RESTARTS   AGE
+default       ephemeral-example                                             1/1     Running   0          28s
+```
+
+we can find pv/pvc/volumes created just like general volume.
+
+```
+# kubectl get pvc
+NAME                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS            AGE
+ephemeral-example-scratch-volume   Bound    pvc-9848ed86-8aa1-439b-9839-9ceba6e6f653   1Gi        RWO            scratch-storage-class   32s
+
+# kubectl get pv
+NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                      STORAGECLASS            REASON   AGE
+pvc-9848ed86-8aa1-439b-9839-9ceba6e6f653   1Gi        RWO            Delete           Bound    default/ephemeral-example-scratch-volume   scratch-storage-class            35s
+
+# cinder list
++--------------------------------------+-----------+------------------------------------------+------+-------------+----------+--------------------------------------+
+| ID                                   | Status    | Name                                     | Size | Volume Type | Bootable | Attached to                          |
++--------------------------------------+-----------+------------------------------------------+------+-------------+----------+--------------------------------------+
+| 7f4a09de-a8a9-4b89-9b70-d01028fcb789 | in-use    | pvc-9848ed86-8aa1-439b-9839-9ceba6e6f653 | 1    | lvmdriver-1 | false    | d438644c-864e-4b36-8a6e-794d35902f97 |
++--------------------------------------+-----------+------------------------------------------+------+-------------+----------+--------------------------------------+
 ```
 
 ## Volume Expansion Example

--- a/docs/cinder-csi-plugin/troubleshooting.md
+++ b/docs/cinder-csi-plugin/troubleshooting.md
@@ -1,5 +1,11 @@
 # Troubleshooting
 
+## When trying to resize a Cinder Volume, PV/PVC is updated but file system not resized.
+
+Check the volume status by using `openstack volume show` command about the volume (it should have `pvc-` prefix) and see whether backend openstack need update, contact with your openstack administrator for help on the error reported.
+
+`openstack volume message list --os-volume-api-version 3.3` might also show some information about a failed resize, e.g. extend volume:Compute service failed to extend volume.
+
 ## When trying to resize a Cinder Volume based on Ceph, the VM doesn't see the new size.
 
 Chances are, the underlying OpenStack is not configured properly.

--- a/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
+++ b/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
@@ -145,6 +145,13 @@ Here are several other config options are not included in the example configurat
     - The security group has tags: `["octavia.ingress.kubernetes.io", "<ingress-namespace>_<ingress-name>"]`
     - The security group is associated with all the Neutron ports of the Kubernetes worker nodes. 
 
+- Options to select a flavor id. The octavia-ingress-controller will use that flavor to create the Octavia load balancer. If not specified, the default flavor will be used.
+
+    ```yaml
+    octavia:
+      flavor-id: a07528cf-4a99-4f8a-94de-691e0b3e2076
+    ```
+
 ### Deploy octavia-ingress-controller
 
 ```shell

--- a/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
+++ b/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
@@ -388,7 +388,7 @@ Ingress and enable the more secure HTTPS protocol.
             # Any image is permissible as long as:
             # 1. It serves a 404 page at /
             # 2. It serves 200 on a /healthz endpoint
-            image: k8s.gcr.io/defaultbackend-amd64:1.5
+            image: registry.k8s.io/defaultbackend-amd64:1.5
             ports:
             - containerPort: 8080
     ---

--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -227,6 +227,11 @@ Request Body:
 
   This annotations explicitly sets a hostname in the status of the load balancer service.
 
+- `loadbalancer.openstack.org/load-balancer-address`
+  
+  This annotation is automatically added and it contains the floating ip address of the load balancer service.
+  When using `loadbalancer.openstack.org/hostname` annotation it is the only place to see the real address of the load balancer.
+
 ### Switching between Floating Subnets by using preconfigured Classes
 
 If you have multiple `FloatingIPPools` and/or `FloatingIPSubnets` it might be desirable to offer the user logical meanings for `LoadBalancers` like `internetFacing` or `DMZ` instead of requiring the user to select a dedicated network or subnet ID at the service object level as an annotation.

--- a/go.mod
+++ b/go.mod
@@ -166,6 +166,7 @@ replace (
 	k8s.io/controller-manager => k8s.io/controller-manager v0.26.0
 	k8s.io/cri-api => k8s.io/cri-api v0.26.0
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.26.0
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.26.0
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.26.0
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.26.0
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.26.0

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ replace github.com/onsi/ginkgo/v2 => github.com/onsi/ginkgo/v2 v2.4.0
 
 require (
 	github.com/container-storage-interface/spec v1.7.0
+	github.com/go-chi/chi/v5 v5.0.8
 	github.com/gophercloud/gophercloud v1.1.1
 	github.com/gophercloud/utils v0.0.0-20221207145018-e8fba78967ca
-	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/kubernetes-csi/csi-lib-utils v0.12.0
 	github.com/kubernetes-csi/csi-test/v5 v5.0.0

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-chi/chi/v5 v5.0.8 h1:lD+NLqFcAi1ovnVZpsnObHGW4xb4J8lNmoYVfECH1Y0=
+github.com/go-chi/chi/v5 v5.0.8/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -239,8 +241,6 @@ github.com/gophercloud/gophercloud v1.1.1 h1:MuGyqbSxiuVBqkPZ3+Nhbytk1xZxhmfCB2R
 github.com/gophercloud/gophercloud v1.1.1/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
 github.com/gophercloud/utils v0.0.0-20221207145018-e8fba78967ca h1:HZWyhvVXgS2rx5StixMKhrTjpfUg5vLSNhF/xHkcRNg=
 github.com/gophercloud/utils v0.0.0-20221207145018-e8fba78967ca/go.mod h1:z4Dey7xsTUXgcB1C8elMvGRKTjV1ez0eoYQlMrduG1g=
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccount: csi-cinder-controller-sa
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v4.0.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.0.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -39,7 +39,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.3.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -55,7 +55,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.1.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.1.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -69,7 +69,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -83,7 +83,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.8.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.8.0
           args:
             - "--csi-address=$(ADDRESS)"
           env:

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -21,7 +21,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.2
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.2
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
@@ -41,7 +41,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.8.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.8.0
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/manifests/manila-csi-plugin/csi-controllerplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-controllerplugin.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: openstack-manila-csi-controllerplugin
       containers:
         - name: provisioner
-          image: "k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0"
+          image: "registry.k8s.io/sig-storage/csi-provisioner:v3.0.0"
           args:
             - "--csi-address=$(ADDRESS)"
             # To enable topology awareness in csi-provisioner, uncomment the following line:
@@ -49,7 +49,7 @@ spec:
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
         - name: snapshotter
-          image: "k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1"
+          image: "registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1"
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -60,7 +60,7 @@ spec:
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
         - name: resizer
-          image: "k8s.gcr.io/sig-storage/csi-resizer:v1.3.0"
+          image: "registry.k8s.io/sig-storage/csi-resizer:v1.3.0"
           args:
             - "--csi-address=$(ADDRESS)"
             - "--handle-volume-inuse-error=false"

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -21,7 +21,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: registrar
-          image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0"
+          image: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.4.0"
           args:
             - "--csi-address=/csi/csi.sock"
             - "--kubelet-registration-path=/var/lib/kubelet/plugins/manila.csi.openstack.org/csi.sock"

--- a/pkg/csi/cinder/openstack/openstack_instances.go
+++ b/pkg/csi/cinder/openstack/openstack_instances.go
@@ -2,12 +2,14 @@ package openstack
 
 import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"k8s.io/cloud-provider-openstack/pkg/metrics"
 )
 
 // GetInstanceByID returns server with specified instanceID
 func (os *OpenStack) GetInstanceByID(instanceID string) (*servers.Server, error) {
+	mc := metrics.NewMetricContext("server", "get")
 	server, err := servers.Get(os.compute, instanceID).Extract()
-	if err != nil {
+	if mc.ObserveRequest(err) != nil {
 		return nil, err
 	}
 	return server, nil

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach"
 	"github.com/gophercloud/gophercloud/pagination"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/cloud-provider-openstack/pkg/metrics"
 	cpoerrors "k8s.io/cloud-provider-openstack/pkg/util/errors"
 
 	"k8s.io/klog/v2"
@@ -65,8 +66,9 @@ func (os *OpenStack) CreateVolume(name string, size int, vtype, availability str
 		opts.Metadata = *tags
 	}
 
+	mc := metrics.NewMetricContext("volume", "create")
 	vol, err := volumes.Create(os.blockstorage, opts).Extract()
-	if err != nil {
+	if mc.ObserveRequest(err) != nil {
 		return nil, err
 	}
 
@@ -79,6 +81,7 @@ func (os *OpenStack) ListVolumes(limit int, startingToken string) ([]volumes.Vol
 	var vols []volumes.Volume
 
 	opts := volumes.ListOpts{Limit: limit, Marker: startingToken}
+	mc := metrics.NewMetricContext("volume", "list")
 	err := volumes.List(os.blockstorage, opts).EachPage(func(page pagination.Page) (bool, error) {
 		var err error
 
@@ -102,7 +105,7 @@ func (os *OpenStack) ListVolumes(limit int, startingToken string) ([]volumes.Vol
 
 		return false, nil
 	})
-	if err != nil {
+	if mc.ObserveRequest(err) != nil {
 		return nil, nextPageToken, err
 	}
 
@@ -125,8 +128,9 @@ func (os *OpenStack) GetVolumesByName(n string) ([]volumes.Volume, error) {
 	}
 
 	opts := volumes.ListOpts{Name: n}
+	mc := metrics.NewMetricContext("volume", "list")
 	pages, err := volumes.List(blockstorageClient, opts).AllPages()
-	if err != nil {
+	if mc.ObserveRequest(err) != nil {
 		return nil, err
 	}
 
@@ -148,15 +152,16 @@ func (os *OpenStack) DeleteVolume(volumeID string) error {
 		return fmt.Errorf("Cannot delete the volume %q, it's still attached to a node", volumeID)
 	}
 
+	mc := metrics.NewMetricContext("volume", "delete")
 	err = volumes.Delete(os.blockstorage, volumeID, nil).ExtractErr()
-	return err
+	return mc.ObserveRequest(err)
 }
 
 // GetVolume retrieves Volume by its ID.
 func (os *OpenStack) GetVolume(volumeID string) (*volumes.Volume, error) {
-
+	mc := metrics.NewMetricContext("volume", "get")
 	vol, err := volumes.Get(os.blockstorage, volumeID).Extract()
-	if err != nil {
+	if mc.ObserveRequest(err) != nil {
 		return nil, err
 	}
 
@@ -189,11 +194,12 @@ func (os *OpenStack) AttachVolume(instanceID, volumeID string) (string, error) {
 		computeServiceClient.Microversion = "2.60"
 	}
 
+	mc := metrics.NewMetricContext("volume", "attach")
 	_, err = volumeattach.Create(computeServiceClient, instanceID, &volumeattach.CreateOpts{
 		VolumeID: volume.ID,
 	}).Extract()
 
-	if err != nil {
+	if mc.ObserveRequest(err) != nil {
 		return "", fmt.Errorf("failed to attach %s volume to %s compute: %v", volumeID, instanceID, err)
 	}
 
@@ -276,8 +282,9 @@ func (os *OpenStack) DetachVolume(instanceID, volumeID string) error {
 	// Incase volume is of type multiattach, it could be attached to more than one instance
 	for _, att := range volume.Attachments {
 		if att.ServerID == instanceID {
+			mc := metrics.NewMetricContext("volume", "detach")
 			err = volumeattach.Delete(os.compute, instanceID, volume.ID).ExtractErr()
-			if err != nil {
+			if mc.ObserveRequest(err) != nil {
 				return fmt.Errorf("failed to detach volume %s from compute %s : %v", volume.ID, instanceID, err)
 			}
 			klog.V(2).Infof("Successfully detached volume: %s from compute: %s", volume.ID, instanceID)
@@ -357,9 +364,11 @@ func (os *OpenStack) ExpandVolume(volumeID string, status string, newSize int) e
 		// https://docs.openstack.org/cinder/latest/contributor/api_microversion_history.html#id40
 		blockstorageClient.Microversion = "3.42"
 
-		return volumeexpand.ExtendSize(blockstorageClient, volumeID, extendOpts).ExtractErr()
+		mc := metrics.NewMetricContext("volume", "expand")
+		return mc.ObserveRequest(volumeexpand.ExtendSize(blockstorageClient, volumeID, extendOpts).ExtractErr())
 	case VolumeAvailableStatus:
-		return volumeexpand.ExtendSize(os.blockstorage, volumeID, extendOpts).ExtractErr()
+		mc := metrics.NewMetricContext("volume", "expand")
+		return mc.ObserveRequest(volumeexpand.ExtendSize(os.blockstorage, volumeID, extendOpts).ExtractErr())
 	}
 
 	// cinder volume can not be expanded when volume status is not volumeInUseStatus or not volumeAvailableStatus

--- a/pkg/identity/keystone/keystone.go
+++ b/pkg/identity/keystone/keystone.go
@@ -24,10 +24,10 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/utils"
-	"github.com/gorilla/mux"
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
 	apiv1 "k8s.io/api/core/v1"
@@ -116,7 +116,7 @@ func (k *Auth) Run() {
 		go wait.Until(k.runWorker, time.Second, k.stopCh)
 	}
 
-	r := mux.NewRouter()
+	r := chi.NewRouter()
 	r.HandleFunc("/webhook", k.Handler)
 
 	klog.Infof("Starting webhook server...")

--- a/pkg/identity/keystone/token_getter.go
+++ b/pkg/identity/keystone/token_getter.go
@@ -19,6 +19,7 @@ package keystone
 import (
 	"crypto/tls"
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/gophercloud/gophercloud"
@@ -29,7 +30,6 @@ import (
 	osClient "k8s.io/cloud-provider-openstack/pkg/client"
 	"k8s.io/cloud-provider-openstack/pkg/version"
 	"k8s.io/klog/v2"
-	"net/http"
 )
 
 type Options struct {
@@ -76,7 +76,6 @@ func GetToken(options Options) (*tokens3.Token, error) {
 			return token, msg
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
-		tlsConfig.BuildNameToCertificate()
 		setTransport = true
 	}
 

--- a/pkg/ingress/config/config.go
+++ b/pkg/ingress/config/config.go
@@ -53,4 +53,8 @@ type octaviaConfig struct {
 	// (Optional) If the ingress controller should manage the security groups attached to the cluster nodes.
 	// Default is false.
 	ManageSecurityGroups bool `mapstructure:"manage-security-groups"`
+
+	// (Optional) Flavor ID to create the load balancer.
+	// If empty, the default flavor will be used.
+	FlavorID string `mapstructure:"flavor-id"`
 }

--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -680,7 +680,7 @@ func (c *Controller) ensureIngress(ing *nwv1.Ingress) error {
 		return fmt.Errorf("TLS Ingress not supported because of Key Manager service unavailable")
 	}
 
-	lb, err := c.osClient.EnsureLoadBalancer(resName, c.config.Octavia.SubnetID, ingNamespace, ingName, clusterName)
+	lb, err := c.osClient.EnsureLoadBalancer(resName, c.config.Octavia.SubnetID, ingNamespace, ingName, clusterName, c.config.Octavia.FlavorID)
 	if err != nil {
 		return err
 	}

--- a/pkg/ingress/controller/openstack/octavia.go
+++ b/pkg/ingress/controller/openstack/octavia.go
@@ -282,7 +282,7 @@ func (os *OpenStack) waitLoadbalancerActiveProvisioningStatus(loadbalancerID str
 }
 
 // EnsureLoadBalancer creates a loadbalancer in octavia if it does not exist, wait for the loadbalancer to be ACTIVE.
-func (os *OpenStack) EnsureLoadBalancer(name string, subnetID string, ingNamespace string, ingName string, clusterName string) (*loadbalancers.LoadBalancer, error) {
+func (os *OpenStack) EnsureLoadBalancer(name string, subnetID string, ingNamespace string, ingName string, clusterName string, flavorId string) (*loadbalancers.LoadBalancer, error) {
 	logger := log.WithFields(log.Fields{"ingress": fmt.Sprintf("%s/%s", ingNamespace, ingName)})
 
 	loadbalancer, err := openstackutil.GetLoadbalancerByName(os.Octavia, name)
@@ -303,6 +303,7 @@ func (os *OpenStack) EnsureLoadBalancer(name string, subnetID string, ingNamespa
 			Description: fmt.Sprintf("Kubernetes ingress %s in namespace %s from cluster %s", ingName, ingNamespace, clusterName),
 			VipSubnetID: subnetID,
 			Provider:    provider,
+			FlavorID:    flavorId,
 		}
 		loadbalancer, err = loadbalancers.Create(os.Octavia, createOpts).Extract()
 		if err != nil {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -59,7 +59,9 @@ func (mc *MetricContext) Observe(om *OpenstackMetrics, err error) error {
 	return err
 }
 
-func RegisterMetrics() {
+func RegisterMetrics(component string) {
 	doRegisterAPIMetrics()
-	doRegisterOccmMetrics()
+	if component == "occm" {
+		doRegisterOccmMetrics()
+	}
 }

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -550,7 +550,7 @@ func (lbaas *LbaasV2) createFullyPopulatedOctaviaLoadBalancer(name, clusterName 
 		svcConf.lbMemberSubnetID = loadbalancer.VipSubnetID
 	}
 
-	if loadbalancer, err = openstackutil.WaitLoadbalancerActive(lbaas.lb, loadbalancer.ID); err != nil {
+	if loadbalancer, err = openstackutil.WaitActiveAndGetLoadBalancer(lbaas.lb, loadbalancer.ID); err != nil {
 		return nil, err
 	}
 

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -160,7 +160,7 @@ type Config struct {
 }
 
 func init() {
-	metrics.RegisterMetrics()
+	metrics.RegisterMetrics("occm")
 
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
 		cfg, err := ReadConfig(config)

--- a/pkg/util/openstack/loadbalancer.go
+++ b/pkg/util/openstack/loadbalancer.go
@@ -159,7 +159,8 @@ func IsOctaviaFeatureSupported(client *gophercloud.ServiceClient, feature int, l
 	return false
 }
 
-func WaitLoadbalancerActive(client *gophercloud.ServiceClient, loadbalancerID string) (*loadbalancers.LoadBalancer, error) {
+// WaitActiveAndGetLoadBalancer wait for LB active then return the LB object for further usage
+func WaitActiveAndGetLoadBalancer(client *gophercloud.ServiceClient, loadbalancerID string) (*loadbalancers.LoadBalancer, error) {
 	klog.InfoS("Waiting for load balancer ACTIVE", "lbID", loadbalancerID)
 	backoff := wait.Backoff{
 		Duration: waitLoadbalancerInitDelay,
@@ -256,7 +257,7 @@ func UpdateLoadBalancerTags(client *gophercloud.ServiceClient, lbID string, tags
 		return err
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after updating: %v", lbID, err)
 	}
 
@@ -320,7 +321,7 @@ func UpdateListener(client *gophercloud.ServiceClient, lbID string, listenerID s
 		return err
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after updating listener: %v", lbID, err)
 	}
 
@@ -335,7 +336,7 @@ func CreateListener(client *gophercloud.ServiceClient, lbID string, opts listene
 		return nil, err
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return nil, fmt.Errorf("failed to wait for load balancer %s ACTIVE after creating listener: %v", lbID, err)
 	}
 
@@ -354,7 +355,7 @@ func DeleteListener(client *gophercloud.ServiceClient, listenerID string, lbID s
 		}
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after deleting listener: %v", lbID, err)
 	}
 
@@ -421,7 +422,7 @@ func CreatePool(client *gophercloud.ServiceClient, opts pools.CreateOptsBuilder,
 		return nil, err
 	}
 
-	if _, err = WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err = WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return nil, fmt.Errorf("failed to wait for load balancer ACTIVE after creating pool: %v", err)
 	}
 
@@ -551,7 +552,7 @@ func DeletePool(client *gophercloud.ServiceClient, poolID string, lbID string) e
 			return fmt.Errorf("error deleting pool %s for load balancer %s: %v", poolID, lbID, err)
 		}
 	}
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after deleting pool: %v", lbID, err)
 	}
 
@@ -566,7 +567,7 @@ func BatchUpdatePoolMembers(client *gophercloud.ServiceClient, lbID string, pool
 		return err
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after updating pool members for %s: %v", lbID, poolID, err)
 	}
 
@@ -602,7 +603,7 @@ func CreateL7Policy(client *gophercloud.ServiceClient, opts l7policies.CreateOpt
 		return nil, err
 	}
 
-	if _, err = WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err = WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return nil, fmt.Errorf("failed to wait for load balancer ACTIVE after creating l7policy: %v", err)
 	}
 
@@ -616,7 +617,7 @@ func DeleteL7policy(client *gophercloud.ServiceClient, policyID string, lbID str
 		return err
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after deleting l7policy: %v", lbID, err)
 	}
 
@@ -646,7 +647,7 @@ func CreateL7Rule(client *gophercloud.ServiceClient, policyID string, opts l7pol
 		return err
 	}
 
-	if _, err = WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err = WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer ACTIVE after creating l7policy rule: %v", err)
 	}
 
@@ -672,7 +673,7 @@ func DeleteHealthMonitor(client *gophercloud.ServiceClient, monitorID string, lb
 		return mc.ObserveRequest(err)
 	}
 	_ = mc.ObserveRequest(nil)
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after deleting healthmonitor: %v", lbID, err)
 	}
 
@@ -687,7 +688,7 @@ func CreateHealthMonitor(client *gophercloud.ServiceClient, opts monitors.Create
 		return nil, fmt.Errorf("failed to create healthmonitor: %v", err)
 	}
 
-	if _, err := WaitLoadbalancerActive(client, lbID); err != nil {
+	if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
 		return nil, fmt.Errorf("failed to wait for load balancer %s ACTIVE after creating healthmonitor: %v", lbID, err)
 	}
 

--- a/release-procedure.md
+++ b/release-procedure.md
@@ -15,15 +15,15 @@ $ git fetch upstream
 $ git checkout -b release-X.Y upstream/release-X.Y
 ```
 
-2. Make tag and push to upstream repo.
+2. Update manifests with new release images, create a PR against release branch to update.
+
+3. Make tag and push to upstream repo.
 
 ```
 $ git tag -m "Release for cloud-provider-openstack to support Kubernetes release x" vX.Y.Z
 $ git push upstream vX.Y.Z
 ```
 
-3. [Github Actions](https://github.com/kubernetes/cloud-provider-openstack/actions/workflows/release-cpo.yaml) will make the new docker images and make [new draft release](https://github.com/kubernetes/cloud-provider-openstack/releases) to repository.
-
-4. Update manifests with new release images, create a PR against release branch to update. This will be a chicked and egg problem as we already created vX.Y.Z tag, but we recommend to do such update on the manifests file.
+4. [Github Actions](https://github.com/kubernetes/cloud-provider-openstack/actions/workflows/release-cpo.yaml) will make the new docker images and make [new draft release](https://github.com/kubernetes/cloud-provider-openstack/releases) to repository.
 
 5. Make release notes and publish the release.

--- a/tests/playbooks/roles/install-devstack/tasks/main.yml
+++ b/tests/playbooks/roles/install-devstack/tasks/main.yml
@@ -101,7 +101,12 @@
           rm -rf /usr/lib/python3/dist-packages/PyYAML-*.egg-info
           # https://bugs.launchpad.net/devstack/+bug/1906322
           sed -i 's|$cmd_pip $upgrade |$cmd_pip $upgrade --ignore-installed |g' {{ workdir }}/inc/python
-          python3 -m pip install --upgrade pip==20.2.3
+          python3 -m pip install --upgrade pip==23.0
+          python3 -m pip install --upgrade keystoneauth1==5.1.1
+          python3 -m pip install --upgrade setuptools
+          python3 -m pip install --upgrade python-debian
+          python3 -m pip install --upgrade distro-info
+          python3 -m pip install --upgrade SecretStorage
 
     - name: Change devstack directory owner
       file:
@@ -121,10 +126,3 @@
         cmd: |
           set -ex
           sudo -u {{ user }} -H ./stack.sh
-
-    - name: Remove openstack CLI warnings
-      shell:
-        executable: /bin/bash
-        cmd: |
-          # To avoid the warning msg: "CryptographyDeprecationWarning: int_from_bytes is deprecated, use int.from_bytes instead"
-          python3 -m pip install cryptography==3.3.2

--- a/tests/playbooks/roles/install-k3s/defaults/main.yaml
+++ b/tests/playbooks/roles/install-k3s/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-k3s_release: "v1.23.6+k3s1"
+k3s_release: v1.26.1+k3s1
 worker_node_count: 1
 cluster_token: "9a08jv.c0izixklcxtmnze7"
 devstack_workdir: "{{ ansible_user_dir }}/devstack"

--- a/tests/playbooks/test-csi-cinder-e2e.yaml
+++ b/tests/playbooks/test-csi-cinder-e2e.yaml
@@ -20,7 +20,7 @@
         - cinder
     - role: install-k3s
       worker_node_count: 0
-      k3s_release: v1.23.6+k3s1
+      k3s_release: v1.26.1+k3s1
     - role: install-docker
     - role: install-docker-registry
       cert_hosts: ' ["{{ ansible_default_ipv4.address }}"]'

--- a/tests/playbooks/test-csi-manila-e2e.yaml
+++ b/tests/playbooks/test-csi-manila-e2e.yaml
@@ -19,7 +19,7 @@
         - manila
     - role: install-k3s
       worker_node_count: 0
-      k3s_release: v1.23.6+k3s1
+      k3s_release: v1.26.1+k3s1
     - role: install-docker
     - role: install-docker-registry
       cert_hosts: ' ["{{ ansible_default_ipv4.address }}"]'

--- a/tests/playbooks/test-occm-e2e.yaml
+++ b/tests/playbooks/test-occm-e2e.yaml
@@ -21,7 +21,7 @@
         - barbican
     - role: install-k3s
       worker_node_count: 0
-      k3s_release: v1.23.6+k3s1
+      k3s_release: v1.26.1+k3s1
     - role: install-docker
     - role: install-docker-registry
       cert_hosts: ' ["{{ ansible_default_ipv4.address }}"]'

--- a/tests/scripts/create-gce-vm.sh
+++ b/tests/scripts/create-gce-vm.sh
@@ -94,7 +94,7 @@ main() {
     if ! gcloud compute disks describe devstack-${FLAVOR} --zone "${GCP_ZONE}" > /dev/null 2>&1;
     then
       gcloud compute disks create devstack-${FLAVOR} \
-        --image-project ubuntu-os-cloud --image-family ubuntu-2004-lts \
+        --image-project ubuntu-os-cloud --image-family ubuntu-2204-lts \
         --zone "${GCP_ZONE}"
     fi
 


### PR DESCRIPTION
**What this PR does / why we need it**: update base cinder image for less CVEs

for your information, here are the vulnerability checks done with the 3 versions:

| version | critical | high | medium | low |
|:-------:|---------:|-----:|-------:|----:|
| v1.26.1 | 15       | 62   | 52     | 111 |
| master  | 9        | 42   | 25     | 77  |
| this MR | 5        | 33   | 22     | 77  |

**Which issue this PR fixes(if applicable)**:
fixes (not entirely) #1994 

**Release note**:

```release-note
NONE
```
