### PR TITLE
[release-1.29] Remove enforcement of IPv6 LB as internal (#2557)

### DIFF
--- a/pkg/openstack/events.go
+++ b/pkg/openstack/events.go
@@ -21,4 +21,5 @@ const (
 	eventLBExternalNetworkSearchFailed = "LoadBalancerExternalNetworkSearchFailed"
 	eventLBSourceRangesIgnored         = "LoadBalancerSourceRangesIgnored"
 	eventLBAZIgnored                   = "LoadBalancerAvailabilityZonesIgnored"
+	eventLBFloatingIPSkipped           = "LoadBalancerFloatingIPSkipped"
 )


### PR DESCRIPTION
In OpenStack IPv6 that uses GUAs don't require NAT to access the outside world, so IPv6 can be
rechable without Floating IPs, which makes the
enforcement of IPv6 LB as internal in CPO not necessary. This commit removes this enforcement, which results in IPv6 load-balancers being allowed to be shared between Services. Also, now it's possible to make the load-balancer use the IPv6 stateful address defined in the loadBalancerIP of the Service.

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
