### PR TITLE
[occm] Get IP addresses of neutron subports v3

### DIFF
--- a/pkg/openstack/instancesv2.go
+++ b/pkg/openstack/instancesv2.go
@@ -128,7 +128,7 @@ func (i *InstancesV2) InstanceMetadata(ctx context.Context, node *v1.Node) (*clo
 		return nil, err
 	}
 
-	addresses, err := nodeAddresses(&server.Server, ports, i.networkingOpts)
+	addresses, err := nodeAddresses(&server.Server, ports, i.network, i.networkingOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -27,6 +27,8 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunk_details"
+	neutronports "github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/spf13/pflag"
 	gcfg "gopkg.in/gcfg.v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -65,6 +67,11 @@ var supportedContainerStore = []string{"barbican", "external"}
 // AddExtraFlags is called by the main package to add component specific command line flags
 func AddExtraFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVar(&userAgentData, "user-agent", nil, "Extra data to add to gophercloud user-agent. Use multiple times to add more than one component.")
+}
+
+type PortWithTrunkDetails struct {
+	neutronports.Port
+	trunk_details.TrunkDetailsExt
 }
 
 // LoadBalancer is used for creating and maintaining load balancers

--- a/pkg/openstack/openstack_test.go
+++ b/pkg/openstack/openstack_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+	neutronports "github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -360,10 +360,10 @@ func TestNodeAddresses(t *testing.T) {
 		PublicNetworkName: []string{"public"},
 	}
 
