### PR TITLE
[occm]: fix blackhole route atomic delete logic (1.27 cherry-pick)

### DIFF
--- a/pkg/openstack/routes.go
+++ b/pkg/openstack/routes.go
@@ -421,6 +421,9 @@ func (r *Routes) DeleteRoute(ctx context.Context, clusterName string, route *clo
 	} else {
 		// atomic route update
 		blackhole := route.Blackhole
+		if blackhole {
+			addr = string(route.TargetNode)
+		}
 		route := []routers.Route{{
 			DestinationCIDR: route.DestinationCIDR,
 			NextHop:         addr,


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Orphaned blackhole routes are not deleted with atomic route update due to `NextHop` is empty.

**Which issue this PR fixes(if applicable)**:

fixes #2256

**Special notes for reviewers**:

See #2134

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Correctly delete oprhaned blackhole routes when atomic routes extension is enabled
```
