### PR TITLE
[helm] occm cinder-csi securityContext

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.27.1
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.28.0-alpha.4
+version: 2.28.0-alpha.5
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -31,8 +31,12 @@ spec:
         {{- end }}
     spec:
       serviceAccount: csi-cinder-controller-sa
+      securityContext:
+        {{- toYaml .Values.csi.plugin.controllerPlugin.podSecurityContext | nindent 8 }}
       containers:
         - name: csi-attacher
+          securityContext:
+            {{- toYaml .Values.csi.plugin.controllerPlugin.securityContext | nindent 12 }}
           image: "{{ .Values.csi.attacher.image.repository }}:{{ .Values.csi.attacher.image.tag }}"
           imagePullPolicy: {{ .Values.csi.attacher.image.pullPolicy }}
           args:
@@ -54,6 +58,8 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           resources: {{ toYaml .Values.csi.attacher.resources | nindent 12 }}
         - name: csi-provisioner
+          securityContext:
+            {{- toYaml .Values.csi.plugin.controllerPlugin.securityContext | nindent 12 }}
           image: "{{ .Values.csi.provisioner.image.repository }}:{{ .Values.csi.provisioner.image.tag }}"
           imagePullPolicy: {{ .Values.csi.provisioner.image.pullPolicy }}
           args:
@@ -77,6 +83,8 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           resources: {{ toYaml .Values.csi.provisioner.resources | nindent 12 }}
         - name: csi-snapshotter
+          securityContext:
+            {{- toYaml .Values.csi.plugin.controllerPlugin.securityContext | nindent 12 }}
           image: "{{ .Values.csi.snapshotter.image.repository }}:{{ .Values.csi.snapshotter.image.tag }}"
           imagePullPolicy: {{ .Values.csi.snapshotter.image.pullPolicy }}
           args:
@@ -97,6 +105,8 @@ spec:
               name: socket-dir
           resources: {{ toYaml .Values.csi.snapshotter.resources | nindent 12 }}
         - name: csi-resizer
+          securityContext:
+            {{- toYaml .Values.csi.plugin.controllerPlugin.securityContext | nindent 12 }}
           image: "{{ .Values.csi.resizer.image.repository }}:{{ .Values.csi.resizer.image.tag }}"
           imagePullPolicy: {{ .Values.csi.resizer.image.pullPolicy }}
           args:
@@ -118,6 +128,8 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           resources: {{ toYaml .Values.csi.resizer.resources | nindent 12 }}
         - name: liveness-probe
+          securityContext:
+            {{- toYaml .Values.csi.plugin.controllerPlugin.securityContext | nindent 12 }}
           image: "{{ .Values.csi.livenessprobe.image.repository }}:{{ .Values.csi.livenessprobe.image.tag }}"
           imagePullPolicy: {{ .Values.csi.livenessprobe.image.pullPolicy }}
           args:
@@ -136,6 +148,8 @@ spec:
               name: socket-dir
           resources: {{ toYaml .Values.csi.livenessprobe.resources | nindent 12 }}
         - name: cinder-csi-plugin
+          securityContext:
+            {{- toYaml .Values.csi.plugin.controllerPlugin.securityContext | nindent 12 }}
           image: "{{ .Values.csi.plugin.image.repository }}:{{ .Values.csi.plugin.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.csi.plugin.image.pullPolicy }}
           args:
