### PR TITLE
Optimize route reconciliation logic cherry-pick to 1.26 (#2090)

### DIFF
--- a/pkg/openstack/instances.go
+++ b/pkg/openstack/instances.go
@@ -504,14 +504,6 @@ func mapNodeNameToServerName(nodeName types.NodeName) string {
 	return string(nodeName)
 }
 
-// mapServerToNodeName maps an OpenStack Server to a k8s NodeName
-func mapServerToNodeName(server *servers.Server) types.NodeName {
-	// Node names are always lowercase, and (at least)
-	// routecontroller does case-sensitive string comparisons
-	// assuming this
-	return types.NodeName(strings.ToLower(server.Name))
-}
-
 func readInstanceID(searchOrder string) (string, error) {
 	// First, try to get data from metadata service because local
 	// data might be changed by accident
@@ -699,35 +691,6 @@ func getAddressesByName(client *gophercloud.ServiceClient, name types.NodeName, 
 	}
 
 	return nodeAddresses(&srv.Server, interfaces, networkingOpts)
-}
-
-func getAddressByName(client *gophercloud.ServiceClient, name types.NodeName, needIPv6 bool, networkingOpts NetworkingOpts) (string, error) {
-	if needIPv6 && networkingOpts.IPv6SupportDisabled {
-		return "", errors.ErrIPv6SupportDisabled
-	}
-
-	addrs, err := getAddressesByName(client, name, networkingOpts)
-	if err != nil {
-		return "", err
-	} else if len(addrs) == 0 {
-		return "", errors.ErrNoAddressFound
-	}
-
-	for _, addr := range addrs {
-		isIPv6 := net.ParseIP(addr.Address).To4() == nil
-		if (addr.Type == v1.NodeInternalIP) && (isIPv6 == needIPv6) {
-			return addr.Address, nil
-		}
-	}
-
-	for _, addr := range addrs {
-		isIPv6 := net.ParseIP(addr.Address).To4() == nil
-		if (addr.Type == v1.NodeExternalIP) && (isIPv6 == needIPv6) {
-			return addr.Address, nil
-		}
-	}
-	// It should never return an address from a different IP Address family than the one needed
-	return "", errors.ErrNoAddressFound
 }
 
 // getAttachedInterfacesByID returns the node interfaces of the specified instance.

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -33,6 +33,8 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
 
+	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/cloud-provider-openstack/pkg/client"
 	"k8s.io/cloud-provider-openstack/pkg/metrics"
 	"k8s.io/cloud-provider-openstack/pkg/util"
@@ -145,8 +147,10 @@ type OpenStack struct {
 	metadataOpts   metadata.Opts
 	networkingOpts NetworkingOpts
 	// InstanceID of the server where this OpenStack object is instantiated.
-	localInstanceID string
-	kclient         kubernetes.Interface
+	localInstanceID       string
+	kclient               kubernetes.Interface
+	nodeInformer          coreinformers.NodeInformer
+	nodeInformerHasSynced func() bool
 }
 
 // Config is used to read and store information from the cloud configuration file
@@ -446,13 +450,7 @@ func (os *OpenStack) Routes() (cloudprovider.Routes, bool) {
 		return nil, false
 	}
 
-	compute, err := client.NewComputeV2(os.provider, os.epOpts)
-	if err != nil {
-		klog.Errorf("Failed to create an OpenStack Compute client: %v", err)
-		return nil, false
-	}
-
-	r, err := NewRoutes(compute, network, os.routeOpts, os.networkingOpts)
+	r, err := NewRoutes(os, network)
 	if err != nil {
 		klog.Warningf("Error initialising Routes support: %v", err)
 		return nil, false
@@ -460,4 +458,12 @@ func (os *OpenStack) Routes() (cloudprovider.Routes, bool) {
 
 	klog.V(1).Info("Claiming to support Routes")
 	return r, true
+}
+
+// SetInformers implements InformerUser interface by setting up informer-fed caches to
+// leverage Kubernetes API for caching
+func (os *OpenStack) SetInformers(informerFactory informers.SharedInformerFactory) {
+	klog.V(1).Infof("Setting up informers for Cloud")
+	os.nodeInformer = informerFactory.Core().V1().Nodes()
+	os.nodeInformerHasSynced = os.nodeInformer.Informer().HasSynced
 }

--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -39,6 +39,9 @@ var ErrIPv6SupportDisabled = errors.New("IPv6 support is disabled")
 // ErrNoRouterID is used when router-id is not set
 var ErrNoRouterID = errors.New("router-id not set in cloud provider config")
 
+// ErrNoNodeInformer is used when node informer is not yet initialized
+var ErrNoNodeInformer = errors.New("node informer is not yet initialized")
+
 func IsNotFound(err error) bool {
 	if err == ErrNotFound {
 		return true


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Cherry pick of the #2090 to 1.26 release

**Which issue this PR fixes(if applicable)**:

fixes #2089

fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
