### PR TITLE
[occm] Support for LB providers that do not implement the bulk update/create API call

### DIFF
--- a/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
+++ b/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
@@ -159,6 +159,15 @@ Here are several other config options are not included in the example configurat
       provider: amphora
     ```
 
+- Option to specify that the Octavia provider does not support creating fully-populated loadbalancers using a single [API
+  call](https://docs.openstack.org/api-ref/load-balancer/v2/?expanded=create-a-load-balancer-detail#creating-a-fully-populated-load-balancer).
+  Setting this option to true will create loadbalancers using serial API calls which first create an unpopulated
+  loadbalancer, then populate its listeners, pools and members. This is a compatibility option at the expense of
+  increased load on the OpenStack API.
+    ```yaml
+    octavia:
+      provider-requires-serial-api-calls: true
+    ```
 ### Deploy octavia-ingress-controller
 
 ```shell

--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -281,6 +281,13 @@ Although the openstack-cloud-controller-manager was initially implemented with N
 * `max-shared-lb`
   The maximum number of Services that share a load balancer. Default: 2
 
+* `provider-requires-serial-api-calls`
+  Some Octavia providers do not support creating fully-populated loadbalancers using a single [API
+  call](https://docs.openstack.org/api-ref/load-balancer/v2/?expanded=create-a-load-balancer-detail#creating-a-fully-populated-load-balancer).
+  Setting this option to true will create loadbalancers using serial API calls which first create an unpopulated
+  loadbalancer, then populate its listeners, pools and members. This is a compatibility option at the expense of
+  increased load on the OpenStack API. Default: false 
+
 NOTE:
 
 * When using `ovn` provider service has limited scope - `create_monitor` is not supported and only supported `lb-method` is `SOURCE_IP`.

--- a/pkg/ingress/config/config.go
+++ b/pkg/ingress/config/config.go
@@ -57,4 +57,9 @@ type octaviaConfig struct {
 	// (Optional) Flavor ID to create the load balancer.
 	// If empty, the default flavor will be used.
 	FlavorID string `mapstructure:"flavor-id"`
+
+	// (Optional) If the ingress controller should use serial API calls when creating and updating
+	// the load balancer instead of the bulk update API call.
+	// Default is false.
+	ProviderRequiresSerialAPICalls bool `mapstructure:"provider-requires-serial-api-calls"`
 }

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -78,31 +78,32 @@ type LoadBalancer struct {
 
 // LoadBalancerOpts have the options to talk to Neutron LBaaSV2 or Octavia
 type LoadBalancerOpts struct {
-	Enabled               bool                `gcfg:"enabled"`              // if false, disables the controller
-	LBVersion             string              `gcfg:"lb-version"`           // overrides autodetection. Only support v2.
-	SubnetID              string              `gcfg:"subnet-id"`            // overrides autodetection.
-	MemberSubnetID        string              `gcfg:"member-subnet-id"`     // overrides autodetection.
-	NetworkID             string              `gcfg:"network-id"`           // If specified, will create virtual ip from a subnet in network which has available IP addresses
-	FloatingNetworkID     string              `gcfg:"floating-network-id"`  // If specified, will create floating ip for loadbalancer, or do not create floating ip.
-	FloatingSubnetID      string              `gcfg:"floating-subnet-id"`   // If specified, will create floating ip for loadbalancer in this particular floating pool subnetwork.
-	FloatingSubnet        string              `gcfg:"floating-subnet"`      // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
-	FloatingSubnetTags    string              `gcfg:"floating-subnet-tags"` // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
-	LBClasses             map[string]*LBClass // Predefined named Floating networks and subnets
-	LBMethod              string              `gcfg:"lb-method"` // default to ROUND_ROBIN.
-	LBProvider            string              `gcfg:"lb-provider"`
-	CreateMonitor         bool                `gcfg:"create-monitor"`
-	MonitorDelay          util.MyDuration     `gcfg:"monitor-delay"`
-	MonitorTimeout        util.MyDuration     `gcfg:"monitor-timeout"`
-	MonitorMaxRetries     uint                `gcfg:"monitor-max-retries"`
-	ManageSecurityGroups  bool                `gcfg:"manage-security-groups"`
-	InternalLB            bool                `gcfg:"internal-lb"` // default false
-	CascadeDelete         bool                `gcfg:"cascade-delete"`
-	FlavorID              string              `gcfg:"flavor-id"`
-	AvailabilityZone      string              `gcfg:"availability-zone"`
-	EnableIngressHostname bool                `gcfg:"enable-ingress-hostname"` // Used with proxy protocol by adding a dns suffix to the load balancer IP address. Default false.
-	IngressHostnameSuffix string              `gcfg:"ingress-hostname-suffix"` // Used with proxy protocol by adding a dns suffix to the load balancer IP address. Default nip.io.
-	MaxSharedLB           int                 `gcfg:"max-shared-lb"`           //  Number of Services in maximum can share a single load balancer. Default 2
-	ContainerStore        string              `gcfg:"container-store"`         // Used to specify the store of the tls-container-ref
+	Enabled                        bool                `gcfg:"enabled"`              // if false, disables the controller
+	LBVersion                      string              `gcfg:"lb-version"`           // overrides autodetection. Only support v2.
+	SubnetID                       string              `gcfg:"subnet-id"`            // overrides autodetection.
+	MemberSubnetID                 string              `gcfg:"member-subnet-id"`     // overrides autodetection.
+	NetworkID                      string              `gcfg:"network-id"`           // If specified, will create virtual ip from a subnet in network which has available IP addresses
+	FloatingNetworkID              string              `gcfg:"floating-network-id"`  // If specified, will create floating ip for loadbalancer, or do not create floating ip.
+	FloatingSubnetID               string              `gcfg:"floating-subnet-id"`   // If specified, will create floating ip for loadbalancer in this particular floating pool subnetwork.
+	FloatingSubnet                 string              `gcfg:"floating-subnet"`      // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
+	FloatingSubnetTags             string              `gcfg:"floating-subnet-tags"` // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
+	LBClasses                      map[string]*LBClass // Predefined named Floating networks and subnets
+	LBMethod                       string              `gcfg:"lb-method"` // default to ROUND_ROBIN.
+	LBProvider                     string              `gcfg:"lb-provider"`
+	CreateMonitor                  bool                `gcfg:"create-monitor"`
+	MonitorDelay                   util.MyDuration     `gcfg:"monitor-delay"`
+	MonitorTimeout                 util.MyDuration     `gcfg:"monitor-timeout"`
+	MonitorMaxRetries              uint                `gcfg:"monitor-max-retries"`
+	ManageSecurityGroups           bool                `gcfg:"manage-security-groups"`
+	InternalLB                     bool                `gcfg:"internal-lb"` // default false
+	CascadeDelete                  bool                `gcfg:"cascade-delete"`
+	FlavorID                       string              `gcfg:"flavor-id"`
+	AvailabilityZone               string              `gcfg:"availability-zone"`
+	EnableIngressHostname          bool                `gcfg:"enable-ingress-hostname"`            // Used with proxy protocol by adding a dns suffix to the load balancer IP address. Default false.
+	IngressHostnameSuffix          string              `gcfg:"ingress-hostname-suffix"`            // Used with proxy protocol by adding a dns suffix to the load balancer IP address. Default nip.io.
+	MaxSharedLB                    int                 `gcfg:"max-shared-lb"`                      //  Number of Services in maximum can share a single load balancer. Default 2
+	ContainerStore                 string              `gcfg:"container-store"`                    // Used to specify the store of the tls-container-ref
+	ProviderRequiresSerialAPICalls bool                `gcfg:"provider-requires-serial-api-calls"` // default false, the provider supportes the "bulk update" API call
 	// revive:disable:var-naming
 	TlsContainerRef string `gcfg:"default-tls-container-ref"` //  reference to a tls container
 	// revive:enable:var-naming
@@ -209,6 +210,7 @@ func ReadConfig(config io.Reader) (Config, error) {
 	cfg.LoadBalancer.TlsContainerRef = ""
 	cfg.LoadBalancer.ContainerStore = "barbican"
 	cfg.LoadBalancer.MaxSharedLB = 2
+	cfg.LoadBalancer.ProviderRequiresSerialAPICalls = false
 
 	err := gcfg.FatalOnly(gcfg.ReadInto(&cfg, config))
 	if err != nil {

--- a/pkg/util/openstack/loadbalancer_serial.go
+++ b/pkg/util/openstack/loadbalancer_serial.go
@@ -1,0 +1,99 @@
+package openstack
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
+	apiv1 "k8s.io/api/core/v1"
+	klog "k8s.io/klog/v2"
+
+	cpoutil "k8s.io/cloud-provider-openstack/pkg/util"
+	cpoerrors "k8s.io/cloud-provider-openstack/pkg/util/errors"
+)
+
+func memberExists(members []pools.Member, addr string, port int) bool {
+	for _, member := range members {
+		if member.Address == addr && member.ProtocolPort == port {
+			return true
+		}
+	}
+
+	return false
+}
+
+func popMember(members []pools.Member, addr string, port int) []pools.Member {
+	for i, member := range members {
+		if member.Address == addr && member.ProtocolPort == port {
+			members[i] = members[len(members)-1]
+			members = members[:len(members)-1]
+		}
+	}
+
+	return members
+}
+
+func getNodeAddressForLB(node *apiv1.Node) (string, error) {
+	addrs := node.Status.Addresses
+	if len(addrs) == 0 {
+		return "", fmt.Errorf("no address found for host")
+	}
+
+	for _, addr := range addrs {
+		if addr.Type == apiv1.NodeInternalIP {
+			return addr.Address, nil
+		}
+	}
+
+	return addrs[0].Address, nil
+}
+
+func SeriallyReconcilePoolMembers(client *gophercloud.ServiceClient, pool *pools.Pool, nodePort int, lbID string, nodes []*apiv1.Node) error {
+
+	members, err := GetMembersbyPool(client, pool.ID)
+	if err != nil && !cpoerrors.IsNotFound(err) {
+		return fmt.Errorf("error getting pool members %s: %v", pool.ID, err)
+	}
+
+	for _, node := range nodes {
+		addr, err := getNodeAddressForLB(node)
+		if err != nil {
+			if err == cpoerrors.ErrNotFound {
+				// Node failure, do not create member
+				klog.Warning("Failed to create LB pool member for node %s: %v", node.Name, err)
+				continue
+			} else {
+				return fmt.Errorf("error getting address for node %s: %v", node.Name, err)
+			}
+		}
+		if !memberExists(members, addr, nodePort) {
+			klog.V(2).Infof("Creating member for pool %s", pool.ID)
+			_, err := pools.CreateMember(client, pool.ID, pools.CreateMemberOpts{
+				Name:         cpoutil.CutString255(fmt.Sprintf("member_%s_%s_%d", node.Name, addr, nodePort)),
+				ProtocolPort: nodePort,
+				Address:      addr,
+			}).Extract()
+			if err != nil {
+				return fmt.Errorf("error creating LB pool member for node: %s, %v", node.Name, err)
+			}
+			if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
+				return err
+			}
+		} else {
+			// After all members have been processed, remaining members are deleted as obsolete.
+			members = popMember(members, addr, nodePort)
+		}
+		klog.V(2).Infof("Ensured pool %s has member for %s at %s", pool.ID, node.Name, addr)
+	}
+	for _, member := range members {
+		klog.V(2).Infof("Deleting obsolete member %s for pool %s address %s", member.ID, pool.ID, member.Address)
+		err := pools.DeleteMember(client, pool.ID, member.ID).ExtractErr()
+		if err != nil && !cpoerrors.IsNotFound(err) {
+			return fmt.Errorf("error deleting obsolete member %s for pool %s address %s: %v", member.ID, pool.ID, member.Address, err)
+		}
+		if _, err := WaitActiveAndGetLoadBalancer(client, lbID); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -16,6 +16,15 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// CutString255 makes sure the string length doesn't exceed 255, which is usually the maximum string length in OpenStack.
+func CutString255(original string) string {
+	ret := original
+	if len(original) > 255 {
+		ret = original[:255]
+	}
+	return ret
+}
+
 // MyDuration is the encoding.TextUnmarshaler interface for time.Duration
 type MyDuration struct {
 	time.Duration


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for LB providers that do not implement the bulk create/update API call.

**Which issue this PR fixes(if applicable)**:
fixes https://github.com/kubernetes/cloud-provider-openstack/issues/2271

**Special notes for reviewers**:
As this PR adds new configuration options for both Octavia ingress and Loadbalancers, additional configuration is required to test:

```
[LoadBalancer]
provider-requires-serial-api-calls=true
```
and
```bash
cat <<EOF > /etc/kubernetes/octavia-ingress-controller/config.yaml
---
kind: ConfigMap
apiVersion: v1
metadata:
  name: octavia-ingress-controller-config
  namespace: kube-system
data:
  config: |
    cluster-name: ${cluster_name}
    openstack:
      auth-url: ${auth_url}
      domain-name: ${domain-name}
      username: ${user_name}
      # user-id: ${user_id}
      password: ${password}
      project-id: ${project_id}
      region: ${region}
    octavia:
      subnet-id: ${subnet_id}
      floating-network-id: ${public_net_id}
      provider-requires-serial-api-calls: true
EOF
kubectl apply -f /etc/kubernetes/octavia-ingress-controller/config.yaml
```

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] Adds provider-requires-serial-api-calls config option to support Octavia providers that do not implement the bulk update/create API call. Set provider-requires-serial-api-calls to true to use serial calls to Octavia to create and populate loadbalancers.
[octavia-ingress-controller] Adds provider-requires-serial-api-calls config option to support Octavia providers that do not implement the bulk update/create API call. Set provider-requires-serial-api-calls to true to use serial calls to Octavia to create and populate loadbalancers.
```
