### PR TITLE
use base image v1.4.3 for CSI cinder

### DIFF
--- a/cluster/images/cinder-csi-plugin/Dockerfile
+++ b/cluster/images/cinder-csi-plugin/Dockerfile
@@ -13,7 +13,7 @@
 ARG DEBIAN_ARCH=amd64
 # We not using scratch because we need to keep the basic image information
 # from parent image
-FROM k8s.gcr.io/build-image/debian-base-${DEBIAN_ARCH}:v2.1.3
+FROM k8s.gcr.io/build-image/debian-base-${DEBIAN_ARCH}:bullseye-v1.4.3
 
 ARG ARCH=amd64
 

--- a/cluster/images/cinder-csi-plugin/Dockerfile.build
+++ b/cluster/images/cinder-csi-plugin/Dockerfile.build
@@ -1,5 +1,5 @@
 ARG DEBIAN_ARCH=amd64
-FROM k8s.gcr.io/build-image/debian-base-${DEBIAN_ARCH}:v2.1.3
+FROM k8s.gcr.io/build-image/debian-base-${DEBIAN_ARCH}:bullseye-v1.4.3
 
 ARG ARCH=amd64
 


### PR DESCRIPTION
**What this PR does / why we need it**: update base cinder image for less CVEs

for your information, here are the vulnerability checks done with the 3 versions:

| version | critical | high | medium | low |
|:-------:|---------:|-----:|-------:|----:|
| v1.26.1 | 15       | 62   | 52     | 111 |
| master  | 9        | 42   | 25     | 77  |
| this MR | 5        | 33   | 22     | 77  |

**Which issue this PR fixes(if applicable)**:
fixes (not entirely) #1994 

**Release note**:

```release-note
NONE
```
