### PR TITLE
[octavia-lb] Add the logic to reattach the VIP to the load balancer if the IP has changed

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -303,13 +303,17 @@ spec:
 
 Sometimes it's useful to use an existing available floating IP rather than creating a new one, especially in the automation scenario. In the example below, 122.112.219.229 is an available floating IP created in the OpenStack Networking service.
 
-> NOTE: If 122.112.219.229 is not available, a new floating IP will be created automatically from the configured public network. If 122.112.219.229 is already associated with another port, the Service creation will fail.
+The service’s annotation loadbalancer.openstack.org/floating-ip can also be utilized to specify a desired floating IP. If this annotation exists and is not empty, the value contained in it will be used as the floating IP. Otherwise, the spec.loadBalancerIP field will be used as shown in the example below.
+
+> NOTE: If the specified floating-ip is not available, a new floating IP will be created automatically from the configured public network. If the specified floating-ip is already associated with another port, the Service creation will fail. 
 
 ```yaml
 apiVersion: v1
 kind: Service
 metadata:
   name: nginx-internet
+  annotations:
+    loadbalancer.openstack.org/floating-ip: "122.112.219.220"  
 spec:
   type: LoadBalancer
   selector:

--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -134,6 +134,12 @@ Request Body:
 
   If 'true', the floating IP will **NOT** be deleted. Default is 'false'.
 
+- `loadbalancer.openstack.org/floating-ip`
+
+  This annotation is utilized to specify the floating IP for the load balancer. 
+
+  If set, both newly created and pre-existing load balancers will utilize it. Furthermore, its precedence is higher than that of `Spec.LoadBalanccerIP`.
+
 - `loadbalancer.openstack.org/proxy-protocol`
 
   If 'true', the loadbalancer pool protocol will be set as `PROXY`. Default is 'false'.

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -73,6 +73,7 @@ const (
 	ServiceAnnotationLoadBalancerFloatingSubnetTags   = "loadbalancer.openstack.org/floating-subnet-tags"
 	ServiceAnnotationLoadBalancerClass                = "loadbalancer.openstack.org/class"
 	ServiceAnnotationLoadBalancerKeepFloatingIP       = "loadbalancer.openstack.org/keep-floatingip"
+	ServiceAnnotationLoadBalancerFloatingIP           = "loadbalancer.openstack.org/floating-ip"
 	ServiceAnnotationLoadBalancerPortID               = "loadbalancer.openstack.org/port-id"
 	ServiceAnnotationLoadBalancerProxyEnabled         = "loadbalancer.openstack.org/proxy-protocol"
 	ServiceAnnotationLoadBalancerSubnetID             = "loadbalancer.openstack.org/subnet-id"
@@ -431,7 +432,13 @@ func getSecurityGroupName(service *corev1.Service) string {
 }
 
 func getLoadBalancerIP(service *corev1.Service) string {
-	return service.Spec.LoadBalancerIP
+	loadBalancerIP := service.Spec.LoadBalancerIP
+	if annotations := service.Annotations; annotations != nil {
+		if val, ok := annotations[ServiceAnnotationLoadBalancerFloatingIP]; ok && val != "" {
+			return val
+		}
+	}
+	return loadBalancerIP
 }
 
 func getFullServiceName(service *corev1.Service) string {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #2443

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Enable OCCM to reassign the new Floating IP from service.spec when spec.loadBalancerIP is changed.
```
