### PR TITLE
test : getStringFromServiceAnnotation() 

### DIFF
--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -973,3 +973,138 @@ func TestLbaasV2_updateServiceAnnotations(t *testing.T) {
 
 	assert.ElementsMatch(t, expectedAnnotations, serviceAnnotations)
 }
+
+func Test_getStringFromServiceAnnotation(t *testing.T) {
+	type testArgs struct {
+		service        *corev1.Service
+		annotationKey  string
+		defaultSetting string
+	}
+
+	tests := []struct {
+		name     string
+		testArgs testArgs
+		expected string
+	}{
+		{
+			name: "enter empty arguments",
+			testArgs: testArgs{
+				service: &corev1.Service{
+					ObjectMeta: v1.ObjectMeta{},
+				},
+				annotationKey:  "",
+				defaultSetting: "",
+			},
+			expected: "",
+		},
+		{
+			name: "enter valid arguments with annotations",
+			testArgs: testArgs{
+				service: &corev1.Service{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace:   "service-namespace",
+						Name:        "service-name",
+						Annotations: map[string]string{"annotationKey": "annotation-Value"},
+					},
+				},
+				annotationKey:  "annotationKey",
+				defaultSetting: "default-setting",
+			},
+			expected: "annotation-Value",
+		},
+		{
+			name: "valid arguments without annotations",
+			testArgs: testArgs{
+				service: &corev1.Service{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "service-namespace",
+						Name:      "service-name",
+					},
+				},
+				annotationKey:  "annotationKey",
+				defaultSetting: "default-setting",
+			},
+			expected: "default-setting",
+		},
+		{
+			name: "enter argument without default-setting",
+			testArgs: testArgs{
+				service: &corev1.Service{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace:   "service-namespace",
+						Name:        "service-name",
+						Annotations: map[string]string{"annotationKey": "annotation-Value"},
+					},
+				},
+				annotationKey:  "annotationKey",
+				defaultSetting: "",
+			},
+			expected: "annotation-Value",
+		},
+		{
+			name: "enter argument without annotation and default-setting",
+			testArgs: testArgs{
+				service: &corev1.Service{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "service-namespace",
+						Name:      "service-name",
+					},
+				},
+				annotationKey:  "annotationKey",
+				defaultSetting: "",
+			},
+			expected: "",
+		},
+		{
+			name: "enter argument with a non-existing annotationKey with default setting",
+			testArgs: testArgs{
+				service: &corev1.Service{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace:   "service-namespace",
+						Name:        "service-name",
+						Annotations: map[string]string{"annotationKey": "annotation-Value"},
+					},
+				},
+				annotationKey:  "invalid-annotationKey",
+				defaultSetting: "default-setting",
+			},
+			expected: "default-setting",
+		},
+		{
+			name: "enter argument with a non-existing annotationKey without a default setting",
+			testArgs: testArgs{
+				service: &corev1.Service{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace:   "service-namespace",
+						Name:        "service-name",
+						Annotations: map[string]string{"annotationKey": "annotation-Value"},
+					},
+				},
+				annotationKey:  "invalid-annotationKey",
+				defaultSetting: "",
+			},
+			expected: "",
+		},
+		{
+			name: "no name-space and service name but valid annotations",
+			testArgs: testArgs{
+				service: &corev1.Service{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{"annotationKey": "annotation-Value"},
+					},
+				},
+				annotationKey:  "annotationKey",
+				defaultSetting: "default-setting",
+			},
+			expected: "annotation-Value",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := getStringFromServiceAnnotation(test.testArgs.service, test.testArgs.annotationKey, test.testArgs.defaultSetting)
+
+			assert.Equal(t, test.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

cover all possible edge cases that can during the use of this function and test for behavour of function giving hardcoded value incase there is a change in the logic of the function