### PR TITLE
test : getSecurityGroupName ()

### DIFF
--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -824,3 +824,49 @@ func Test_buildPoolCreateOpt(t *testing.T) {
 		})
 	}
 }
+
+func Test_getSecurityGroupName(t *testing.T) {
+	tests := []struct {
+		name     string
+		service  *corev1.Service
+		expected string
+	}{
+		{
+			name: "regular test security group name and length",
+			service: &corev1.Service{
+				ObjectMeta: v1.ObjectMeta{
+					UID:       "12345",
+					Namespace: "security-group-namespace",
+					Name:      "security-group-name",
+				},
+			},
+			expected: "lb-sg-12345-security-group-namespace-security-group-name",
+		},
+		{
+			name: "security group name longer than 255 byte",
+			service: &corev1.Service{
+				ObjectMeta: v1.ObjectMeta{
+					UID:       "12345678-90ab-cdef-0123-456789abcdef",
+					Namespace: "security-group-longer-test-namespace",
+					Name:      "security-group-longer-test-service-name-with-more-than-255-byte-this-test-should-be-longer-than-255-i-need-that-ijiojohoo-afhwefkbfk-jwebfwbifwbewifobiu-efbiobfoiqwebi-the-end-e-end-pardon-the-long-string-i-really-apologize-if-this-is-a-bad-thing-to-do",
+				},
+			},
+			expected: "lb-sg-12345678-90ab-cdef-0123-456789abcdef-security-group-longer-test-namespace-security-group-longer-test-service-name-with-more-than-255-byte-this-test-should-be-longer-than-255-i-need-that-ijiojohoo-afhwefkbfk-jwebfwbifwbewifobiu-efbiobfoiqwebi-the-end",
+		},
+		{
+			name: "test the security group name with all empty param",
+			service: &corev1.Service{
+				ObjectMeta: v1.ObjectMeta{},
+			},
+			expected: "lb-sg---",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := getSecurityGroupName(test.service)
+
+			assert.Equal(t, test.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
