### PR TITLE
[occm] add a new `hack/bump-release.sh` script

### DIFF
--- a/hack/bump-release.sh
+++ b/hack/bump-release.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM_MAJOR="${1:?FROM_MAJOR (1st arg) not set or empty}"
+TO_MAJOR="${2:?TO_MAJOR (2nd arg) not set or empty}"
+TO_MINOR="${3:?TO_MINOR (3rd arg) not set or empty}"
+
+# example usage: hack/bump_release.sh 28 28 1
+# should replace 1.28.x with 1.28.1 / 2.28.x with 2.28.1
+
+find charts docs manifests tests examples -type f -exec sed -i -re 's/((ersion)?: ?v?)?([1-2]\.)'${FROM_MAJOR}'\.([0-9][0-9a-zA-Z.-]*)/\1\3'${TO_MAJOR}'.'${TO_MINOR}'/g' "{}" \;

--- a/release-procedure.md
+++ b/release-procedure.md
@@ -1,32 +1,42 @@
 # Release Procedure
 
-Cloud Provider OpenStack Release is done in sync with kubernetes/kubernetes, Minor versions can be released intermittently for critical bug fixes.
-
-## Before Release
-
-Update cloud-provider-openstack to kubernetes/kubernetes latest release. Make Sure all CI check passed.
+The Cloud Provider OpenStack Release is done in sync with
+kubernetes/kubernetes. Minor versions can be released intermittently for
+critical bug fixes.
 
 ## Making a Release
 
-1. Checkout the release branch
+1. Checkout the release branch.
 
-```
+```bash
 $ git fetch upstream
+$ git checkout -b my-release upstream/release-X.Y
+```
+
+2. Update the minor version with the expected version.
+
+Make changes in the `docs/manifests/tests/examples` directories using the
+`hack/bump_release.sh` script by running the following command:
+
+```bash
+$ hack/bump_release.sh 28 29 0
+```
+
+This will replace `1.28.x`/`2.28.x` with `1.29.0`/`2.29.0` strings in the
+`docs/manifests/tests/examples` directories. Ensure that you double-check the
+diff before committing the changes. Non-related changes must not be shipped.
+
+3. Create a new pull request (PR) and make sure all CI checks have passed.
+
+4. Once the PR is merged, make a tag and push it to the upstream repository.
+
+```bash
 $ git checkout -b release-X.Y upstream/release-X.Y
-```
-
-2. Update manifests with new release images, create a PR against release branch to update.
-
-3. Make tag and push to upstream repo.
-
-```
-$ git tag vX.Y.Z
+$ git pull upstream release-X.Y --tags
+$ git tag -m "Release for cloud-provider-openstack to support Kubernetes release x" vX.Y.Z
 $ git push upstream vX.Y.Z
 ```
 
-4. [Github Actions](https://github.com/kubernetes/cloud-provider-openstack/actions/workflows/release-cpo.yaml) will make [new draft release](https://github.com/kubernetes/cloud-provider-openstack/releases) to repository.
-Cloudbuild should build new images to gcr.io/k8s-staging-provider-os. 
+5. [Github Actions](https://github.com/kubernetes/cloud-provider-openstack/actions/workflows/release-cpo.yaml) will create new [Docker images](https://console.cloud.google.com/gcr/images/k8s-staging-provider-os) and generate a [new draft release](https://github.com/kubernetes/cloud-provider-openstack/releases) in the repository.
 
-5. Make PR modifying [images.yaml](https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/images/k8s-staging-provider-os/images.yaml) to promote gcr.io images to registry.k8s.io.
-
-6. Make release notes and publish the release after the new images are published.
+6. Create release notes using the "Generate release notes" button in the GitHub "New release" UI and publish the release.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a script for easy release management. It was already tested with 1.26.x, 1.27.x and 1.28.x releases

**Which issue this PR fixes(if applicable)**:

n/a

**Special notes for reviewers**:

example usage: `hack/bump_release.sh 28 28 1` should replace 1.28.x with 1.28.1 / 2.28.x with 2.28.1 strings in docs/manifests/tests/examples

The script was tested in GNU/Linux. Needs to be tested on *BSD (e.g. MacOS) as well.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
