### PR TITLE
Remove handling code for glog

### DIFF
--- a/cmd/barbican-kms-plugin/main.go
+++ b/cmd/barbican-kms-plugin/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"flag"
 	"os"
 	"os/signal"
 
@@ -35,12 +34,6 @@ var (
 )
 
 func main() {
-	flag.Parse()
-
-	// This is a temporary hack to enable proper logging until upstream dependencies
-	// are migrated to fully utilize klog instead of glog.
-	klog.InitFlags(nil)
-
 	cmd := &cobra.Command{
 		Use:   "barbican-kms-plugin",
 		Short: "Barbican KMS plugin for Kubernetes",

--- a/cmd/cinder-csi-plugin/main.go
+++ b/cmd/cinder-csi-plugin/main.go
@@ -17,8 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"flag"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -41,34 +39,9 @@ var (
 )
 
 func main() {
-	if err := flag.CommandLine.Parse([]string{}); err != nil {
-		klog.Fatalf("Unable to parse flags: %v", err)
-	}
-
 	cmd := &cobra.Command{
 		Use:   "Cinder",
 		Short: "CSI based Cinder driver",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			// Glog requires this otherwise it complains.
-			if err := flag.CommandLine.Parse(nil); err != nil {
-				return fmt.Errorf("unable to parse flags: %w", err)
-			}
-
-			// This is a temporary hack to enable proper logging until upstream dependencies
-			// are migrated to fully utilize klog instead of glog.
-			klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
-			klog.InitFlags(klogFlags)
-
-			// Sync the glog and klog flags.
-			cmd.Flags().VisitAll(func(f1 *pflag.Flag) {
-				f2 := klogFlags.Lookup(f1.Name)
-				if f2 != nil {
-					value := f1.Value.String()
-					_ = f2.Value.Set(value)
-				}
-			})
-			return nil
-		},
 		Run: func(cmd *cobra.Command, args []string) {
 			handle()
 		},
@@ -99,7 +72,6 @@ func main() {
 }
 
 func handle() {
-
 	// Initialize cloud
 	d := cinder.NewDriver(endpoint, cluster)
 	openstack.InitOpenStackProvider(cloudConfig, httpEndpoint)

--- a/cmd/client-keystone-auth/main.go
+++ b/cmd/client-keystone-auth/main.go
@@ -187,9 +187,8 @@ func main() {
 	logs.AddFlags(pflag.CommandLine)
 
 	pflag.CommandLine.AddGoFlagSet(klogFlags)
-	kflag.InitFlags()
 
-	pflag.Parse()
+	kflag.InitFlags()
 
 	if showVersion {
 		fmt.Println(version.Version)

--- a/cmd/client-keystone-auth/main.go
+++ b/cmd/client-keystone-auth/main.go
@@ -138,24 +138,6 @@ func argumentsAreSet(url, user, project, password, domain, applicationCredential
 }
 
 func main() {
-	// Glog requires this otherwise it complains.
-	if err := flag.CommandLine.Parse(nil); err != nil {
-		klog.Fatalf("Unable to parse flags: %v", err)
-	}
-	// This is a temporary hack to enable proper logging until upstream dependencies
-	// are migrated to fully utilize klog instead of glog.
-	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
-	klog.InitFlags(klogFlags)
-
-	// Sync the glog and klog flags.
-	flag.CommandLine.VisitAll(func(f1 *flag.Flag) {
-		f2 := klogFlags.Lookup(f1.Name)
-		if f2 != nil {
-			value := f1.Value.String()
-			_ = f2.Value.Set(value)
-		}
-	})
-
 	var url string
 	var domain string
 	var user string
@@ -186,6 +168,8 @@ func main() {
 
 	logs.AddFlags(pflag.CommandLine)
 
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
 	pflag.CommandLine.AddGoFlagSet(klogFlags)
 
 	kflag.InitFlags()

--- a/cmd/k8s-keystone-auth/main.go
+++ b/cmd/k8s-keystone-auth/main.go
@@ -55,19 +55,18 @@ func main() {
 		}
 	})
 
-	pflag.Parse()
-
-	if showVersion {
-		fmt.Println(version.Version)
-		os.Exit(0)
-	}
-
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
 	config := keystone.NewConfig()
 	config.AddFlags(pflag.CommandLine)
+
 	kflag.InitFlags()
+
+	if showVersion {
+		fmt.Println(version.Version)
+		os.Exit(0)
+	}
 
 	if err := config.ValidateFlags(); err != nil {
 		klog.Errorf("%v", err)

--- a/cmd/k8s-keystone-auth/main.go
+++ b/cmd/k8s-keystone-auth/main.go
@@ -15,7 +15,6 @@ limitations under the License.
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
@@ -29,31 +28,11 @@ import (
 )
 
 func main() {
-	// Glog requires this otherwise it complains.
-	err := flag.CommandLine.Parse(nil)
-	if err != nil {
-		klog.Fatalf("Unable to parse flags: %v", err)
-	}
-
 	var showVersion bool
 	pflag.BoolVar(&showVersion, "version", false, "Show current version and exit")
 
-	// This is a temporary hack to enable proper logging until upstream dependencies
-	// are migrated to fully utilize klog instead of glog.
-	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
-	klog.InitFlags(klogFlags)
-
 	logs.AddFlags(pflag.CommandLine)
 	keystone.AddExtraFlags(pflag.CommandLine)
-
-	// Sync the glog and klog flags.
-	flag.CommandLine.VisitAll(func(f1 *flag.Flag) {
-		f2 := klogFlags.Lookup(f1.Name)
-		if f2 != nil {
-			value := f1.Value.String()
-			_ = f2.Value.Set(value)
-		}
-	})
 
 	logs.InitLogs()
 	defer logs.FlushLogs()


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Everything in k8s has switched to klog for some time now. Lots more context in the individual commit messages.

Some minor issues introduced in #2324 are addressed. Again, there's lots more context in the commit messages.

**Which issue this PR fixes(if applicable)**:
N/A

**Special notes for reviewers**:
N/A

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
