### PR TITLE
[occm] Don't seed math/rand

### DIFF
--- a/cmd/openstack-cloud-controller-manager/main.go
+++ b/cmd/openstack-cloud-controller-manager/main.go
@@ -22,9 +22,7 @@ package main
 import (
 	goflag "flag"
 	"fmt"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -44,8 +42,6 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
-
 	ccmOptions, err := options.NewCloudControllerManagerOptions()
 	if err != nil {
 		klog.Fatalf("unable to initialize command options: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
As the linter notes, `rand.Seed` is deprecated. We don't use `math/rand` directly, and if we did we would use `crypto/rand` instead if we needed cryptographically unpredictable numbers.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
