### PR TITLE
update helm github actions and versions release-1.24

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,23 +10,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Fetch history
-        run: git fetch --prune --unshallow
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
-          version: v3.6.1
+          version: v3.10.0
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.9'
+          check-latest: true
 
+      # see example https://github.com/helm/chart-testing-action
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.1.0
+        uses: helm/chart-testing-action@v2.3.1
 
-      # https://github.com/helm/chart-testing/blob/main/doc/ct_lint.md
       - name: Run chart-testing (lint)
-        run: ct lint --target-branch=${GITHUB_BASE_REF} --check-version-increment=false
+        run: ct lint --target-branch ${GITHUB_BASE_REF}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,10 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Fetch history
-        run: git fetch --prune --unshallow
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Configure Git
         run: |

--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.24.6
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.2.1
+version: 2.24.0
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.24.6
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 1.5.0
+version: 2.24.0
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/templates/controllerplugin-clusterrole.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-clusterrole.yaml
@@ -7,5 +7,5 @@ metadata:
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
-        rbac.manila.csi.openstack.org/aggregate-to-{{ include "openstack-manila-csi.controllerplugin.fullname" . }}: "true"
+        rbac.manila.csi.openstack.org/aggregate-to-controller-{{ include "openstack-manila-csi.name" . }}: "true"
 rules: []

--- a/charts/manila-csi-plugin/templates/controllerplugin-rules-clusterrole.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-rules-clusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "openstack-manila-csi.controllerplugin.fullname" . }}-rules
   labels:
     {{- include "openstack-manila-csi.controllerplugin.labels" .  | nindent 4 }}
-    rbac.manila.csi.openstack.org/aggregate-to-{{ include "openstack-manila-csi.controllerplugin.fullname" . }}: "true"
+    rbac.manila.csi.openstack.org/aggregate-to-controller-{{ include "openstack-manila-csi.name" . }}: "true"
 rules:
   - apiGroups: [""]
     resources: ["nodes"]

--- a/charts/manila-csi-plugin/templates/nodeplugin-clusterrole.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-clusterrole.yaml
@@ -7,5 +7,5 @@ metadata:
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
-        rbac.manila.csi.openstack.org/aggregate-to-{{ include "openstack-manila-csi.nodeplugin.fullname" . }}: "true"
+        rbac.manila.csi.openstack.org/aggregate-to-nodeplugin-{{ include "openstack-manila-csi.name" . }}: "true"
 rules: []

--- a/charts/manila-csi-plugin/templates/nodeplugin-rules-clusterrole.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-rules-clusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "openstack-manila-csi.nodeplugin.fullname" . }}-rules
   labels:
     {{- include "openstack-manila-csi.nodeplugin.labels" .  | nindent 4 }}
-    rbac.manila.csi.openstack.org/aggregate-to-{{ include "openstack-manila-csi.nodeplugin.fullname" . }}: "true"
+    rbac.manila.csi.openstack.org/aggregate-to-nodeplugin-{{ include "openstack-manila-csi.name" . }}: "true"
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]

--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,11 +4,8 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 1.3.0
+version: 2.24.0
 maintainers:
-  - name: morremeyer
-    email: kubernetes@maurice-meyer.de
-    url: https://maurice-meyer.de
   - name: eumel8
     email: f.kloeker@telekom.de
     url: https://www.telekom.com


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
