### PR TITLE
[occm] Improve no fip message

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -954,7 +954,7 @@ func (lbaas *LbaasV2) getServiceAddress(clusterName string, service *corev1.Serv
 					return "", fmt.Errorf("error updating LB floatingip %+v: %v", floatUpdateOpts, err)
 				}
 			} else {
-				return "", fmt.Errorf("floating IP %s is not available", loadBalancerIP)
+				return "", fmt.Errorf("floating IP %s specified in .spec.loadBalancerIP does not exist. It has to be precreated by the user", loadBalancerIP)
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
If user specifies an address in `.spec.loadBalancerIP`,
cloud-provider-openstack expects it to be precreated by the user and
never attempts to actually create the FIP with that address, because
default Neutron policy forbids that action for non-admin users.

While we can argue if CPO should actually try that expecting a
non-default policy, for now we can at least communicate this to the
users clearly. This commits makes sure the message explains the reason
behind LB creation failure better. The event should be then logged by
the controller above with `SyncLoadBalancerFailed` event.

**Which issue this PR fixes(if applicable)**:


**Special notes for reviewers**:


**Release note**:
```release-note
NONE
```
