### PR TITLE
manila-csi: Fix image tag in e2e test scripts

### DIFF
--- a/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
@@ -123,7 +123,7 @@
       csimanila:
         image:
           repository: {{ remote_registry_host }}/manila-csi-plugin
-          tag: {{ github_pr }}
+          tag: v0.0.{{ github_pr }}
       shareProtocols:
         - protocolSelector: NFS
           fsGroupPolicy: None


### PR DESCRIPTION
**What this PR does / why we need it**:

the csi driver images are built with a prefix "v0.0."; but the script isn't using this script when
starting the driver.


**Which issue this PR fixes(if applicable)**:
related to issue #2142 and pr #2065

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```