### PR TITLE
use go 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.19.6
+ARG GOLANG_IMAGE=golang:1.20.1
 
 # The distroless image on which the CPI manager image is built.
 #
@@ -22,7 +22,7 @@ ARG GOLANG_IMAGE=golang:1.19.6
 # deterministic builds. Follow what kubernetes uses to build
 # kube-controller-manager, for example for 1.23.x:
 # https://github.com/kubernetes/kubernetes/blob/release-1.24/build/common.sh#L94
-ARG DISTROLESS_IMAGE=k8s.gcr.io/build-image/go-runner:v2.3.1-go1.19.6-bullseye.0
+ARG DISTROLESS_IMAGE=k8s.gcr.io/build-image/go-runner:v2.3.1-go1.20.1-bullseye.0
 
 # We use Alpine as the source for default CA certificates and some output
 # images

--- a/cmd/openstack-cloud-controller-manager/main.go
+++ b/cmd/openstack-cloud-controller-manager/main.go
@@ -22,9 +22,7 @@ package main
 import (
 	goflag "flag"
 	"fmt"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -44,8 +42,6 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UnixNano()) //nolint:staticcheck
-
 	ccmOptions, err := options.NewCloudControllerManagerOptions()
 	if err != nil {
 		klog.Fatalf("unable to initialize command options: %v", err)

--- a/cmd/openstack-cloud-controller-manager/main.go
+++ b/cmd/openstack-cloud-controller-manager/main.go
@@ -44,7 +44,7 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
+	rand.Seed(time.Now().UnixNano()) //nolint:staticcheck
 
 	ccmOptions, err := options.NewCloudControllerManagerOptions()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/cloud-provider-openstack
 
-go 1.19
+go 1.20
 
 replace github.com/onsi/ginkgo/v2 => github.com/onsi/ginkgo/v2 v2.4.0
 

--- a/tests/playbooks/roles/install-golang/defaults/main.yml
+++ b/tests/playbooks/roles/install-golang/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-go_version: '1.19'
+go_version: '1.20'
 arch: 'amd64'
 go_tarball: 'go{{ go_version }}.linux-{{ arch }}.tar.gz'
 go_download_location: 'https://go.dev/dl/{{ go_tarball }}'


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
