### PR TITLE
[occm] Add ability to add Events by OCCM

### DIFF
--- a/pkg/openstack/events.go
+++ b/pkg/openstack/events.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+const (
+	eventLBForceInternal               = "LoadBalancerForcedInternal"
+	eventLBExternalNetworkSearchFailed = "LoadBalancerExternalNetworkSearchFailed"
+	eventLBSourceRangesIgnored         = "LoadBalancerSourceRangesIgnored"
+	eventLBAZIgnored                   = "LoadBalancerAvailabilityZonesIgnored"
+)

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -36,8 +36,12 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
 
+	"k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/cloud-provider-openstack/pkg/client"
 	"k8s.io/cloud-provider-openstack/pkg/metrics"
 	"k8s.io/cloud-provider-openstack/pkg/util"
@@ -76,11 +80,12 @@ type PortWithTrunkDetails struct {
 
 // LoadBalancer is used for creating and maintaining load balancers
 type LoadBalancer struct {
-	secret  *gophercloud.ServiceClient
-	network *gophercloud.ServiceClient
-	lb      *gophercloud.ServiceClient
-	opts    LoadBalancerOpts
-	kclient kubernetes.Interface
+	secret        *gophercloud.ServiceClient
+	network       *gophercloud.ServiceClient
+	lb            *gophercloud.ServiceClient
+	opts          LoadBalancerOpts
+	kclient       kubernetes.Interface
+	eventRecorder record.EventRecorder
 }
 
 // LoadBalancerOpts have the options to talk to Neutron LBaaSV2 or Octavia
@@ -160,6 +165,9 @@ type OpenStack struct {
 	useV1Instances        bool // TODO: v1 instance apis can be deleted after the v2 is verified enough
 	nodeInformer          coreinformers.NodeInformer
 	nodeInformerHasSynced func() bool
+
+	eventBroadcaster record.EventBroadcaster
+	eventRecorder    record.EventRecorder
 }
 
 // Config is used to read and store information from the cloud configuration file
@@ -193,6 +201,9 @@ func init() {
 func (os *OpenStack) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
 	clientset := clientBuilder.ClientOrDie("cloud-controller-manager")
 	os.kclient = clientset
+	os.eventBroadcaster = record.NewBroadcaster()
+	os.eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: os.kclient.CoreV1().Events("")})
+	os.eventRecorder = os.eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "cloud-provider-openstack"})
 }
 
 // ReadConfig reads values from the cloud.conf
@@ -367,7 +378,7 @@ func (os *OpenStack) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 
 	klog.V(1).Info("Claiming to support LoadBalancer")
 
-	return &LbaasV2{LoadBalancer{secret, network, lb, os.lbOpts, os.kclient}}, true
+	return &LbaasV2{LoadBalancer{secret, network, lb, os.lbOpts, os.kclient, os.eventRecorder}}, true
 }
 
 // Zones indicates that we support zones


### PR DESCRIPTION
**What this PR does / why we need it**:
We often find situations when it's useful to use events to warn user about implicit choices that the OCCM makes, e.g. when a provided option is ignored because Octavia does not support it.

This commit adds `eventRecorder` to the `LbaasV2` interface that can be used to create events in these cases. In addition a few places when we just logged a warning are now extended to create events on Services that users will be able to read.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] OCCM will now emit events on Services regarding various implicit decisions it makes.
```
