### PR TITLE
[occm] Remove filtering by device_owner.

### DIFF
--- a/pkg/openstack/instances.go
+++ b/pkg/openstack/instances.go
@@ -703,8 +703,7 @@ func getAddressesByName(client *gophercloud.ServiceClient, name types.NodeName, 
 // getAttachedPorts returns a list of ports attached to a server.
 func getAttachedPorts(client *gophercloud.ServiceClient, serverID string) ([]ports.Port, error) {
 	listOpts := ports.ListOpts{
-		DeviceID:    serverID,
-		DeviceOwner: "compute:nova",
+		DeviceID: serverID,
 	}
 
 	return openstack.GetPorts(client, listOpts)


### PR DESCRIPTION
In OpenStack default AZ is called 'nova', thus device_owner is filled with 'compute:nova', and that's ok for deployments within one (default) AZ.

Filtering by device_owner however, will make function getAttachedPorts to return zero ports for provided node. In this patch, filtering by device_owner is simply removed.

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #2303

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
