### PR TITLE
[release-1.26] [occm] Use standard service account name in OCCM helm chart

### DIFF
--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.26.4
+version: 2.26.5
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: system:openstack-cloud-controller-manager
+  name: {{ .Values.clusterRoleName }}
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/charts/openstack-cloud-controller-manager/templates/clusterrolebinding.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrolebinding.yaml
@@ -1,12 +1,13 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:openstack-cloud-controller-manager
+  name: {{ .Values.clusterRoleName }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:openstack-cloud-controller-manager
+  name: {{ .Values.clusterRoleName }}
 subjects:
 - kind: ServiceAccount
-  name: openstack-cloud-controller-manager
+  name: {{ .Values.serviceAccountName }}
   namespace: {{ .Release.Namespace | quote }}

--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: openstack-cloud-controller-manager
+      serviceAccountName: {{ .Values.serviceAccountName }}
       containers:
         - name: openstack-cloud-controller-manager
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"

--- a/charts/openstack-cloud-controller-manager/templates/serviceaccount.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: openstack-cloud-controller-manager
+  name: {{ .Values.serviceAccountName }}
   namespace: {{ .Release.Namespace }}

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -114,6 +114,6 @@ extraVolumeMounts:
 cluster:
   name: kubernetes
 
-clusterRoleName : system:cloud-controller-manager
+clusterRoleName: system:cloud-controller-manager
 
 serviceAccountName: cloud-controller-manager

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -113,3 +113,7 @@ extraVolumeMounts:
 # cluster name that used for created cluster
 cluster:
   name: kubernetes
+
+clusterRoleName : system:cloud-controller-manager
+
+serviceAccountName: cloud-controller-manager


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a cherry-pick of:

- #2332
- #2347

**Which issue this PR fixes(if applicable)**:
fixes #2440

**Special notes for reviewers**:

At the time #2332 was merged the CI was sadly somewhat broken and missed a spurious space. This has been fixed in #2347 which is also included here to ensure that CI is passing.

As discussed, I bumped the helm chart version to `2.26.5`.

I've also tested this helm chart version in a new 1.26 cluster and was unable to reproduce the bug fixed in #2332.

Please let me know if you'd like me to combine (i.e. squash/fixup) both commits in here into a single, correct, one.

**Release note**:

```release-note
ACTION REQUIRED: Please note that you might have to delete the `cloud-controller-manager` service account in the `kube-system` namespace if it exists, as upgrading with helm would fail otherwise.
```
