### PR TITLE
Automated cherry pick of #2211: ignore others than v1.* tags

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -28,9 +28,10 @@ steps:
       # appropriately for the image before running make
       /buildx-entrypoint version
 
+      REALTAG=$(git describe --tags --always --dirty --match 'v1.*')
       make push-multiarch-images \
         REGISTRY=gcr.io/$PROJECT_ID \
-        VERSION=$_SHORT_TAG
+        VERSION=$REALTAG
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form
   # vYYYYMMDD-hash, and can be used as a substitution


### PR DESCRIPTION
Cherry pick of #2211 on release-1.27.

#2211: ignore others than v1.* tags

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
None
```