### PR TITLE
[cinder-csi-plugin] Fix dmesg binary in the container image

### DIFF
--- a/tools/csi-deps.sh
+++ b/tools/csi-deps.sh
@@ -63,7 +63,8 @@ else
 fi
 
 # To collect dmesg logs
-copy_deps /usr/bin/dmesg || copy_deps /bin/dmesg
+copy_deps /usr/bin/dmesg || true
+copy_deps /bin/dmesg || true
 
 # This utils are using by
 # go mod k8s.io/mount-utils


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

A follow-up fix for the #2486. It appeared that dmesg logs were not collected in the recent build: https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/cloud-provider-openstack/2486/openstack-cloud-csi-cinder-e2e-test/1734190366644506624/artifacts/logs/dmesg.log

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
