### PR TITLE
enh: add unit tests for add/remove node address

### DIFF
--- a/pkg/openstack/instances_test.go
+++ b/pkg/openstack/instances_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -188,4 +189,72 @@ func TestSortNodeAddressesWithMultipleCIDRs(t *testing.T) {
 	}
 
 	executeSortNodeAddressesTest(t, addressSortOrder, want)
+}
+
+func TestAddToNodeAddresses(t *testing.T) {
+	type args struct {
+		addresses    *[]v1.NodeAddress
+		addAddresses v1.NodeAddress
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "it adds address into the addresses slice",
+			args: args{
+				addresses: &[]v1.NodeAddress{
+					{
+						Address: "test-1",
+					},
+					{
+						Address: "test-2",
+					},
+				},
+				addAddresses: v1.NodeAddress{
+					Address: "test-3",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			AddToNodeAddresses(tt.args.addresses, tt.args.addAddresses)
+			assert.Contains(t, *tt.args.addresses, tt.args.addAddresses)
+		})
+	}
+}
+
+func TestRemoveFromNodeAddresses(t *testing.T) {
+	type args struct {
+		addresses       *[]v1.NodeAddress
+		removeAddresses v1.NodeAddress
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "it adds address into the addresses slice",
+			args: args{
+				addresses: &[]v1.NodeAddress{
+					{
+						Address: "test-1",
+					},
+					{
+						Address: "test-2",
+					},
+				},
+				removeAddresses: v1.NodeAddress{
+					Address: "test-2",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RemoveFromNodeAddresses(tt.args.addresses, tt.args.removeAddresses)
+			assert.NotContains(t, *tt.args.addresses, tt.args.removeAddresses)
+		})
+	}
 }


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Adds unit test for add/remove node addresses


**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
