### PR TITLE
[cinder-csi-plugin] define availability zone for snapshot backup

### DIFF
--- a/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
+++ b/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
@@ -269,6 +269,7 @@ helm install --namespace kube-system --name cinder-csi ./charts/cinder-csi-plugi
 | VolumeSnapshotClass `parameters` | `force-create`    | `false`         | Enable to support creating snapshot for a volume in in-use status |
 | VolumeSnapshotClass `parameters` | `type`            | Empty String    | `snapshot` creates a VolumeSnapshot object linked to a Cinder volume snapshot. `backup` creates a VolumeSnapshot object linked to a cinder volume backup. Defaults to `snapshot` if not defined |
 | VolumeSnapshotClass `parameters` | `backup-max-duration-seconds-per-gb`  | `20`    | Defines the amount of time to wait for a backup to complete in seconds per GB of volume size |
+| VolumeSnapshotClass `parameters`  | `availability`          | Same as volume | String. Backup Availability Zone |
 | Inline Volume `volumeAttributes`   | `capacity`              | `1Gi`       | volume size for creating inline volumes| 
 | Inline Volume `VolumeAttributes`   | `type`              | Empty String  | Name/ID of Volume type. Corresponding volume type should exist in cinder |
 

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -593,7 +593,7 @@ func (cs *controllerServer) createBackup(name string, volumeID string, snap *sna
 		}
 	}
 
