### PR TITLE
CI: Fix "error: externally-managed-environment"

### DIFF
--- a/tests/ci-occm-e2e.sh
+++ b/tests/ci-occm-e2e.sh
@@ -45,7 +45,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-python3 -m pip install requests ansible
+apt-get update
+apt-get install -y python3-requests ansible
 
 # If BOSKOS_HOST is set then acquire a resource of type ${RESOURCE_TYPE} from Boskos.
 if [ -n "${BOSKOS_HOST:-}" ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
Seems like the CI OS changed and now it won't allow installing Python packages in the system without explicitly requesting that. This commit solves this by installing needed packages through `apt-get`.

**Which issue this PR fixes(if applicable)**:
fixes #2412

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
```release-note
NONE
```
