### PR TITLE
helm: cinder-csi: Add extraArgs support for containers (#2160)

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.24.6
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.2.0
+version: 2.2.1
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -32,6 +32,11 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--timeout={{ .Values.timeout }}"
             - "--leader-election=true"
+            {{- if .Values.csi.attacher.extraArgs }}
+            {{- with .Values.csi.attacher.extraArgs }}
+            {{- tpl . $ | trim | nindent 12 }}
+            {{- end }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -50,6 +55,11 @@ spec:
             - "--default-fstype=ext4"
             - "--feature-gates=Topology={{ .Values.csi.provisioner.topology }}"
             - "--extra-create-metadata"
+            {{- if .Values.csi.provisioner.extraArgs }}
+            {{- with .Values.csi.provisioner.extraArgs }}
+            {{- tpl . $ | trim | nindent 12 }}
+            {{- end }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -65,6 +75,11 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--timeout={{ .Values.timeout }}"
             - "--leader-election=true"
+            {{- if .Values.csi.snapshotter.extraArgs }}
+            {{- with .Values.csi.snapshotter.extraArgs }}
+            {{- tpl . $ | trim | nindent 12 }}
+            {{- end }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -81,6 +96,11 @@ spec:
             - "--timeout={{ .Values.timeout }}"
             - "--handle-volume-inuse-error=false"
             - "--leader-election=true"
+            {{- if .Values.csi.resizer.extraArgs }}
+            {{- with .Values.csi.resizer.extraArgs }}
+            {{- tpl . $ | trim | nindent 12 }}
+            {{- end }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -94,6 +114,11 @@ spec:
           args:
             - "-v={{ .Values.logVerbosityLevel }}"
             - "--csi-address=$(ADDRESS)"
+            {{- if .Values.csi.livenessprobe.extraArgs }}
+            {{- with .Values.csi.livenessprobe.extraArgs }}
+            {{- tpl . $ | trim | nindent 12 }}
+            {{- end }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -110,6 +135,11 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--cloud-config=$(CLOUD_CONFIG)"
             - "--cluster=$(CLUSTER_NAME)"
+            {{- if .Values.csi.plugin.extraArgs }}
+            {{- with .Values.csi.plugin.extraArgs }}
+            {{- tpl . $ | trim | nindent 12 }}
+            {{- end }}
+            {{- end }}
           env:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -24,6 +24,11 @@ spec:
             - "-v={{ .Values.logVerbosityLevel }}"
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+            {{- if .Values.csi.nodeDriverRegistrar.extraArgs }}
+            {{- with .Values.csi.nodeDriverRegistrar.extraArgs }}
+            {{- tpl . $ | trim | nindent 12 }}
+            {{- end }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -45,6 +50,11 @@ spec:
           args:
             - "-v={{ .Values.logVerbosityLevel }}"
             - --csi-address=/csi/csi.sock
+            {{- if .Values.csi.livenessprobe.extraArgs }}
+            {{- with .Values.csi.livenessprobe.extraArgs }}
+            {{- tpl . $ | trim | nindent 12 }}
+            {{- end }}
+            {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -62,6 +72,11 @@ spec:
             - "-v={{ .Values.logVerbosityLevel }}"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--cloud-config=$(CLOUD_CONFIG)"
+            {{- if .Values.csi.plugin.extraArgs }}
+            {{- with .Values.csi.plugin.extraArgs }}
+            {{- tpl . $ | trim | nindent 12 }}
+            {{- end }}
+            {{- end }}
           env:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -11,6 +11,7 @@ csi:
       tag: v3.4.0
       pullPolicy: IfNotPresent
     resources: {}
+    extraArgs: {}
   provisioner:
     topology: "true"
     image:
@@ -18,18 +19,21 @@ csi:
       tag: v3.1.0
       pullPolicy: IfNotPresent
     resources: {}
+    extraArgs: {}
   snapshotter:
     image:
       repository: k8s.gcr.io/sig-storage/csi-snapshotter
       tag: v5.0.1
       pullPolicy: IfNotPresent
     resources: {}
+    extraArgs: {}
   resizer:
     image:
       repository: k8s.gcr.io/sig-storage/csi-resizer
       tag: v1.4.0
       pullPolicy: IfNotPresent
     resources: {}
+    extraArgs: {}
   livenessprobe:
     image:
       repository: k8s.gcr.io/sig-storage/livenessprobe
@@ -40,12 +44,14 @@ csi:
     timeoutSeconds: 10
     periodSeconds: 60
     resources: {}
+    extraArgs: {}
   nodeDriverRegistrar:
     image:
       repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
       tag: v2.5.0
       pullPolicy: IfNotPresent
     resources: {}
+    extraArgs: {}
   plugin:
     image:
       repository: docker.io/k8scloudprovider/cinder-csi-plugin
@@ -85,6 +91,7 @@ csi:
       nodeSelector: {}
       tolerations: []
     resources: {}
+    extraArgs: {}
   snapshotController:
     enabled: false
     image:


### PR DESCRIPTION
Add an extraArgs value to the various containers that are deployed by cinder-csi. Implementation is similar to occm helm chart

Cherry-pick: https://github.com/kubernetes/cloud-provider-openstack/pull/2160 to release-1.24

```release-note
Enable passing extra arguments to containers being deployed by cinder-csi helm chart
```