-	ports := []ports.Port{
-		{
+	ports := []PortWithTrunkDetails{{
+		Port: neutronports.Port{
 			Status: "ACTIVE",
-			FixedIPs: []ports.IP{
+			FixedIPs: []neutronports.IP{
 				{
 					IPAddress: "10.0.0.32",
 				},
@@ -372,9 +372,10 @@ func TestNodeAddresses(t *testing.T) {
 				},
 			},
 		},
+	},
 	}
 
-	addrs, err := nodeAddresses(&srv, ports, networkingOpts)
+	addrs, err := nodeAddresses(&srv, ports, nil, networkingOpts)
 	if err != nil {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}
@@ -439,10 +440,10 @@ func TestNodeAddressesCustomPublicNetwork(t *testing.T) {
 		PublicNetworkName: []string{"pub-net"},
 	}
 
-	ports := []ports.Port{
-		{
+	ports := []PortWithTrunkDetails{{
+		Port: neutronports.Port{
 			Status: "ACTIVE",
-			FixedIPs: []ports.IP{
+			FixedIPs: []neutronports.IP{
 				{
 					IPAddress: "10.0.0.32",
 				},
@@ -451,9 +452,10 @@ func TestNodeAddressesCustomPublicNetwork(t *testing.T) {
 				},
 			},
 		},
+	},
 	}
 
-	addrs, err := nodeAddresses(&srv, ports, networkingOpts)
+	addrs, err := nodeAddresses(&srv, ports, nil, networkingOpts)
 	if err != nil {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}
@@ -512,10 +514,10 @@ func TestNodeAddressesCustomPublicNetworkWithIntersectingFixedIP(t *testing.T) {
 		PublicNetworkName: []string{"pub-net"},
 	}
 
-	ports := []ports.Port{
-		{
+	ports := []PortWithTrunkDetails{{
+		Port: neutronports.Port{
 			Status: "ACTIVE",
-			FixedIPs: []ports.IP{
+			FixedIPs: []neutronports.IP{
 				{
 					IPAddress: "10.0.0.32",
 				},
@@ -528,9 +530,10 @@ func TestNodeAddressesCustomPublicNetworkWithIntersectingFixedIP(t *testing.T) {
 				},
 			},
 		},
+	},
 	}
 
-	addrs, err := nodeAddresses(&srv, ports, networkingOpts)
+	addrs, err := nodeAddresses(&srv, ports, nil, networkingOpts)
 	if err != nil {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}
@@ -600,10 +603,10 @@ func TestNodeAddressesMultipleCustomInternalNetworks(t *testing.T) {
 		InternalNetworkName: []string{"private", "also-private"},
 	}
 
-	ports := []ports.Port{
-		{
+	ports := []PortWithTrunkDetails{{
+		Port: neutronports.Port{
 			Status: "ACTIVE",
-			FixedIPs: []ports.IP{
+			FixedIPs: []neutronports.IP{
 				{
 					IPAddress: "10.0.0.32",
 				},
@@ -612,9 +615,10 @@ func TestNodeAddressesMultipleCustomInternalNetworks(t *testing.T) {
 				},
 			},
 		},
+	},
 	}
 
-	addrs, err := nodeAddresses(&srv, ports, networkingOpts)
+	addrs, err := nodeAddresses(&srv, ports, nil, networkingOpts)
 	if err != nil {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}
@@ -684,10 +688,10 @@ func TestNodeAddressesOneInternalNetwork(t *testing.T) {
 		InternalNetworkName: []string{"also-private"},
 	}
 
-	ports := []ports.Port{
-		{
+	ports := []PortWithTrunkDetails{{
+		Port: neutronports.Port{
 			Status: "ACTIVE",
-			FixedIPs: []ports.IP{
+			FixedIPs: []neutronports.IP{
 				{
 					IPAddress: "10.0.0.32",
 				},
@@ -696,9 +700,10 @@ func TestNodeAddressesOneInternalNetwork(t *testing.T) {
 				},
 			},
 		},
+	},
 	}
 
-	addrs, err := nodeAddresses(&srv, ports, networkingOpts)
+	addrs, err := nodeAddresses(&srv, ports, nil, networkingOpts)
 	if err != nil {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}
@@ -760,10 +765,10 @@ func TestNodeAddressesIPv6Disabled(t *testing.T) {
 		IPv6SupportDisabled: true,
 	}
 
-	ports := []ports.Port{
-		{
+	ports := []PortWithTrunkDetails{{
+		Port: neutronports.Port{
 			Status: "ACTIVE",
-			FixedIPs: []ports.IP{
+			FixedIPs: []neutronports.IP{
 				{
 					IPAddress: "10.0.0.32",
 				},
@@ -772,9 +777,10 @@ func TestNodeAddressesIPv6Disabled(t *testing.T) {
 				},
 			},
 		},
+	},
 	}
 
-	addrs, err := nodeAddresses(&srv, ports, networkingOpts)
+	addrs, err := nodeAddresses(&srv, ports, nil, networkingOpts)
 	if err != nil {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}
@@ -841,10 +847,10 @@ func TestNodeAddressesWithAddressSortOrderOptions(t *testing.T) {
 		AddressSortOrder:  "10.0.0.0/8, 50.56.176.0/24, 2001:4800::/32",
 	}
 
-	ports := []ports.Port{
-		{
+	ports := []PortWithTrunkDetails{{
+		Port: neutronports.Port{
 			Status: "ACTIVE",
-			FixedIPs: []ports.IP{
+			FixedIPs: []neutronports.IP{
 				{
 					IPAddress: "10.0.0.32",
 				},
@@ -853,9 +859,10 @@ func TestNodeAddressesWithAddressSortOrderOptions(t *testing.T) {
 				},
 			},
 		},
+	},
 	}
 
-	addrs, err := nodeAddresses(&srv, ports, networkingOpts)
+	addrs, err := nodeAddresses(&srv, ports, nil, networkingOpts)
 	if err != nil {
 		t.Fatalf("nodeAddresses returned error: %v", err)
 	}


### PR DESCRIPTION
Vlan-aware VMs are commonly used in telecom.
Those VMs are plugged into flat networks and use neutron trunk:
https://docs.openstack.org/neutron/latest/admin/config-trunking.html

Currenlty, nodeAddresses() only returns neutron ports directly attached to VM. For vlan-aware VMs, IP addresses are assigned on neutron subports. Subports are attached to the trunk; they are not attached to the VM directly. This pull request changes nodeAddresses() to return IP addresses of neutron subports when they exist. Without this change, Kubernetes is unable to IP addresses of vlan-aware VMs. This change is transparent to VMs not using neturon trunk.


**Special notes for reviewers**:
This is a rebase of the following PR:
https://github.com/kubernetes/cloud-provider-openstack/pull/2270

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
