### PR TITLE
[occm] Fixed the typo in the load balancing section in the README

### DIFF
--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.28.0-alpha.5
+version: 2.28.0-alpha.6
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/README.md
+++ b/charts/openstack-cloud-controller-manager/README.md
@@ -13,11 +13,11 @@ You need to configure an `openstack-ccm.yaml` values file with at least:
   - with password: `cloudConfig.global.username` and `cloudconfig.global.password`
   - with application credentials: (`cloudConfig.global.application-credential-id` or `cloudConfig.global.application-credential-name`) and `cloudConfig.global.application-credential-secret`
 - Load balancing
-  - `cloudConfig.loadbalancer.floating-network-id` **or**
-  - `cloudConfig.loadbalancer.floating-subnet-id` **or**
-  - `cloudConfig.loadbalancer.floating-subnet`
+  - `cloudConfig.loadBalancer.floating-network-id` **or**
+  - `cloudConfig.loadBalancer.floating-subnet-id` **or**
+  - `cloudConfig.loadBalancer.floating-subnet`
 
-If you want to enable health checks for your Load Balancers (optional), set `cloudConfig.loadbalancer.create-monitor: true`.
+If you want to enable health checks for your Load Balancers (optional), set `cloudConfig.loadBalancer.create-monitor: true`.
 
 Then run:
 


### PR DESCRIPTION
[occm] Fixed the typo in the load balancing section in the README

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)

**What this PR does / why we need it**:
If you set the variable with a lowercase "b", the template will not catch that and the secret that is created via the helm chart will lack the [LoadBalancer] section. the correct value should be "loadBalancer", instead of "loadbalancer", as you can see from the values.yaml.

**Release note**:

```release-note
NONE
```