### PR TITLE
Improved the grammar in sidecarcompatibility.md

### DIFF
--- a/docs/cinder-csi-plugin/sidecarcompatibility.md
+++ b/docs/cinder-csi-plugin/sidecarcompatibility.md
@@ -11,6 +11,6 @@
 
 ## Set file type in provisioner
 
-There is a change in [csi-provisioner 2.0](https://github.com/kubernetes-csi/external-provisioner/blob/master/CHANGELOG/CHANGELOG-2.0.md): The fstype on provisioned PVs no longer defaults to "ext4". A defaultFStype arg is added to the provisioner. Admins can also specify this fstype via storage class parameter. If fstype is set in storage class parameter, it will be used. The sidecar arg is only checked if fstype is not set in the SC param.
+There is a change in [CSI-provisioner 2.0](https://github.com/kubernetes-csi/external-provisioner/blob/master/CHANGELOG/CHANGELOG-2.0.md): The fsType on provisioned PVs no longer defaults to "ext4". A defaultFSType argument is added to the provisioner. Admins can also specify this fstype via storage class parameter. If fsType is set in storage class parameter, it will be used. The sidecar argument is only checked if fstype is not set in the SC param.
 
-By default, in the manifest file a `--default-fstype=ext4` default settings are added to [manifests](../../manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml), if you want to update it , please add a `fsType: ext4` into the storageclass definition.
+By default, in the manifest file with the `--default-fstype=ext4` default settings are added to [manifests](../../manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml), if you want to update it , please add a `fsType: ext4` into the storage class definition.

--- a/docs/cinder-csi-plugin/sidecarcompatibility.md
+++ b/docs/cinder-csi-plugin/sidecarcompatibility.md
@@ -11,6 +11,6 @@
 
 ## Set file type in provisioner
 
-There is a change in [CSI-provisioner 2.0](https://github.com/kubernetes-csi/external-provisioner/blob/master/CHANGELOG/CHANGELOG-2.0.md): The fsType on provisioned PVs no longer defaults to "ext4". A defaultFSType argument is added to the provisioner. Admins can also specify this fstype via storage class parameter. If fsType is set in storage class parameter, it will be used. The sidecar argument is only checked if fstype is not set in the SC param.
+There is a change in [CSI provisioner 2.0](https://github.com/kubernetes-csi/external-provisioner/blob/master/CHANGELOG/CHANGELOG-2.0.md): The fstype on provisioned PVs no longer defaults to "ext4". A `defaultFSType` argument is added to the provisioner. Admins can also specify this fstype via storage class parameter. If fstype is set in storage class parameter, it will be used. The sidecar argument is only checked if fstype is not set in the SC param.
 
-By default, in the manifest file with the `--default-fstype=ext4` default settings are added to [manifests](../../manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml), if you want to update it , please add a `fsType: ext4` into the storage class definition.
+By default, in the manifest file a `--default-fstype=ext4` default settings are added to [manifests](../../manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml), if you want to update it , please add a `fsType: ext4` into the storage class definition.


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
I improved some sentences which are misspelt and some grammar as well for a better user experience. 


**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
