### PR TITLE
Fix CSI spec versions

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.27.1
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.28.0-alpha.2
+version: 2.28.0-alpha.3
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -30,7 +30,7 @@ csi:
   resizer:
     image:
       repository: registry.k8s.io/sig-storage/csi-resizer
-      tag: v1.7.0
+      tag: v1.8.0
       pullPolicy: IfNotPresent
     resources: {}
     extraArgs: {}

--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.27.1
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 2.28.0-alpha.2
+version: 2.28.0-alpha.3
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -92,7 +92,7 @@ controllerplugin:
   resizer:
     image:
       repository: registry.k8s.io/sig-storage/csi-resizer
-      tag: v1.3.0
+      tag: v1.8.0
       pullPolicy: IfNotPresent
     resources: {}
   nodeSelector: {}

--- a/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
+++ b/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
@@ -32,7 +32,7 @@ The Cinder CSI Driver is a CSI Specification compliant driver used by Container 
 
 ## CSI Compatibility
 
-This plugin is compatible with CSI versions v1.3.0, v1.2.0 , v1.1.0, and v1.0.0
+This plugin is compatible with CSI v1.8.0
 
 ## Downloads
 

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -69,7 +69,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.7.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.8.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"

--- a/manifests/manila-csi-plugin/csi-controllerplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-controllerplugin.yaml
@@ -60,7 +60,7 @@ spec:
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
         - name: resizer
-          image: "registry.k8s.io/sig-storage/csi-resizer:v1.3.0"
+          image: "registry.k8s.io/sig-storage/csi-resizer:v1.8.0"
           args:
             - "--csi-address=$(ADDRESS)"
             - "--handle-volume-inuse-error=false"

--- a/pkg/csi/cinder/driver.go
+++ b/pkg/csi/cinder/driver.go
@@ -36,7 +36,7 @@ const (
 
 var (
 	// CSI spec version
-	specVersion = "1.3.0"
+	specVersion = "1.8.0"
 
 	// Driver version
 	// Version history:

--- a/pkg/csi/manila/driver.go
+++ b/pkg/csi/manila/driver.go
@@ -85,7 +85,7 @@ type nonBlockingGRPCServer struct {
 }
 
 const (
-	specVersion   = "1.2.0"
+	specVersion   = "1.8.0"
 	driverVersion = "0.9.0"
 	topologyKey   = "topology.manila.csi.openstack.org/zone"
 )

--- a/pkg/csi/manila/identityserver.go
+++ b/pkg/csi/manila/identityserver.go
@@ -18,6 +18,7 @@ package manila
 
 import (
 	"context"
+
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
@@ -123,7 +123,7 @@
       csimanila:
         image:
           repository: {{ remote_registry_host }}/manila-csi-plugin
-          tag: {{ github_pr }}
+          tag: v0.0.{{ github_pr }}
       shareProtocols:
         - protocolSelector: NFS
           fsGroupPolicy: None
@@ -224,7 +224,7 @@
         --ginkgo.v \
         --ginkgo.noColor \
         --ginkgo.progress \
-        --ginkgo.skip="\[Disruptive\]|\[sig-storage\]\s+\[manila-csi-e2e\]\s+CSI\s+Volumes\s+\[Driver:\s+nfs.manila.csi.openstack.org\]\s+\[Testpattern:\s+Dynamic\s+PV\s+\(default\s+fs\)\]\s+provisioning\s+should\s+provision\s+storage\s+with\s+any\s+volume\s+data\s+source\s+\[Serial\]|should\s+provision\s+storage\s+with\s+snapshot\s+data\s+source" \
+        --ginkgo.skip="\[Disruptive\]|\[sig-storage\]\s+\[manila-csi-e2e\]\s+CSI\s+Volumes\s+\[Driver:\s+nfs.manila.csi.openstack.org\]\s+\[Testpattern:\s+Dynamic\s+PV\s+\(default\s+fs\)\]\s+provisioning\s+should\s+provision\s+storage\s+with\s+any\s+volume\s+data\s+source\s+\[Serial\]|should\s+provision\s+storage\s+with\s+snapshot\s+data\s+source|restoring\s+snapshot\s+to\s+larger\s+size" \
         --ginkgo.focus="\[manila-csi-e2e\]" \
         -report-dir /var/log/csi-pod \
         -timeout=0 | tee "/var/log/csi-pod/manila-csi-e2e.log"
@@ -238,8 +238,8 @@
       set -x
       set -e
 
-      kubectl logs statefulset/manila-openstack-manila-csi-controllerplugin -n default -c nfs-nodeplugin > /var/log/csi-pod/csi-manila-controllerplugin.log
-      kubectl logs daemonset/manila-openstack-manila-csi-nodeplugin -n default -c nfs-nodeplugin > /var/log/csi-pod/csi-manila-nodeplugin.log
+      kubectl logs -l app=openstack-manila-csi,component=controllerplugin -n default -c nfs-nodeplugin --tail=-1 > /var/log/csi-pod/csi-manila-controllerplugin.log
+      kubectl logs -l app=openstack-manila-csi,component=nodeplugin -n default -c nfs-nodeplugin --tail=-1 > /var/log/csi-pod/csi-manila-nodeplugin.log
   ignore_errors: true
 
 - fail: msg="The execution has failed because of errors."


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

The PR aligns the go.mod CSI spec version with CSI driver variables.

**Which issue this PR fixes(if applicable)**:

fixes #2253

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Align the go.mod CSI spec version with CSI driver variables
```
