### PR TITLE
Corrected the grammar

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -33,7 +33,7 @@ Create an application of Deployment as the Service backend:
 kubectl run echoserver --image=gcr.io/google-containers/echoserver:1.10 --port=8080
 ```
 
-To provide the echoserver application with an internet-facing loadbalancer we can simply run the following:
+To provide the echoserver application with an internet-facing loadbalancer, we can simply run the following:
 
 ```shell
 cat <<EOF | kubectl apply -f -
@@ -53,7 +53,7 @@ spec:
 EOF
 ```
 
-Check the state the status of the loadbalanced-service until the `EXTERNAL-IP` status is no longer pending.
+Check the state and status of the loadbalanced-service until the `EXTERNAL-IP` status is no longer pending.
 
 ```shell
 $ kubectl get service loadbalanced-service


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Corrected & improved some grammar.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
