### PR TITLE
[occm] Replace call to Nova os-interfaces with direct Neutron call

### DIFF
--- a/pkg/openstack/openstack_test.go
+++ b/pkg/openstack/openstack_test.go
@@ -27,8 +27,8 @@ import (
 	"time"
 
 	"github.com/gophercloud/gophercloud"
-	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -360,10 +360,10 @@ func TestNodeAddresses(t *testing.T) {
 		PublicNetworkName: []string{"public"},
 	}
 
-	interfaces := []attachinterfaces.Interface{
+	ports := []ports.Port{
 		{
-			PortState: "ACTIVE",
-			FixedIPs: []attachinterfaces.FixedIP{
+			Status: "ACTIVE",
+			FixedIPs: []ports.IP{
 				{
 					IPAddress: "10.0.0.32",
 				},
@@ -374,7 +374,7 @@ func TestNodeAddresses(t *testing.T) {
 		},
 	}
 
-	addrs, err := nodeAddresses(&srv, interfaces, networkingOpts)
+	addrs, err := nodeAddresses(&srv, ports, networkingOpts)
 	if err != nil {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}
@@ -439,10 +439,10 @@ func TestNodeAddressesCustomPublicNetwork(t *testing.T) {
 		PublicNetworkName: []string{"pub-net"},
 	}
 
-	interfaces := []attachinterfaces.Interface{
+	ports := []ports.Port{
 		{
-			PortState: "ACTIVE",
-			FixedIPs: []attachinterfaces.FixedIP{
+			Status: "ACTIVE",
+			FixedIPs: []ports.IP{
 				{
 					IPAddress: "10.0.0.32",
 				},
@@ -453,7 +453,7 @@ func TestNodeAddressesCustomPublicNetwork(t *testing.T) {
 		},
 	}
 
-	addrs, err := nodeAddresses(&srv, interfaces, networkingOpts)
+	addrs, err := nodeAddresses(&srv, ports, networkingOpts)
 	if err != nil {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}
@@ -512,10 +512,10 @@ func TestNodeAddressesCustomPublicNetworkWithIntersectingFixedIP(t *testing.T) {
 		PublicNetworkName: []string{"pub-net"},
 	}
 
-	interfaces := []attachinterfaces.Interface{
+	ports := []ports.Port{
 		{
-			PortState: "ACTIVE",
-			FixedIPs: []attachinterfaces.FixedIP{
+			Status: "ACTIVE",
+			FixedIPs: []ports.IP{
 				{
 					IPAddress: "10.0.0.32",
 				},
@@ -530,7 +530,7 @@ func TestNodeAddressesCustomPublicNetworkWithIntersectingFixedIP(t *testing.T) {
 		},
 	}
 
-	addrs, err := nodeAddresses(&srv, interfaces, networkingOpts)
+	addrs, err := nodeAddresses(&srv, ports, networkingOpts)
 	if err != nil {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}
@@ -600,10 +600,10 @@ func TestNodeAddressesMultipleCustomInternalNetworks(t *testing.T) {
 		InternalNetworkName: []string{"private", "also-private"},
 	}
 
-	interfaces := []attachinterfaces.Interface{
+	ports := []ports.Port{
 		{
-			PortState: "ACTIVE",
-			FixedIPs: []attachinterfaces.FixedIP{
+			Status: "ACTIVE",
+			FixedIPs: []ports.IP{
 				{
 					IPAddress: "10.0.0.32",
 				},
@@ -614,7 +614,7 @@ func TestNodeAddressesMultipleCustomInternalNetworks(t *testing.T) {
 		},
 	}
 
-	addrs, err := nodeAddresses(&srv, interfaces, networkingOpts)
+	addrs, err := nodeAddresses(&srv, ports, networkingOpts)
 	if err != nil {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}
@@ -684,10 +684,10 @@ func TestNodeAddressesOneInternalNetwork(t *testing.T) {
 		InternalNetworkName: []string{"also-private"},
 	}
 
-	interfaces := []attachinterfaces.Interface{
+	ports := []ports.Port{
 		{
-			PortState: "ACTIVE",
-			FixedIPs: []attachinterfaces.FixedIP{
+			Status: "ACTIVE",
+			FixedIPs: []ports.IP{
 				{
 					IPAddress: "10.0.0.32",
 				},
@@ -698,7 +698,7 @@ func TestNodeAddressesOneInternalNetwork(t *testing.T) {
 		},
 	}
 
-	addrs, err := nodeAddresses(&srv, interfaces, networkingOpts)
+	addrs, err := nodeAddresses(&srv, ports, networkingOpts)
 	if err != nil {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}
@@ -760,10 +760,10 @@ func TestNodeAddressesIPv6Disabled(t *testing.T) {
 		IPv6SupportDisabled: true,
 	}
 
-	interfaces := []attachinterfaces.Interface{
+	ports := []ports.Port{
 		{
-			PortState: "ACTIVE",
-			FixedIPs: []attachinterfaces.FixedIP{
+			Status: "ACTIVE",
+			FixedIPs: []ports.IP{
 				{
 					IPAddress: "10.0.0.32",
 				},
@@ -774,7 +774,7 @@ func TestNodeAddressesIPv6Disabled(t *testing.T) {
 		},
 	}
 
-	addrs, err := nodeAddresses(&srv, interfaces, networkingOpts)
+	addrs, err := nodeAddresses(&srv, ports, networkingOpts)
 	if err != nil {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}
@@ -841,10 +841,10 @@ func TestNodeAddressesWithAddressSortOrderOptions(t *testing.T) {
 		AddressSortOrder:  "10.0.0.0/8, 50.56.176.0/24, 2001:4800::/32",
 	}
 
-	interfaces := []attachinterfaces.Interface{
+	ports := []ports.Port{
 		{
-			PortState: "ACTIVE",
-			FixedIPs: []attachinterfaces.FixedIP{
+			Status: "ACTIVE",
+			FixedIPs: []ports.IP{
 				{
 					IPAddress: "10.0.0.32",
 				},
@@ -855,7 +855,7 @@ func TestNodeAddressesWithAddressSortOrderOptions(t *testing.T) {
 		},
 	}
 
-	addrs, err := nodeAddresses(&srv, interfaces, networkingOpts)
+	addrs, err := nodeAddresses(&srv, ports, networkingOpts)
 	if err != nil {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
os-interfaces is a proxy API for neutron's ports list. This has 2 significant disadvantages to us:
* It adds the overhead of an extra API call every time it is used
* It doesn't contain all the information returned by Neutron

This is a non-functional change, although is does reduce the load on nova-api without reducing functionality.

The primary motivation for this is to enable additional filtering using information from ports, e.g. filtering by port tag or the addition of subports as in #2228.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
