### PR TITLE
(barbican-kms-plugin)Refactor and enhance Barbican KMS plugin codebase. 

### DIFF
--- a/cmd/barbican-kms-plugin/main.go
+++ b/cmd/barbican-kms-plugin/main.go
@@ -29,51 +29,39 @@ import (
 )
 
 var (
-	socketpath  string
-	cloudconfig string
+	socketPath  string
+	cloudConfig string
 )
 
 func main() {
-	// Glog requires this otherwise it complains.
-	if err := flag.CommandLine.Parse(nil); err != nil {
-		klog.Fatalf("Unable to parse flags: %v", err)
-	}
+	flag.Parse()
+
 	// This is a temporary hack to enable proper logging until upstream dependencies
 	// are migrated to fully utilize klog instead of glog.
-	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
-	klog.InitFlags(klogFlags)
-	// Sync the glog and klog flags.
-	flag.CommandLine.VisitAll(func(f1 *flag.Flag) {
-		f2 := klogFlags.Lookup(f1.Name)
-		if f2 != nil {
-			value := f1.Value.String()
-			_ = f2.Value.Set(value)
-		}
-	})
+	klog.InitFlags(nil)
 
 	cmd := &cobra.Command{
 		Use:   "barbican-kms-plugin",
-		Short: "Barbican KMS plugin for kubernetes",
+		Short: "Barbican KMS plugin for Kubernetes",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			sigchan := make(chan os.Signal, 1)
-			signal.Notify(sigchan, unix.SIGTERM, unix.SIGINT)
-			err := server.Run(cloudconfig, socketpath, sigchan)
+			sigChan := make(chan os.Signal, 1)
+			signal.Notify(sigChan, unix.SIGTERM, unix.SIGINT)
+			err := server.Run(cloudConfig, socketPath, sigChan)
 			return err
 		},
 	}
 
-	cmd.Flags().AddGoFlagSet(flag.CommandLine)
-
-	cmd.PersistentFlags().StringVar(&socketpath, "socketpath", "", "Barbican KMS Plugin unix socket endpoint")
+	cmd.PersistentFlags().StringVar(&socketPath, "socketpath", "", "Barbican KMS Plugin unix socket endpoint")
 	if err := cmd.MarkPersistentFlagRequired("socketpath"); err != nil {
-		klog.Fatalf("Unable to mark flag socketpath to be required: %v", err)
+		klog.Fatalf("Unable to mark flag socketpath as required: %v", err)
 	}
 
-	cmd.PersistentFlags().StringVar(&cloudconfig, "cloud-config", "", "Barbican KMS Plugin cloud config")
+	cmd.PersistentFlags().StringVar(&cloudConfig, "cloud-config", "", "Barbican KMS Plugin cloud config")
 	if err := cmd.MarkPersistentFlagRequired("cloud-config"); err != nil {
-		klog.Fatalf("Unable to mark flag cloud-config to be required: %v", err)
+		klog.Fatalf("Unable to mark flag cloud-config as required: %v", err)
 	}
 
 	code := cli.Run(cmd)
 	os.Exit(code)
 }
+

--- a/cmd/barbican-kms-plugin/main.go
+++ b/cmd/barbican-kms-plugin/main.go
@@ -64,4 +64,3 @@ func main() {
 	code := cli.Run(cmd)
 	os.Exit(code)
 }
-


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This PR refactors and enhances the codebase of the Barbican KMS plugin. It improves code readability, simplifies flag parsing and klog initialization, handles errors gracefully, updates signal handling, applies proper logging, and performs general code cleanup.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[barbican-kms-plugin] Refactor and enhance codebase

This pull request refactors and enhances the codebase of the Barbican KMS plugin. It improves code readability, simplifies flag parsing and klog initialization, handles errors gracefully, updates signal handling, applies proper logging, and performs general code cleanup.

No user action is required.

For more information, please refer to the documentation for the Barbican KMS plugin.

```
