### PR TITLE
Cleanup OWNERS and change co-lead in project

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,7 @@
+emeritus_approvers:
+- lingxiankong
 approvers:
 - chrigl
-- lingxiankong
 - ramineni
 - zetaab
 - jichenjc
@@ -8,6 +9,5 @@ reviewers:
 - chrigl
 - Fedosin
 - jichenjc
-- lingxiankong
 - ramineni
 - zetaab

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Refer to [Getting Started Guide](/docs/developers-guide.md/) for setting up deve
 Please join us on [Kubernetes provider-openstack slack channel](https://kubernetes.slack.com/messages/provider-openstack)
 
 Project Co-Leads:
-* @lxkong - Lingxian Kong
 * @ramineni - Anusha Ramineni
 * @chrigl - Christoph Glaubitz
 * @jichenjc - Chen Ji
+* @zetaab - Jesse Haka
 
 ## License
 


### PR DESCRIPTION
I propose that we will move @lingxiankong to emeritus_approvers. If you disagree and want to continue actively contributing to project, feel free to comment.

Statistics from last 9 months

```
approves:
jichenjc 58
chrigl 7
zetaab 6
ramineni 2
reviews:
jichenjc 20
zetaab 11
chrigl 6
ramineni 4
mdbooth 3
olemarkus 1
stephenfin 1
dulek 1
mandre 1
joepvd 1
```

Also PR contains adding me as co-lead to project and removing @lingxiankong.

```release-note
NONE
```

cc @jichenjc 