### PR TITLE
[cinder-csi-plugin] Enable optional storageclasses.

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.29.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.29.1
+version: 2.29.2
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.29.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.29.0
+version: 2.29.1
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/README.md
+++ b/charts/cinder-csi-plugin/README.md
@@ -3,7 +3,7 @@
 Deploys a Cinder csi provisioner to your cluster, with the appropriate storageClass.
 
 ## How To install
-- Enable deployment of storageclasses using `storageClass.enabled`
+- Enable deployment of retain or delete class using `storageClass.<name>.enabled`
 - Tag the retain or delete class as default class using `storageClass.delete.isDefault` in your value yaml
 - Set `storageClass.<reclaim-policy>.allowVolumeExpansion` to `true` or `false`
 

--- a/charts/cinder-csi-plugin/templates/storageclass.yaml
+++ b/charts/cinder-csi-plugin/templates/storageclass.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.storageClass.enabled }}
+{{- if .Values.storageClass.delete.enabled }}
+---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -10,6 +11,8 @@ metadata:
 provisioner: cinder.csi.openstack.org
 reclaimPolicy: Delete
 allowVolumeExpansion: {{ .Values.storageClass.delete.allowVolumeExpansion }}
+{{- end }}
+{{- if .Values.storageClass.retain.enabled }}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass

--- a/charts/cinder-csi-plugin/templates/storageclass.yaml
+++ b/charts/cinder-csi-plugin/templates/storageclass.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.storageClass.delete.enabled }}
+{{- if or .Values.storageClass.enabled .Values.storageClass.delete.enabled }}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -12,7 +12,7 @@ provisioner: cinder.csi.openstack.org
 reclaimPolicy: Delete
 allowVolumeExpansion: {{ .Values.storageClass.delete.allowVolumeExpansion }}
 {{- end }}
-{{- if .Values.storageClass.retain.enabled }}
+{{- if or .Values.storageClass.enabled .Values.storageClass.retain.enabled }}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -160,12 +160,13 @@ secret:
 #      ca-file=/etc/cacert/ca-bundle.crt
 
 storageClass:
+  enabled: true
   delete:
-    enabled: false
+    enabled: true
     isDefault: false
     allowVolumeExpansion: true
   retain:
-    enabled: false
+    enabled: true
     isDefault: false
     allowVolumeExpansion: true
 # any kind of custom StorageClasses

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -160,11 +160,12 @@ secret:
 #      ca-file=/etc/cacert/ca-bundle.crt
 
 storageClass:
-  enabled: true
   delete:
+    enabled: false
     isDefault: false
     allowVolumeExpansion: true
   retain:
+    enabled: false
     isDefault: false
     allowVolumeExpansion: true
 # any kind of custom StorageClasses


### PR DESCRIPTION

[cinder-csi-plugin] Enable Optional StorageClasses

**What this PR does / why we need it**:
If you enable the included storageclasses, you get both the `retain` and `delete`. This PR allows each class to be enabled individually.

**Which issue this PR fixes(if applicable)**:
na

**Special notes for reviewers**:
na

**Release note**:
```release-note
[cinder-csi-plugin] Included storageclasses can be individually enabled.
```
