### PR TITLE
[occm] Use `instanceIDFromProviderID()` function

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -690,9 +690,9 @@ func getSubnetIDForLB(network *gophercloud.ServiceClient, node corev1.Node, pref
 		return "", err
 	}
 
-	instanceID := node.Spec.ProviderID
-	if ind := strings.LastIndex(instanceID, "/"); ind >= 0 {
-		instanceID = instanceID[(ind + 1):]
+	_, instanceID, err := instanceIDFromProviderID(node.Spec.ProviderID)
+	if err != nil {
+		return "", fmt.Errorf("can't determine instance ID from ProviderID when autodetecting LB subnet: %w", err)
 	}
 
 	ports, err := getAttachedPorts(network, instanceID)


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit makes sure that in all instances of reading Nova instance ID from the `.Spec.ProviderID` field, we're using
`instanceIDFromProviderID()` function which is designed for that purpose.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
