### PR TITLE
Add Test for  getting bool from service annotation

### DIFF
--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -870,3 +870,78 @@ func Test_getSecurityGroupName(t *testing.T) {
 		})
 	}
 }
+
+func Test_getBoolFromServiceAnnotation(t *testing.T) {
+	type testargs struct {
+		service        *corev1.Service
+		annotationKey  string
+		defaultSetting bool
+	}
+	tests := []struct {
+		name     string
+		testargs testargs
+		want     bool
+	}{
+		{
+			name: "Return default setting if no service annotation",
+			testargs: testargs{
+				annotationKey:  "bar",
+				defaultSetting: true,
+				service: &corev1.Service{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{"foo": "false"},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Return annotation key if it exists in service annotation (true)",
+			testargs: testargs{
+				annotationKey:  "foo",
+				defaultSetting: false,
+				service: &corev1.Service{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{"foo": "true"},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Return annotation key if it exists in service annotation (false)",
+			testargs: testargs{
+				annotationKey:  "foo",
+				defaultSetting: true,
+				service: &corev1.Service{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{"foo": "false"},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Return default setting if key isn't a valid boolean value",
+			testargs: testargs{
+				annotationKey:  "foo",
+				defaultSetting: true,
+				service: &corev1.Service{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{"foo": "invalid"},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getBoolFromServiceAnnotation(tt.testargs.service, tt.testargs.annotationKey, tt.testargs.defaultSetting)
+			if got != tt.want {
+				t.Errorf("getBoolFromServiceAnnotation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Add unit test for getting bool from service annotation

**Special notes for reviewers**:
To run the test, on your terminal run  `make unit`

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
