### PR TITLE
fix gate

### DIFF
--- a/tests/playbooks/roles/install-docker/defaults/main.yml
+++ b/tests/playbooks/roles/install-docker/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-docker_version: 5:19.03.15~3-0~ubuntu-focal
+docker_version: 5:20.10.18~3-0~ubuntu-focal

--- a/tests/playbooks/roles/install-docker/tasks/main.yml
+++ b/tests/playbooks/roles/install-docker/tasks/main.yml
@@ -28,7 +28,7 @@
 # apt-get update; apt install -y docker-ce=<version>
 - name: Install docker-ce
   apt:
-    name: docker-ce={{ docker_version }}
+    name: docker-ce #={{ docker_version }}
     state: present
     update_cache: yes
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #2282 

this will not use given docker-ce, instead, use latest 
**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
