### PR TITLE
[barbican-kms-plugin] Update KMS API to v2

### DIFF
--- a/docs/barbican-kms-plugin/using-barbican-kms-plugin.md
+++ b/docs/barbican-kms-plugin/using-barbican-kms-plugin.md
@@ -84,7 +84,7 @@ plane nodes.
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/cloud-provider-openstack/master/manifests/barbican-kms/ds.yaml
 ```
 *recommendation:* Use the tag corresponding to your Kubernetes release, for
-example `release-1.25` for kubernetes version 1.25.
+example `release-1.29` for kubernetes version 1.29.
 
 
 ### Create encryption configuration
@@ -99,9 +99,9 @@ resources:
     - secrets
     providers:
     - kms:
-        name : barbican
+        apiVersion: v2
+        name: barbican
         endpoint: unix:///var/lib/kms/kms.sock
-        cachesize: 100
     - identity: {}
 ```
 

--- a/manifests/barbican-kms/encryption-config.yaml
+++ b/manifests/barbican-kms/encryption-config.yaml
@@ -5,7 +5,7 @@ resources:
     - secrets
     providers:
     - kms:
+        apiVersion: v2
         name: barbican
         endpoint: unix:///var/lib/kms/kms.sock
-        cachesize: 20
     - identity: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
KMS v1 API is deprecated and in v1.29 core K8s won't allow it with default feature gates set. This commit makes sure we're proposing configuration of v2 API in example EncryptionConfigs.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
```release-note
KMS EncryptionConfig examples are updated to configure barbican-kms-plugin with v2 API.
```
