### PR TITLE
[release-1.27] [ci] Bump golangci-lint for go 1.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ $(BUILD_CMDS): $(SOURCES)
 test: unit functional
 
 check: work
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2 run ./...
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.0 run ./...
 
 unit: work
 	go test -tags=unit $(shell go list ./... | sed -e '/sanity/ { N; d; }' | sed -e '/tests/ {N; d;}') $(TESTARGS)


### PR DESCRIPTION
**What this PR does / why we need it**:

The test image was recently changed and now ships with go1.22rc2. We need to use a version of golangci-lint that is compatible with it.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
Manual cherry-pick of https://github.com/kubernetes/cloud-provider-openstack/pull/2544 since the branch used a different version of golangci-lint and the original patch didn't apply cleanly.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
