### PR TITLE
[tests] retry ubuntu image download on temp error

### DIFF
--- a/tests/playbooks/roles/install-k3s/tasks/main.yaml
+++ b/tests/playbooks/roles/install-k3s/tasks/main.yaml
@@ -16,8 +16,17 @@
 
       set +x; source openrc admin admin > /dev/null; set -x
       openstack image show {{ image_name }} > /dev/null 2>&1
+
       if [[ "$?" != "0" ]]; then
-        curl -sSL {{ image_url }} -o {{ image_name }}.img
+        # retry ubuntu image download on failure,
+        # e.g. "curl: (35) OpenSSL SSL_connect: Connection reset by peer in connection to cloud-images.ubuntu.com:443"
+        tries=0
+        until [ "$tries" -ge 5 ]; do
+          curl -sSL {{ image_url }} -o {{ image_name }}.img && break
+          echo "Error downloading an image"
+          ((tries++))
+          sleep 10
+        done
         openstack image create {{ image_name }} --container-format bare --disk-format qcow2 --public --file {{ image_name }}.img
       fi
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Quite frequently tests are failing because ubuntu image cannot be downloaded:

```
curl -sSL https://cloud-images.ubuntu.com/releases/jammy/release/ubuntu-22.04-server-cloudimg-amd64.img -o ubuntu-jammy.img
curl: (35) OpenSSL SSL_connect: Connection reset by peer in connection to cloud-images.ubuntu.com:443
```

This PR adds a retry 

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
