### PR TITLE
[occm] helm chart - added route section to cloud-config secret

### DIFF
--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.29.1
+version: 2.29.2
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
+++ b/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
@@ -60,8 +60,12 @@ Create cloud-config makro.
 {{- range $key, $value := .Values.cloudConfig.metadata }}
 {{ $key }} = {{ $value | quote }}
 {{- end }}
-{{- end }}
 
+[Route]
+{{- range $key, $value := .Values.cloudConfig.route }}
+{{ $key }} = {{ $value | quote }}
+{{- end }}
+{{- end }}
 
 {{/*
 Generate string of enabled controllers. Might have a trailing comma (,) which needs to be trimmed.

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -108,6 +108,7 @@ cloudConfig:
   loadBalancer:
   blockStorage:
   metadata:
+  route:
 
 # Allow for specifying internal IP addresses for multiple hostnames
 # hostAliases:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the Route section to the cloud-config secret. This allows the Cloud Controller to add routes to Openstack routers. 

**Which issue this PR fixes(if applicable)**:

This fixes the issue that it is currently not possible to add a Route section to the cloud-config secret via the helm chart.


**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
