### PR TITLE
[occm] Fix protocol case mismatch (tcp vs TCP)

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -2156,7 +2156,7 @@ func (lbaas *LbaasV2) UpdateLoadBalancer(ctx context.Context, clusterName string
 
 func compareSecurityGroupRuleAndCreateOpts(rule rules.SecGroupRule, opts rules.CreateOpts) bool {
 	return rule.Direction == string(opts.Direction) &&
-		rule.Protocol == string(opts.Protocol) &&
+		strings.EqualFold(rule.Protocol, string(opts.Protocol)) &&
 		rule.EtherType == string(opts.EtherType) &&
 		rule.RemoteIPPrefix == opts.RemoteIPPrefix &&
 		rule.PortRangeMin == opts.PortRangeMin &&
@@ -2282,10 +2282,11 @@ func (lbaas *LbaasV2) ensureAndUpdateOctaviaSecurityGroup(clusterName string, ap
 			continue
 		}
 		for _, cidr := range cidrs {
+			protocol := strings.ToLower(string(port.Protocol)) // K8s uses TCP, Neutron uses tcp, etc.
 			wantedRules = append(wantedRules,
 				rules.CreateOpts{
 					Direction:      rules.DirIngress,
-					Protocol:       rules.RuleProtocol(port.Protocol),
+					Protocol:       rules.RuleProtocol(protocol),
 					EtherType:      etherType,
 					RemoteIPPrefix: cidr,
 					SecGroupID:     lbSecGroupID,

--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -208,6 +208,34 @@ func TestGetRulesToCreateAndDelete(t *testing.T) {
 			},
 		},
 		{
+			testName: "Protocol case mismatch",
+			wantedRules: []rules.CreateOpts{
+				{
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					PortRangeMax:   123,
+					PortRangeMin:   123,
+					Protocol:       "TCP",
+					RemoteIPPrefix: "10.0.0.0/8",
+				},
+			},
+			existingRules: []rules.SecGroupRule{
+				{
+					ID:             "bar",
+					Direction:      "ingress",
+					EtherType:      "IPv4",
+					SecGroupID:     "foo",
+					PortRangeMax:   123,
+					PortRangeMin:   123,
+					Protocol:       "tcp",
+					RemoteIPPrefix: "10.0.0.0/8",
+				},
+			},
+			toCreate: []rules.CreateOpts{},
+			toDelete: []rules.SecGroupRule{},
+		},
+		{
 			testName: "changing a port number",
 			wantedRules: []rules.CreateOpts{
 				{


### PR DESCRIPTION
**What this PR does / why we need it**:
K8s denotes protocol names in uppercase (TCP) while Neutron uses lowercase (tcp) on the security group rules. This created conflicts and caused occm to incorrectly compare SG rules and make unnecessary creates and deletes.

This commit fixes that by making sure we're always comparing `ToLower()` version of the protocol name. Also I made sure that we're always passing lowercase to the Neutron SG rule creation API too.

**Which issue this PR fixes(if applicable)**:
fixes #2319

**Special notes for reviewers**:
Enable `manage-security-groups=true`

**Release note**:
```release-note
NONE
```
