### PR TITLE
[occm] Optimize `applyNodeSecurityGroupIDForLB()`

### DIFF
--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -71,7 +71,6 @@ func AddExtraFlags(fs *pflag.FlagSet) {
 type LoadBalancer struct {
 	secret  *gophercloud.ServiceClient
 	network *gophercloud.ServiceClient
-	compute *gophercloud.ServiceClient
 	lb      *gophercloud.ServiceClient
 	opts    LoadBalancerOpts
 	kclient kubernetes.Interface
@@ -335,12 +334,6 @@ func (os *OpenStack) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 		return nil, false
 	}
 
-	compute, err := client.NewComputeV2(os.provider, os.epOpts)
-	if err != nil {
-		klog.Errorf("Failed to create an OpenStack Compute client: %v", err)
-		return nil, false
-	}
-
 	lb, err := client.NewLoadBalancerV2(os.provider, os.epOpts)
 	if err != nil {
 		klog.Errorf("Failed to create an OpenStack LoadBalancer client: %v", err)
@@ -363,7 +356,7 @@ func (os *OpenStack) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 
 	klog.V(1).Info("Claiming to support LoadBalancer")
 
-	return &LbaasV2{LoadBalancer{secret, network, compute, lb, os.lbOpts, os.kclient}}, true
+	return &LbaasV2{LoadBalancer{secret, network, lb, os.lbOpts, os.kclient}}, true
 }
 
 // Zones indicates that we support zones


### PR DESCRIPTION
**What this PR does / why we need it**:
Matt noticed several optimizations that can be done in `applyNodeSecurityGroupIDForLB()` function. I added a few more refactorings. In particular:

* We don't need to lookup servers by name as we have `.spec.providerID` in the nodes passed to the function.
* We don't need to lookup servers at all when we have the ID, we can fetch ports by `deviceID`.
* This means we don't need a Nova client in the LB instance anymore.
* `slices.Contains()` from K8s utils can be used to check if SG is in the list.
* It's better to tag the port with SG before we actually apply it. This will protect us from situations when the SG is applied, but tagging the port failed and now when deleting the SG CPO would be unable to find the port and therefore delete the SG.

**Special notes for reviewers**:
`[LoadBalancer]manage-security-groups` has to be on.

**Release note**:
```release-note
NONE
```
