### PR TITLE
modify images to use registry.k8s.io

### DIFF
--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -48,7 +48,7 @@ csi:
     resources: {}
   plugin:
     image:
-      repository: docker.io/k8scloudprovider/cinder-csi-plugin
+      repository: registry.k8s.io/provider-os/cinder-csi-plugin
       pullPolicy: IfNotPresent
       tag:  # defaults to .Chart.AppVersion
     volumes:

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -41,7 +41,7 @@ csimanila:
 
   # Image spec
   image:
-    repository: k8scloudprovider/manila-csi-plugin
+    repository: registry.k8s.io/provider-os/manila-csi-plugin
     pullPolicy: IfNotPresent
     tag:  # defaults to .Chart.AppVersion
 

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -4,7 +4,7 @@
 #
 # Image repository name and tag
 image:
-  repository: docker.io/k8scloudprovider/openstack-cloud-controller-manager
+  repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
   tag: ""
 
 # Additional containers which are run before the app containers are started.

--- a/docs/barbican-kms-plugin/using-barbican-kms-plugin.md
+++ b/docs/barbican-kms-plugin/using-barbican-kms-plugin.md
@@ -83,7 +83,7 @@ $ docker run -d --volume=/var/lib/kms:/var/lib/kms \
 --volume=/etc/kubernetes:/etc/kubernetes \
 -e socketpath=/var/lib/kms/kms.sock \
 -e cloudconfig=/etc/kubernetes/cloud-config \
-docker.io/k8scloudprovider/barbican-kms-plugin-amd64:latest
+registry.k8s.io/provider-os/barbican-kms-plugin:v1.26.2
 ```
 6. Create /etc/kubernetes/encryption-config.yaml
 ```

--- a/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
+++ b/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
@@ -36,7 +36,7 @@ This plugin is compatible with CSI versions v1.3.0, v1.2.0 , v1.1.0, and v1.0.0
 
 ## Downloads
 
