### PR TITLE
fix(occm): Empty nodeSelector by default

### DIFF
--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.29.2
+version: 2.29.3
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/README.md
+++ b/charts/openstack-cloud-controller-manager/README.md
@@ -57,7 +57,7 @@ tolerations:
 
 ## NodeSelector
 
-To deploy OCCM to control-plane nodes only, adjust the nodeSelectors in the chart:
+To deploy OCCM to control-plane nodes only, adjust the nodeSelector key in the chart:
 
 ```yaml
 nodeSelector:

--- a/charts/openstack-cloud-controller-manager/README.md
+++ b/charts/openstack-cloud-controller-manager/README.md
@@ -55,6 +55,15 @@ tolerations:
     effect: NoSchedule
 ```
 
+## NodeSelector
+
+To deploy OCCM to control-plane nodes only, adjust the nodeSelectors in the chart:
+
+```yaml
+nodeSelector:
+  node-role.kubernetes.io/control-plane: "true"
+```
+
 ## Unsupported configurations
 
 - The chart does not support the mounting of custom `clouds.yaml` files. Therefore, the following config values in the `[Global]` section won’t have any effect:

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -46,9 +46,10 @@ livenessProbe: {}
 # Set readinessProbe in the same way like livenessProbe
 readinessProbe: {}
 
-# Set nodeSelector where the controller should run, i.e. controlplane nodes
-nodeSelector:
-  node-role.kubernetes.io/control-plane: ""
+# Set nodeSelector where the controller should run.
+nodeSelector: {}
+  # i.e. controlplane nodes
+  # node-role.kubernetes.io/control-plane: "true"
 
 # Set tolerations for nodes where the controller should run, i.e. node
 # should be uninitialized, controlplane...


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
* keep the nodeSelector empty by default so users can easily use their own.
* add documentation in the README

**Which issue this PR fixes(if applicable)**:
fixes #2550

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
