### PR TITLE
[occm] Update docs for default-tls-container-ref

### DIFF
--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -281,9 +281,9 @@ Although the openstack-cloud-controller-manager was initially implemented with N
   This option is currently a workaround for the issue https://github.com/kubernetes/ingress-nginx/issues/3996, should be removed or refactored after the Kubernetes [KEP-1860](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1860-kube-proxy-IP-node-binding) is implemented.
 
 * `default-tls-container-ref`
-  Reference to a tls container. This option works with Octavia, when this option is set then the cloud provider will create an Octavia Listener of type TERMINATED_HTTPS for a TLS Terminated loadbalancer.
+  Reference to a tls container or secret. This option works with Octavia, when this option is set then the cloud provider will create an Octavia Listener of type TERMINATED_HTTPS for a TLS Terminated loadbalancer.
 
-  Format for tls container ref: `https://{keymanager_host}/v1/containers/{uuid}`
+  Accepted format for tls container ref are `https://{keymanager_host}/v1/containers/{uuid}` and `https://{keymanager_host}/v1/secrets/{uuid}`.
   Check `container-store` parameter if you want to disable validation.
 
 * `container-store`


### PR DESCRIPTION
**What this PR does / why we need it**: Since eeba48501bf743e3992093bd806a513ad103a347, occm now accepts barbican secrets (https://<keymanager_host>/v1/secrets/<uuid>) in addition to container ref (https://<keymanager_host>/v1/containers/<uuid>) for the `default-tls-container-ref` option.

This commit updates the doc to reflect the change.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
