### PR TITLE
[cinder-csi-plugin] Metrics (backport into 1.25)

### DIFF
--- a/cmd/cinder-csi-plugin/main.go
+++ b/cmd/cinder-csi-plugin/main.go
@@ -32,10 +32,11 @@ import (
 )
 
 var (
-	endpoint    string
-	nodeID      string
-	cloudconfig []string
-	cluster     string
+	endpoint     string
+	nodeID       string
+	cloudconfig  []string
+	cluster      string
+	httpEndpoint string
 )
 
 func main() {
@@ -88,7 +89,7 @@ func main() {
 	}
 
 	cmd.PersistentFlags().StringVar(&cluster, "cluster", "", "The identifier of the cluster that the plugin is running in.")
-
+	cmd.PersistentFlags().StringVar(&httpEndpoint, "http-endpoint", "", "The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080`). The default is empty string, which means the server is disabled.")
 	openstack.AddExtraFlags(pflag.CommandLine)
 
 	code := cli.Run(cmd)
@@ -99,7 +100,7 @@ func handle() {
 
 	// Initialize cloud
 	d := cinder.NewDriver(endpoint, cluster)
-	openstack.InitOpenStackProvider(cloudconfig)
+	openstack.InitOpenStackProvider(cloudconfig, httpEndpoint)
 	cloud, err := openstack.GetOpenStackProvider()
 	if err != nil {
 		klog.Warningf("Failed to GetOpenStackProvider: %v", err)

--- a/pkg/csi/cinder/openstack/openstack_instances.go
+++ b/pkg/csi/cinder/openstack/openstack_instances.go
@@ -2,12 +2,14 @@ package openstack
 
 import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"k8s.io/cloud-provider-openstack/pkg/metrics"
 )
 
 // GetInstanceByID returns server with specified instanceID
 func (os *OpenStack) GetInstanceByID(instanceID string) (*servers.Server, error) {
+	mc := metrics.NewMetricContext("server", "get")
 	server, err := servers.Get(os.compute, instanceID).Extract()
-	if err != nil {
+	if mc.ObserveRequest(err) != nil {
 		return nil, err
 	}
 	return server, nil

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach"
 	"github.com/gophercloud/gophercloud/pagination"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/cloud-provider-openstack/pkg/metrics"
 	cpoerrors "k8s.io/cloud-provider-openstack/pkg/util/errors"
 
 	"k8s.io/klog/v2"
@@ -65,8 +66,9 @@ func (os *OpenStack) CreateVolume(name string, size int, vtype, availability str
 		opts.Metadata = *tags
 	}
 
+	mc := metrics.NewMetricContext("volume", "create")
 	vol, err := volumes.Create(os.blockstorage, opts).Extract()
-	if err != nil {
+	if mc.ObserveRequest(err) != nil {
 		return nil, err
 	}
 
@@ -79,6 +81,7 @@ func (os *OpenStack) ListVolumes(limit int, startingToken string) ([]volumes.Vol
 	var vols []volumes.Volume
 
 	opts := volumes.ListOpts{Limit: limit, Marker: startingToken}
+	mc := metrics.NewMetricContext("volume", "list")
 	err := volumes.List(os.blockstorage, opts).EachPage(func(page pagination.Page) (bool, error) {
 		var err error
 
@@ -102,7 +105,7 @@ func (os *OpenStack) ListVolumes(limit int, startingToken string) ([]volumes.Vol
 
 		return false, nil
 	})
-	if err != nil {
+	if mc.ObserveRequest(err) != nil {
 		return nil, nextPageToken, err
 	}
 
@@ -125,8 +128,9 @@ func (os *OpenStack) GetVolumesByName(n string) ([]volumes.Volume, error) {
 	}
 
 	opts := volumes.ListOpts{Name: n}
+	mc := metrics.NewMetricContext("volume", "list")
 	pages, err := volumes.List(blockstorageClient, opts).AllPages()
-	if err != nil {
+	if mc.ObserveRequest(err) != nil {
 		return nil, err
 	}
 
@@ -148,15 +152,16 @@ func (os *OpenStack) DeleteVolume(volumeID string) error {
 		return fmt.Errorf("Cannot delete the volume %q, it's still attached to a node", volumeID)
 	}
 
+	mc := metrics.NewMetricContext("volume", "delete")
 	err = volumes.Delete(os.blockstorage, volumeID, nil).ExtractErr()
-	return err
+	return mc.ObserveRequest(err)
 }
 
 // GetVolume retrieves Volume by its ID.
 func (os *OpenStack) GetVolume(volumeID string) (*volumes.Volume, error) {
-
+	mc := metrics.NewMetricContext("volume", "get")
 	vol, err := volumes.Get(os.blockstorage, volumeID).Extract()
-	if err != nil {
+	if mc.ObserveRequest(err) != nil {
 		return nil, err
 	}
 
@@ -189,11 +194,12 @@ func (os *OpenStack) AttachVolume(instanceID, volumeID string) (string, error) {
 		computeServiceClient.Microversion = "2.60"
 	}
 
+	mc := metrics.NewMetricContext("volume", "attach")
 	_, err = volumeattach.Create(computeServiceClient, instanceID, &volumeattach.CreateOpts{
 		VolumeID: volume.ID,
 	}).Extract()
 
-	if err != nil {
+	if mc.ObserveRequest(err) != nil {
 		return "", fmt.Errorf("failed to attach %s volume to %s compute: %v", volumeID, instanceID, err)
 	}
 
@@ -276,8 +282,9 @@ func (os *OpenStack) DetachVolume(instanceID, volumeID string) error {
 	// Incase volume is of type multiattach, it could be attached to more than one instance
 	for _, att := range volume.Attachments {
 		if att.ServerID == instanceID {
+			mc := metrics.NewMetricContext("volume", "detach")
 			err = volumeattach.Delete(os.compute, instanceID, volume.ID).ExtractErr()
-			if err != nil {
+			if mc.ObserveRequest(err) != nil {
 				return fmt.Errorf("failed to detach volume %s from compute %s : %v", volume.ID, instanceID, err)
 			}
 			klog.V(2).Infof("Successfully detached volume: %s from compute: %s", volume.ID, instanceID)
@@ -357,9 +364,11 @@ func (os *OpenStack) ExpandVolume(volumeID string, status string, newSize int) e
 		// https://docs.openstack.org/cinder/latest/contributor/api_microversion_history.html#id40
 		blockstorageClient.Microversion = "3.42"
 
-		return volumeexpand.ExtendSize(blockstorageClient, volumeID, extendOpts).ExtractErr()
+		mc := metrics.NewMetricContext("volume", "expand")
+		return mc.ObserveRequest(volumeexpand.ExtendSize(blockstorageClient, volumeID, extendOpts).ExtractErr())
 	case VolumeAvailableStatus:
-		return volumeexpand.ExtendSize(os.blockstorage, volumeID, extendOpts).ExtractErr()
+		mc := metrics.NewMetricContext("volume", "expand")
+		return mc.ObserveRequest(volumeexpand.ExtendSize(os.blockstorage, volumeID, extendOpts).ExtractErr())
 	}
 
 	// cinder volume can not be expanded when volume status is not volumeInUseStatus or not volumeAvailableStatus

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -59,7 +59,9 @@ func (mc *MetricContext) Observe(om *OpenstackMetrics, err error) error {
 	return err
 }
 
-func RegisterMetrics() {
+func RegisterMetrics(component string) {
 	doRegisterAPIMetrics()
-	doRegisterOccmMetrics()
+	if component == "occm" {
+		doRegisterOccmMetrics()
+	}
 }

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -165,7 +165,7 @@ type Config struct {
 }
 
 func init() {
-	metrics.RegisterMetrics()
+	metrics.RegisterMetrics("occm")
 
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
 		cfg, err := ReadConfig(config)


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport to 1.25 of:
- https://github.com/kubernetes/cloud-provider-openstack/pull/2077

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

Would we be up for backporting the metrics support into 1.25 (1.26 too)? Not all clusters are able to upgrade to 1.27+ yet, and having metrics support earlier will help troubleshooting and operations of the CSI plugin.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add support for metrics in cinder-csi-plugin
```
