### PR TITLE
Add Test Case for Protocol Forced to HTTP in `buildListenerCreateOpt` function [OCP]

### DIFF
--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -2385,6 +2385,27 @@ func TestBuildListenerCreateOpt(t *testing.T) {
 				Tags:                   nil,
 			},
 		},
+		{
+			name: "Test with Protocol forced to HTTP",
+			port: corev1.ServicePort{
+				Protocol: "TCP",
+				Port:     80,
+			},
+			svcConf: &serviceConfig{
+				connLimit:       100,
+				lbName:          "my-lb",
+				keepClientIP:    true,
+				tlsContainerRef: "",
+			},
+			expectedCreateOpt: listeners.CreateOpts{
+				Name:          "Test with Protocol forced to HTTP",
+				Protocol:      listeners.ProtocolHTTP,
+				ProtocolPort:  80,
+				ConnLimit:     &svcConf.connLimit,
+				InsertHeaders: map[string]string{"X-Forwarded-For": "true"},
+				Tags:          nil,
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
adds test case for protocol forced to http in the `buildListenerCreateOpt` function

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
