### PR TITLE
[e2e] Remove depending on `PULL_NUMBER` in e2e

### DIFF
--- a/tests/ci-csi-cinder-e2e.sh
+++ b/tests/ci-csi-cinder-e2e.sh
@@ -29,9 +29,7 @@ set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${REPO_ROOT}" || exit 1
-# PULL_NUMBER and PULL_BASE_REF are Prow job environment variables
-PR_NUMBER="${PULL_NUMBER:-}"
-[[ -z $PR_NUMBER ]] && echo "PR_NUMBER is required" && exit 1
+GOPATH=${PWD%/*/*/*}  # /home/prow/go will be 3 directories up from where code is
 CONFIG_ANSIBLE="${CONFIG_ANSIBLE:-"true"}"
 RESOURCE_TYPE="${RESOURCE_TYPE:-"gce-project"}"
 ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
@@ -97,6 +95,11 @@ stdout_callback = debug
 EOF
 fi
 
+# Upload CPO code
+scp -i ~/.ssh/google_compute_engine \
+  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+  -r ${GOPATH}/* ${USERNAME}@${PUBLIC_IP}:/root/
+
 # Run ansible playbook on the CI host, e.g. a VM in GCP
 # USERNAME and PUBLIC_IP are global env variables set after creating the CI host.
 ansible-playbook -v \
@@ -104,8 +107,7 @@ ansible-playbook -v \
   --private-key ~/.ssh/google_compute_engine \
   --inventory ${PUBLIC_IP}, \
   --ssh-common-args "-o StrictHostKeyChecking=no" \
-  tests/playbooks/test-csi-cinder-e2e.yaml \
-  -e github_pr=${PR_NUMBER}
+  tests/playbooks/test-csi-cinder-e2e.yaml
 exit_code=$?
 
 # Fetch cinder-csi tests logs for debugging purpose

--- a/tests/ci-csi-manila-e2e.sh
+++ b/tests/ci-csi-manila-e2e.sh
@@ -29,9 +29,7 @@ set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${REPO_ROOT}" || exit 1
-# PULL_NUMBER and PULL_BASE_REF are Prow job environment variables
-PR_NUMBER="${PULL_NUMBER:-}"
-[[ -z $PR_NUMBER ]] && echo "PR_NUMBER is required" && exit 1
+GOPATH=${PWD%/*/*/*}  # /home/prow/go will be 3 directories up from where code is
 CONFIG_ANSIBLE="${CONFIG_ANSIBLE:-"true"}"
 RESOURCE_TYPE="${RESOURCE_TYPE:-"gce-project"}"
 ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
@@ -97,6 +95,11 @@ stdout_callback = debug
 EOF
 fi
 
+# Upload CPO code
+scp -i ~/.ssh/google_compute_engine \
+  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+  -r ${GOPATH}/* ${USERNAME}@${PUBLIC_IP}:/root/
+
 # Run ansible playbook on the CI host, e.g. a VM in GCP
 # USERNAME and PUBLIC_IP are global env variables set after creating the CI host.
 ansible-playbook -v \
@@ -104,8 +107,7 @@ ansible-playbook -v \
   --private-key ~/.ssh/google_compute_engine \
   --inventory ${PUBLIC_IP}, \
   --ssh-common-args "-o StrictHostKeyChecking=no" \
-  tests/playbooks/test-csi-manila-e2e.yaml \
-  -e github_pr=${PR_NUMBER}
+  tests/playbooks/test-csi-manila-e2e.yaml
 exit_code=$?
 
 # Fetch manila-csi tests results

--- a/tests/playbooks/roles/install-cpo-occm/defaults/main.yaml
+++ b/tests/playbooks/roles/install-cpo-occm/defaults/main.yaml
@@ -1,5 +1,4 @@
 ---
-github_pr: ""
 devstack_workdir: "{{ ansible_user_dir }}/devstack"
 
 # Used for uploading image to local registry.

--- a/tests/playbooks/roles/install-cpo-occm/tasks/main.yaml
+++ b/tests/playbooks/roles/install-cpo-occm/tasks/main.yaml
@@ -3,13 +3,9 @@
   shell:
     executable: /bin/bash
     cmd: |
-      rm -rf $GOPATH/src/k8s.io/cloud-provider-openstack
-      mkdir -p $GOPATH/src/k8s.io; cd $_
-      git clone https://github.com/kubernetes/cloud-provider-openstack
-      cd cloud-provider-openstack
-      if [[ {{ github_pr }} != "" ]]; then
-        git fetch origin +refs/pull/{{ github_pr }}/merge
-        git checkout FETCH_HEAD; git checkout -b PR{{ github_pr }}
+      if [ ! -d $GOPATH/src/k8s.io/cloud-provider-openstack ]; then
+        mkdir -p $GOPATH/src/k8s.io; cd $_
+        git clone https://github.com/kubernetes/cloud-provider-openstack
       fi
 
 - name: Build and upload openstack-cloud-controller-manager image
@@ -17,10 +13,7 @@
     executable: /bin/bash
     cmd: |
       cd $GOPATH/src/k8s.io/cloud-provider-openstack
-      VERSION="latest"
-      if [[ {{ github_pr }} != "" ]]; then
-        VERSION=v0.0.{{ github_pr }}
-      fi
+      VERSION="v0.0.99" # Fake version, but in proper format.
 
       make push-multiarch-image-openstack-cloud-controller-manager \
         ARCHS='amd64' \
@@ -76,10 +69,8 @@
   shell:
     executable: /bin/bash
     cmd: |
-      VERSION="latest"
-      if [[ {{ github_pr }} != "" ]]; then
-        VERSION=v0.0.{{ github_pr }}
-      fi
+      VERSION="v0.0.99" # Fake version, but in proper format.
+
       cd $GOPATH/src/k8s.io/cloud-provider-openstack
       # replace image with built image
       sed -i "s#registry.k8s.io/provider-os/openstack-cloud-controller-manager:[^'\"]\+#{{ remote_registry_host }}/openstack-cloud-controller-manager:${VERSION}#" manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml

--- a/tests/playbooks/roles/install-csi-cinder/defaults/main.yaml
+++ b/tests/playbooks/roles/install-csi-cinder/defaults/main.yaml
@@ -1,5 +1,4 @@
 ---
-github_pr: ""
 devstack_workdir: "{{ ansible_user_dir }}/devstack"
 
 # Used for uploading image to local registry.

--- a/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
@@ -3,13 +3,9 @@
   shell:
     executable: /bin/bash
     cmd: |
-      rm -rf $GOPATH/src/k8s.io/cloud-provider-openstack
-      mkdir -p $GOPATH/src/k8s.io; cd $_
-      git clone https://github.com/kubernetes/cloud-provider-openstack
-      cd cloud-provider-openstack
-      if [[ {{ github_pr }} != "" ]]; then
-        git fetch origin +refs/pull/{{ github_pr }}/merge
-        git checkout FETCH_HEAD; git checkout -b PR{{ github_pr }}
+      if [ ! -d $GOPATH/src/k8s.io/cloud-provider-openstack ]; then
+        mkdir -p $GOPATH/src/k8s.io; cd $_
+        git clone https://github.com/kubernetes/cloud-provider-openstack
       fi
 
 - name: Build and upload cinder-csi-plugin image
@@ -17,10 +13,7 @@
     executable: /bin/bash
     cmd: |
       cd $GOPATH/src/k8s.io/cloud-provider-openstack
-      VERSION="latest"
-      if [[ {{ github_pr }} != "" ]]; then
-        VERSION=v0.0.{{ github_pr }}
-      fi
+      VERSION="v0.0.99" # Fake version, but in proper format.
 
       make push-multiarch-image-cinder-csi-plugin \
         ARCHS='amd64' \
@@ -65,10 +58,7 @@
 
       sed -i "/cloud\.conf/c\  cloud.conf: $b64data" manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml
 
-      VERSION="latest"
-      if [[ {{ github_pr }} != "" ]]; then
-        VERSION=v0.0.{{ github_pr }}
-      fi
+      VERSION="v0.0.99" # Fake version, but in proper format.
       # replace image with built image
       sed -i "s#registry.k8s.io/provider-os/cinder-csi-plugin:[^'\"]\+#{{ remote_registry_host }}/cinder-csi-plugin:${VERSION}#" manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
       sed -i "s#registry.k8s.io/provider-os/cinder-csi-plugin:[^'\"]\+#{{ remote_registry_host }}/cinder-csi-plugin:${VERSION}#" manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml

--- a/tests/playbooks/roles/install-csi-manila/defaults/main.yaml
+++ b/tests/playbooks/roles/install-csi-manila/defaults/main.yaml
@@ -1,5 +1,4 @@
 ---
-github_pr: ""
 devstack_workdir: "{{ ansible_user_dir }}/devstack"
 
 # Used for uploading image to local registry.

--- a/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
@@ -3,24 +3,17 @@
   shell:
     executable: /bin/bash
     cmd: |
-      rm -rf {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack
-      mkdir -p {{ ansible_user_dir }}/src/k8s.io; cd $_
-      git clone https://github.com/kubernetes/cloud-provider-openstack
-      cd cloud-provider-openstack
-      if [[ {{ github_pr }} != "" ]]; then
-        git fetch origin +refs/pull/{{ github_pr }}/merge
-        git checkout FETCH_HEAD; git checkout -b PR{{ github_pr }}
+      if [ ! -d $GOPATH/src/k8s.io/cloud-provider-openstack ]; then
+        mkdir -p $GOPATH/src/k8s.io; cd $_
+        git clone https://github.com/kubernetes/cloud-provider-openstack
       fi
 
 - name: Build and upload manila-csi-plugin image
   shell:
     executable: /bin/bash
     cmd: |
-      cd {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack
-      VERSION="latest"
-      if [[ {{ github_pr }} != "" ]]; then
-        VERSION=v0.0.{{ github_pr }}
-      fi
+      cd $GOPATH/src/k8s.io/cloud-provider-openstack
+      VERSION="v0.0.99" # Fake version, but in proper format.
 
       make push-multiarch-image-manila-csi-plugin \
         ARCHS='amd64' \
@@ -124,10 +117,7 @@
   shell:
     executable: /bin/bash
     cmd: |
-      VERSION="latest"
-      if [[ {{ github_pr }} != "" ]]; then
-        VERSION=v0.0.{{ github_pr }}
-      fi
+      VERSION="v0.0.99" # Fake version, but in proper format.
       cd {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack/charts/manila-csi-plugin
       cat <<EOF >> override-helm-values.yaml
       csimanila:

--- a/tests/playbooks/test-csi-cinder-e2e.yaml
+++ b/tests/playbooks/test-csi-cinder-e2e.yaml
@@ -6,7 +6,6 @@
   vars:
     e2e_test_version: v1.29.0
     user: stack
-    github_pr: 123
     global_env: {}
     devstack_workdir: /home/{{ user }}/devstack
 

--- a/tests/playbooks/test-csi-manila-e2e.yaml
+++ b/tests/playbooks/test-csi-manila-e2e.yaml
@@ -5,7 +5,6 @@
 
   vars:
     user: stack
-    github_pr: 123
     global_env: {}
     devstack_workdir: /home/{{ user }}/devstack
 

--- a/tests/playbooks/test-occm-e2e.yaml
+++ b/tests/playbooks/test-occm-e2e.yaml
@@ -5,7 +5,6 @@
 
   vars:
     user: stack
-    github_pr: 123
     global_env: {}
     devstack_workdir: /home/{{ user }}/devstack
     octavia_provider: ""


### PR DESCRIPTION
**What this PR does / why we need it**:
I'm not exactly sure why our e2e tests attempted to pull the code on their own based on the `PULL_NUMBER` envvar passed from the test system, but it should be unnecessary. We should expect the code to test is placed properly in the `GOPATH`.

This should help with issues with merging multiple PRs at the same time, when tide tends to bind them together to make sure our daily merge capacity is higher than `24h/<time-to-execute-longest-tests>.`

**Which issue this PR fixes(if applicable)**:
fixes #2513

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