-Stable released version images of the plugin can be found at [Docker Hub](https://hub.docker.com/r/k8scloudprovider/cinder-csi-plugin)
+Stable released version images of the plugin can be pulled from `registry.k8s.io/provider-os/cinder-csi-plugin:[release tag]`
 
 ## Kubernetes Compatibility
 

--- a/docs/keystone-auth/using-keystone-webhook-authenticator-and-authorizer.md
+++ b/docs/keystone-auth/using-keystone-webhook-authenticator-and-authorizer.md
@@ -251,8 +251,8 @@ Now we are ready to create the k8s-keystone-auth deployment and expose
 it as a service. There are several things we need to notice in the
 deployment manifest:
 
-- We are using the official nightly-built image
-  `k8scloudprovider/k8s-keystone-auth:latest`
+- We are using image
+  `registry.k8s.io/provider-os/k8s-keystone-auth:v1.26.2`
 - We use `k8s-auth-policy` configmap created above.
 - The pod uses service account `keystone-auth` created above.
 - We use `keystone-auth-certs` secret created above to inject the

--- a/docs/magnum-auto-healer/using-magnum-auto-healer.md
+++ b/docs/magnum-auto-healer/using-magnum-auto-healer.md
@@ -73,7 +73,7 @@ user_id=ceb61464a3d341ebabdf97d1d4b97099
 user_project_id=b23a5e41d1af4c20974bf58b4dff8e5a
 password=password
 region=RegionOne
-image=k8scloudprovider/magnum-auto-healer:latest
+image=registry.k8s.io/provider-os/magnum-auto-healer:v1.26.2
 
 cat <<EOF | kubectl apply -f -
 ---

--- a/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
+++ b/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
@@ -148,7 +148,7 @@ Here are several other config options are not included in the example configurat
 ### Deploy octavia-ingress-controller
 
 ```shell
-image="docker.io/k8scloudprovider/octavia-ingress-controller:latest"
+image="registry.k8s.io/provider-os/octavia-ingress-controller:v1.26.2"
 
 cat <<EOF > /etc/kubernetes/octavia-ingress-controller/deployment.yaml
 ---

--- a/examples/webhook/keystone-deployment.yaml
+++ b/examples/webhook/keystone-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: k8s-keystone
       containers:
         - name: k8s-keystone-auth
-          image: k8scloudprovider/k8s-keystone-auth:v1.26.2
+          image: registry.k8s.io/provider-os/k8s-keystone-auth:v1.26.2
           args:
             - ./bin/k8s-keystone-auth
             - --tls-cert-file

--- a/manifests/barbican-kms/pod.yaml
+++ b/manifests/barbican-kms/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: barbican-kms
-      image: docker.io/k8scloudprovider/barbican-kms-plugin:v1.26.2
+      image: registry.k8s.io/provider-os/barbican-kms-plugin:v1.26.2
       args:
         - "--socketpath=/kms/kms.sock"
         - "--cloud-config=/etc/kubernetes/cloud-config"

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -93,7 +93,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: cinder-csi-plugin
-          image: docker.io/k8scloudprovider/cinder-csi-plugin:v1.26.2
+          image: registry.k8s.io/provider-os/cinder-csi-plugin:v1.26.2
           args:
             - /bin/cinder-csi-plugin
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -53,7 +53,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: docker.io/k8scloudprovider/cinder-csi-plugin:v1.26.2
+          image: registry.k8s.io/provider-os/cinder-csi-plugin:v1.26.2
           args:
             - /bin/cinder-csi-plugin
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -38,7 +38,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: openstack-cloud-controller-manager
-          image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.26.2
+          image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.26.2
           args:
             - /bin/openstack-cloud-controller-manager
             - --v=1

--- a/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   containers:
     - name: openstack-cloud-controller-manager
-      image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.26.2
+      image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.26.2
       args:
         - /bin/openstack-cloud-controller-manager
         - --v=1

--- a/manifests/magnum-auto-healer/magnum-auto-healer.yaml
+++ b/manifests/magnum-auto-healer/magnum-auto-healer.yaml
@@ -88,7 +88,7 @@ spec:
         node-role.kubernetes.io/control-plane: ""
       containers:
         - name: magnum-auto-healer
-          image: docker.io/k8scloudprovider/magnum-auto-healer:v1.26.2
+          image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.26.2
           imagePullPolicy: Always
           args:
             - /bin/magnum-auto-healer

--- a/manifests/magnum-auto-healer/magnum-auto-healer.yaml
+++ b/manifests/magnum-auto-healer/magnum-auto-healer.yaml
@@ -88,7 +88,7 @@ spec:
         node-role.kubernetes.io/control-plane: ""
       containers:
         - name: magnum-auto-healer
-          image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.26.2
+          image: registry.k8s.io/provider-os/magnum-auto-healer:v1.26.2
           imagePullPolicy: Always
           args:
             - /bin/magnum-auto-healer

--- a/manifests/manila-csi-plugin/csi-controllerplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-controllerplugin.yaml
@@ -77,7 +77,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.26.2
+          image: registry.k8s.io/provider-os/manila-csi-plugin:v1.26.2
           command: ["/bin/sh", "-c",
             '/bin/manila-csi-plugin
             --nodeid=$(NODE_ID)

--- a/manifests/manila-csi-plugin/csi-controllerplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-controllerplugin.yaml
@@ -77,7 +77,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: "k8scloudprovider/manila-csi-plugin:v1.26.2"
+          image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.26.2
           command: ["/bin/sh", "-c",
             '/bin/manila-csi-plugin
             --nodeid=$(NODE_ID)

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -50,7 +50,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: "k8scloudprovider/manila-csi-plugin:v1.26.2"
+          image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.26.2
           command: ["/bin/sh", "-c",
             '/bin/manila-csi-plugin
             --nodeid=$(NODE_ID)

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -50,7 +50,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.26.2
+          image: registry.k8s.io/provider-os/manila-csi-plugin:v1.26.2
           command: ["/bin/sh", "-c",
             '/bin/manila-csi-plugin
             --nodeid=$(NODE_ID)

--- a/tests/playbooks/roles/install-cpo-occm/defaults/main.yaml
+++ b/tests/playbooks/roles/install-cpo-occm/defaults/main.yaml
@@ -9,4 +9,4 @@ run_e2e: false
 # Used for access the private registry image from k8s
 remote_registry_host: "{{ ansible_default_ipv4.address }}"
 generated_image_url: "{{ remote_registry_host }}/openstack-cloud-controller-manager-amd64:v0.0.{{ github_pr }}"
-image_url: "{{ generated_image_url if build_image else 'docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.26.2' }}"
+image_url: "{{ generated_image_url if build_image else 'registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.26.2' }}"

--- a/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
@@ -60,8 +60,8 @@
       sed -i "/cloud\.conf/c\  cloud.conf: $b64data" manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml
 
       # replace image with built image
-      sed -i "s#docker.io/k8scloudprovider/cinder-csi-plugin:v1.26.2#{{ remote_registry_host }}/cinder-csi-plugin-amd64:{{ github_pr }}#" manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
-      sed -i "s#docker.io/k8scloudprovider/cinder-csi-plugin:v1.26.2#{{ remote_registry_host }}/cinder-csi-plugin-amd64:{{ github_pr }}#" manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+      sed -i "s#registry.k8s.io/provider-os/cinder-csi-plugin:v1.26.2#{{ remote_registry_host }}/cinder-csi-plugin-amd64:{{ github_pr }}#" manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+      sed -i "s#registry.k8s.io/provider-os/cinder-csi-plugin:v1.26.2#{{ remote_registry_host }}/cinder-csi-plugin-amd64:{{ github_pr }}#" manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
 
       sed -i "s#--v=1#--v=5#" manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
       sed -i "s#--v=1#--v=5#" manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
