### PR TITLE
[all] Switch cloudbuild image to gcr.io/cloud-builders/docker

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,21 +9,19 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: gcr.io/k8s-testimages/gcb-docker-gcloud
+  - name: gcr.io/cloud-builders/docker
     entrypoint: bash
-    env:
-    # Required because the default HOME is /builder/root but buildx is
-    # installed in /root/.docker. Not setting this results in docker not
-    # finding buildx during make.
-    - HOME=/root
     args:
     - -c
     - |
       set -xeuo pipefail
 
-      # Run the image's buildx entrypoint to initialise the build environment
-      # appropriately for the image before running make
-      /buildx-entrypoint version
+      # Initialise a new builder instance
+      docker buildx create --use
+
+      # Create docker credentials for pushing to gcr.io from our inherited
+      # gcloud credentials
+      gcloud auth configure-docker
 
       make push-multiarch-images \
         REGISTRY=gcr.io/$PROJECT_ID \


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes 2 principal changes. Firstly it moves us to a vanilla docker cloud-builder image as it already includes everything we need. gcr.io/k8s-testimages/gcb-docker-gcloud also includes go, which we don't need because we have a completely containerized build. This allows us to ignore the quirks of how buildx is installed in gcb-docker-gcloud.

Secondly it adds an explicit `gcloud auth configure-docker`. This will hopefully fix the docker authentication error, and seems to be widely used in other k8s images, e.g. https://github.com/kubernetes/release/blob/b1394e2f1d533de1cb30307b1b3bd74ab7ae1a4c/images/build/cross/cloudbuild.yaml#L31-L32

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
