### PR TITLE
detach volume if its attached when deleting volume

### DIFF
--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -151,7 +151,7 @@ func (os *OpenStack) DeleteVolume(volumeID string) error {
 	if instanceID != "" {
 		err := os.DetachVolume(instanceID, volumeID)
 		if err != nil {
-			return fmt.Errorf("cannot detach the volume %q: %v", volumeID, err)
+			return fmt.Errorf("cannot detach the volume %q from instance %s %v", volumeID, instanceID, err)
 		}
 	}
 


### PR DESCRIPTION
We are all the time seeing issues with the volume deletion. Our platform at least is leaving orphan volumes. Orphan volumes means that CSI cinder is trying to remove volumes, but after n retries the controller will give up and delete the `pv` and `pvc` objects from kubernetes. However, the cinder volumes will keep attached to nodes in OpenStack itself and this is making orphan objects.

here we can see some logs of single event https://gist.github.com/zetaab/c61cba65ee2008b8a0b0c8a8433ea624 it looks like there is no detach call coming in at all, its just retrying DeleteVolume calls.

![Screenshot 2024-01-25 at 15 34 09 (1)](https://github.com/kubernetes/cloud-provider-openstack/assets/22482503/c2b76220-bf02-49f8-9f08-de80f29dc390)

In total we had about 400-500 cinder volumes in our OpenStack that were orphan. No objects anymore in Kubernetes cluster, but there were cinder volumes still available.

These can be scanned by using `kubectl get pv` and comparing that to `openstack volume list|grep pvc-` commands.

**Release note**:
```release-note
When calling DeleteVolume, detach the volume if its still attached.
```
