### PR TITLE
[occm] Use standard service account name in OCCM helm chart

### DIFF
--- a/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: system:openstack-cloud-controller-manager
+  name: {{ .Values.clusterRoleName }}
   annotations:
     {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/openstack-cloud-controller-manager/templates/clusterrolebinding.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrolebinding.yaml
@@ -1,7 +1,8 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:openstack-cloud-controller-manager
+  name: {{ .Values.clusterRoleName }}
   annotations:
     {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}
@@ -9,8 +10,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:openstack-cloud-controller-manager
+  name: {{ .Values.clusterRoleName }}
 subjects:
 - kind: ServiceAccount
-  name: openstack-cloud-controller-manager
+  name: {{ .Values.serviceAccountName }}
   namespace: {{ .Release.Namespace | quote }}

--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -37,7 +37,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: openstack-cloud-controller-manager
+      serviceAccountName: {{ .Values.serviceAccountName }}
       containers:
         - name: openstack-cloud-controller-manager
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"

--- a/charts/openstack-cloud-controller-manager/templates/serviceaccount.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: openstack-cloud-controller-manager
+  name: {{ .Values.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- with .Values.commonAnnotations }}

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -130,3 +130,7 @@ extraVolumeMounts:
 # cluster name that used for created cluster
 cluster:
   name: kubernetes
+
+clusterRoleName : system:cloud-controller-manager
+
+serviceAccountName: cloud-controller-manager


### PR DESCRIPTION
**What this PR does / why we need it**:

This removes the `openstack-` prefix from the service account name used by the cloud-controller-manager.

The change is motivated by the following:

- Create suitable service accounts, cluster roles and cluster role bindings for use with `--use-service-accounts-credentials=true`
- Normalise service account names in the helm chart and plain manifests
- Adhere to naming conventions across external cloud controller managers for different clouds (e.g. AWS, GCP, ...)

Specifically the first point deserves further details. Prior to this change, users who install the cloud controller manager with helm, would run into the following error when creating load balancers:

```
E0818 08:27:33.802407      11 controller.go:291] error processing service default/hello-bug (will retry): failed to ensure load balancer: failed to patch service object default/hello-bug: services "hello-bug" is forbidden: User "system:serviceaccount:kube-system:cloud-controller-manager" cannot patch resource "services" in API group "" in the namespace "default"
```

Which is due to the fact that the controller is running with the `cloud-controller-manager` service account because `--use-service-account-credentials` is set to `true` by default and the client is initialised with:

```
clientset := clientBuilder.ClientOrDie("cloud-controller-manager")
```

Whilst users can work around this by passing
`--use-service-account-credentials=false`, the desired behaviour would be to install suitable RBAC in the first place.

See:

- https://kubernetes.io/docs/concepts/architecture/cloud-controller/
- https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/
- https://github.com/kubernetes/cloud-provider-openstack/issues/2049
- https://github.com/kubernetes/cloud-provider-openstack/issues/1722
- https://github.com/kubernetes/cloud-provider-openstack/pull/1755

**Which issue this PR fixes(if applicable)**:
fixes #2049

**Special notes for reviewers**:

One slightly tricky aspect of this change is, that the controller creates the `cloud-controller-manager` service account if users installed the helm chart in the default configuration, i.e. without explicitly setting:

```
controllerExtraArgs: |
  - --use-service-account-credentials=false
```

Any service account created by `getOrCreateServiceAccount` would not be managed by Helm and a helm upgrade would fail with:

```
Error: UPGRADE FAILED: rendered manifests contain a resource that already exists. Unable to continue with update: ServiceAccount "cloud-controller-manager" in namespace "kube-system" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "foo"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "kube-system"
```

**Release note**:

```release-note
ACTION REQUIRED: Please note that you might have to delete the `cloud-controller-manager` service account in the `kube-system` namespace if it exists, as upgrading with helm would fail otherwise.
```
