### PR TITLE
cinder-csi: Adds support for managing backups (kubernetes#2473)

### DIFF
--- a/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
+++ b/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
@@ -267,7 +267,9 @@ helm install --namespace kube-system --name cinder-csi ./charts/cinder-csi-plugi
 | StorageClass `parameters`  | `availability`          | `nova`          | String. Volume Availability Zone |
 | StorageClass `parameters`  | `type`                  | Empty String    | String. Name/ID of Volume type. Corresponding volume type should exist in cinder     |
 | VolumeSnapshotClass `parameters` | `force-create`    | `false`         | Enable to support creating snapshot for a volume in in-use status |
-| Inline Volume `volumeAttributes`   | `capacity`              | `1Gi`       | volume size for creating inline volumes|
+| VolumeSnapshotClass `parameters` | `type`            | Empty String    | `snapshot` creates a VolumeSnapshot object linked to a Cinder volume snapshot. `backup` creates a VolumeSnapshot object linked to a cinder volume backup. Defaults to `snapshot` if not defined |
+| VolumeSnapshotClass `parameters` | `backup-max-duration-seconds-per-gb`  | `20`    | Defines the amount of time to wait for a backup to complete in seconds per GB of volume size |
+| Inline Volume `volumeAttributes`   | `capacity`              | `1Gi`       | volume size for creating inline volumes| 
 | Inline Volume `VolumeAttributes`   | `type`              | Empty String  | Name/ID of Volume type. Corresponding volume type should exist in cinder |
 
 ## Local Development

--- a/pkg/csi/cinder/fake.go
+++ b/pkg/csi/cinder/fake.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cinder
 
 import (
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/backups"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"golang.org/x/net/context"
@@ -94,6 +95,7 @@ var FakeSnapshotRes = snapshots.Snapshot{
 	Name:     "fake-snapshot",
 	VolumeID: FakeVolID,
 	Size:     1,
+	Status:   "available",
 }
 
 var FakeSnapshotsRes = []snapshots.Snapshot{FakeSnapshotRes}
@@ -102,6 +104,7 @@ var FakeVolListMultiple = []volumes.Volume{FakeVol1, FakeVol3}
 var FakeVolList = []volumes.Volume{FakeVol1}
 var FakeVolListEmpty = []volumes.Volume{}
 var FakeSnapshotListEmpty = []snapshots.Snapshot{}
+var FakeBackupListEmpty = []backups.Backup{}
 
 var FakeInstanceID = "321a8b81-3660-43e5-bab8-6470b65ee4e8"
 

--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -150,7 +150,7 @@ func nodePublishEphemeral(req *csi.NodePublishVolumeRequest, ns *nodeServer) (*c
 		volumeType = ""
 	}
 
-	evol, err := ns.Cloud.CreateVolume(volName, size, volumeType, volAvailability, "", "", &properties)
+	evol, err := ns.Cloud.CreateVolume(volName, size, volumeType, volAvailability, "", "", "", properties)
 
 	if err != nil {
 		klog.V(3).Infof("Failed to Create Ephemeral Volume: %v", err)

--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -129,7 +129,7 @@ func TestNodePublishVolumeEphermeral(t *testing.T) {
 	fvolName := fmt.Sprintf("ephemeral-%s", FakeVolID)
 	tState := []string{"available"}
 
-	omock.On("CreateVolume", fvolName, 2, "test", "nova", "", "", &properties).Return(&FakeVol, nil)
+	omock.On("CreateVolume", fvolName, 2, "test", "nova", "", "", "", properties).Return(&FakeVol, nil)
 
 	omock.On("AttachVolume", FakeNodeID, FakeVolID).Return(FakeVolID, nil)
 	omock.On("WaitDiskAttached", FakeNodeID, FakeVolID).Return(nil)

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/backups"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
@@ -44,7 +45,7 @@ func AddExtraFlags(fs *pflag.FlagSet) {
 }
 
 type IOpenStack interface {
-	CreateVolume(name string, size int, vtype, availability string, snapshotID string, sourcevolID string, tags *map[string]string) (*volumes.Volume, error)
+	CreateVolume(name string, size int, vtype, availability string, snapshotID string, sourceVolID string, sourceBackupID string, tags map[string]string) (*volumes.Volume, error)
 	DeleteVolume(volumeID string) error
 	AttachVolume(instanceID, volumeID string) (string, error)
 	ListVolumes(limit int, startingToken string) ([]volumes.Volume, string, error)
@@ -55,11 +56,17 @@ type IOpenStack interface {
 	GetAttachmentDiskPath(instanceID, volumeID string) (string, error)
 	GetVolume(volumeID string) (*volumes.Volume, error)
 	GetVolumesByName(name string) ([]volumes.Volume, error)
-	CreateSnapshot(name, volID string, tags *map[string]string) (*snapshots.Snapshot, error)
+	CreateSnapshot(name, volID string, tags map[string]string) (*snapshots.Snapshot, error)
 	ListSnapshots(filters map[string]string) ([]snapshots.Snapshot, string, error)
 	DeleteSnapshot(snapID string) error
 	GetSnapshotByID(snapshotID string) (*snapshots.Snapshot, error)
-	WaitSnapshotReady(snapshotID string) error
+	WaitSnapshotReady(snapshotID string) (string, error)
+	CreateBackup(name, volID string, snapshotID string, tags map[string]string) (*backups.Backup, error)
+	ListBackups(filters map[string]string) ([]backups.Backup, error)
+	DeleteBackup(backupID string) error
+	GetBackupByID(backupID string) (*backups.Backup, error)
+	BackupsAreEnabled() (bool, error)
+	WaitBackupReady(backupID string, snapshotSize int, backupMaxDurationSecondsPerGB int) (string, error)
 	GetInstanceByID(instanceID string) (*servers.Server, error)
 	ExpandVolume(volumeID string, status string, size int) error
 	GetMaxVolLimit() int64

--- a/pkg/csi/cinder/openstack/openstack_backups.go
+++ b/pkg/csi/cinder/openstack/openstack_backups.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package openstack backups provides an implementation of Cinder Backup features
+// cinder functions using Gophercloud.
+package openstack
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/backups"
+	"golang.org/x/net/context"
+	"k8s.io/cloud-provider-openstack/pkg/metrics"
+	"k8s.io/klog/v2"
+)
+
+const (
+	backupReadyStatus                    = "available"
+	backupErrorStatus                    = "error"
+	backupBinary                         = "cinder-backup"
+	backupDescription                    = "Created by OpenStack Cinder CSI driver"
+	BackupMaxDurationSecondsPerGBDefault = 20
+	BackupMaxDurationPerGB               = "backup-max-duration-seconds-per-gb"
+	backupBaseDurationSeconds            = 30
+	backupReadyCheckIntervalSeconds      = 7
+)
+
+// CreateBackup issues a request to create a Backup from the specified Snapshot with the corresponding ID and
+// returns the resultant gophercloud Backup Item upon success.
+func (os *OpenStack) CreateBackup(name, volID string, snapshotID string, tags map[string]string) (*backups.Backup, error) {
+	blockstorageServiceClient, err := openstack.NewBlockStorageV3(os.blockstorage.ProviderClient, os.epOpts)
+	if err != nil {
+		return &backups.Backup{}, err
+	}
+
+	force := false
+	// if no flag given, then force will be false by default
+	// if flag it given , check it
+	if item, ok := (tags)[SnapshotForceCreate]; ok {
+		var err error
+		force, err = strconv.ParseBool(item)
+		if err != nil {
+			klog.V(5).Infof("Make force create flag to false due to: %v", err)
+		}
+		delete(tags, SnapshotForceCreate)
+	}
+
+	opts := &backups.CreateOpts{
+		VolumeID:    volID,
+		SnapshotID:  snapshotID,
+		Name:        name,
+		Force:       force,
+		Description: backupDescription,
+	}
+
+	if tags != nil {
+		// Set openstack microversion to 3.43 to send metadata along with the backup
+		blockstorageServiceClient.Microversion = "3.43"
+		opts.Metadata = tags
+	}
+
+	// TODO: Do some check before really call openstack API on the input
+	mc := metrics.NewMetricContext("backup", "create")
+	backup, err := backups.Create(blockstorageServiceClient, opts).Extract()
+	if mc.ObserveRequest(err) != nil {
+		return &backups.Backup{}, err
+	}
+	// There's little value in rewrapping these gophercloud types into yet another abstraction/type, instead just
+	// return the gophercloud item
+	return backup, nil
+}
+
+// ListBackups retrieves a list of active backups from Cinder for the corresponding Tenant.  We also
+// provide the ability to provide limit and offset to enable the consumer to provide accurate pagination.
+// In addition the filters argument provides a mechanism for passing in valid filter strings to the list
+// operation.  Valid filter keys are:  Name, Status, VolumeID, Limit, Marker (TenantID has no effect).
+func (os *OpenStack) ListBackups(filters map[string]string) ([]backups.Backup, error) {
+	var allBackups []backups.Backup
+
+	// Build the Opts
+	opts := backups.ListOpts{}
+	for key, val := range filters {
+		switch key {
+		case "Status":
+			opts.Status = val
+		case "Name":
+			opts.Name = val
+		case "VolumeID":
+			opts.VolumeID = val
+		case "Marker":
+			opts.Marker = val
+		case "Limit":
+			opts.Limit, _ = strconv.Atoi(val)
+		default:
+			klog.V(3).Infof("Not a valid filter key %s", key)
+		}
+	}
+	mc := metrics.NewMetricContext("backup", "list")
+
+	allPages, err := backups.List(os.blockstorage, opts).AllPages()
+	if err != nil {
+		return nil, err
+	}
+	allBackups, err = backups.ExtractBackups(allPages)
+	if err != nil {
+		return nil, err
+	}
+
+	if mc.ObserveRequest(err) != nil {
+		return nil, err
+	}
+
+	return allBackups, nil
+}
+
+// DeleteBackup issues a request to delete the Backup with the specified ID from the Cinder backend.
+func (os *OpenStack) DeleteBackup(backupID string) error {
+	mc := metrics.NewMetricContext("backup", "delete")
+	err := backups.Delete(os.blockstorage, backupID).ExtractErr()
+	if mc.ObserveRequest(err) != nil {
+		klog.Errorf("Failed to delete backup: %v", err)
+	}
+	return err
+}
+
+// GetBackupByID returns backup details by id.
+func (os *OpenStack) GetBackupByID(backupID string) (*backups.Backup, error) {
+	mc := metrics.NewMetricContext("backup", "get")
+	backup, err := backups.Get(os.blockstorage, backupID).Extract()
+	if mc.ObserveRequest(err) != nil {
+		klog.Errorf("Failed to get backup: %v", err)
+		return nil, err
+	}
+	return backup, nil
+}
+
+func (os *OpenStack) BackupsAreEnabled() (bool, error) {
+	// TODO: Check if the backup service is enabled
+	return true, nil
+}
+
+// WaitBackupReady waits until backup is ready. It waits longer depending on
+// the size of the corresponding snapshot.
+func (os *OpenStack) WaitBackupReady(backupID string, snapshotSize int, backupMaxDurationSecondsPerGB int) (string, error) {
+	var err error
+
+	duration := time.Duration(backupMaxDurationSecondsPerGB*snapshotSize + backupBaseDurationSeconds)
+
+	err = os.waitBackupReadyWithContext(backupID, duration)
+	if err == context.DeadlineExceeded {
+		err = fmt.Errorf("timeout, Backup %s is still not Ready: %v", backupID, err)
+	}
+
+	back, _ := os.GetBackupByID(backupID)
+
+	if back != nil {
+		return back.Status, err
+	} else {
+		return "Failed to get backup status", err
+	}
+}
+
+// Supporting function for WaitBackupReady().
+// Allows for a timeout while waiting for the backup to be ready.
+func (os *OpenStack) waitBackupReadyWithContext(backupID string, duration time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), duration*time.Second)
+	defer cancel()
+	var done bool
+	var err error
+	ticker := time.NewTicker(backupReadyCheckIntervalSeconds * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			done, err = os.backupIsReady(backupID)
+			if err != nil {
+				return err
+			}
+
+			if done {
+				return nil
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+}
+
+// Supporting function for waitBackupReadyWithContext().
+// Returns true when the backup is ready.
+func (os *OpenStack) backupIsReady(backupID string) (bool, error) {
+	backup, err := os.GetBackupByID(backupID)
+	if err != nil {
+		return false, err
+	}
+
+	if backup.Status == backupErrorStatus {
+		return false, errors.New("backup is in error state")
+	}
+
+	return backup.Status == backupReadyStatus, nil
+}

--- a/pkg/csi/cinder/openstack/openstack_mock.go
+++ b/pkg/csi/cinder/openstack/openstack_mock.go
@@ -17,6 +17,7 @@ limitations under the License.
 package openstack
 
 import (
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/backups"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
@@ -39,6 +40,18 @@ var fakeSnapshot = snapshots.Snapshot{
 	Size:     1,
 	VolumeID: "CSIVolumeID",
 	Metadata: make(map[string]string),
+}
+
+var fakemap = make(map[string]string)
+
+var fakeBackup = backups.Backup{
+	ID:         "eb5e4e9a-a4e5-4728-a748-04f9e2868573",
+	Name:       "fake-snapshot",
+	Status:     "available",
+	Size:       1,
+	VolumeID:   "CSIVolumeID",
+	SnapshotID: "261a8b81-3660-43e5-bab8-6470b65ee4e8",
+	Metadata:   &fakemap,
 }
 
 // revive:disable:exported
@@ -72,19 +85,19 @@ func (_m *OpenStackMock) AttachVolume(instanceID string, volumeID string) (strin
 }
 
 // CreateVolume provides a mock function with given fields: name, size, vtype, availability, tags
-func (_m *OpenStackMock) CreateVolume(name string, size int, vtype string, availability string, snapshotID string, sourceVolID string, tags *map[string]string) (*volumes.Volume, error) {
-	ret := _m.Called(name, size, vtype, availability, snapshotID, sourceVolID, tags)
+func (_m *OpenStackMock) CreateVolume(name string, size int, vtype string, availability string, snapshotID string, sourceVolID string, sourceBackupID string, tags map[string]string) (*volumes.Volume, error) {
+	ret := _m.Called(name, size, vtype, availability, snapshotID, sourceVolID, sourceBackupID, tags)
 
 	var r0 *volumes.Volume
-	if rf, ok := ret.Get(0).(func(string, int, string, string, string, string, *map[string]string) *volumes.Volume); ok {
-		r0 = rf(name, size, vtype, availability, snapshotID, sourceVolID, tags)
+	if rf, ok := ret.Get(0).(func(string, int, string, string, string, string, string, map[string]string) *volumes.Volume); ok {
+		r0 = rf(name, size, vtype, availability, snapshotID, sourceVolID, sourceBackupID, tags)
 	} else {
 		r0 = ret.Get(0).(*volumes.Volume)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, int, string, string, string, string, *map[string]string) error); ok {
-		r1 = rf(name, size, vtype, availability, snapshotID, sourceVolID, tags)
+	if rf, ok := ret.Get(1).(func(string, int, string, string, string, string, string, map[string]string) error); ok {
+		r1 = rf(name, size, vtype, availability, snapshotID, sourceVolID, sourceBackupID, tags)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -245,11 +258,11 @@ func (_m *OpenStackMock) ListSnapshots(filters map[string]string) ([]snapshots.S
 }
 
 // CreateSnapshot provides a mock function with given fields: name, volID, tags
-func (_m *OpenStackMock) CreateSnapshot(name string, volID string, tags *map[string]string) (*snapshots.Snapshot, error) {
+func (_m *OpenStackMock) CreateSnapshot(name string, volID string, tags map[string]string) (*snapshots.Snapshot, error) {
 	ret := _m.Called(name, volID, tags)
 
 	var r0 *snapshots.Snapshot
-	if rf, ok := ret.Get(0).(func(string, string, *map[string]string) *snapshots.Snapshot); ok {
+	if rf, ok := ret.Get(0).(func(string, string, map[string]string) *snapshots.Snapshot); ok {
 		r0 = rf(name, volID, tags)
 	} else {
 		if ret.Get(0) != nil {
@@ -258,7 +271,7 @@ func (_m *OpenStackMock) CreateSnapshot(name string, volID string, tags *map[str
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string, *map[string]string) error); ok {
+	if rf, ok := ret.Get(1).(func(string, string, map[string]string) error); ok {
 		r1 = rf(name, volID, tags)
 	} else {
 		r1 = ret.Error(1)
@@ -274,6 +287,62 @@ func (_m *OpenStackMock) DeleteSnapshot(snapID string) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string) error); ok {
 		r0 = rf(snapID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+func (_m *OpenStackMock) ListBackups(filters map[string]string) ([]backups.Backup, error) {
+	ret := _m.Called(filters)
+
+	var r0 []backups.Backup
+	if rf, ok := ret.Get(0).(func(map[string]string) []backups.Backup); ok {
+		r0 = rf(filters)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]backups.Backup)
+		}
+	}
+	var r1 error
+	if rf, ok := ret.Get(1).(func(map[string]string) error); ok {
+		r1 = rf(filters)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+func (_m *OpenStackMock) CreateBackup(name, volID string, snapshotID string, tags map[string]string) (*backups.Backup, error) {
+	ret := _m.Called(name, volID, snapshotID, tags)
+
+	var r0 *backups.Backup
+	if rf, ok := ret.Get(0).(func(string, string, string, map[string]string) *backups.Backup); ok {
+		r0 = rf(name, volID, snapshotID, tags)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*backups.Backup)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string, string, map[string]string) error); ok {
+		r1 = rf(name, volID, snapshotID, tags)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+func (_m *OpenStackMock) DeleteBackup(backupID string) error {
+	ret := _m.Called(backupID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(backupID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -342,21 +411,57 @@ func (_m *OpenStackMock) GetSnapshotByID(snapshotID string) (*snapshots.Snapshot
 	return &fakeSnapshot, nil
 }
 
-func (_m *OpenStackMock) WaitSnapshotReady(snapshotID string) error {
+func (_m *OpenStackMock) WaitSnapshotReady(snapshotID string) (string, error) {
 	ret := _m.Called(snapshotID)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
 		r0 = rf(snapshotID)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.String(0)
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(snapshotID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+func (_m *OpenStackMock) GetBackupByID(backupID string) (*backups.Backup, error) {
+
+	return &fakeBackup, nil
+}
+
+func (_m *OpenStackMock) WaitBackupReady(backupID string, snapshotSize int, backupMaxDurationSecondsPerGB int) (string, error) {
+	ret := _m.Called(backupID)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(backupID)
+	} else {
+		r0 = ret.String(0)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(backupID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 func (_m *OpenStackMock) GetMaxVolLimit() int64 {
 	return 256
+}
+
+func (_m *OpenStackMock) BackupsAreEnabled() (bool, error) {
+	return true, nil
 }
 
 func (_m *OpenStackMock) GetInstanceByID(instanceID string) (*servers.Server, error) {


### PR DESCRIPTION
<!--
[cinder-csi-plugin] Adds support for managing backups
-->

**What this PR does / why we need it**:
This allows for creating and deleting cinder backups from K8S via VolumeSnapshot objects that have a VolumeSnapshotClass with `parameters.type = "backup"`. 

Backups are different from snapshots in that they are usually stored off-site, for example via S3 or NFS.

**Which issue this PR fixes(if applicable)**:
fixes #2473 

**Special notes for reviewers**:
Create a VolumeSnapshotClass that has parameters.type equal to "backup"
```
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshotClass
metadata:
  name: csi-cinder-snapclass
driver: cinder.csi.openstack.org
deletionPolicy: Delete
parameters:
  force-create: "false"
  type: "snapshot"
```

Create a volumeSnapshot that has a Cinder PVC as the Source. This creates a Backup. Deleting this also deletes the backup.
```
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  name: new-snapshot-demo
spec:
  volumeSnapshotClassName: csi-cinder-snapclass
  source:
    persistentVolumeClaimName: pvc-snapshot-demo
```

Create a PVC that has the previouse VolumeSnapshot as the source.
The requested size must be greater than the backup size.
This creates a volume populated with the backup data.
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: snapshot-demo-restore
spec:
  storageClassName: csi-sc-cinderplugin
  dataSource:
    name: new-snapshot-demo
    kind: VolumeSnapshot
    apiGroup: snapshot.storage.k8s.io
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 2Gi
```

**Release note**:
```release-note
[cinder-csi-plugin] Adds support for managing cinder backups via volumeSnapshot objects by adding a parameter to the corresponding volumeSnapshotClass
```
