### PR TITLE
mod : removed the unused service config argument and modified the tes…

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1433,7 +1433,7 @@ func (lbaas *LbaasV2) buildListenerCreateOpt(port corev1.ServicePort, svcConf *s
 }
 
 // getMemberSubnetID gets the configured member-subnet-id from the different possible sources.
-func (lbaas *LbaasV2) getMemberSubnetID(service *corev1.Service, svcConf *serviceConfig) (string, error) {
+func (lbaas *LbaasV2) getMemberSubnetID(service *corev1.Service) (string, error) {
 	// Get Member Subnet from Service Annotation
 	memberSubnetIDAnnotation := getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerMemberSubnetID, "")
 	if memberSubnetIDAnnotation != "" {
@@ -1532,7 +1532,7 @@ func (lbaas *LbaasV2) checkServiceUpdate(service *corev1.Service, nodes []*corev
 	svcConf.supportLBTags = openstackutil.IsOctaviaFeatureSupported(lbaas.lb, openstackutil.OctaviaFeatureTags, lbaas.opts.LBProvider)
 
 	// Find subnet ID for creating members
-	memberSubnetID, err := lbaas.getMemberSubnetID(service, svcConf)
+	memberSubnetID, err := lbaas.getMemberSubnetID(service)
 	if err != nil {
 		return fmt.Errorf("unable to get member-subnet-id, %w", err)
 	}
@@ -1679,7 +1679,7 @@ func (lbaas *LbaasV2) checkService(service *corev1.Service, nodes []*corev1.Node
 
 	// Override the specific member-subnet-id, if explictly configured.
 	// Otherwise use subnet-id.
-	memberSubnetID, err := lbaas.getMemberSubnetID(service, svcConf)
+	memberSubnetID, err := lbaas.getMemberSubnetID(service)
 	if err != nil {
 		return fmt.Errorf("unable to get member-subnet-id, %w", err)
 	}

--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -1618,7 +1618,7 @@ func TestLbaasV2_getMemberSubnetID(t *testing.T) {
 				},
 			}
 
-			got, err := lbaas.getMemberSubnetID(tt.service, &serviceConfig{})
+			got, err := lbaas.getMemberSubnetID(tt.service)
 			if tt.wantErr != "" {
 				assert.EqualError(t, err, tt.wantErr)
 			} else {


### PR DESCRIPTION
* openstack-cloud-controller-manager (occm)
- removed the redundant method argument `serviceConfig` that isn't used in the method and called around the program 

*[ pro ] :  it reduces complexity of program definition and easy readability of the method


 ```release-note 
 NONE 
 ```