### PR TITLE
chore: remove morremeyer as maintainer

### DIFF
--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,11 +4,8 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 1.5.0
+version: 1.5.1
 maintainers:
-  - name: morremeyer
-    email: kubernetes@maurice-meyer.de
-    url: https://maurice-meyer.de
   - name: eumel8
     email: f.kloeker@telekom.de
     url: https://www.telekom.com


### PR DESCRIPTION
**What this PR does / why we need it**:

This removes me as maintainer of the ccm chart. I have not been working with OpenStack since mid 2021 and have in fact not been contributing to the chart since its inception.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Removes morremeyer as chart maintainer
```
