### PR TITLE
[charts/occm] Implement imagePullSecret support for release 1.28

### DIFF
--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.28.2
+version: 2.28.3
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -25,6 +25,10 @@ spec:
       labels:
         {{- include "occm.controllermanager.labels" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -9,6 +9,11 @@ commonAnnotations: {}
 #   "helm.sh/hook-weight": "-100"
 #   "helm.sh/hook-delete-policy": before-hook-creation
 
+# List of secrets to use as image pull secret
+imagePullSecrets: []
+# - pull-secret-1
+# - pull-secret-2
+
 # Image repository name and tag
 image:
   repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements `imagePullSecrets` for the `openstack-cloud-controller-manager` helm chart on release 1.28 branch.

**Which issue this PR fixes(if applicable)**:
None applicable

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
