### PR TITLE
CI: Fix "error: externally-managed-environment" in CSI

### DIFF
--- a/tests/ci-csi-cinder-e2e.sh
+++ b/tests/ci-csi-cinder-e2e.sh
@@ -44,7 +44,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-python3 -m pip install requests ansible
+apt-get update
+apt-get install -y python3-requests ansible
 
 # If BOSKOS_HOST is set then acquire a resource of type ${RESOURCE_TYPE} from Boskos.
 if [ -n "${BOSKOS_HOST:-}" ]; then

--- a/tests/ci-csi-manila-e2e.sh
+++ b/tests/ci-csi-manila-e2e.sh
@@ -44,7 +44,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-python3 -m pip install requests ansible
+apt-get update
+apt-get install -y python3-requests ansible
 
 # If BOSKOS_HOST is set then acquire a resource of type ${RESOURCE_TYPE} from Boskos.
 if [ -n "${BOSKOS_HOST:-}" ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
PR #2414 missed fixing this for Cinder and Manila e2e tests, this makes sure these tests work too.

**Which issue this PR fixes(if applicable)**:
fixes #2412

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
