### PR TITLE
[occm] - add annotation for custom octavia listener tags

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -236,6 +236,11 @@ Request Body:
   This annotation is automatically added and it contains the floating ip address of the load balancer service.
   When using `loadbalancer.openstack.org/hostname` annotation it is the only place to see the real address of the load balancer.
 
+- `loadbalancer.openstack.org/custom-tags`
+
+  Allows to specify custom tags for the *load balancer* and the *listeners* resources for that Service. *Pools* do not have any tags at the moment. Other than the custom tags, each resource has a tag in the format of "$NAMESPACE-$SERVICE_NAME'.
+  Tags are arbitrary strings, to specify multiple tags separate them using a comma , in the annotation.
+  > NOTE: If the `loadbalancer.openstack.org/load-balancer-id` annotation is specified, this one doesn't have any effect. 
 ### Switching between Floating Subnets by using preconfigured Classes
 
 If you have multiple `FloatingIPPools` and/or `FloatingIPSubnets` it might be desirable to offer the user logical meanings for `LoadBalancers` like `internetFacing` or `DMZ` instead of requiring the user to select a dedicated network or subnet ID at the service object level as an annotation.


### PR DESCRIPTION
Added support for new annotation which provides the ability to add tags when the load balancer is created. Those tags affect the load balancer and the listener. The rest of the resources are not tagged

**What this PR does / why we need it**:
https://github.com/kubernetes/cloud-provider-openstack/issues/2327

**Special notes for reviewers**:
1. As far as  I understood(based on Slack conversation) this functionality will be expanded. That is more features will be added.
2. Testing notes - There is e2e test, but basically adding the annotation specified in the docs, must result in having one or multiple tags on the load balancer and listener resource in openstack.
3. No extra validation is done, as the openstack document doesn't mention any excluded chars(as far as I managed to understand). There is edge-case mentioned in the openstack docs, but I don't think they apply for the LB resources. Namely:
> Filtering resources with a tag whose name contains a comma is not supported. Thus, do not put such a tag name to resources.
> Source: https://docs.openstack.org/mitaka/networking-guide/ops-resource-tags.html#limitations

But I don't think this will impact us, since "," is used to split the tags. Hence tag containing "," cannot exist. I didn't document this behavior as it fells like common sense. Also the docs are coming from the Mitaka project. 
4. I'm not sure if this change is big enough for release notes, but I can add them if necessary 

**Release note**:
```release-note
NONE
```