### PR TITLE
remove version

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -28,10 +28,8 @@ steps:
       # appropriately for the image before running make
       /buildx-entrypoint version
 
-      REALTAG=$(git describe --tags --always --dirty --match 'v1.*')
       make push-multiarch-images \
-        REGISTRY=gcr.io/$PROJECT_ID \
-        VERSION=$REALTAG
+        REGISTRY=gcr.io/$PROJECT_ID
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form
   # vYYYYMMDD-hash, and can be used as a substitution


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #2209 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
