### PR TITLE
✨ Add --version flags to binaries

### DIFF
--- a/cmd/barbican-kms-plugin/main.go
+++ b/cmd/barbican-kms-plugin/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
 	"k8s.io/cloud-provider-openstack/pkg/kms/server"
+	"k8s.io/cloud-provider-openstack/pkg/version"
 	"k8s.io/component-base/cli"
 	"k8s.io/klog/v2"
 )
@@ -49,6 +50,7 @@ func main() {
 			err := server.Run(cloudConfig, socketPath, sigChan)
 			return err
 		},
+		Version: version.Version,
 	}
 
 	cmd.PersistentFlags().StringVar(&socketPath, "socketpath", "", "Barbican KMS Plugin unix socket endpoint")

--- a/cmd/cinder-csi-plugin/main.go
+++ b/cmd/cinder-csi-plugin/main.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack"
 	"k8s.io/cloud-provider-openstack/pkg/util/metadata"
 	"k8s.io/cloud-provider-openstack/pkg/util/mount"
+	"k8s.io/cloud-provider-openstack/pkg/version"
 	"k8s.io/component-base/cli"
 	"k8s.io/klog/v2"
 )
@@ -71,6 +72,7 @@ func main() {
 		Run: func(cmd *cobra.Command, args []string) {
 			handle()
 		},
+		Version: version.Version,
 	}
 
 	cmd.PersistentFlags().StringVar(&nodeID, "nodeid", "", "node id")

--- a/cmd/client-keystone-auth/main.go
+++ b/cmd/client-keystone-auth/main.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/term"
 
 	"k8s.io/cloud-provider-openstack/pkg/identity/keystone"
+	"k8s.io/cloud-provider-openstack/pkg/version"
 	kflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
 )
@@ -168,6 +169,7 @@ func main() {
 	var applicationCredentialID string
 	var applicationCredentialName string
 	var applicationCredentialSecret string
+	var showVersion bool
 
 	pflag.StringVar(&url, "keystone-url", os.Getenv("OS_AUTH_URL"), "URL for the OpenStack Keystone API")
 	pflag.StringVar(&domain, "domain-name", os.Getenv("OS_DOMAIN_NAME"), "Keystone domain name")
@@ -180,13 +182,22 @@ func main() {
 	pflag.StringVar(&applicationCredentialID, "application-credential-id", os.Getenv("OS_APPLICATION_CREDENTIAL_ID"), "Application Credential ID")
 	pflag.StringVar(&applicationCredentialName, "application-credential-name", os.Getenv("OS_APPLICATION_CREDENTIAL_NAME"), "Application Credential Name")
 	pflag.StringVar(&applicationCredentialSecret, "application-credential-secret", os.Getenv("OS_APPLICATION_CREDENTIAL_SECRET"), "Application Credential Secret")
+	pflag.BoolVar(&showVersion, "version", false, "Show current version and exit")
 
 	logs.AddFlags(pflag.CommandLine)
-	logs.InitLogs()
-	defer logs.FlushLogs()
 
 	pflag.CommandLine.AddGoFlagSet(klogFlags)
 	kflag.InitFlags()
+
+	pflag.Parse()
+
+	if showVersion {
+		fmt.Println(version.Version)
+		os.Exit(0)
+	}
+
+	logs.InitLogs()
+	defer logs.FlushLogs()
 
 	// Generate Gophercloud Auth Options based on input data from stdin
 	// if IsTerminal returns "true", or from env variables otherwise.

--- a/cmd/k8s-keystone-auth/main.go
+++ b/cmd/k8s-keystone-auth/main.go
@@ -16,12 +16,14 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
 
 	"k8s.io/cloud-provider-openstack/pkg/identity/keystone"
+	"k8s.io/cloud-provider-openstack/pkg/version"
 	kflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 )
@@ -32,6 +34,10 @@ func main() {
 	if err != nil {
 		klog.Fatalf("Unable to parse flags: %v", err)
 	}
+
+	var showVersion bool
+	pflag.BoolVar(&showVersion, "version", false, "Show current version and exit")
+
 	// This is a temporary hack to enable proper logging until upstream dependencies
 	// are migrated to fully utilize klog instead of glog.
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
@@ -48,6 +54,13 @@ func main() {
 			_ = f2.Value.Set(value)
 		}
 	})
+
+	pflag.Parse()
+
+	if showVersion {
+		fmt.Println(version.Version)
+		os.Exit(0)
+	}
 
 	logs.InitLogs()
 	defer logs.FlushLogs()

--- a/cmd/manila-csi-plugin/main.go
+++ b/cmd/manila-csi-plugin/main.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila/csiclient"
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila/manilaclient"
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila/runtimeconfig"
+	"k8s.io/cloud-provider-openstack/pkg/version"
 	"k8s.io/component-base/cli"
 	"k8s.io/klog/v2"
 )
@@ -124,6 +125,7 @@ func main() {
 
 			d.Run()
 		},
+		Version: version.Version,
 	}
 
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)

--- a/pkg/autohealing/cmd/root.go
+++ b/pkg/autohealing/cmd/root.go
@@ -35,6 +35,7 @@ import (
 
 	"k8s.io/cloud-provider-openstack/pkg/autohealing/config"
 	"k8s.io/cloud-provider-openstack/pkg/autohealing/controller"
+	"k8s.io/cloud-provider-openstack/pkg/version"
 )
 
 var (
@@ -82,6 +83,7 @@ var rootCmd = &cobra.Command{
 		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 		<-sigCh
 	},
+	Version: version.Version,
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.

--- a/pkg/ingress/cmd/root.go
+++ b/pkg/ingress/cmd/root.go
@@ -29,6 +29,7 @@ import (
 
 	"k8s.io/cloud-provider-openstack/pkg/ingress/config"
 	"k8s.io/cloud-provider-openstack/pkg/ingress/controller"
+	"k8s.io/cloud-provider-openstack/pkg/version"
 	"k8s.io/component-base/cli"
 	"k8s.io/klog/v2"
 )
@@ -54,6 +55,7 @@ var rootCmd = &cobra.Command{
 		signal.Notify(sigterm, syscall.SIGINT)
 		<-sigterm
 	},
+	Version: version.Version,
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.


### PR DESCRIPTION
**What this PR does / why we need it**:

Provide a quick and easy way to check the version of the binaries from the CLI. This is already present for `openstack-cloud-controller-manager` but not for any of the other binaries.

**Which issue this PR fixes(if applicable)**:

N/A

**Special notes for reviewers**:

N/A

**Release note**:
```release-note
All binaries now provide a `--version` option.
```
