### PR TITLE
[cinder-csi-plugin] enable secret injection and common annotations

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.27.1
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.28.0-alpha.3
+version: 2.28.0-alpha.4
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cinder-csi.controllerplugin.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.csi.plugin.controllerPlugin.replicas }}
   strategy:
@@ -169,11 +173,13 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir:
-        - name: cloud-config
         {{- if .Values.secret.enabled }}
+        - name: cloud-config
           secret:
             secretName: {{ .Values.secret.name }}
-        {{- else }}
+        {{- end }}
+        {{- if .Values.secret.hostMount }}
+        - name: cloud-config
           hostPath:
             path: /etc/kubernetes
         {{- end }}

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cinder-csi.nodeplugin.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -127,11 +131,13 @@ spec:
           hostPath:
             path: /dev
             type: Directory
-        - name: cloud-config
         {{- if .Values.secret.enabled }}
+        - name: cloud-config
           secret:
             secretName: {{ .Values.secret.name }}
-        {{- else }}
+        {{- end }}
+        {{- if .Values.secret.hostMount }}
+        - name: cloud-config
           hostPath:
             path: /etc/kubernetes
         {{- end }}

--- a/charts/cinder-csi-plugin/templates/secret.yaml
+++ b/charts/cinder-csi-plugin/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.secret.create }}
+{{- if and (.Values.secret.create) (.Values.secret.enabled) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -106,7 +106,7 @@ logVerbosityLevel: 2
 # 4) via agent-injector (e.g. hashicorp vault): set "enabled" and "hostMount" to false, you have to provide credentials on your own by injecting credentials into the pod
 secret:
   enabled: false
-  hostMount: false
+  hostMount: true
   create: false
   filename: cloud.conf
 #  name: cinder-csi-cloud-config

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -98,8 +98,15 @@ csi:
 # for description of individual verbosity levels.
 logVerbosityLevel: 2
 
+# the secret should contain the openstack credentials
+# there are several options to inject the credentials:
+# 1) from kubernetes secret that doesn't exist: set "enabled" and "create" to true, this will create a secret from the values written to "data" down below
+# 2) from kubernetes ecret that already exists: set "enabled" to true and "create" to false
+# 3) from host system path /etc/cloud/cloud.conf: set "enabled" to false and "hostMount" to true
+# 4) via agent-injector (e.g. hashicorp vault): set "enabled" and "hostMount" to false, you have to provide credentials on your own by injecting credentials into the pod
 secret:
   enabled: false
+  hostMount: false
   create: false
   filename: cloud.conf
 #  name: cinder-csi-cloud-config
@@ -149,3 +156,6 @@ priorityClassName: ""
 
 imagePullSecrets: []
 # - name: my-imagepull-secret
+
+# add annotations to all pods
+commonAnnotations: {}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.

For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This PR enables secret injection via agent-injection (e.g. hashicorp vault) by adding secret disabled options via values and adding common annotations. 

**Which issue this PR fixes(if applicable)**:
none

**Special notes for reviewers**:
Testable by testing the different secret injection options (listed inside values file). 

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[cinder-csi-plugin] enable secret injection and common annotations
```
