### PR TITLE
test : UpdateServiceAnnotations 

### DIFF
--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -945,3 +945,31 @@ func Test_getBoolFromServiceAnnotation(t *testing.T) {
 		})
 	}
 }
+
+func TestLbaasV2_updateServiceAnnotations(t *testing.T) {
+	service := &corev1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Annotations: nil,
+		},
+	}
+
+	annotations := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+
+	lbaas := LbaasV2{}
+	lbaas.updateServiceAnnotations(service, annotations)
+
+	serviceAnnotations := make([]map[string]string, 0)
+	for key, value := range service.ObjectMeta.Annotations {
+		serviceAnnotations = append(serviceAnnotations, map[string]string{key: value})
+	}
+
+	expectedAnnotations := []map[string]string{
+		{"key1": "value1"},
+		{"key2": "value2"},
+	}
+
+	assert.ElementsMatch(t, expectedAnnotations, serviceAnnotations)
+}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
