### PR TITLE
[openstack-cloud-controller-manager] Remove enforcement of IPv6 LB as internal

### DIFF
--- a/pkg/openstack/events.go
+++ b/pkg/openstack/events.go
@@ -21,4 +21,5 @@ const (
 	eventLBExternalNetworkSearchFailed = "LoadBalancerExternalNetworkSearchFailed"
 	eventLBSourceRangesIgnored         = "LoadBalancerSourceRangesIgnored"
 	eventLBAZIgnored                   = "LoadBalancerAvailabilityZonesIgnored"
+	eventLBFloatingIPSkipped           = "LoadBalancerFloatingIPSkipped"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

In OpenStack IPv6 that uses GUAs don't require NAT
to access the outside world, so IPv6 can be
rechable without Floating IPs, which makes the
enforcement of IPv6 LB as internal in CPO not necessary.
This commit removes this enforcement, which results in
IPv6 load-balancers being allowed to be shared between
Services. Also, now it's possible to make the load-balancer
use the IPv6 stateful address defined in the loadBalancerIP
of the Service.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
It's now possible to share the load balancer for IPv6 Services and to use IPv6 addresses pre-defined in the `loadBalancerIP`. When using `loadBalancerIP` with IPv6, only stateful addresses are allowed.
```
