### PR TITLE
[octavia-ingress-controller] support wildcard in the host field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ vendor
 
 # Vscode files
 .vscode
+__debug_bin
 
 # This is where the result of the go build goes
 /output*/

--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,7 @@ zz_generated.openapi.go
 
 # local gopath
 .go
+
+### Okteto ###
+okteto.yml
+.stignore

--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -824,10 +824,17 @@ func (c *Controller) ensureIngress(ing *nwv1.Ingress) error {
 			var policyRules []l7policies.CreateRuleOpts
 
 			if host != "" {
+
+				// Escape dot to be regex proof
+				hostRegex := strings.ReplaceAll(host, ".", "\\.")
+
+				// Handle wildcard
+				hostRegex = strings.ReplaceAll(hostRegex, "*", ".*")
+
 				policyRules = append(policyRules, l7policies.CreateRuleOpts{
 					RuleType:    l7policies.TypeHostName,
 					CompareType: l7policies.CompareTypeRegex,
-					Value:       fmt.Sprintf("^%s(:%d)?$", strings.ReplaceAll(host, ".", "\\."), port)})
+					Value:       fmt.Sprintf("^%s(:%d)?$", hostRegex, port)})
 			}
 
 			// make the pool name unique in the load balancer


### PR DESCRIPTION
**What this PR does / why we need it**:
Support wildcard for the `host` field in `ingress` resource

**Which issue this PR fixes(if applicable)**:
fixes #2245

**Special notes for reviewers**:

**Release note**:
```release-note
NONE
```
