### PR TITLE
Test get subnet

### DIFF
--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"sort"
 	"testing"
@@ -767,11 +768,10 @@ func TestLbaasV2_GetLoadBalancerName(t *testing.T) {
 
 func Test_buildPoolCreateOpt(t *testing.T) {
 	type args struct {
-		protocol    string
-		svcConf     *serviceConfig
-		service     *corev1.Service
-		lbaasV2     *LbaasV2
-		lbAlgorithm string
+		protocol string
+		svcConf  *serviceConfig
+		service  *corev1.Service
+		lbaasV2  *LbaasV2
 	}
 	tests := []struct {
 		name string
@@ -1752,6 +1752,132 @@ func TestBuildBatchUpdateMemberOpts(t *testing.T) {
 			} else {
 				assert.Len(t, newMembers, tc.expectedNewMembersCount)
 			}
+		})
+	}
+}
+
+func Test_getSubnetID(t *testing.T) {
+	type args struct {
+		svcConf *serviceConfig
+		service *corev1.Service
+		lbaasV2 *LbaasV2
+	}
+	tests := []struct {
+		name        string
+		args        args
+		want        string
+		expectedErr string
+	}{
+		{
+			name: "test get subnet from service annotation",
+			args: args{
+				svcConf: &serviceConfig{},
+				lbaasV2: &LbaasV2{
+					LoadBalancer{
+						opts: LoadBalancerOpts{
+							LBClasses: map[string]*LBClass{
+								"test-class": {
+									SubnetID: "test-class-subnet-id",
+								},
+							},
+						},
+					},
+				},
+				service: &corev1.Service{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							"loadbalancer.openstack.org/subnet-id": "annotation-test-id",
+							"loadbalancer.openstack.org/class":     "test-class",
+						},
+					},
+				},
+			},
+			want: "annotation-test-id",
+		},
+		{
+			name: "test get subnet from config class",
+			args: args{
+				svcConf: &serviceConfig{},
+				lbaasV2: &LbaasV2{
+					LoadBalancer{
+						opts: LoadBalancerOpts{
+							LBClasses: map[string]*LBClass{
+								"test-class": {
+									SubnetID: "test-class-subnet-id",
+								},
+							},
+						},
+					},
+				},
+				service: &corev1.Service{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							"loadbalancer.openstack.org/class": "test-class",
+						},
+					},
+				},
+			},
+			want: "test-class-subnet-id",
+		},
+		{
+			name: "test get subnet from config class with invalid loadbalancer class",
+			args: args{
+				svcConf: &serviceConfig{},
+				lbaasV2: &LbaasV2{
+					LoadBalancer{
+						opts: LoadBalancerOpts{
+							LBClasses: map[string]*LBClass{
+								"decoy-class": {
+									SubnetID: "test-id",
+								},
+							},
+							SubnetID: "test-subnet-id",
+						},
+					},
+				},
+				service: &corev1.Service{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							"loadbalancer.openstack.org/class": "test-class",
+						},
+					},
+				},
+			},
+			want:        "",
+			expectedErr: fmt.Sprintf("invalid loadbalancer class %q", "test-class"),
+		},
+		{
+			name: "test get subnet from default config",
+			args: args{
+				svcConf: &serviceConfig{},
+				lbaasV2: &LbaasV2{
+					LoadBalancer{
+						opts: LoadBalancerOpts{
+							LBClasses: map[string]*LBClass{
+								"test-config-class-subnet-id": {
+									SubnetID: "test-id",
+								},
+							},
+							SubnetID: "test-default-subnet-id",
+						},
+					},
+				},
+				service: &corev1.Service{},
+			},
+			want: "test-default-subnet-id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.args.lbaasV2.getSubnetID(tt.args.service, tt.args.svcConf)
+			if tt.expectedErr != "" {
+				assert.EqualError(t, err, tt.expectedErr)
+			}
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -767,10 +767,11 @@ func TestLbaasV2_GetLoadBalancerName(t *testing.T) {
 
 func Test_buildPoolCreateOpt(t *testing.T) {
 	type args struct {
-		protocol string
-		svcConf  *serviceConfig
-		service  *corev1.Service
-		lbaasV2  *LbaasV2
+		protocol    string
+		svcConf     *serviceConfig
+		service     *corev1.Service
+		lbaasV2     *LbaasV2
+		lbAlgorithm string
 	}
 	tests := []struct {
 		name string


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
this pr adds unit test for getSubnetID LbaasV2 method in loadbalancer.go
**Which issue this PR fixes(if applicable)**:
refers #2400 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
