### PR TITLE
[barbican-kms-plugin] Pass KeyId to EncryptResponse

### DIFF
--- a/pkg/kms/server/server.go
+++ b/pkg/kms/server/server.go
@@ -148,5 +148,5 @@ func (s *KMSserver) Encrypt(ctx context.Context, req *pb.EncryptRequest) (*pb.En
 		klog.V(4).Infof("Failed to encrypt data %v: ", err)
 		return nil, err
 	}
-	return &pb.EncryptResponse{Ciphertext: cipher}, nil
+	return &pb.EncryptResponse{Ciphertext: cipher, KeyId: s.cfg.KeyManager.KeyID}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it:**

The `KMSv2` API requires to pass the remote `KeyID` in the `EncryptResponse` object. Indeed, the documentation of the `EncryptResponse` ProtoBuf object says:

```proto
message EncryptResponse {
    // The encrypted data.
    // ciphertext must satisfy the following constraints:  
    // 1. The ciphertext is not empty.  
    // 2. The ciphertext is less than 1 kB.
    bytes ciphertext = 1;
    // The KMS key ID used to encrypt the data. This must always refer to the KMS KEK and not any local KEKs that may be in use.
    // This can be used to inform staleness of data updated via value.Transformer.TransformFromStorage.
    // keyID must satisfy the following constraints:
    // 1. The keyID is not empty.
    // 2. The size of keyID is less than 1 kB.
    string key_id = 2;
    // Additional metadata to be stored with the encrypted data.
    // This data is stored in plaintext in etcd. KMS plugin implementations are responsible for pre-encrypting any sensitive data.
    // Annotations must satisfy the following constraints:
    //  1. Annotation key must be a fully qualified domain name that conforms to the definition in DNS (RFC 1123).
    //  2. The size of annotations keys + values is less than 32 kB.
    map<string, bytes> annotations = 3;
}
```
This PR implements this requirement in the Barbican KMS Plugin.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Propagate KeyID in the EncryptResponse object as per KMSv2 API spec
```