### PR TITLE
Manila: Add support for imagePullSecrets to helm chart

### DIFF
--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.27.1
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 2.28.0-alpha.3
+version: 2.28.0-alpha.4
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -153,3 +153,7 @@ spec:
     {{- if .Values.controllerplugin.tolerations }}
       tolerations: {{ toYaml .Values.controllerplugin.tolerations | nindent 8 }}
     {{- end }}
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+    {{- end }}

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -120,3 +120,7 @@ spec:
     {{- if .Values.nodeplugin.priorityClassName }}
       priorityClassName: {{ .Values.nodeplugin.priorityClassName }}
     {{- end }}
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+    {{- end }}

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -16,6 +16,10 @@ shareProtocols:
  #     dir: /var/lib/kubelet/plugins/cephfs.csi.ceph.com
  #     sockFile: csi.sock
 
+# ImagePullSecret for all pods
+imagePullSecrets: []
+# - name: my-imagepull-secret
+
 extraLabels: {}
 # CSI Manila spec
 csimanila:


### PR DESCRIPTION
[manila-csi-plugin] Add support for imagePullSecrets to helm chart

**What this PR does / why we need it**:
This PR adds support for imagePullSecrets into all necessary resources in manila helm chart.

Implementation is backwards compatible.

```release-note
[manila] Add support for ImagePullSecrets
```

Based on Related/Similar PRs: 
- https://github.com/kubernetes/cloud-provider-openstack/pull/2105
- https://github.com/kubernetes/cloud-provider-openstack/pull/2317