### PR TITLE
[release-1.28] Remove duplicate pflag.Parse calls

### DIFF
--- a/cmd/client-keystone-auth/main.go
+++ b/cmd/client-keystone-auth/main.go
@@ -187,9 +187,8 @@ func main() {
 	logs.AddFlags(pflag.CommandLine)
 
 	pflag.CommandLine.AddGoFlagSet(klogFlags)
-	kflag.InitFlags()
 
-	pflag.Parse()
+	kflag.InitFlags()
 
 	if showVersion {
 		fmt.Println(version.Version)

--- a/cmd/k8s-keystone-auth/main.go
+++ b/cmd/k8s-keystone-auth/main.go
@@ -55,19 +55,18 @@ func main() {
 		}
 	})
 
-	pflag.Parse()
-
-	if showVersion {
-		fmt.Println(version.Version)
-		os.Exit(0)
-	}
-
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
 	config := keystone.NewConfig()
 	config.AddFlags(pflag.CommandLine)
+
 	kflag.InitFlags()
+
+	if showVersion {
+		fmt.Println(version.Version)
+		os.Exit(0)
+	}
 
 	if err := config.ValidateFlags(); err != nil {
 		klog.Errorf("%v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a partial backport of #2325, namely the fixes for issues introduced by #2324. This will fix #2464.

**Which issue this PR fixes(if applicable)**:

Fixes #2464

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
