### PR TITLE
[occm] LoadBalancers: Remove dead SG code

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -37,7 +37,6 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 	neutronports "github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
-	"github.com/gophercloud/gophercloud/pagination"
 	secgroups "github.com/gophercloud/utils/openstack/networking/v2/extensions/security/groups"
 	"gopkg.in/godo.v2/glob"
 	corev1 "k8s.io/api/core/v1"
@@ -421,28 +420,6 @@ func getSecurityGroupName(service *corev1.Service) string {
 	}
 
 	return securityGroupName
-}
-
-func getSecurityGroupRules(client *gophercloud.ServiceClient, opts rules.ListOpts) ([]rules.SecGroupRule, error) {
-	var securityRules []rules.SecGroupRule
-
-	mc := metrics.NewMetricContext("security_group_rule", "list")
-	pager := rules.List(client, opts)
-
-	err := pager.EachPage(func(page pagination.Page) (bool, error) {
-		ruleList, err := rules.ExtractRules(page)
-		if err != nil {
-			return false, err
-		}
-		securityRules = append(securityRules, ruleList...)
-		return true, nil
-	})
-
-	if mc.ObserveRequest(err) != nil {
-		return nil, err
-	}
-
-	return securityRules, nil
 }
 
 func getListenerProtocol(protocol corev1.Protocol, svcConf *serviceConfig) listeners.Protocol {
@@ -2517,49 +2494,7 @@ func (lbaas *LbaasV2) EnsureSecurityGroupDeleted(_ string, service *corev1.Servi
 	}
 	_ = mc.ObserveRequest(nil)
 
-	if len(lbaas.opts.NodeSecurityGroupIDs) == 0 {
-		// Just happen when nodes have not Security Group, or should not happen
-		// UpdateLoadBalancer and EnsureLoadBalancer can set lbaas.opts.NodeSecurityGroupIDs when it is empty
-		// And service controller call UpdateLoadBalancer to set lbaas.opts.NodeSecurityGroupIDs when controller manager service is restarted.
-		klog.Warningf("Can not find node-security-group from all the nodes of this cluster when delete loadbalancer service %s/%s",
-			service.Namespace, service.Name)
-	} else {
-		// Delete the rules in the Node Security Group
-		for _, nodeSecurityGroupID := range lbaas.opts.NodeSecurityGroupIDs {
-			opts := rules.ListOpts{
-				SecGroupID:    nodeSecurityGroupID,
-				RemoteGroupID: lbSecGroupID,
-			}
-			secGroupRules, err := getSecurityGroupRules(lbaas.network, opts)
-
-			if err != nil && !cpoerrors.IsNotFound(err) {
-				msg := fmt.Sprintf("error finding rules for remote group id %s in security group id %s: %v", lbSecGroupID, nodeSecurityGroupID, err)
-				return fmt.Errorf(msg)
-			}
-
-			for _, rule := range secGroupRules {
-				mc := metrics.NewMetricContext("security_group_rule", "delete")
-				res := rules.Delete(lbaas.network, rule.ID)
-				if res.Err != nil && !cpoerrors.IsNotFound(res.Err) {
-					_ = mc.ObserveRequest(res.Err)
-					return fmt.Errorf("error occurred deleting security group rule: %s: %v", rule.ID, res.Err)
-				}
-				_ = mc.ObserveRequest(nil)
-			}
-		}
-	}
-
 	return nil
-}
-
-// IsAllowAll checks whether the netsets.IPNet allows traffic from 0.0.0.0/0
-func IsAllowAll(ipnets netsets.IPNet) bool {
-	for _, s := range ipnets.StringSlice() {
-		if s == "0.0.0.0/0" {
-			return true
-		}
-	}
-	return false
 }
 
 // GetLoadBalancerSourceRanges first try to parse and verify LoadBalancerSourceRanges field from a service.

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -96,7 +96,6 @@ type LoadBalancerOpts struct {
 	MonitorTimeout        util.MyDuration     `gcfg:"monitor-timeout"`
 	MonitorMaxRetries     uint                `gcfg:"monitor-max-retries"`
 	ManageSecurityGroups  bool                `gcfg:"manage-security-groups"`
-	NodeSecurityGroupIDs  []string            // Do not specify, get it automatically when enable manage-security-groups. TODO(FengyunPan): move it into cache
 	InternalLB            bool                `gcfg:"internal-lb"` // default false
 	CascadeDelete         bool                `gcfg:"cascade-delete"`
 	FlavorID              string              `gcfg:"flavor-id"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Seems like there was some dead code related to handling of the security groups in the implementation of the LoadBalancer Services support. This commit removes it. In particular:

* `LoadBalancerOpts.NodeSecurityGroupIDs` is never populated, so we can remove it as well as code using it.
* `IsAllowAll` function is never used. Moreover I have no idea why it was exported.

**Special notes for reviewers**:
Please, please double-check if I'm right that this code is not used anywhere.

```release-note
`[LoadBalancer]NodeSecurityGroupIDs` is completely removed from the configuration options. The option was deprecated and unsupported, but remained accessible as `nodesecuritygroupids`. This won't be true anymore.
```
