### PR TITLE
[octavia-ingress-controller] Do not default Octavia provider to "octavia"

### DIFF
--- a/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
+++ b/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
@@ -152,6 +152,13 @@ Here are several other config options are not included in the example configurat
       flavor-id: a07528cf-4a99-4f8a-94de-691e0b3e2076
     ```
 
+- Option to set which Octavia provider to use. If unset octavia-ingress-controller will leave it unset so the load balancers will be created with the default provider configured for that OpenStack cloud, decided by the cloud administrator. You can use `openstack loadbalancer provider list` to check available Octavia providers. Please note that currently only Amphora provider is supporting all the features required for octavia-ingress-controller to work correctly. That provider can be named differently in the cloud you use.
+
+    ```yaml
+    octavia:
+      provider: amphora
+    ```
+
 ### Deploy octavia-ingress-controller
 
 ```shell

--- a/pkg/ingress/controller/openstack/octavia.go
+++ b/pkg/ingress/controller/openstack/octavia.go
@@ -291,18 +291,11 @@ func (os *OpenStack) EnsureLoadBalancer(name string, subnetID string, ingNamespa
 			return nil, fmt.Errorf("error getting loadbalancer %s: %v", name, err)
 		}
 
-		var provider string
-		if os.config.Octavia.Provider == "" {
-			provider = "octavia"
-		} else {
-			provider = os.config.Octavia.Provider
-		}
-
 		createOpts := loadbalancers.CreateOpts{
 			Name:        name,
 			Description: fmt.Sprintf("Kubernetes ingress %s in namespace %s from cluster %s", ingName, ingNamespace, clusterName),
 			VipSubnetID: subnetID,
-			Provider:    provider,
+			Provider:    os.config.Octavia.Provider,
 			FlavorID:    flavorId,
 		}
 		loadbalancer, err = loadbalancers.Create(os.Octavia, createOpts).Extract()


### PR DESCRIPTION
**What this PR does / why we need it**:
In Octavia the names of the providers are completely free-form and up to cloud administrator. While the standard names are "amphora" (aliased as "octavia") and "ovn", we cannot be guaranteed these names will work with every OpenStack cloud.

This commit makes sure we do not default the Provider name to "octavia" when creating an LB for the ingress-controller as this may not work for every cloud. Instead when option is unset we will pass an empty value causing Octavia to use whatever is configured as the cloud's default.

I also added docs explaining that option a bit better.

**Which issue this PR fixes(if applicable)**:
fixes #2201

**Special notes for reviewers**:


**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[octavia-ingress-controller] When creating the load balancer octavia-ingress-controller will no longer default the `provider` option to `"octavia"`. Cloud's default provider will be used instead.
```