### PR TITLE
images: don't build ca-certs separately for each architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,13 +37,15 @@ ARG DEBIAN_IMAGE=registry.k8s.io/build-image/debian-base:bullseye-v1.4.3
 
 # Build an image containing a common ca-certificates used by all target images
 # regardless of how they are built. We arbitrarily take ca-certificates from
-# the Alpine image.
-FROM ${ALPINE_IMAGE} as certs
+# the amd64 Alpine image.
+FROM --platform=linux/amd64 ${ALPINE_IMAGE} as certs
 RUN apk add --no-cache ca-certificates
 
 
 # Build all command targets. We build all command targets in a single build
 # stage for efficiency. Target images copy their binary from this image.
+# We use go's native cross compilation for multi-arch in this stage, so the
+# builder itself is always amd64
 FROM --platform=linux/amd64 ${GOLANG_IMAGE} as builder
 
 ARG GOPROXY=https://goproxy.io,direct


### PR DESCRIPTION
This is a minor efficiency improvement in the docker build. We only use the certs build step as a source for ca-certificates. This is architecture independent, so we don't need to build a separate one for each architecture.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
