### PR TITLE
[occm] KEP-1860: Add support for LoadBalancer ipMode

### DIFF
--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -709,12 +709,15 @@ func TestLbaasV2_checkListenerPorts(t *testing.T) {
 	}
 }
 func TestLbaasV2_createLoadBalancerStatus(t *testing.T) {
+	ipmodeProxy := corev1.LoadBalancerIPModeProxy
+	ipmodeVIP := corev1.LoadBalancerIPModeVIP
 	type fields struct {
 		LoadBalancer LoadBalancer
 	}
 	type result struct {
 		HostName  string
 		IPAddress string
+		IPMode    *corev1.LoadBalancerIPMode
 	}
 	type args struct {
 		service *corev1.Service
@@ -800,6 +803,33 @@ func TestLbaasV2_createLoadBalancerStatus(t *testing.T) {
 			},
 			want: result{
 				IPAddress: "10.10.0.6",
+				IPMode:    &ipmodeVIP,
+			},
+		},
+		{
+			name: "it should return ipMode proxy if using proxyProtocol and not EnableIngressHostname",
+			fields: fields{
+				LoadBalancer: LoadBalancer{
+					opts: LoadBalancerOpts{
+						EnableIngressHostname: false,
+						IngressHostnameSuffix: "ingress-suffix",
+					},
+				},
+			},
+			args: args{
+				service: &corev1.Service{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{"test": "key"},
+					},
+				},
+				svcConf: &serviceConfig{
+					enableProxyProtocol: true,
+				},
+				addr: "10.10.0.6",
+			},
+			want: result{
+				IPAddress: "10.10.0.6",
+				IPMode:    &ipmodeProxy,
 			},
 		},
 	}
@@ -812,6 +842,7 @@ func TestLbaasV2_createLoadBalancerStatus(t *testing.T) {
 			result := lbaas.createLoadBalancerStatus(tt.args.service, tt.args.svcConf, tt.args.addr)
 			assert.Equal(t, tt.want.HostName, result.Ingress[0].Hostname)
 			assert.Equal(t, tt.want.IPAddress, result.Ingress[0].IP)
+			assert.EqualValues(t, tt.want.IPMode, result.Ingress[0].IPMode)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for ipMode in LoadBalancer status field introduced in KEP-1860.
This enables the usage of Proxy Protocol without workaround (EnableIngressHostname + IngressHostnameSuffix).

The workarounds were introducing new issues, e.g. externalDNS was not functional with a loadbalancer with ingress Hostname set.

**Which issue this PR fixes(if applicable)**:
There is no open issue as a workaround was introduced. 

**Special notes for reviewers**:
Tthe ipMode field is available even if  IpMode is still behind a featureGate. 

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[occm] KEP-1860: Add support for LoadBalancer ipMode
```
