### PR TITLE
[util] Ignore proxies when calling Nova Metadata

### DIFF
--- a/pkg/util/metadata/metadata.go
+++ b/pkg/util/metadata/metadata.go
@@ -189,11 +189,17 @@ func getFromConfigDrive(metadataVersion string) (*Metadata, error) {
 	return parseMetadata(f)
 }
 
+func noProxyHTTPClient() *http.Client {
+	noProxyTransport := http.DefaultTransport.(*http.Transport).Clone()
+	noProxyTransport.Proxy = nil
+	return &http.Client{Transport: noProxyTransport}
+}
+
 func getFromMetadataService(metadataVersion string) (*Metadata, error) {
 	// Try to get JSON from metadata server.
 	metadataURL := getMetadataURL(metadataVersion)
-	klog.V(4).Infof("Attempting to fetch metadata from %s", metadataURL)
-	resp, err := http.Get(metadataURL)
+	klog.V(4).Infof("Attempting to fetch metadata from %s, ignoring proxy settings", metadataURL)
+	resp, err := noProxyHTTPClient().Get(metadataURL)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching %s: %v", metadataURL, err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Prior to this change, the call to the Nova Metadata service used HTTP proxies as directed by the environment variables HTTP_PROXY, HTTPS_PROXY and NO_PROXY (or the lowercase versions thereof).

However, the call to the Metadata well-known IP must originate from the requesting server directly to be correctly served.

With this change, calls to the Nova Metadata service ignore proxy settings.

**Which issue this PR fixes(if applicable)**:
fixes #2217

**Release note**:
```release-note
NONE
```
