### PR TITLE
fix(occm/loadbalancer): enable proxy-protocol only for supported list…

### DIFF
--- a/pkg/openstack/events.go
+++ b/pkg/openstack/events.go
@@ -23,4 +23,5 @@ const (
 	eventLBAZIgnored                   = "LoadBalancerAvailabilityZonesIgnored"
 	eventLBFloatingIPSkipped           = "LoadBalancerFloatingIPSkipped"
 	eventLBRename                      = "LoadBalancerRename"
+	eventLBProxyProtocolUnsupported    = "LoadBalancerProxyProtocolUnsupported"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This is copy of #2368 with merge conflict resolved and comments addressed.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
the proxy-protocol is ignored when the listener protocol is not supported (UDP/SCTP)
```
