### PR TITLE
helm: cinder-csi: Add extraArgs support for containers

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.23.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.1.0
+version: 2.1.1
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -31,6 +31,11 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--timeout={{ .Values.timeout }}"
             - "--leader-election=true"
+            {{- if .Values.csi.attacher.extraArgs }}
+            {{- with .Values.csi.attacher.extraArgs }}
+            {{- tpl . $ | trim | nindent 12 }}
+            {{- end }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -49,6 +54,11 @@ spec:
             - "--default-fstype=ext4"
             - "--feature-gates=Topology={{ .Values.csi.provisioner.topology }}"
             - "--extra-create-metadata"
+            {{- if .Values.csi.provisioner.extraArgs }}
+            {{- with .Values.csi.provisioner.extraArgs }}
+            {{- tpl . $ | trim | nindent 12 }}
+            {{- end }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -64,6 +74,11 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--timeout={{ .Values.timeout }}"
             - "--leader-election=true"
+            {{- if .Values.csi.snapshotter.extraArgs }}
+            {{- with .Values.csi.snapshotter.extraArgs }}
+            {{- tpl . $ | trim | nindent 12 }}
+            {{- end }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -80,6 +95,11 @@ spec:
             - "--timeout={{ .Values.timeout }}"
             - "--handle-volume-inuse-error=false"
             - "--leader-election=true"
+            {{- if .Values.csi.resizer.extraArgs }}
+            {{- with .Values.csi.resizer.extraArgs }}
+            {{- tpl . $ | trim | nindent 12 }}
+            {{- end }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -93,6 +113,11 @@ spec:
           args:
             - "-v={{ .Values.logVerbosityLevel }}"
             - "--csi-address=$(ADDRESS)"
+            {{- if .Values.csi.livenessprobe.extraArgs }}
+            {{- with .Values.csi.livenessprobe.extraArgs }}
+            {{- tpl . $ | trim | nindent 12 }}
+            {{- end }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -109,6 +134,11 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--cloud-config=$(CLOUD_CONFIG)"
             - "--cluster=$(CLUSTER_NAME)"
+            {{- if .Values.csi.plugin.extraArgs }}
+            {{- with .Values.csi.plugin.extraArgs }}
+            {{- tpl . $ | trim | nindent 12 }}
+            {{- end }}
+            {{- end }}
           env:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -23,6 +23,11 @@ spec:
             - "-v={{ .Values.logVerbosityLevel }}"
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+            {{- if .Values.csi.nodeDriverRegistrar.extraArgs }}
+            {{- with .Values.csi.nodeDriverRegistrar.extraArgs }}
+            {{- tpl . $ | trim | nindent 12 }}
+            {{- end }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -44,6 +49,11 @@ spec:
           args:
             - "-v={{ .Values.logVerbosityLevel }}"
             - --csi-address=/csi/csi.sock
+            {{- if .Values.csi.livenessprobe.extraArgs }}
+            {{- with .Values.csi.livenessprobe.extraArgs }}
+            {{- tpl . $ | trim | nindent 12 }}
+            {{- end }}
+            {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -61,6 +71,11 @@ spec:
             - "-v={{ .Values.logVerbosityLevel }}"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--cloud-config=$(CLOUD_CONFIG)"
+            {{- if .Values.csi.plugin.extraArgs }}
+            {{- with .Values.csi.plugin.extraArgs }}
+            {{- tpl . $ | trim | nindent 12 }}
+            {{- end }}
+            {{- end }}
           env:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -9,6 +9,7 @@ csi:
       tag: v3.3.0
       pullPolicy: IfNotPresent
     resources: {}
+    extraArgs: {}
   provisioner:
     topology: "true"
     image:
@@ -16,18 +17,21 @@ csi:
       tag: v3.0.0
       pullPolicy: IfNotPresent
     resources: {}
+    extraArgs: {}
   snapshotter:
     image:
       repository: k8s.gcr.io/sig-storage/csi-snapshotter
       tag: v4.2.1
       pullPolicy: IfNotPresent
     resources: {}
+    extraArgs: {}
   resizer:
     image:
       repository: k8s.gcr.io/sig-storage/csi-resizer
       tag: v1.3.0
       pullPolicy: IfNotPresent
     resources: {}
+    extraArgs: {}
   livenessprobe:
     image:
       repository: k8s.gcr.io/sig-storage/livenessprobe
@@ -38,12 +42,14 @@ csi:
     timeoutSeconds: 10
     periodSeconds: 60
     resources: {}
+    extraArgs: {}
   nodeDriverRegistrar:
     image:
       repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
       tag: v2.4.0
       pullPolicy: IfNotPresent
     resources: {}
+    extraArgs: {}
   plugin:
     image:
       repository: docker.io/k8scloudprovider/cinder-csi-plugin
@@ -83,6 +89,7 @@ csi:
       nodeSelector: {}
       tolerations: []
     resources: {}
+    extraArgs: {}
   snapshotController:
     enabled: false
     image:


### PR DESCRIPTION
Add an extraArgs value to the various containers that are deployed by cinder-csi. Implementation is similar to occm helm chart

Cherry-pick: #2160 to release-1.23

```release-note
Enable passing extra arguments to containers being deployed by cinder-csi helm chart
```