-	backup, err := cs.Cloud.CreateBackup(name, volumeID, snap.ID, properties)
+	backup, err := cs.Cloud.CreateBackup(name, volumeID, snap.ID, parameters[openstack.SnapshotAvailabilityZone], properties)
 	if err != nil {
 		klog.Errorf("Failed to Create backup: %v", err)
 		return nil, status.Error(codes.Internal, fmt.Sprintf("CreateBackup failed with error %v", err))

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -61,7 +61,7 @@ type IOpenStack interface {
 	DeleteSnapshot(snapID string) error
 	GetSnapshotByID(snapshotID string) (*snapshots.Snapshot, error)
 	WaitSnapshotReady(snapshotID string) (string, error)
-	CreateBackup(name, volID string, snapshotID string, tags map[string]string) (*backups.Backup, error)
+	CreateBackup(name, volID, snapshotID, availabilityZone string, tags map[string]string) (*backups.Backup, error)
 	ListBackups(filters map[string]string) ([]backups.Backup, error)
 	DeleteBackup(backupID string) error
 	GetBackupByID(backupID string) (*backups.Backup, error)

--- a/pkg/csi/cinder/openstack/openstack_backups.go
+++ b/pkg/csi/cinder/openstack/openstack_backups.go
@@ -44,7 +44,7 @@ const (
 
 // CreateBackup issues a request to create a Backup from the specified Snapshot with the corresponding ID and
 // returns the resultant gophercloud Backup Item upon success.
-func (os *OpenStack) CreateBackup(name, volID string, snapshotID string, tags map[string]string) (*backups.Backup, error) {
+func (os *OpenStack) CreateBackup(name, volID, snapshotID, availabilityZone string, tags map[string]string) (*backups.Backup, error) {
 	blockstorageServiceClient, err := openstack.NewBlockStorageV3(os.blockstorage.ProviderClient, os.epOpts)
 	if err != nil {
 		return &backups.Backup{}, err
@@ -74,6 +74,12 @@ func (os *OpenStack) CreateBackup(name, volID string, snapshotID string, tags ma
 		// Set openstack microversion to 3.43 to send metadata along with the backup
 		blockstorageServiceClient.Microversion = "3.43"
 		opts.Metadata = tags
+	}
+
+	if availabilityZone != "" {
+		// 3.51 is minimum if az is defined for the request
+		blockstorageServiceClient.Microversion = "3.51"
+		opts.AvailabilityZone = availabilityZone
 	}
 
 	// TODO: Do some check before really call openstack API on the input

--- a/pkg/csi/cinder/openstack/openstack_backups.go
+++ b/pkg/csi/cinder/openstack/openstack_backups.go
@@ -63,23 +63,18 @@ func (os *OpenStack) CreateBackup(name, volID, snapshotID, availabilityZone stri
 	}
 
 	opts := &backups.CreateOpts{
-		VolumeID:    volID,
-		SnapshotID:  snapshotID,
-		Name:        name,
-		Force:       force,
-		Description: backupDescription,
+		VolumeID:         volID,
+		SnapshotID:       snapshotID,
+		Name:             name,
+		Force:            force,
+		Description:      backupDescription,
+		AvailabilityZone: availabilityZone,
 	}
 
 	if tags != nil {
-		// Set openstack microversion to 3.43 to send metadata along with the backup
-		blockstorageServiceClient.Microversion = "3.43"
-		opts.Metadata = tags
-	}
-
-	if availabilityZone != "" {
-		// 3.51 is minimum if az is defined for the request
+		// Set openstack microversion to 3.51 to send metadata along with the backup
 		blockstorageServiceClient.Microversion = "3.51"
-		opts.AvailabilityZone = availabilityZone
+		opts.Metadata = tags
 	}
 
 	// TODO: Do some check before really call openstack API on the input

--- a/pkg/csi/cinder/openstack/openstack_mock.go
+++ b/pkg/csi/cinder/openstack/openstack_mock.go
@@ -315,12 +315,12 @@ func (_m *OpenStackMock) ListBackups(filters map[string]string) ([]backups.Backu
 	return r0, r1
 }
 
-func (_m *OpenStackMock) CreateBackup(name, volID string, snapshotID string, tags map[string]string) (*backups.Backup, error) {
-	ret := _m.Called(name, volID, snapshotID, tags)
+func (_m *OpenStackMock) CreateBackup(name, volID, snapshotID, availabilityZone string, tags map[string]string) (*backups.Backup, error) {
+	ret := _m.Called(name, volID, snapshotID, availabilityZone, tags)
 
 	var r0 *backups.Backup
-	if rf, ok := ret.Get(0).(func(string, string, string, map[string]string) *backups.Backup); ok {
-		r0 = rf(name, volID, snapshotID, tags)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, map[string]string) *backups.Backup); ok {
+		r0 = rf(name, volID, snapshotID, availabilityZone, tags)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*backups.Backup)
@@ -328,8 +328,8 @@ func (_m *OpenStackMock) CreateBackup(name, volID string, snapshotID string, tag
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string, string, map[string]string) error); ok {
-		r1 = rf(name, volID, snapshotID, tags)
+	if rf, ok := ret.Get(1).(func(string, string, string, string, map[string]string) error); ok {
+		r1 = rf(name, volID, snapshotID, availabilityZone, tags)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/csi/cinder/openstack/openstack_snapshots.go
+++ b/pkg/csi/cinder/openstack/openstack_snapshots.go
@@ -37,9 +37,10 @@ const (
 	snapReadyFactor     = 1.2
 	snapReadySteps      = 10
 
-	snapshotDescription = "Created by OpenStack Cinder CSI driver"
-	SnapshotForceCreate = "force-create"
-	SnapshotType        = "type"
+	snapshotDescription      = "Created by OpenStack Cinder CSI driver"
+	SnapshotForceCreate      = "force-create"
+	SnapshotType             = "type"
+	SnapshotAvailabilityZone = "availability"
 )
 
 // CreateSnapshot issues a request to take a Snapshot of the specified Volume with the corresponding ID and

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -72,10 +72,10 @@ func (os *OpenStack) CreateVolume(name string, size int, vtype, availability str
 		return nil, err
 	}
 
-	// creating volumes from backups is available since 3.47 microversion
+	// creating volumes from backups and backups cross-az is available since 3.51 microversion
 	// https://docs.openstack.org/cinder/latest/contributor/api_microversion_history.html#id47
 	if !os.bsOpts.IgnoreVolumeMicroversion && sourceBackupID != "" {
-		blockstorageClient.Microversion = "3.47"
+		blockstorageClient.Microversion = "3.51"
 	}
 
 	mc := metrics.NewMetricContext("volume", "create")

--- a/tests/sanity/cinder/fakecloud.go
+++ b/tests/sanity/cinder/fakecloud.go
@@ -227,15 +227,16 @@ func (cloud *cloud) WaitSnapshotReady(snapshotID string) (string, error) {
 	return "available", nil
 }
 
-func (cloud *cloud) CreateBackup(name, volID string, snapshotID string, tags map[string]string) (*backups.Backup, error) {
+func (cloud *cloud) CreateBackup(name, volID, snapshotID, availabilityZone string, tags map[string]string) (*backups.Backup, error) {
 
 	backup := &backups.Backup{
-		ID:         randString(10),
-		Name:       name,
-		Status:     "available",
-		VolumeID:   volID,
-		SnapshotID: snapshotID,
-		CreatedAt:  time.Now(),
+		ID:               randString(10),
+		Name:             name,
+		Status:           "available",
+		VolumeID:         volID,
+		SnapshotID:       snapshotID,
+		AvailabilityZone: &availabilityZone,
+		CreatedAt:        time.Now(),
 	}
 
 	cloud.backups[backup.ID] = backup


### PR DESCRIPTION
**What this PR does / why we need it**: Original snapshot backup support was added in https://github.com/kubernetes/cloud-provider-openstack/pull/2480. However, it assumes that openstack volume backup zones will match to cinder zones. In our case, that is not true. We have different names for cinder zones than backup zone. That is why availability zone parameter is needed.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:


**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
