### PR TITLE
[all] Tag pushes to master as :latest

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -28,9 +28,18 @@ steps:
       # appropriately for the image before running make
       /buildx-entrypoint version
 
+      # Tag the image with _SHORT_TAG, which is the same as VERSION
+      tags=($_SHORT_TAG)
+
+      # If this is a commit to master also update the 'latest' tag.
+      if [ "$_PULL_BASE_REF" == "master" ]; then
+        tags+=(latest)
+      fi
+
       make push-multiarch-images \
         REGISTRY=gcr.io/$PROJECT_ID \
-        VERSION=$_SHORT_TAG
+        VERSION=$_SHORT_TAG \
+        IMAGE_TAGS="${tags[@]}"
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form
   # vYYYYMMDD-hash, and can be used as a substitution


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
When the cloudbuild job pushes to staging it will tag the image with the `git describe` of the commit. With this PR, pushes to the `master` branch will additionally be tagged with `latest`.

The change contains logic to detect pushes to `master` which is technically redundant. We could simply hardcode this in `cloudbuild.yaml` in the master branch and either remove it or hardcode something else when creating a release branch. I am personally undecided what the best approach is.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The lastest images pushed to master are now available from registry.k8s.io/k8s-staging-provider-os/[image-name]:latest
```
