### PR TITLE
Specify hostAliases in the cinder-csi-plugin nodeplugin-daemonset

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.28.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.29.0-alpha.1
+version: 2.29.0-alpha.2
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -216,6 +216,10 @@ spec:
       affinity: {{ toYaml .Values.csi.plugin.controllerPlugin.affinity | nindent 8 }}
       nodeSelector: {{ toYaml .Values.csi.plugin.controllerPlugin.nodeSelector | nindent 8 }}
       tolerations: {{ toYaml .Values.csi.plugin.controllerPlugin.tolerations | nindent 8 }}
+      {{- with .Values.csi.plugin.controllerPlugin.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
     {{- end }}

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -156,6 +156,10 @@ spec:
       affinity: {{ toYaml .Values.csi.plugin.nodePlugin.affinity | nindent 8 }}
       nodeSelector: {{ toYaml .Values.csi.plugin.nodePlugin.nodeSelector | nindent 8 }}
       tolerations: {{ toYaml .Values.csi.plugin.nodePlugin.tolerations | nindent 8 }}
+      {{- with .Values.csi.plugin.nodePlugin.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
     {{- end }}

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -81,6 +81,11 @@ csi:
       tolerations:
         - operator: Exists
       kubeletDir: /var/lib/kubelet
+      # Allow for specifying internal IP addresses for multiple hostnames
+      # hostAliases:
+      #   - ip: "10.0.0.1"
+      #     hostnames:
+      #     - "keystone.hostname.com"
     controllerPlugin:
       replicas: 1
       strategy:
@@ -110,6 +115,11 @@ csi:
       affinity: {}
       nodeSelector: {}
       tolerations: []
+      # Allow for specifying internal IP addresses for multiple hostnames
+      # hostAliases:
+      #   - ip: "10.0.0.1"
+      #     hostnames:
+      #     - "keystone.hostname.com"
     resources: {}
     # Enable built-in http server through the http-endpoint flag
     httpEndpoint:

--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.28.0
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 2.29.0-alpha.0
+version: 2.29.0-alpha.1
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -153,6 +153,10 @@ spec:
     {{- if .Values.controllerplugin.tolerations }}
       tolerations: {{ toYaml .Values.controllerplugin.tolerations | nindent 8 }}
     {{- end }}
+    {{- with .Values.controllerplugin.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -117,6 +117,10 @@ spec:
     {{- if .Values.nodeplugin.tolerations }}
       tolerations: {{ toYaml .Values.nodeplugin.tolerations | nindent 8 }}
     {{- end }}
+    {{- with .Values.nodeplugin.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- if .Values.nodeplugin.priorityClassName }}
       priorityClassName: {{ .Values.nodeplugin.priorityClassName }}
     {{- end }}

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -66,6 +66,11 @@ nodeplugin:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Allow for specifying internal IP addresses for multiple hostnames
+  # hostAliases:
+  #   - ip: "10.0.0.1"
+  #     hostnames:
+  #     - "keystone.hostname.com"
   priorityClassName: ""
   # Use fullnameOverride to fully override the name of this component
   # fullnameOverride: some-other-name
@@ -102,6 +107,11 @@ controllerplugin:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Allow for specifying internal IP addresses for multiple hostnames
+  # hostAliases:
+  #   - ip: "10.0.0.1"
+  #     hostnames:
+  #     - "keystone.hostname.com"
   # Use fullnameOverride to fully override the name of this component
   # fullnameOverride: some-other-name
 

--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.29.0-alpha.2
+version: 2.29.0-alpha.3
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -37,6 +37,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ .Values.serviceAccountName }}
       containers:
         - name: openstack-cloud-controller-manager

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -99,6 +99,12 @@ cloudConfig:
   blockStorage:
   metadata:
 
+# Allow for specifying internal IP addresses for multiple hostnames
+# hostAliases:
+#   - ip: "10.0.0.1"
+#     hostnames:
+#     - "keystone.hostname.com"
+
 ## Pod priority settings
 ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 priorityClassName:


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This PR allows to specify hostAliases in the nodeplugin-daemonset to allow for setting custom hosts. This functionality is off by default in the PR and has appropriate comments to structure and enable. 

The reason for submitting this PR is because this chart is not using hosts from coredns' corefile.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
