### PR TITLE
Added  comments and arranged the variable names

### DIFF
--- a/cmd/manila-csi-plugin/main.go
+++ b/cmd/manila-csi-plugin/main.go
@@ -34,17 +34,22 @@ import (
 )
 
 var (
-	endpoint              string
+	// Driver configuration
 	driverName            string
-	nodeID                string
-	nodeAZ                string
-	runtimeConfigFile     string
 	withTopology          bool
 	protoSelector         string
 	fwdEndpoint           string
-	userAgentData         []string
 	compatibilitySettings string
-	clusterID             string
+
+	// Node information
+	nodeID    string
+	nodeAZ    string
+	clusterID string
+
+	// Runtime options
+	endpoint          string
+	runtimeConfigFile string
+	userAgentData     []string
 )
 
 func validateShareProtocolSelector(v string) error {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Added comments and arranged the variable names for better understanding and readability to users.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
