### PR TITLE
Doc: update doc to be a better link with examples

### DIFF
--- a/docs/cinder-csi-plugin/features.md
+++ b/docs/cinder-csi-plugin/features.md
@@ -90,7 +90,7 @@ This feature allows CSI volumes to be directly embedded in the Pod specification
 
 As of Kubernetes v1.21, this is beta feature and enabled by default.
 
-The key design idea is that the parameters for a volume claim are allowed inside a volume source of the Pod. For sample app, refer [here](../../examples/cinder-csi-plugin/ephemeral/generic-ephemeral-volumes.yaml)
+The key design idea is that the parameters for a volume claim are allowed inside a volume source of the Pod. For sample app, refer [here](./examples.md#generic-ephemeral-volumes)
 
 ## Volume Cloning
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
