### PR TITLE
[docs] :seedling: Update image repo in the release procedure

### DIFF
--- a/release-procedure.md
+++ b/release-procedure.md
@@ -27,6 +27,6 @@ $ git push upstream vX.Y.Z
 4. [Github Actions](https://github.com/kubernetes/cloud-provider-openstack/actions/workflows/release-cpo.yaml) will make [new draft release](https://github.com/kubernetes/cloud-provider-openstack/releases) to repository.
 Cloudbuild should build new images to gcr.io/k8s-staging-provider-os. 
 
-5. Make PR https://github.com/kubernetes/k8s.io/blob/main/k8s.gcr.io/images/k8s-staging-provider-os/images.yaml to promote gcr.io images to registry.k8s.io.
+5. Make PR modifying [images.yaml](https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/images/k8s-staging-provider-os/images.yaml) to promote gcr.io images to registry.k8s.io.
 
 6. Make release notes and publish the release after the new images are published.


### PR DESCRIPTION
**What this PR does / why we need it**:
Seems like we no longer need to modify k8s.gcr.io, it's registry.k8s.io instead.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