@@ -172,7 +186,9 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
-            {{- .Values.csi.plugin.volumeMounts | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- with .Values.csi.plugin.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources: {{ toYaml .Values.csi.plugin.resources | nindent 12 }}
       volumes:
         - name: socket-dir
@@ -181,13 +197,14 @@ spec:
         - name: cloud-config
           secret:
             secretName: {{ .Values.secret.name }}
-        {{- end }}
-        {{- if .Values.secret.hostMount }}
+        {{- else if .Values.secret.hostMount }}
         - name: cloud-config
           hostPath:
             path: /etc/kubernetes
         {{- end }}
-        {{ .Values.csi.plugin.volumes | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- with .Values.csi.plugin.volumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       affinity: {{ toYaml .Values.csi.plugin.controllerPlugin.affinity | nindent 8 }}
       nodeSelector: {{ toYaml .Values.csi.plugin.controllerPlugin.nodeSelector | nindent 8 }}
       tolerations: {{ toYaml .Values.csi.plugin.controllerPlugin.tolerations | nindent 8 }}

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -26,6 +26,8 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
+          securityContext:
+            {{- toYaml .Values.csi.plugin.nodePlugin.securityContext | nindent 12 }}
           image: "{{ .Values.csi.nodeDriverRegistrar.image.repository }}:{{ .Values.csi.nodeDriverRegistrar.image.tag }}"
           imagePullPolicy: {{ .Values.csi.nodeDriverRegistrar.image.pullPolicy }}
           args:
@@ -53,6 +55,8 @@ spec:
               mountPath: /registration
           resources: {{ toYaml .Values.csi.nodeDriverRegistrar.resources | nindent 12 }}
         - name: liveness-probe
+          securityContext:
+            {{- toYaml .Values.csi.plugin.nodePlugin.securityContext | nindent 12 }}
           image: "{{ .Values.csi.livenessprobe.image.repository }}:{{ .Values.csi.livenessprobe.image.tag }}"
           imagePullPolicy: {{ .Values.csi.livenessprobe.image.pullPolicy }}
           args:
@@ -112,7 +116,9 @@ spec:
             - name: pods-probe-dir
               mountPath: /dev
               mountPropagation: "HostToContainer"
-            {{- .Values.csi.plugin.volumeMounts | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- with .Values.csi.plugin.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources: {{ toYaml .Values.csi.plugin.resources | nindent 12 }}
       volumes:
         - name: socket-dir
@@ -139,13 +145,14 @@ spec:
         - name: cloud-config
           secret:
             secretName: {{ .Values.secret.name }}
-        {{- end }}
-        {{- if .Values.secret.hostMount }}
+        {{- else if .Values.secret.hostMount }}
         - name: cloud-config
           hostPath:
             path: /etc/kubernetes
         {{- end }}
-        {{ .Values.csi.plugin.volumes | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- with .Values.csi.plugin.volumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       affinity: {{ toYaml .Values.csi.plugin.nodePlugin.affinity | nindent 8 }}
       nodeSelector: {{ toYaml .Values.csi.plugin.nodePlugin.nodeSelector | nindent 8 }}
       tolerations: {{ toYaml .Values.csi.plugin.nodePlugin.tolerations | nindent 8 }}

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -69,6 +69,13 @@ csi:
         mountPath: /etc/kubernetes
         readOnly: true
     nodePlugin:
+      podSecurityContext: {}
+      securityContext: {}
+        # capabilities:
+        #   drop:
+        #   - ALL
+        # seccompProfile:
+        #   type: RuntimeDefault
       affinity: {}
       nodeSelector: {}
       tolerations:
@@ -87,6 +94,19 @@ csi:
           # maxSurge is the maximum number of pods that can be
           # created over the desired number of pods.
           maxSurge: 1
+      podSecurityContext: {}
+        # runAsNonRoot: true
+        # runAsUser: 65532
+        # runAsGroup: 65532
+        # fsGroup: 65532
+        # fsGroupChangePolicy: OnRootMismatch
+      securityContext: {}
+        # capabilities:
+        #   drop:
+        #   - ALL
+        # seccompProfile:
+        #   type: RuntimeDefault
+        # readOnlyRootFilesystem: true
       affinity: {}
       nodeSelector: {}
       tolerations: []

--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.28.0-alpha.6
+version: 2.28.0-alpha.7
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -37,7 +37,7 @@ livenessProbe: {}
 readinessProbe: {}
 
 # Set nodeSelector where the controller shut run, i.e. controlplane nodes
-nodeSelector: []
+nodeSelector: {}
 # nodeSelector:
 #   node-role.kubernetes.io/controlplane: "true"
 
@@ -58,6 +58,8 @@ tolerations: []
 # For all available options, see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
 podSecurityContext:
   runAsUser: 1001
+  # seccompProfile:
+  #   type: RuntimeDefault
 
 # List of controllers should be enabled.
 # Use '*' to enable all controllers.


### PR DESCRIPTION
**What this PR does / why we need it**:

* Add podSecurityContext, securityContext to the Cinder-CSI
* Volumes cosmetic fixes

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

