### PR TITLE
[occm] Wait for LB to be ACTIVE on HM update

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1075,7 +1075,7 @@ func (lbaas *LbaasV2) ensureOctaviaHealthMonitor(lbID string, name string, pool 
 				MaxRetries: svcConf.healthMonitorMaxRetries,
 			}
 			klog.Infof("Updating health monitor %s updateOpts %+v", monitorID, updateOpts)
-			if err := openstackutil.UpdateHealthMonitor(lbaas.lb, monitorID, updateOpts); err != nil {
+			if err := openstackutil.UpdateHealthMonitor(lbaas.lb, monitorID, updateOpts, lbID); err != nil {
 				return err
 			}
 		}

--- a/pkg/util/openstack/loadbalancer.go
+++ b/pkg/util/openstack/loadbalancer.go
@@ -668,11 +668,15 @@ func CreateL7Rule(client *gophercloud.ServiceClient, policyID string, opts l7pol
 }
 
 // UpdateHealthMonitor updates a health monitor.
-func UpdateHealthMonitor(client *gophercloud.ServiceClient, monitorID string, opts monitors.UpdateOpts) error {
+func UpdateHealthMonitor(client *gophercloud.ServiceClient, monitorID string, opts monitors.UpdateOpts, lbID string) error {
 	mc := metrics.NewMetricContext("loadbalancer_healthmonitor", "update")
 	_, err := monitors.Update(client, monitorID, opts).Extract()
 	if mc.ObserveRequest(err) != nil {
 		return fmt.Errorf("failed to update healthmonitor: %v", err)
+	}
+
+	if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
+		return fmt.Errorf("failed to wait for load balancer %s ACTIVE after updating healthmonitor: %v", lbID, err)
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit makes sure that on exit from UpdateHealthMonitor() the LB is ACTIVE so that next operations can be called safely.

**Which issue this PR fixes(if applicable)**:
fixes #2267

**Special notes for reviewers**:

**Release note**:
```release-note
NONE
```
