### PR TITLE
[occm] Improve route controller reconciling to ensure the cluster's nodes can access each other

### DIFF
--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -177,6 +177,9 @@ The options in `Global` section are used for openstack-cloud-controller-manager 
 
 * `router-id`
   Specifies the Neutron router ID to activate [route controller](https://kubernetes.io/docs/concepts/architecture/cloud-controller/#route-controller) to manage Kubernetes cluster routes.
+* `auto-config-node-security-group`
+  Whether or not to enable auto config node security group feature. The node security group used to ensure the node permit other nodes packets enter into.
+   Default: false 
 
   **NOTE: This require openstack-cloud-controller-manager's `--cluster-cidr` flag to be set.**
 

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -149,7 +149,8 @@ type NetworkingOpts struct {
 
 // RouterOpts is used for Neutron routes
 type RouterOpts struct {
-	RouterID string `gcfg:"router-id"`
+	RouterID                string `gcfg:"router-id"`
+	AutoConfigSecurityGroup bool   `gcfg:"auto-config-node-security-group"`
 }
 
 // OpenStack is an implementation of cloud provider Interface for OpenStack.
@@ -230,6 +231,7 @@ func ReadConfig(config io.Reader) (Config, error) {
 	cfg.LoadBalancer.ContainerStore = "barbican"
 	cfg.LoadBalancer.MaxSharedLB = 2
 	cfg.LoadBalancer.ProviderRequiresSerialAPICalls = false
+	cfg.Route.AutoConfigSecurityGroup = false
 
 	err := gcfg.FatalOnly(gcfg.ReadInto(&cfg, config))
 	if err != nil {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

In order to the nodes of one cluster can access each other, route controller need to check and set three things:

1. The openstack router's route rules, so that the packets can be forwarded to correct nodes.
2. The node port's AllowAddressPair, to ensure the node permit the packets that access the node's pods/services pass through.
3. The openstack security group's rules, so that the nodes that bind the security group permit the packets from other nodes enter into.

The current codes just check router's route rule when controller call `ListRoutes` and just set `Route` and `AllowAddressPair` when controller call `CreateRoute`. This PR complements all of the other works.

**Which issue this PR fixes(if applicable)**:
fixes #2482

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

This PR lack of unit tests, because of I found occm lack of a mechanism to mock openstack client. Further more the whole occm lack of lots of unit tests  due to the reason. I plan to dive deeper into gophercloud in the next several days try to study whether it is possible  to mock it. If it is possible I'll commit anohter PR to add the unit tests.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
