### PR TITLE
fix(occm/loadbalancer): enable the proxy-protocol only for supported listeners

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
+	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 	golang.org/x/net v0.13.0
 	golang.org/x/sys v0.10.0
 	golang.org/x/term v0.10.0
@@ -124,7 +125,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.11.0 // indirect
-	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect
 	golang.org/x/oauth2 v0.8.0 // indirect
 	golang.org/x/sync v0.2.0 // indirect
 	golang.org/x/text v0.11.0 // indirect


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This PR fix an issue when trying to activate the ProxyProtocol on a K8S LoadBalancer with, at least, one UDP or SCTP port.

The CCM try, when the proxy-protocol's annotation is set, to enable the proxy-protocols on all pools, whatever the protocol used by the listener.

Octavia doesn't support  the proxy protocol with a UDP or SCTP listener: <https://docs.openstack.org/api-ref/load-balancer/v2/index.html?expanded=create-pool-detail#protocol-combinations-listener-pool>

**Which issue this PR fixes(if applicable)**:
N/A

**Special notes for reviewers**:
ATM, this service __cannot__ be deployed. This kind of service will be more common due to "new" protocol HTTP/3/QUIC (TCP and UDP usage on the same service).
```yaml
apiVersion: v1
kind: Service
metadata:
  name: octavia-udp-tcp-with-proxyprotocol
  annotations:
    loadbalancer.openstack.org/proxy-protocol: "true"
spec:
  ports:
  - name: client
    port: 443
    protocol: TCP
    targetPort: 443
  - name: client-udp
    port: 443
    protocol: UDP
    targetPort: 443
  selector:
    app: nginx
  type: LoadBalancer
```
Without this patch, this will result to a 409 from the Octavia's API.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
the proxy-protocol is ignored when the listener protocol is not supported (UDP/SCTP)
```
