### PR TITLE
drop support for docker hub

### DIFF
--- a/.github/workflows/release-cpo.yaml
+++ b/.github/workflows/release-cpo.yaml
@@ -13,30 +13,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    -
-      # Add support for more platforms with QEMU (optional)
-      # https://github.com/docker/setup-qemu-action
-      name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
-
-    - name: Login to docker hub
-      uses: docker/login-action@v2
-      with:
-        registry: docker.io
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-
-    - name: Get the version from ref
-      id: get_version
-      run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
-
-    - name: build & publish images
-      run: |
-        make push-multiarch-images REGISTRY=docker.io/k8scloudprovider VERSION=${{ steps.get_version.outputs.VERSION }}
-
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ GOFLAGS		:=
 TAGS		:=
 LDFLAGS		:= "-w -s -X 'k8s.io/component-base/version.gitVersion=$(VERSION)'"
 GOX_LDFLAGS	:= $(shell echo "$(LDFLAGS) -extldflags \"-static\"")
-REGISTRY	?= k8scloudprovider
+REGISTRY	?= registry.k8s.io/provider-os
 IMAGE_OS	?= linux
 IMAGE_NAMES	?= openstack-cloud-controller-manager \
 				cinder-csi-plugin \

--- a/release-procedure.md
+++ b/release-procedure.md
@@ -20,10 +20,13 @@ $ git checkout -b release-X.Y upstream/release-X.Y
 3. Make tag and push to upstream repo.
 
 ```
-$ git tag -m "Release for cloud-provider-openstack to support Kubernetes release x" vX.Y.Z
+$ git tag vX.Y.Z
 $ git push upstream vX.Y.Z
 ```
 
-4. [Github Actions](https://github.com/kubernetes/cloud-provider-openstack/actions/workflows/release-cpo.yaml) will make the new docker images and make [new draft release](https://github.com/kubernetes/cloud-provider-openstack/releases) to repository.
+4. [Github Actions](https://github.com/kubernetes/cloud-provider-openstack/actions/workflows/release-cpo.yaml) will make [new draft release](https://github.com/kubernetes/cloud-provider-openstack/releases) to repository.
+Cloudbuild should build new images to gcr.io/k8s-staging-provider-os. 
 
-5. Make release notes and publish the release.
+5. Make PR https://github.com/kubernetes/k8s.io/blob/main/k8s.gcr.io/images/k8s-staging-provider-os/images.yaml to promote gcr.io images to registry.k8s.io.
+
+6. Make release notes and publish the release after the new images are published.


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

as we are now publishing images to gcr.io and using that we can promote those to registry.k8s.io. I see that starting from 1.27.0 we could publish images ONLY to official registry.k8s.io. Older release branches will still be using docker hub for new images (if we make new patch releases), but I need to manually also upload those to gcr.io. That is what the community wants currently. Also read https://blog.alexellis.io/docker-is-deleting-open-source-images/ it makes me feel that docker does not want to support opensource anymore. So our home is not there.

Currently all images from 1.24.6, 1.25.5 and 1.26.2 are already located in registry.k8s.io

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

cc @jichenjc @mdbooth