### PR TITLE
[charts/occm] Support `extraEnv` on the cloud-controller-manager helm chart

### DIFF
--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.29.0-alpha.4
+version: 2.29.0-alpha.5
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -98,6 +98,9 @@ spec:
               value: /etc/config/cloud.conf
             - name: CLUSTER_NAME
               value: {{ .Values.cluster.name }}
+            {{- if .Values.extraEnv }}
+              {{- toYaml .Values.extraEnv | nindent 12 }}
+            {{- end }}
       {{- if .Values.extraInitContainers }}
       initContainers: {{ toYaml .Values.extraInitContainers | nindent 6 }}
       {{- end }}

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -20,6 +20,11 @@ extraInitContainers: []
 #   image: busybox
 #   command: ['sh', '-c', 'echo waiting for 10 seconds; sleep 10;']
 
+# Additional environment variables for the cloud-controller-manager.
+extraEnv: []
+# - name: OS_CCM_REGIONAL
+#   value: "true"
+
 # Set resources for Kubernetes daemonset
 resources: {}
 # resources:


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Add a new configuration option `extraEnv` in the cloud-controller-manager helm chart, which are passed to the daemonset.

**Which issue this PR fixes(if applicable)**:

This allows setting `OS_CCM_REGIONAL`, or perhaps other config options as needed.

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add optional `extraEnv` configuration to the openstack-cloud-controller-manager helm chart
```
