### PR TITLE
[cinder-csi-plugin] Fix multiarch builds of Cinder CSI

### DIFF
--- a/tools/csi-deps.sh
+++ b/tools/csi-deps.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -x
 
 # Copyright 2022 The Kubernetes Authors.
 #
@@ -51,7 +51,16 @@ copy_deps() {
 
 # Commmon lib /lib64/ld-linux-*.so.2
 # needs for all utils
-mkdir -p ${DEST}/lib64 && cp -Lv /lib64/ld-linux-*.so.2 ${DEST}/lib64/
+ARCH=$(uname -m)
+if [ $ARCH = "aarch64" ] || [ $ARCH = "armv7l" ]; then
+  mkdir -p ${DEST}/lib && cp -Lv /lib/ld-linux-*.so.* ${DEST}/lib/
+elif [ $ARCH = "s390x" ]; then
+  mkdir -p ${DEST}/lib && cp -Lv /lib/ld64.so.* ${DEST}/lib/
+elif [ $ARCH = "ppc64le" ]; then
+  mkdir -p ${DEST}/lib64 && cp -Lv /lib64/ld64.so.* ${DEST}/lib64/
+else
+  mkdir -p ${DEST}/lib64 && cp -Lv /lib64/ld-linux-*.so.* ${DEST}/lib64/
+fi
 
 # This utils are using by
 # go mod k8s.io/mount-utils


### PR DESCRIPTION
**What this PR does / why we need it**:
The libs copied into cinder-csi-plugin image are named and placed differently across platforms. This commit attempts to solve this by differentiating where we take them from.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
