### PR TITLE
build occm always in e2e test

### DIFF
--- a/tests/playbooks/roles/install-cpo-occm/defaults/main.yaml
+++ b/tests/playbooks/roles/install-cpo-occm/defaults/main.yaml
@@ -4,9 +4,6 @@ devstack_workdir: "{{ ansible_user_dir }}/devstack"
 
 # Used for uploading image to local registry.
 image_registry_host: localhost
-build_image: true
 run_e2e: false
 # Used for access the private registry image from k8s
 remote_registry_host: "{{ ansible_default_ipv4.address }}"
-generated_image_url: "{{ remote_registry_host }}/openstack-cloud-controller-manager:v0.0.{{ github_pr }}"
-image_url: "{{ generated_image_url if build_image else 'registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.28.0' }}"

--- a/tests/playbooks/roles/install-cpo-occm/tasks/main.yaml
+++ b/tests/playbooks/roles/install-cpo-occm/tasks/main.yaml
@@ -11,7 +11,6 @@
       git checkout FETCH_HEAD; git checkout -b PR{{ github_pr }}
 
 - name: Build and upload openstack-cloud-controller-manager image
-  when: build_image
   shell:
     executable: /bin/bash
     cmd: |
@@ -19,8 +18,8 @@
 
       make push-multiarch-image-openstack-cloud-controller-manager \
         ARCHS='amd64' \
-        REGISTRY={{ image_registry_host }} \
-        VERSION=v0.0.{{ github_pr }}
+        VERSION=v0.0.{{ github_pr }} \
+        REGISTRY={{ image_registry_host }}
 
 - name: Prepare openstack-cloud-controller-manager config
   shell:
@@ -55,79 +54,27 @@
 
       kubectl create secret -n kube-system generic cloud-config --from-file={{ ansible_user_dir }}/cloud.conf
 
+- name: Replace manifests
+  shell:
+    executable: /bin/bash
+    cmd: |
+      cd $GOPATH/src/k8s.io/cloud-provider-openstack
+      # replace image with built image
+      sed -i "s#registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.28.0#{{ remote_registry_host }}/openstack-cloud-controller-manager:v0.0.{{ github_pr }}#" manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+      sed -i "s#node-role.kubernetes.io/control-plane: \"\"#node-role.kubernetes.io/control-plane: \"true\"#" manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+      sed -i "s#--v=1#--v=5#" manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+      cat manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+
 - name: Deploy openstack-cloud-controller-manager
   shell:
     executable: /bin/bash
     cmd: |
-      set -x
+      cd $GOPATH/src/k8s.io/cloud-provider-openstack
 
-      cat <<EOF | kubectl apply -f -
-      ---
-      apiVersion: v1
-      kind: ServiceAccount
-      metadata:
-        name: cloud-controller-manager
-        namespace: kube-system
-      ---
-      apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRoleBinding
-      metadata:
-        name: system:cloud-controller-manager
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: cluster-admin
-      subjects:
-      - kind: ServiceAccount
-        name: cloud-controller-manager
-        namespace: kube-system
-      ---
-      apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        name: openstack-cloud-controller-manager
-        namespace: kube-system
-        labels:
-          k8s-app: openstack-cloud-controller-manager
-      spec:
-        replicas: 1
-        selector:
-          matchLabels:
-            k8s-app: openstack-cloud-controller-manager
-        template:
-          metadata:
-            labels:
-              k8s-app: openstack-cloud-controller-manager
-          spec:
-            tolerations:
-            - key: node.cloudprovider.kubernetes.io/uninitialized
-              value: "true"
-              effect: NoSchedule
-            - key: node-role.kubernetes.io/master
-              effect: NoSchedule
-            - key: node-role.kubernetes.io/control-plane
-              effect: NoSchedule
-            serviceAccountName: cloud-controller-manager
-            containers:
-              - name: openstack-cloud-controller-manager
-                image: "{{ image_url }}"
-                args:
-                  - /bin/openstack-cloud-controller-manager
-                  - --v=4
-                  - --cloud-config=/etc/config/cloud.conf
-                  - --cloud-provider=openstack
-                  - --use-service-account-credentials=false
-                  - --bind-address=127.0.0.1
-                volumeMounts:
-                  - mountPath: /etc/config
-                    name: cloud-config-volume
-                    readOnly: true
-            hostNetwork: true
-            volumes:
-            - name: cloud-config-volume
-              secret:
-                secretName: cloud-config
-      EOF
+      kubectl apply -f manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+      kubectl apply -f manifests/controller-manager/cloud-controller-manager-roles.yaml
+      kubectl apply -f manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
+  ignore_errors: true
 
 - name: Wait for openstack-cloud-controller-manager up and running
   shell:
@@ -147,7 +94,9 @@
       shell:
         executable: /bin/bash
         cmd: |
-          kubectl -n kube-system describe deployment openstack-cloud-controller-manager
+          kubectl describe nodes
+          kubectl get pods -n kube-system -o wide
+          kubectl -n kube-system describe ds openstack-cloud-controller-manager
       register: describe_occm
       changed_when: false
 
@@ -159,7 +108,7 @@
       shell:
         executable: /bin/bash
         cmd: |
-          kubectl -n kube-system logs deployment/openstack-cloud-controller-manager
+          kubectl -n kube-system logs ds/openstack-cloud-controller-manager
 
     - name: &failmsg Stop due to prior failure of openstack-cloud-controller-manager
       fail:


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
