### PR TITLE
[release-1.26] [occm] add `max_retries_down` support for octavia health monitors

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -192,7 +192,11 @@ Request Body:
 
 - `loadbalancer.openstack.org/health-monitor-max-retries`
 
-  Defines the health monitor retry count for the loadbalancer pools.
+  Defines the health monitor retry count for the loadbalancer pool members.
+
+- `loadbalancer.openstack.org/health-monitor-max-retries-down`
+
+  Defines the health monitor retry count for the loadbalancer pool members to be marked down.
 
 - `loadbalancer.openstack.org/flavor-id`
 
@@ -255,7 +259,8 @@ subnet-id="fa6a4e6c-6ae4-4dde-ae86-3e2f452c1f03"
 create-monitor=true
 monitor-delay=60s
 monitor-timeout=30s
-monitor-max-retries=5
+monitor-max-retries=1
+monitor-max-retries-down=3
 
 [LoadBalancerClass "internetFacing"]
 floating-network-id="c57af0a0-da92-49be-a98a-345ceca004b3"

--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -229,6 +229,9 @@ Although the openstack-cloud-controller-manager was initially implemented with N
 * `monitor-max-retries`
   The number of successful checks before changing the operating status of the load balancer member to ONLINE. A valid value is from 1 to 10. Default: 1
 
+* `monitor-max-retries-down`
+  The number of unsuccessful checks before changing the operating status of the load balancer member to ERROR. A valid value is from 1 to 10. Default: 3
+
 * `monitor-timeout`
   The maximum time, in seconds, that a monitor waits to connect backend before it times out. Default: 3
 

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -94,6 +94,7 @@ type LoadBalancerOpts struct {
 	MonitorDelay          util.MyDuration     `gcfg:"monitor-delay"`
 	MonitorTimeout        util.MyDuration     `gcfg:"monitor-timeout"`
 	MonitorMaxRetries     uint                `gcfg:"monitor-max-retries"`
+	MonitorMaxRetriesDown uint                `gcfg:"monitor-max-retries-down"`
 	ManageSecurityGroups  bool                `gcfg:"manage-security-groups"`
 	NodeSecurityGroupIDs  []string            // Do not specify, get it automatically when enable manage-security-groups. TODO(FengyunPan): move it into cache
 	InternalLB            bool                `gcfg:"internal-lb"` // default false
@@ -203,6 +204,7 @@ func ReadConfig(config io.Reader) (Config, error) {
 	cfg.LoadBalancer.MonitorDelay = util.MyDuration{Duration: 5 * time.Second}
 	cfg.LoadBalancer.MonitorTimeout = util.MyDuration{Duration: 3 * time.Second}
 	cfg.LoadBalancer.MonitorMaxRetries = 1
+	cfg.LoadBalancer.MonitorMaxRetriesDown = 3
 	cfg.LoadBalancer.CascadeDelete = true
 	cfg.LoadBalancer.EnableIngressHostname = false
 	cfg.LoadBalancer.IngressHostnameSuffix = defaultProxyHostnameSuffix

--- a/pkg/openstack/openstack_test.go
+++ b/pkg/openstack/openstack_test.go
@@ -98,7 +98,8 @@ func TestReadConfig(t *testing.T) {
  create-monitor = yes
  monitor-delay = 1m
  monitor-timeout = 30s
- monitor-max-retries = 3
+ monitor-max-retries = 1
+ monitor-max-retries-down = 3
  [Metadata]
  search-order = configDrive, metadataService
  `))
@@ -131,16 +132,19 @@ func TestReadConfig(t *testing.T) {
 	}
 
 	if !cfg.LoadBalancer.CreateMonitor {
-		t.Errorf("incorrect lb.createmonitor: %t", cfg.LoadBalancer.CreateMonitor)
+		t.Errorf("incorrect lb.create-monitor: %t", cfg.LoadBalancer.CreateMonitor)
 	}
 	if cfg.LoadBalancer.MonitorDelay.Duration != 1*time.Minute {
-		t.Errorf("incorrect lb.monitordelay: %s", cfg.LoadBalancer.MonitorDelay)
+		t.Errorf("incorrect lb.monitor-delay: %s", cfg.LoadBalancer.MonitorDelay)
 	}
 	if cfg.LoadBalancer.MonitorTimeout.Duration != 30*time.Second {
-		t.Errorf("incorrect lb.monitortimeout: %s", cfg.LoadBalancer.MonitorTimeout)
+		t.Errorf("incorrect lb.monitor-timeout: %s", cfg.LoadBalancer.MonitorTimeout)
 	}
-	if cfg.LoadBalancer.MonitorMaxRetries != 3 {
-		t.Errorf("incorrect lb.monitormaxretries: %d", cfg.LoadBalancer.MonitorMaxRetries)
+	if cfg.LoadBalancer.MonitorMaxRetries != 1 {
+		t.Errorf("incorrect lb.monitor-max-retries: %d", cfg.LoadBalancer.MonitorMaxRetries)
+	}
+	if cfg.LoadBalancer.MonitorMaxRetriesDown != 3 {
+		t.Errorf("incorrect lb.monitor-max-retries-down: %d", cfg.LoadBalancer.MonitorMaxRetriesDown)
 	}
 	if cfg.Metadata.SearchOrder != "configDrive, metadataService" {
 		t.Errorf("incorrect md.search-order: %v", cfg.Metadata.SearchOrder)
@@ -187,7 +191,8 @@ clouds:
  create-monitor = yes
  monitor-delay = 1m
  monitor-timeout = 30s
- monitor-max-retries = 3
+ monitor-max-retries = 1
+ monitor-max-retries-down = 3
  [Metadata]
  search-order = configDrive, metadataService
 `))
@@ -227,7 +232,15 @@ clouds:
 
 	// Make non-global sections dont get overwritten
 	if !cfg.LoadBalancer.CreateMonitor {
-		t.Errorf("incorrect lb.createmonitor: %t", cfg.LoadBalancer.CreateMonitor)
+		t.Errorf("incorrect lb.create-monitor: %t", cfg.LoadBalancer.CreateMonitor)
+	}
+
+	if cfg.LoadBalancer.MonitorMaxRetries != 1 {
+		t.Errorf("incorrect lb.monitor-max-retries: %d", cfg.LoadBalancer.MonitorMaxRetries)
+	}
+
+	if cfg.LoadBalancer.MonitorMaxRetriesDown != 3 {
+		t.Errorf("incorrect lb.monitor-max-retries-down: %d", cfg.LoadBalancer.MonitorMaxRetriesDown)
 	}
 }
 


### PR DESCRIPTION
This is a cherry-pick of #2372

```release-note
[occm] Add `max_retries_down` health monitors option support for OCCM LoadBalancer global config and service annotations
```