### PR TITLE
[all] Fix cloudbuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,7 @@ TAR_FILE	?= rootfs.tar
 
 GOOS		?= $(shell go env GOOS)
 GOPROXY		?= $(shell go env GOPROXY)
-GIT_VERSION     := $(shell git describe --dirty --tags --match='v*')
-VERSION         ?= $(GIT_VERSION)
+VERSION         ?= $(shell git describe --dirty --tags --match='v*')
 GOARCH		:=
 GOFLAGS		:=
 TAGS		:=

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,16 +9,29 @@ options:
   machineType: 'N1_HIGHCPU_8'
 steps:
   - name: gcr.io/k8s-testimages/gcb-docker-gcloud
-    entrypoint: make
+    entrypoint: bash
     env:
-    - REGISTRY=gcr.io/$PROJECT_ID
-    - VERSION=$_GIT_TAG
+    # Required because the default HOME is /builder/root but buildx is
+    # installed in /root/.docker. Not setting this results in docker not
+    # finding buildx during make.
+    - HOME=/root
     args:
-    - push-multiarch-images
+    - -c
+    - |
+      # Run the image's buildx entrypoint to initialise the build environment
+      # appropriately for the image before running make
+      /buildx-entrypoint version
+
+      make push-multiarch-images \
+        REGISTRY=gcr.io/$PROJECT_ID \
+        VERSION=$_SHORT_TAG
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form
   # vYYYYMMDD-hash, and can be used as a substitution
-  _GIT_TAG: '12345'
+  _GIT_TAG: 'v99999999-v12345'
+  # Remove date prefix (first 10 characters) to create valid semver version:
+  # v20220510-v1.24.0-alpha.0-15-g09bd268 => v1.24.0-alpha.0-15-g09bd268
+  _SHORT_TAG: '${_GIT_TAG:10}'
   # _PULL_BASE_REF will contain the ref that was pushed to to trigger this
   # build - a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
   _PULL_BASE_REF: 'master'


### PR DESCRIPTION
**What this PR does / why we need it**:
cloudbuild is failing, e.g.: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/cloud-provider-openstack-push-images/1632991558871552000

This PR addresses 2 issues with cloudbuild.

The immediate cause of the above error is a quirk in the build environment: HOME is set to /builders/root but buildx is installed in /root, so we need to set HOME correctly for buildx to work. [Discussion](https://kubernetes.slack.com/archives/CCK68P2Q2/p1678184220721889).

Secondly we need to initialise the buildx environment before running make. If we were using the image's buildx entrypoint it would do this for us. We don't want to do that, though: because we re-use the compilation build stage for all image targets, building them all in separate builders would mean we could not take advantage of caching this stage, which would increase build times by approximately the number of images, which is currently 7. To re-use the initialisation which the image owners maintain in that entrypoint we call it once manually before invoking make.

**Which issue this PR fixes(if applicable)**:
fixes #2143

**Special notes for reviewers**:
I have managed to give this a measure of local testing by running the following:

```
> docker run --privileged --rm -ti \
    --entrypoint bash -e HOME=/root \
    -v (pwd):/workspace \
    -v /var/run/docker.sock:/var/run/docker.sock \
    --entrypoint bash \
    gcr.io/k8s-testimages/gcb-docker-gcloud@sha256:13bb9f426fba44b7e482c19f62796c44a1598d5bc9617aaccea1aa8f6086d1ae \
  -c "
      # Run the image's buildx entrypoint to initialise the build environment
      # appropriately for the image before running make
      /buildx-entrypoint version

      make push-multiarch-images \
        REGISTRY=gcr.io/$PROJECT_ID \
        VERSION=$_SHORT_TAG
"
```

This runs far enough to fail when it doesn't have credentials to push to the registry, so for the first time in this series of PRs I am hopeful it might actually work.

**Release note**:
```release-note
NONE
```
