### PR TITLE
fixed Grammatical mistakes in barbican-kms-plugin

### DIFF
--- a/docs/barbican-kms-plugin/using-barbican-kms-plugin.md
+++ b/docs/barbican-kms-plugin/using-barbican-kms-plugin.md
@@ -9,10 +9,10 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # OpenStack Barbican KMS Plugin
-Kubernetes supports to encrypt etcd data with various providers listed [here](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#providers), one of which is *kms*. The Kubernetes *kms provider* uses envelope encryption scheme. The data is encrypted using *DEK's* by kubernetes *kms provider*, *DEK's* are encrypted by *kms plugin* (e.g. barbican) using *KEK*. *Barbican-kms-plugin* uses *key* from barbican to encrypt/decrypt the *DEK's* as requested by kubernetes api server. 
+Kubernetes supports to encrypt etcd data with various providers listed [here](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#providers), one of which is *kms*. The Kubernetes *kms provider* uses an envelope encryption scheme. The data is encrypted using *DEK's* by kubernetes *kms provider*, *DEK's* are encrypted by *kms plugin* (e.g. barbican) using *KEK*. *Barbican-kms-plugin* uses *key* from barbican to encrypt/decrypt the *DEK's* as requested by kubernetes api server. 
 The *KMS provider* uses gRPC to communicate with a specific *KMS plugin*.
 
-It is recommended to read following kubernetes documents  
+It is recommended to read the following kubernetes documents  
 
 * [Encrypting Secret Data at Rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#verifying-that-data-is-encrypted)  
 * [Using a KMS provider for data encryption](https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/)
@@ -23,7 +23,7 @@ It is recommended to read following kubernetes documents
 The following installation steps assumes that you have a Kubernetes cluster(v1.10+) running on OpenStack Cloud.
 
 
-### Create 256-bit (32 byte) CBC key and store in barbican
+### Create 256-bit (32 bytes) CBC key and store in barbican
 
 ```
 $ openstack secret order create --name k8s_key --algorithm aes --mode cbc --bit-length 256 --payload-content-type=application/octet-stream key
@@ -90,7 +90,7 @@ example `release-1.25` for kubernetes version 1.25.
 ### Create encryption configuration
 
 Create `/etc/kubernetes/encryption-config.yaml` on each of your control plane
-nodes
+nodes.
 ```yaml
 kind: EncryptionConfig
 apiVersion: v1
@@ -108,7 +108,7 @@ resources:
 
 ### Update the API server
 
-On each of your control plane nodes you need to edit the kube-apiserver, the
+On each of your control plane nodes, you need to edit the kube-apiserver, the
 configuration is usually found at
 `/etc/kubernetes/manifests/kube-apiserver.yaml`. You can just edit it and
 kubernetes will eventually restart the pod with the new configuration.
@@ -142,5 +142,5 @@ spec:
 
 
 ### Verify
-[Verify the secret data is encrypted](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#verifying-that-data-is-encrypted
+[Verify that the secret data is encrypted](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#verifying-that-data-is-encrypted
 )

--- a/docs/barbican-kms-plugin/using-barbican-kms-plugin.md
+++ b/docs/barbican-kms-plugin/using-barbican-kms-plugin.md
@@ -9,7 +9,7 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # OpenStack Barbican KMS Plugin
-Kubernetes supports to encrypting etcd data with various providers listed [here](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#providers), one of which is *kms*. The Kubernetes *kms provider* uses an envelope encryption scheme. The data is encrypted using *DEK's* by kubernetes *kms provider*, *DEK's* are encrypted by *kms plugin* (e.g. barbican) using *KEK*. *Barbican-kms-plugin* uses *key* from barbican to encrypt/decrypt the *DEK's* as requested by kubernetes api server. 
+Kubernetes supports encrypting etcd data with various providers listed [here](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#providers), one of which is *kms*. The Kubernetes *kms provider* uses an envelope encryption scheme. The data is encrypted using *DEK's* by kubernetes *kms provider*, *DEK's* are encrypted by *kms plugin* (e.g. barbican) using *KEK*. *Barbican-kms-plugin* uses *key* from barbican to encrypt/decrypt the *DEK's* as requested by kubernetes api server. 
 The *KMS provider* uses gRPC to communicate with a specific *KMS plugin*.
 
 It is recommended to read the following kubernetes documents  

--- a/docs/barbican-kms-plugin/using-barbican-kms-plugin.md
+++ b/docs/barbican-kms-plugin/using-barbican-kms-plugin.md
@@ -23,7 +23,7 @@ It is recommended to read following kubernetes documents
 The following installation steps assumes that you have a Kubernetes cluster(v1.10+) running on OpenStack Cloud.
 
 
-### Create 256bit(32 byte) cbc key and store in barbican
+### Create 256-bit(32 byte) cbc key and store in barbican
 
 ```
 $ openstack secret order create --name k8s_key --algorithm aes --mode cbc --bit-length 256 --payload-content-type=application/octet-stream key
@@ -41,7 +41,7 @@ $ openstack secret order create --name k8s_key --algorithm aes --mode cbc --bit-
 +----------------+----------------------------------------------------------------------+
 ```
 
-### Get the Key ID, It is the **uuid** in *Secret href*
+### Get the Key ID, it is the **uuid** in *Secret href*
 
 ```
 $ openstack secret order get http://hostname:9311/v1/orders/e477a578-4a46-4c3f-b071-79e220207b0e
@@ -60,7 +60,7 @@ $ openstack secret order get http://hostname:9311/v1/orders/e477a578-4a46-4c3f-b
 ```
 
 
-### Add the Key ID in your cloud-config file
+### Add the key ID in your cloud-config file
 
 ```toml
 [Global]
@@ -79,7 +79,7 @@ key-id = "<key-id>"
 ### Run the KMS Plugin in your cluster
 
 This will provide a socket at `/var/lib/kms/kms.sock` on each of the control
-plane node
+plane nodes.
 ```
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/manifests/barbican-kms/ds.yaml
 ```
@@ -87,7 +87,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/cloud-provider-ope
 example `release-1.25` for kubernetes version 1.25.
 
 
-### Create encrytion configuration
+### Create encryption configuration
 
 Create `/etc/kubernetes/encryption-config.yaml` on each of your control plane
 nodes

--- a/docs/barbican-kms-plugin/using-barbican-kms-plugin.md
+++ b/docs/barbican-kms-plugin/using-barbican-kms-plugin.md
@@ -23,7 +23,7 @@ It is recommended to read following kubernetes documents
 The following installation steps assumes that you have a Kubernetes cluster(v1.10+) running on OpenStack Cloud.
 
 
-### Create 256-bit(32 byte) cbc key and store in barbican
+### Create 256-bit (32 byte) CBC key and store in barbican
 
 ```
 $ openstack secret order create --name k8s_key --algorithm aes --mode cbc --bit-length 256 --payload-content-type=application/octet-stream key
@@ -41,7 +41,7 @@ $ openstack secret order create --name k8s_key --algorithm aes --mode cbc --bit-
 +----------------+----------------------------------------------------------------------+
 ```
 
-### Get the Key ID, it is the **uuid** in *Secret href*
+### Get the key ID, it is the **uuid** in *Secret href*
 
 ```
 $ openstack secret order get http://hostname:9311/v1/orders/e477a578-4a46-4c3f-b071-79e220207b0e

--- a/docs/barbican-kms-plugin/using-barbican-kms-plugin.md
+++ b/docs/barbican-kms-plugin/using-barbican-kms-plugin.md
@@ -9,7 +9,7 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # OpenStack Barbican KMS Plugin
-Kubernetes supports to encrypt etcd data with various providers listed [here](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#providers), one of which is *kms*. The Kubernetes *kms provider* uses an envelope encryption scheme. The data is encrypted using *DEK's* by kubernetes *kms provider*, *DEK's* are encrypted by *kms plugin* (e.g. barbican) using *KEK*. *Barbican-kms-plugin* uses *key* from barbican to encrypt/decrypt the *DEK's* as requested by kubernetes api server. 
+Kubernetes supports to encrypting etcd data with various providers listed [here](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#providers), one of which is *kms*. The Kubernetes *kms provider* uses an envelope encryption scheme. The data is encrypted using *DEK's* by kubernetes *kms provider*, *DEK's* are encrypted by *kms plugin* (e.g. barbican) using *KEK*. *Barbican-kms-plugin* uses *key* from barbican to encrypt/decrypt the *DEK's* as requested by kubernetes api server. 
 The *KMS provider* uses gRPC to communicate with a specific *KMS plugin*.
 
 It is recommended to read the following kubernetes documents  


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Improved and fixed Grammatical mistakes in barbican-kms-plugin

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
