### PR TITLE
Test buid monitor create opts

### DIFF
--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -7,7 +7,9 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
+	v2monitors "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 	"github.com/stretchr/testify/assert"
@@ -2136,6 +2138,153 @@ func TestLbaasV2_getNetworkID(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_buildMonitorCreateOpts(t *testing.T) {
+	type testArg struct {
+		lbaas   *LbaasV2
+		svcConf *serviceConfig
+		port    corev1.ServicePort
+	}
+	tests := []struct {
+		name    string
+		testArg testArg
+		want    v2monitors.CreateOpts
+	}{
+		{
+			name: "test for port protocol udp with ovn provider",
+			testArg: testArg{
+				lbaas: &LbaasV2{
+					LoadBalancer{
+						opts: LoadBalancerOpts{
+							LBProvider: "ovn",
+						},
+						lb: &gophercloud.ServiceClient{},
+					},
+				},
+				svcConf: &serviceConfig{
+					healthMonitorDelay:          6,
+					healthMonitorTimeout:        5,
+					healthMonitorMaxRetries:     4,
+					healthMonitorMaxRetriesDown: 3,
+					healthCheckNodePort:         32100,
+				},
+				port: corev1.ServicePort{
+					Protocol: corev1.ProtocolUDP,
+				},
+			},
+			want: v2monitors.CreateOpts{
+				Name:           "test for port protocol udp with ovn provider",
+				Type:           "UDP-CONNECT",
+				Delay:          6,
+				Timeout:        5,
+				MaxRetries:     4,
+				MaxRetriesDown: 3,
+			},
+		},
+		{
+			name: "using tcp with ovn provider",
+			testArg: testArg{
+				lbaas: &LbaasV2{
+					LoadBalancer{
+						opts: LoadBalancerOpts{
+							LBProvider: "ovn",
+						},
+					},
+				},
+				svcConf: &serviceConfig{
+					healthMonitorDelay:          3,
+					healthMonitorTimeout:        8,
+					healthMonitorMaxRetries:     6,
+					healthMonitorMaxRetriesDown: 2,
+					healthCheckNodePort:         31200,
+				},
+				port: corev1.ServicePort{
+					Protocol: corev1.ProtocolTCP,
+				},
+			},
+			want: v2monitors.CreateOpts{
+				Name:           "using tcp with ovn provider",
+				Type:           "TCP",
+				Delay:          3,
+				Timeout:        8,
+				MaxRetries:     6,
+				MaxRetriesDown: 2,
+			},
+		},
+		{
+			name: "using node port zero",
+			testArg: testArg{
+				lbaas: &LbaasV2{
+					LoadBalancer{
+						opts: LoadBalancerOpts{
+							LBProvider: "ovn",
+						},
+					},
+				},
+				svcConf: &serviceConfig{
+					healthMonitorDelay:          3,
+					healthMonitorTimeout:        5,
+					healthMonitorMaxRetries:     1,
+					healthMonitorMaxRetriesDown: 2,
+					healthCheckNodePort:         0,
+				},
+				port: corev1.ServicePort{
+					Protocol: corev1.ProtocolTCP,
+				},
+			},
+			want: v2monitors.CreateOpts{
+				Name:           "using node port zero",
+				Type:           "TCP",
+				Delay:          3,
+				Timeout:        5,
+				MaxRetries:     1,
+				MaxRetriesDown: 2,
+			},
+		},
+		{
+			name: "using tcp protocol with not-ovn provider",
+			testArg: testArg{
+				lbaas: &LbaasV2{
+					LoadBalancer{
+						opts: LoadBalancerOpts{
+							LBProvider: "amphora",
+						},
+						lb: &gophercloud.ServiceClient{},
+					},
+				},
+				svcConf: &serviceConfig{
+					healthMonitorDelay:          3,
+					healthMonitorTimeout:        4,
+					healthMonitorMaxRetries:     1,
+					healthMonitorMaxRetriesDown: 5,
+					healthCheckNodePort:         310000,
+				},
+				port: corev1.ServicePort{
+					Protocol: corev1.ProtocolTCP,
+				},
+			},
+			want: v2monitors.CreateOpts{
+				Name:           "using tcp protocol with not-ovn provider",
+				Type:           "HTTP",
+				Delay:          3,
+				Timeout:        4,
+				MaxRetries:     1,
+				MaxRetriesDown: 5,
+
+				URLPath:       "/healthz",
+				HTTPMethod:    "GET",
+				ExpectedCodes: "200",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.testArg.lbaas.buildMonitorCreateOpts(tt.testArg.svcConf, tt.testArg.port, tt.name)
+			assert.Equal(t, tt.want, result)
 		})
 	}
 }


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
this pr adds unit test for buildMonitorCreateOpts LbaasV2 method in loadbalancer.go
**Which issue this PR fixes(if applicable)**:
refers #2400

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
