### PR TITLE
[occm] Delete unused SG rules with manage-security-groups

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -2256,10 +2256,10 @@ func (lbaas *LbaasV2) ensureAndUpdateOctaviaSecurityGroup(clusterName string, ap
 				"failed to apply security rule for port %d, %w",
 				port.NodePort, err)
 		}
+	}
 
-		if err := applyNodeSecurityGroupIDForLB(lbaas.compute, lbaas.network, nodes, lbSecGroupID); err != nil {
-			return err
-		}
+	if err := applyNodeSecurityGroupIDForLB(lbaas.compute, lbaas.network, nodes, lbSecGroupID); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 )
 
 type testPopListener struct {
@@ -131,5 +132,303 @@ func TestPopListener(t *testing.T) {
 		sort.Strings(item.result)
 		sort.Strings(ids)
 		assert.Equal(t, ids, item.result, item.name)
+	}
+}
+
+type testGetRulesToCreateAndDelete struct {
+	testName      string
+	wantedRules   []rules.CreateOpts
+	existingRules []rules.SecGroupRule
+	toCreate      []rules.CreateOpts
+	toDelete      []rules.SecGroupRule
+}
+
+func TestGetRulesToCreateAndDelete(t *testing.T) {
+	tests := []testGetRulesToCreateAndDelete{
+		{
+			testName:      "Empty elements",
+			wantedRules:   []rules.CreateOpts{},
+			existingRules: []rules.SecGroupRule{},
+			toCreate:      []rules.CreateOpts{},
+			toDelete:      []rules.SecGroupRule{},
+		},
+		{
+			testName: "Removal of default egress SG rules",
+			wantedRules: []rules.CreateOpts{
+				{
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					PortRangeMax:   123,
+					PortRangeMin:   123,
+					Protocol:       "TCP",
+					RemoteIPPrefix: "10.0.0.0/8",
+				},
+			},
+			existingRules: []rules.SecGroupRule{
+				{
+					ID:             "bar",
+					Direction:      "egress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					RemoteIPPrefix: "0.0.0.0/0",
+				}, {
+					ID:             "baz",
+					Direction:      "egress",
+					EtherType:      "IPv6",
+					SecGroupID:     "foo",
+					RemoteIPPrefix: "::/0",
+				},
+			},
+			toCreate: []rules.CreateOpts{
+				{
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					PortRangeMax:   123,
+					PortRangeMin:   123,
+					Protocol:       "TCP",
+					RemoteIPPrefix: "10.0.0.0/8",
+				},
+			},
+			toDelete: []rules.SecGroupRule{
+				{
+					ID:             "bar",
+					Direction:      "egress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					RemoteIPPrefix: "0.0.0.0/0",
+				}, {
+					ID:             "baz",
+					Direction:      "egress",
+					EtherType:      "IPv6",
+					SecGroupID:     "foo",
+					RemoteIPPrefix: "::/0",
+				},
+			},
+		},
+		{
+			testName: "changing a port number",
+			wantedRules: []rules.CreateOpts{
+				{
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					PortRangeMax:   124,
+					PortRangeMin:   124,
+					Protocol:       "TCP",
+					RemoteIPPrefix: "10.0.0.0/8",
+				},
+			},
+			existingRules: []rules.SecGroupRule{
+				{
+					ID:             "bar",
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					RemoteIPPrefix: "10.0.0.0/8",
+					PortRangeMax:   123,
+					PortRangeMin:   123,
+				},
+			},
+			toCreate: []rules.CreateOpts{
+				{
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					PortRangeMax:   124,
+					PortRangeMin:   124,
+					Protocol:       "TCP",
+					RemoteIPPrefix: "10.0.0.0/8",
+				},
+			},
+			toDelete: []rules.SecGroupRule{
+				{
+					ID:             "bar",
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					RemoteIPPrefix: "10.0.0.0/8",
+					PortRangeMax:   123,
+					PortRangeMin:   123,
+				},
+			},
+		},
+		{
+			testName: "changing the CIDR",
+			wantedRules: []rules.CreateOpts{
+				{
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					PortRangeMax:   123,
+					PortRangeMin:   123,
+					Protocol:       "TCP",
+					RemoteIPPrefix: "10.0.0.0/24",
+				},
+			},
+			existingRules: []rules.SecGroupRule{
+				{
+					ID:             "bar",
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					RemoteIPPrefix: "10.0.0.0/8",
+					PortRangeMax:   123,
+					PortRangeMin:   123,
+				},
+			},
+			toCreate: []rules.CreateOpts{
+				{
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					PortRangeMax:   123,
+					PortRangeMin:   123,
+					Protocol:       "TCP",
+					RemoteIPPrefix: "10.0.0.0/24",
+				},
+			},
+			toDelete: []rules.SecGroupRule{
+				{
+					ID:             "bar",
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					RemoteIPPrefix: "10.0.0.0/8",
+					PortRangeMax:   123,
+					PortRangeMin:   123,
+				},
+			},
+		},
+		{
+			testName:    "wiping all rules",
+			wantedRules: []rules.CreateOpts{},
+			existingRules: []rules.SecGroupRule{
+				{
+					ID:             "bar",
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					RemoteIPPrefix: "10.0.0.0/8",
+					PortRangeMax:   123,
+					PortRangeMin:   123,
+				},
+				{
+					ID:             "bar",
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					RemoteIPPrefix: "10.0.0.0/8",
+					PortRangeMax:   124,
+					PortRangeMin:   124,
+				},
+				{
+					ID:             "bar",
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					RemoteIPPrefix: "10.0.0.0/8",
+					PortRangeMax:   125,
+					PortRangeMin:   125,
+				},
+			},
+			toCreate: []rules.CreateOpts{},
+			toDelete: []rules.SecGroupRule{
+				{
+					ID:             "bar",
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					RemoteIPPrefix: "10.0.0.0/8",
+					PortRangeMax:   123,
+					PortRangeMin:   123,
+				},
+				{
+					ID:             "bar",
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					RemoteIPPrefix: "10.0.0.0/8",
+					PortRangeMax:   124,
+					PortRangeMin:   124,
+				},
+				{
+					ID:             "bar",
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					RemoteIPPrefix: "10.0.0.0/8",
+					PortRangeMax:   125,
+					PortRangeMin:   125,
+				},
+			},
+		},
+		{
+			testName: "several rules for an empty SG",
+			wantedRules: []rules.CreateOpts{
+				{
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					PortRangeMax:   123,
+					PortRangeMin:   123,
+					Protocol:       "TCP",
+					RemoteIPPrefix: "10.0.0.0/8",
+				}, {
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					PortRangeMax:   124,
+					PortRangeMin:   124,
+					Protocol:       "TCP",
+					RemoteIPPrefix: "10.0.10.0/24",
+				}, {
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					PortRangeMax:   124,
+					PortRangeMin:   124,
+					Protocol:       "UDP",
+					RemoteIPPrefix: "10.0.12.0/24",
+				},
+			},
+			existingRules: []rules.SecGroupRule{},
+			toCreate: []rules.CreateOpts{
+				{
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					PortRangeMax:   123,
+					PortRangeMin:   123,
+					Protocol:       "TCP",
+					RemoteIPPrefix: "10.0.0.0/8",
+				}, {
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					PortRangeMax:   124,
+					PortRangeMin:   124,
+					Protocol:       "TCP",
+					RemoteIPPrefix: "10.0.10.0/24",
+				}, {
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					PortRangeMax:   124,
+					PortRangeMin:   124,
+					Protocol:       "UDP",
+					RemoteIPPrefix: "10.0.12.0/24",
+				},
+			},
+			toDelete: []rules.SecGroupRule{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			toCreate, toDelete := getRulesToCreateAndDelete(tt.wantedRules, tt.existingRules)
+			assert.ElementsMatch(t, tt.toCreate, toCreate)
+			assert.ElementsMatch(t, tt.toDelete, toDelete)
+		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This is iteration of #2033. The PR makes sure unnecessary SG rules are removed when we're
reconciling a Service.

**Which issue this PR fixes(if applicable)**:
fixes #2003

**Special notes for reviewers**:
You need to enable `[LoadBalancer]manage-security-groups` to test this.

**Release note**:
```release-note
NONE
```
