### PR TITLE
[occm] add secret enabled option

### DIFF
--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.28.0-alpha.4
+version: 2.28.0-alpha.5
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.28.0-alpha.3
+version: 2.28.0-alpha.4
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -67,7 +67,7 @@ spec:
             name: http
             protocol: TCP
           {{- end }}
-          {{- if .Values.extraVolumeMounts or .Values.secret.enabled }}
+          {{- if or (.Values.extraVolumeMounts) (.Values.secret.enabled) }}
           volumeMounts:
           {{- end }}
           {{- if .Values.secret.enabled }}
@@ -103,7 +103,7 @@ spec:
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
 
-      {{- if .Values.extraVolumes or .Values.secret.enabled }}
+      {{- if or (.Values.extraVolumes) (.Values.secret.enabled) }}
       volumes:
       {{- end }}
       {{- if .Values.secret.enabled }}

--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -67,10 +67,14 @@ spec:
             name: http
             protocol: TCP
           {{- end }}
+          {{- if .Values.extraVolumeMounts or .Values.secret.enabled }}
           volumeMounts:
+          {{- end }}
+          {{- if .Values.secret.enabled }}
             - mountPath: /etc/config
               name: cloud-config-volume
               readOnly: true
+          {{- end }}
           {{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
@@ -98,10 +102,15 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+
+      {{- if .Values.extraVolumes or .Values.secret.enabled }}
       volumes:
+      {{- end }}
+      {{- if .Values.secret.enabled }}
       - name: cloud-config-volume
         secret:
           secretName: {{ .Values.secret.name }}
+      {{- end }}
       {{- if .Values.extraVolumes }}
         {{ toYaml .Values.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/openstack-cloud-controller-manager/templates/secret.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.secret.create and .Values.secret.enabled }}
+{{- if and (.Values.secret.create) (.Values.secret.enabled) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/openstack-cloud-controller-manager/templates/secret.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.secret.create }}
+{{- if .Values.secret.create and .Values.secret.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -82,8 +82,8 @@ serviceMonitor: {}
 # You can also provide your own secret (not created by the Helm chart), in this case set create to false
 # and adjust the name of the secret as necessary
 # If you dont want to use a secret (because you are using something like an agent injector to inject the cloud config file)
-# you can disable the secret usage by setting enabled to false. 
-# If you disable the secret, you have to insert the cloud config file into the path /etc/cloud/config. 
+# you can disable the secret usage by setting enabled to false.
+# If you disable the secret, you have to insert the cloud config file into the path /etc/cloud/config.
 secret:
   enabled: true
   create: true

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -81,7 +81,11 @@ serviceMonitor: {}
 # Create a secret resource cloud-config (or other name) to store credentials and settings from cloudConfig
 # You can also provide your own secret (not created by the Helm chart), in this case set create to false
 # and adjust the name of the secret as necessary
+# If you dont want to use a secret (because you are using something like an agent injector to inject the cloud config file)
+# you can disable the secret usage by setting enabled to false. 
+# If you disable the secret, you have to insert the cloud config file into the path /etc/cloud/config. 
 secret:
+  enabled: true
   create: true
   name: cloud-config
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the abbility to disable the secret mount into the daemonset. 
This allows to mount the secrets with init-containers (like vault-agent-injector). 

**Which issue this PR fixes(if applicable)**:
none

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] add secret enabled option
```
