### PR TITLE
occm: LB: Fall back to TCP health mon w/o HTTP.

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1156,7 +1156,7 @@ func (lbaas *LbaasV2) buildMonitorCreateOpts(svcConf *serviceConfig, port corev1
 			opts.URLPath = "/healthz"
 			opts.HTTPMethod = "GET"
 			opts.ExpectedCodes = "200"
-		} else {
+		} else if port.Protocol == corev1.ProtocolTCP  {
 			opts.Type = "TCP"
 		}
 	}

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1156,7 +1156,7 @@ func (lbaas *LbaasV2) buildMonitorCreateOpts(svcConf *serviceConfig, port corev1
 			opts.URLPath = "/healthz"
 			opts.HTTPMethod = "GET"
 			opts.ExpectedCodes = "200"
-		} else if port.Protocol == corev1.ProtocolTCP  {
+		} else if port.Protocol == corev1.ProtocolTCP {
 			opts.Type = "TCP"
 		}
 	}


### PR DESCRIPTION
If the Loadbalancer does not support HTTP health-monitor, we currently fail to create one. This is currently the case with OVN loadbalancers, and knowledge that HTTP health-mon is unsupported is hardcoded into occm. While HTTP is preferable and is on the roadmap for OVN, it is not straight-forward and not likely to happen very soon.

TCP health-monitoring is supported and still detects the vast majority of cases with unavailable service, e.g. situations where a node is unavailable, the listening process has died or the node is severed from the network. So TCP health-mon is much better than no health-mon.

This patch implements an unconditional fall back to TCP health monitoring if HTTP health monitoring is not available. This is similar to UDP where we already use UDP-CONNECT health mon. The patch also outputs the type of health mon into the logs.

Tested with OpenStack Zed using OvS-3.1.1 and OVN 23.03 (SCS R4), k8s-v1.26 and -v1.27 and occm-v.26.2 and -1.27. Test scenario using nginx-ingress with externalTrafficPolicy: Local.

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Without this patch, OVN provider octavia loadbalancers can not have health-monitors for TCP listeners, as OCCM wants to create an HTTP health-monitor, which OVN LBs don't currently support.
With it, we fall back to TCP health-monitors, which still cover the vast majority of situations with non-working backend member service and is certainly much better than no health-mon.
This makes OVN LBs a really attractive choice in front of a service with externalTrafficPolicy: local, as OVN LB does retain the original client IP (unlike the amphorae where you need to do workarounds with proxy protocol to get the information). 

**Which issue this PR fixes(if applicable)**:
fixes #2225

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->
Containers to test are on:
registry.scs.community/occm-kg/garloff/openstack-cloud-controller-manager:v1.27.103 
registry.scs.community/occm-kg/garloff/openstack-cloud-controller-manager:v1.26.203 

I would like to see this patch applied not just to master, but also v1.27, v1.26 and v1.25 stable branches.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[occm] Support health-mon for OVN loadbalancers by falling back from HTTP to TCP.
```
