### PR TITLE
[all] Fix substitution of _SHORT_TAG in cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,6 +5,7 @@ timeout: 1200s
 # this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
 # or any new substitutions added in the future.
 options:
+  dynamic_substitutions: true
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
@@ -18,6 +19,8 @@ steps:
     args:
     - -c
     - |
+      set -xeuo pipefail
+
       # Run the image's buildx entrypoint to initialise the build environment
       # appropriately for the image before running make
       /buildx-entrypoint version


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the next discovered error in cloudbuild. We were missing:

```yaml
options:
  dynamic_substitutions: true
```

This prevented `_SHORT_TAG` from being defined correctly, as it is defined in terms of `_GIT_TAG`.

**Which issue this PR fixes(if applicable)**:
fixes #2143

```release-note
NONE
```