### PR TITLE
[manila-csi-plugin]fix manila sanity test

### DIFF
--- a/tests/sanity/manila/fakecsiclient.go
+++ b/tests/sanity/manila/fakecsiclient.go
@@ -99,11 +99,11 @@ func (c fakeNodeSvcClient) UnpublishVolume(ctx context.Context, req *csi.NodeUnp
 type fakeCSIClientBuilder struct{}
 
 func (b fakeCSIClientBuilder) NewConnection(string) (*grpc.ClientConn, error) {
-	return grpc.Dial("", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	return grpc.Dial("localhost", grpc.WithTransportCredentials(insecure.NewCredentials()))
 }
 
 func (b fakeCSIClientBuilder) NewConnectionWithContext(context.Context, string) (*grpc.ClientConn, error) {
-	return grpc.Dial("", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	return grpc.Dial("localhost", grpc.WithTransportCredentials(insecure.NewCredentials()))
 }
 
 func (b fakeCSIClientBuilder) NewNodeServiceClient(conn *grpc.ClientConn) csiclient.Node {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
