### PR TITLE
[1.26.4] Switch to a new CI

### DIFF
--- a/.github/workflows/release-cpo.yaml
+++ b/.github/workflows/release-cpo.yaml
@@ -13,28 +13,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - uses: actions/setup-go@v3
-      with:
-        go-version: 1.19
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-
-    - name: Login to docker hub
-      uses: docker/login-action@v1
-      with:
-        registry: docker.io
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-
-    - name: Get the version from ref
-      id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
-    - name: build & publish images
-      run: |
-        REGISTRY=docker.io/k8scloudprovider ARCHS='amd64 arm arm64 ppc64le s390x' GOOS=linux VERSION=${{ steps.get_version.outputs.VERSION }} make upload-images
-
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,42 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+
+# this must be specified in seconds. If omitted, defaults to 600s (10 mins)
+timeout: 1200s
+# this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
+# or any new substitutions added in the future.
+options:
+  dynamic_substitutions: true
+  substitution_option: ALLOW_LOOSE
+  machineType: 'N1_HIGHCPU_8'
+steps:
+  - name: gcr.io/k8s-testimages/gcb-docker-gcloud
+    entrypoint: bash
+    env:
+    # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx
+    # set the home to /root explicitly to if using docker buildx
+    - HOME=/root
+    args:
+    - -c
+    - |
+      set -xeuo pipefail
+
+      # Create docker credentials for pushing to gcr.io from our inherited
+      # gcloud credentials
+      gcloud auth configure-docker
+
+      # Run the image's buildx entrypoint to initialise the build environment
+      # appropriately for the image before running make
+      /buildx-entrypoint version
+
+      make push-multiarch-images \
+        REGISTRY=gcr.io/$PROJECT_ID
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form
+  # vYYYYMMDD-hash, and can be used as a substitution
+  _GIT_TAG: 'v99999999-v12345'
+  # Remove date prefix (first 10 characters) to create valid semver version:
+  # v20220510-v1.24.0-alpha.0-15-g09bd268 => v1.24.0-alpha.0-15-g09bd268
+  _SHORT_TAG: '${_GIT_TAG:10}'
+  # _PULL_BASE_REF will contain the ref that was pushed to to trigger this
+  # build - a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
+  _PULL_BASE_REF: 'master'


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
