### PR TITLE
Use ci-built occm in all e2e tests

### DIFF
--- a/tests/playbooks/roles/install-cpo-occm/defaults/main.yaml
+++ b/tests/playbooks/roles/install-cpo-occm/defaults/main.yaml
@@ -4,7 +4,7 @@ devstack_workdir: "{{ ansible_user_dir }}/devstack"
 
 # Used for uploading image to local registry.
 image_registry_host: localhost
-build_image: false
+build_image: true
 run_e2e: false
 # Used for access the private registry image from k8s
 remote_registry_host: "{{ ansible_default_ipv4.address }}"

--- a/tests/playbooks/test-csi-cinder-e2e.yaml
+++ b/tests/playbooks/test-csi-cinder-e2e.yaml
@@ -26,7 +26,6 @@
       cert_hosts: ' ["{{ ansible_default_ipv4.address }}"]'
     - role: install-cpo-occm
       run_e2e: false
-      build_image: false
       environment: "{{ global_env }}"
     - role: install-csi-cinder
       environment: "{{ global_env }}"

--- a/tests/playbooks/test-csi-manila-e2e.yaml
+++ b/tests/playbooks/test-csi-manila-e2e.yaml
@@ -25,7 +25,6 @@
       cert_hosts: ' ["{{ ansible_default_ipv4.address }}"]'
     - role: install-cpo-occm
       run_e2e: false
-      build_image: false
     - role: install-helm
     - role: install-csi-manila
       environment: "{{ global_env }}"

--- a/tests/playbooks/test-occm-e2e.yaml
+++ b/tests/playbooks/test-occm-e2e.yaml
@@ -27,5 +27,4 @@
       cert_hosts: ' ["{{ ansible_default_ipv4.address }}"]'
     - role: install-cpo-occm
       run_e2e: true
-      build_image: true
       environment: "{{ global_env }}"


### PR DESCRIPTION
Previously in e2e tests we only used ci-built occm for the occm e2e test. The cinder and manila e2e tests used the latest release occm image. With this change all e2e tests deploy a ci-built occm.

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This came about because we were surprised that cinder and manila e2e tests were broken by an issue in the release images.

There are pros and cons to doing this:

Pros:
* You can test changes which may affect the interaction of CPO and CSI, e.g. node labels.

Cons:
* We might accidentally merge commits which require the simultaneous upgrade of both CSI and OCCM.

Ideally we'd test both, of course. If we pick one, which is better? If we decided not to merge this, we should at least add documentation and/or comments explaining the decision for posterity.

**Which issue this PR fixes(if applicable)**:
fixes #2220

**Release note**:
```release-note
NONE
```

/cc @pierreprinetti 