### PR TITLE
[occm] Remove spurious space in OCCM values file

### DIFF
--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.29.0-alpha.0
+version: 2.29.0-alpha.1
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -131,6 +131,6 @@ extraVolumeMounts:
 cluster:
   name: kubernetes
 
-clusterRoleName : system:cloud-controller-manager
+clusterRoleName: system:cloud-controller-manager
 
 serviceAccountName: cloud-controller-manager


### PR DESCRIPTION
**What this PR does / why we need it**:

The spurious space character was sadly introduced in an earlier PR and had not been picked up by the helm linter, presumably because the GHA did not run.

**Release note**:

```release-note
NONE
```
