### PR TITLE
fix: add missing labels to resources

### DIFF
--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -1,11 +1,15 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: v1.29.0
 description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.29.0
+version: 2.29.0-1
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de
     url: https://www.telekom.com
+dependencies:
+  - name: common
+    version: 2.14.1
+    repository: https://charts.bitnami.com/bitnami

--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.29.0-1
+version: 2.29.1
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
+++ b/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
@@ -12,19 +12,6 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{/*
-Common labels and app labels
-*/}}
-{{- define "occm.labels" -}}
-app.kubernetes.io/name: {{ include "occm.name" . }}
-helm.sh/chart: {{ include "occm.chart" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end -}}
-
 {{- define "occm.common.matchLabels" -}}
 app: {{ template "occm.name" . }}
 release: {{ .Release.Name }}

--- a/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Values.clusterRoleName }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   annotations:
     {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/openstack-cloud-controller-manager/templates/clusterrolebinding-sm.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrolebinding-sm.yaml
@@ -3,6 +3,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: system:{{ include "occm.name" . }}:auth-delegate
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   annotations:
     {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/openstack-cloud-controller-manager/templates/clusterrolebinding.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Values.clusterRoleName }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   annotations:
     {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -2,9 +2,8 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "occm.name" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "occm.labels" . | nindent 4 }}
   annotations:
     {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/openstack-cloud-controller-manager/templates/secret.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.secret.name | default "cloud-config" }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- with .Values.commonAnnotations }}

--- a/charts/openstack-cloud-controller-manager/templates/service-sm.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/service-sm.yaml
@@ -2,9 +2,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    {{- include "occm.labels" . | nindent 4 }}
   name: {{ include "occm.name" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- with .Values.commonAnnotations }}

--- a/charts/openstack-cloud-controller-manager/templates/serviceaccount.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccountName }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- with .Values.commonAnnotations }}

--- a/charts/openstack-cloud-controller-manager/templates/servicemonitor.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/servicemonitor.yaml
@@ -2,9 +2,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  labels:
-    {{- include "occm.labels" . | nindent 4 }}
   name: {{ include "occm.name" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- with .Values.commonAnnotations }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the chart doesn't contain the required labels on the applied resources, this makes it impossible to update the chart without manual intervention

**Which issue this PR fixes(if applicable)**:


**Special notes for reviewers**:
I introduced the common chart from bitnami to standardly handle labels. The chart could also be used to handle resource names, secrets, matchlabels, ... . But I wanted to have this change be backwards-compatible and non-intrusive

**Release note**:
```release-note
- adds missing labels to enable helm upgrades
```
