### PR TITLE
Documentation Update: New Image Build Command 

### DIFF
--- a/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
+++ b/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
@@ -262,7 +262,7 @@ To build cinder-csi-plugin image
 
 ```
 $ export ARCH=amd64 # Defaults to amd64
-$ make image-cinder-csi-plugin
+$ make build-local-image-cinder-csi-plugin
 ``` 
 
 ### Testing

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -106,7 +106,7 @@ In cloud-provider-openstack repo directory, run:
 ```
 REGISTRY=<your-dockerhub-account> \
 VERSION=<image-tag> \
-make image-openstack-cloud-controller-manager
+make build-local-image-openstack-cloud-controller-manager
 ```
 
 The above command builds a container image locally with the name:
@@ -121,7 +121,7 @@ You may notice there is a suffix `-amd64` because cloud-provider-openstack suppo
 ARCH=amd64 \
 REGISTRY=<your-dockerhub-account> \
 VERSION=<image-tag> \
-make image-openstack-cloud-controller-manager
+make build-local-image-openstack-cloud-controller-manager
 ```
 
 If the kubernetes cluster can't access the image locally, you need to upload the image to container registry first by running `docker push`.


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Updates the image build command
**Which issue this PR fixes(if applicable)**:
fixes #2269

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
