### PR TITLE
[cinder-csi-plugin] [manila-csi-plugin] Update Cinder and Manila CSI charts maintainers

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,9 +2,11 @@ apiVersion: v1
 appVersion: v1.29.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.29.0
+version: 2.29.1
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:
-  - name: brtknr
-    email: brtknr@bath.edu
+  - name: mnasiadka
+    email: mnasiadka@gmail.com
+  - name: mkjpryor
+    email: matt@stackhpc.com

--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,9 +2,11 @@ apiVersion: v1
 appVersion: v1.29.0
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 2.29.0
+version: 2.29.1
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:
-  - name: brtknr
-    email: brtknr@bath.edu
+  - name: mnasiadka
+    email: mnasiadka@gmail.com
+  - name: mkjpryor
+    email: matt@stackhpc.com


### PR DESCRIPTION
**What this PR does / why we need it**:

The GitHub account @brtknr does not exist anymore and our chart linter complains about this. This commit adds me as the maintainer.

**Which issue this PR fixes(if applicable)**:
fixes #2582

**Special notes for reviewers**:

**Release note**:
```release-note
Maintainer for Cinder and Manila CSI charts is updated.
```
