### PR TITLE
Use dl.k8s.io instead of hardcoded GCS URIs

### DIFF
--- a/tests/playbooks/roles/install-k3s/tasks/main.yaml
+++ b/tests/playbooks/roles/install-k3s/tasks/main.yaml
@@ -157,7 +157,7 @@
 
       mkdir -p {{ ansible_user_dir }}/.kube
       scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ ansible_user_dir }}/.ssh/id_rsa ubuntu@{{ k3s_fip }}:/etc/rancher/k3s/k3s.yaml {{ ansible_user_dir }}/.kube/config
-      curl -sLO# https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+      curl -sLO# https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl
       chmod +x ./kubectl; sudo mv ./kubectl /usr/local/bin/kubectl
       kubectl config set-cluster default --server=https://{{ k3s_fip }}:6443 --kubeconfig {{ ansible_user_dir }}/.kube/config
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The `storage.googleapis.com/kubernetes-release` URL is a hard coded path to a GCS bucket location. To allow redirecting and spreading the load across multiple hosting locations, the `dl.k8s.io` URL has been introduced.

**Which issue this PR fixes(if applicable)**:

Related PRs:

- https://github.com/kubernetes-sigs/image-builder/pull/656
- https://github.com/kubernetes-sigs/cluster-api/pull/4958

**Special notes for reviewers**:

None

**Release note**:

```release-note
NONE
```
