### PR TITLE
simplify loadbalancer enable

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1992,10 +1992,6 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 
 // EnsureLoadBalancer creates a new load balancer or updates the existing one.
 func (lbaas *LbaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string, apiService *corev1.Service, nodes []*corev1.Node) (*corev1.LoadBalancerStatus, error) {
-	if !lbaas.opts.Enabled {
-		return nil, cloudprovider.ImplementedElsewhere
-	}
-
 	mc := metrics.NewMetricContext("loadbalancer", "ensure")
 	status, err := lbaas.ensureLoadBalancer(ctx, clusterName, apiService, nodes)
 	return status, mc.ObserveReconcile(err)
@@ -2156,9 +2152,6 @@ func (lbaas *LbaasV2) updateOctaviaLoadBalancer(ctx context.Context, clusterName
 
 // UpdateLoadBalancer updates hosts under the specified load balancer.
 func (lbaas *LbaasV2) UpdateLoadBalancer(ctx context.Context, clusterName string, service *corev1.Service, nodes []*corev1.Node) error {
-	if !lbaas.opts.Enabled {
-		return cloudprovider.ImplementedElsewhere
-	}
 	mc := metrics.NewMetricContext("loadbalancer", "update")
 	err := lbaas.updateLoadBalancer(ctx, clusterName, service, nodes)
 	return mc.ObserveReconcile(err)

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -312,6 +312,10 @@ func (os *OpenStack) HasClusterID() bool {
 // LoadBalancer initializes a LbaasV2 object
 func (os *OpenStack) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 	klog.V(4).Info("openstack.LoadBalancer() called")
+	if !os.lbOpts.Enabled {
+		klog.V(4).Info("openstack.LoadBalancer() support for LoadBalancer controller is disabled")
+		return nil, false
+	}
 
 	network, err := client.NewNetworkV2(os.provider, os.epOpts)
 	if err != nil {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Like https://github.com/kubernetes/cloud-provider/blob/master/cloud.go#L48 says, we can return `nil, false` already in LoadBalancer() interface and that will disable the support for LoadBalancer.

cc @dulek as you did the original PR

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
