### PR TITLE
fix: use dl.k8s.io, not kubernetes-release bucket

### DIFF
--- a/tests/playbooks/roles/install-k3s/tasks/main.yaml
+++ b/tests/playbooks/roles/install-k3s/tasks/main.yaml
@@ -157,7 +157,7 @@
 
       mkdir -p {{ ansible_user_dir }}/.kube
       scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ ansible_user_dir }}/.ssh/id_rsa ubuntu@{{ k3s_fip }}:/etc/rancher/k3s/k3s.yaml {{ ansible_user_dir }}/.kube/config
-      curl -sLO# https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+      curl -sLO# https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl
       chmod +x ./kubectl; sudo mv ./kubectl /usr/local/bin/kubectl
       kubectl config set-cluster default --server=https://{{ k3s_fip }}:6443 --kubeconfig {{ ansible_user_dir }}/.kube/config
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind deprecation

#### What this PR does / why we need it:
There are still references to https://storage.googleapis.com/kubernetes-release instead of https://dl.k8s.io/

dl.k8s.io is the correct advertised download host and will eventually move to be fastly shielding a fully community-owned bucket

ref: https://github.com/kubernetes/k8s.io/issues/2396

```release-notes
NONE
```