### PR TITLE
[occm] Switch DevStack to use OVN

### DIFF
--- a/tests/playbooks/roles/install-cpo-occm/tasks/main.yaml
+++ b/tests/playbooks/roles/install-cpo-occm/tasks/main.yaml
@@ -116,6 +116,7 @@
 
 - name: Run functional tests for openstack-cloud-controller-manager
   when: run_e2e
+  register: run_tests
   shell:
     executable: /bin/bash
     cmd: |
@@ -125,3 +126,34 @@
       GATEWAY_IP=172.24.5.1 \
       DEVSTACK_OS_RC={{ devstack_workdir }}/openrc \
       bash tests/e2e/cloudprovider/test-lb-service.sh
+  timeout: 3600
+  ignore_errors: true
+
+- name: Print logs for debugging
+  when:
+    - run_e2e
+    - run_tests.failed
+  block:
+  - name: Show openstack-cloud-controller-manager pod logs
+    shell:
+      executable: /bin/bash
+      cmd: |
+        kubectl -n kube-system logs daemonset/openstack-cloud-controller-manager
+
+  - name: Show Octavia logs
+    become: true
+    shell:
+      executable: /bin/bash
+      cmd: |
+        sudo journalctl -u devstack@o-api.service --no-pager
+
+  - name: Show Neutron logs
+    become: true
+    shell:
+      executable: /bin/bash
+      cmd: |
+        sudo journalctl -u devstack@q-svc.service --no-pager
+
+  - name: &failmsg2 Stop due to prior failure of tests
+    fail:
+      msg: *failmsg2

--- a/tests/playbooks/roles/install-devstack/defaults/main.yaml
+++ b/tests/playbooks/roles/install-devstack/defaults/main.yaml
@@ -1,13 +1,14 @@
 ---
 user: "stack"
 workdir: "/home/{{ user }}/devstack"
-branch: "stable/zed"
+branch: "stable/2023.1"
 enable_services:
   - nova
   - glance
   - cinder
   - neutron
   - octavia
+  - ovn-octavia
   - barbican
 octavia_amphora_url: "https://tarballs.opendev.org/openstack/octavia/test-images/test-only-amphora-x64-haproxy-ubuntu-focal.qcow2"
 octavia_amphora_dir: /opt/octavia-amphora

--- a/tests/playbooks/roles/install-devstack/templates/local.conf.j2
+++ b/tests/playbooks/roles/install-devstack/templates/local.conf.j2
@@ -51,21 +51,24 @@ enable_service c-sch
 # Neutron
 enable_plugin neutron ${GIT_BASE}/openstack/neutron.git {{ branch }}
 enable_service q-svc
-enable_service q-agt
-enable_service q-dhcp
-enable_service q-l3
-enable_service q-meta
+enable_service q-ovn-metadata-agent
+enable_service q-trunk
+enable_service q-qos
+enable_service ovn-controller
+enable_service ovn-northd
+enable_service ovs-vswitchd
+enable_service ovsdb-server
+
+ML2_L3_PLUGIN="ovn-router,trunk,qos"
+OVN_L3_CREATE_PUBLIC_NETWORK="True"
+PUBLIC_BRIDGE_MTU="1430"
+
 IP_VERSION=4
 IPV4_ADDRS_SAFE_TO_USE=10.1.0.0/26
 FIXED_RANGE=10.1.0.0/26
 NETWORK_GATEWAY=10.1.0.1
 FLOATING_RANGE=172.24.5.0/24
 PUBLIC_NETWORK_GATEWAY=172.24.5.1
-Q_PLUGIN=ml2
-Q_ML2_TENANT_NETWORK_TYPE=vxlan
-Q_DVR_MODE=legacy
-Q_AGENT=openvswitch
-Q_ML2_PLUGIN_MECHANISM_DRIVERS=openvswitch
 {% endif %}
 
 {% if "octavia" in enable_services %}
@@ -75,6 +78,7 @@ enable_service octavia
 enable_service o-cw
 enable_service o-hm
 enable_service o-hk
+enable_service o-da
 enable_service o-api
 
 LIBS_FROM_GIT+=,python-octaviaclient
@@ -87,6 +91,10 @@ OCTAVIA_MGMT_SUBNET_END=10.51.0.254
 {% if octavia_amphora_url %}
 OCTAVIA_AMP_IMAGE_FILE={{ octavia_amphora_dir }}/{{ octavia_amphora_filename }}
 {% endif %}
+{% endif %}
+
+{% if "ovn-octavia" in enable_services %}
+enable_plugin ovn-octavia-provider https://opendev.org/openstack/ovn-octavia-provider {{ branch }}
 {% endif %}
 
 {% if "barbican" in enable_services %}
@@ -130,6 +138,9 @@ global_physnet_mtu = 1430
 [[post-config|$OCTAVIA_CONF]]
 [api_settings]
 allow_tls_terminated_listeners = True
+{% if "ovn-octavia" in enable_services %}
+enabled_provider_drivers = amphora:'Octavia Amphora driver',ovn:'Octavia OVN driver'
+{% endif %}
 [controller_worker]
 loadbalancer_topology = SINGLE
 amp_active_retries = 60

--- a/tests/playbooks/test-occm-e2e.yaml
+++ b/tests/playbooks/test-occm-e2e.yaml
@@ -18,6 +18,7 @@
         - cinder
         - neutron
         - octavia
+        - ovn-octavia
         - barbican
     - role: install-k3s
       worker_node_count: 0


### PR DESCRIPTION
**What this PR does / why we need it**:
/hold
This aims to update DevStack configs to deploy OVN instead of ML2/OVS. OVN is the Neutron default for several releases and I believe we should test against it. Also it will enable us to test the OVN Octavia Provider too which is not available when DevStack is configured with ML2/OVS.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:

**Release note**:
```release-note
OCCM is now tested against OpenStack Antelope configured with OVN.
```
