### PR TITLE
[all] Revert cloudbuild to gcr.io/k8s-testimages/gcb-docker-gcloud

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,19 +9,24 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: gcr.io/cloud-builders/docker
+  - name: gcr.io/k8s-testimages/gcb-docker-gcloud
     entrypoint: bash
+    env:
+    # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx
+    # set the home to /root explicitly to if using docker buildx
+    - HOME=/root
     args:
     - -c
     - |
       set -xeuo pipefail
 
-      # Initialise a new builder instance
-      docker buildx create --use
-
       # Create docker credentials for pushing to gcr.io from our inherited
       # gcloud credentials
       gcloud auth configure-docker
+
+      # Run the image's buildx entrypoint to initialise the build environment
+      # appropriately for the image before running make
+      /buildx-entrypoint version
 
       make push-multiarch-images \
         REGISTRY=gcr.io/$PROJECT_ID \


### PR DESCRIPTION
We can't use the vanilla docker image because we also need the `gcloud` binary.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
