### PR TITLE
[occm] multizone race condition

### DIFF
--- a/pkg/openstack/instances.go
+++ b/pkg/openstack/instances.go
@@ -448,27 +448,6 @@ func isValidLabelValue(v string) bool {
 	return true
 }
 
-// If Instances.InstanceID or cloudprovider.GetInstanceProviderID is changed, the regexp should be changed too.
-var providerIDRegexp = regexp.MustCompile(`^` + ProviderName + `://([^/]*)/([^/]+)$`)
-
-// instanceIDFromProviderID splits a provider's id and return instanceID.
-// A providerID is build out of '${ProviderName}:///${instance-id}' which contains ':///'.
-// or '${ProviderName}://${region}/${instance-id}' which contains '://'.
-// See cloudprovider.GetInstanceProviderID and Instances.InstanceID.
-func instanceIDFromProviderID(providerID string) (instanceID string, region string, err error) {
-
-	// https://github.com/kubernetes/kubernetes/issues/85731
-	if providerID != "" && !strings.Contains(providerID, "://") {
-		providerID = ProviderName + "://" + providerID
-	}
-
-	matches := providerIDRegexp.FindStringSubmatch(providerID)
-	if len(matches) != 3 {
-		return "", "", fmt.Errorf("ProviderID \"%s\" didn't match expected format \"openstack://region/InstanceID\"", providerID)
-	}
-	return matches[2], matches[1], nil
-}
-
 // AddToNodeAddresses appends the NodeAddresses to the passed-by-pointer slice,
 // only if they do not already exist
 func AddToNodeAddresses(addresses *[]v1.NodeAddress, addAddresses ...v1.NodeAddress) {

--- a/pkg/openstack/instances_test.go
+++ b/pkg/openstack/instances_test.go
@@ -22,7 +22,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -189,75 +188,4 @@ func TestSortNodeAddressesWithMultipleCIDRs(t *testing.T) {
 	}
 
 	executeSortNodeAddressesTest(t, addressSortOrder, want)
-}
-
-func Test_instanceIDFromProviderID(t *testing.T) {
-	type args struct {
-		providerID string
-	}
-	tests := []struct {
-		name           string
-		args           args
-		wantInstanceID string
-		wantRegion     string
-		wantErr        bool
-	}{
-		{
-			name: "it parses region & instanceID correctly from providerID",
-			args: args{
-				providerID: "openstack://us-east-1/testInstanceID",
-			},
-			wantInstanceID: "testInstanceID",
-			wantRegion:     "us-east-1",
-			wantErr:        false,
-		},
-		{
-			name: "it parses instanceID if providerID has empty protocol & no region",
-			args: args{
-				providerID: "/testInstanceID",
-			},
-			wantInstanceID: "testInstanceID",
-			wantRegion:     "",
-			wantErr:        false,
-		},
-		{
-			name: "it returns error in case of invalid providerID format with no region",
-			args: args{
-				providerID: "openstack://us-east-1-testInstanceID",
-			},
-			wantInstanceID: "",
-			wantRegion:     "",
-			wantErr:        true,
-		},
-		{
-			name: "it parses correct instanceID in case the region name is the empty string",
-			args: args{
-				providerID: "openstack:///testInstanceID",
-			},
-			wantInstanceID: "testInstanceID",
-			wantRegion:     "",
-			wantErr:        false,
-		},
-		{
-			name: "it appends openstack:// in case of missing protocol in providerID",
-			args: args{
-				providerID: "us-east-1/testInstanceID",
-			},
-			wantInstanceID: "testInstanceID",
-			wantRegion:     "us-east-1",
-			wantErr:        false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotInstanceID, gotRegion, err := instanceIDFromProviderID(tt.args.providerID)
-			assert.Equal(t, tt.wantInstanceID, gotInstanceID)
-			assert.Equal(t, tt.wantRegion, gotRegion)
-			if tt.wantErr == true {
-				assert.ErrorContains(t, err, "didn't match expected format")
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
 }

--- a/pkg/openstack/utils.go
+++ b/pkg/openstack/utils.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// If Instances.InstanceID or cloudprovider.GetInstanceProviderID is changed, the regexp should be changed too.
+var providerIDRegexp = regexp.MustCompile(`^` + ProviderName + `://([^/]*)/([^/]+)$`)
+
+// instanceIDFromProviderID splits a provider's id and return instanceID.
+// A providerID is build out of '${ProviderName}:///${instance-id}' which contains ':///'.
+// or '${ProviderName}://${region}/${instance-id}' which contains '://'.
+// See cloudprovider.GetInstanceProviderID and Instances.InstanceID.
+func instanceIDFromProviderID(providerID string) (instanceID string, region string, err error) {
+
+	// https://github.com/kubernetes/kubernetes/issues/85731
+	if providerID != "" && !strings.Contains(providerID, "://") {
+		providerID = ProviderName + "://" + providerID
+	}
+
+	matches := providerIDRegexp.FindStringSubmatch(providerID)
+	if len(matches) != 3 {
+		return "", "", fmt.Errorf("ProviderID \"%s\" didn't match expected format \"openstack://region/InstanceID\"", providerID)
+	}
+	return matches[2], matches[1], nil
+}
+
+// Return true if instance is not openstack.
+func isNodeUnmanaged(providerID string) bool {
+	if providerID != "" {
+		return strings.Contains(providerID, "://") && !strings.HasPrefix(providerID, ProviderName+"://")
+	}
+
+	return false
+}

--- a/pkg/openstack/utils_test.go
+++ b/pkg/openstack/utils_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_instanceIDFromProviderID(t *testing.T) {
+	type args struct {
+		providerID string
+	}
+	tests := []struct {
+		name           string
+		args           args
+		wantInstanceID string
+		wantRegion     string
+		wantErr        bool
+	}{
+		{
+			name: "it parses region & instanceID correctly from providerID",
+			args: args{
+				providerID: "openstack://us-east-1/testInstanceID",
+			},
+			wantInstanceID: "testInstanceID",
+			wantRegion:     "us-east-1",
+			wantErr:        false,
+		},
+		{
+			name: "it parses instanceID if providerID has empty protocol & no region",
+			args: args{
+				providerID: "/testInstanceID",
+			},
+			wantInstanceID: "testInstanceID",
+			wantRegion:     "",
+			wantErr:        false,
+		},
+		{
+			name: "it returns error in case of invalid providerID format with no region",
+			args: args{
+				providerID: "openstack://us-east-1-testInstanceID",
+			},
+			wantInstanceID: "",
+			wantRegion:     "",
+			wantErr:        true,
+		},
+		{
+			name: "it parses correct instanceID in case the region name is the empty string",
+			args: args{
+				providerID: "openstack:///testInstanceID",
+			},
+			wantInstanceID: "testInstanceID",
+			wantRegion:     "",
+			wantErr:        false,
+		},
+		{
+			name: "it appends openstack:// in case of missing protocol in providerID",
+			args: args{
+				providerID: "us-east-1/testInstanceID",
+			},
+			wantInstanceID: "testInstanceID",
+			wantRegion:     "us-east-1",
+			wantErr:        false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotInstanceID, gotRegion, err := instanceIDFromProviderID(tt.args.providerID)
+			assert.Equal(t, tt.wantInstanceID, gotInstanceID)
+			assert.Equal(t, tt.wantRegion, gotRegion)
+			if tt.wantErr == true {
+				assert.ErrorContains(t, err, "didn't match expected format")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_isNodeUnmanaged(t *testing.T) {
+	tests := []struct {
+		name       string
+		providerID string
+		wantResult bool
+	}{
+		{
+			name:       "openstack node, providerID not set yet",
+			providerID: "",
+			wantResult: false,
+		},
+		{
+			name:       "openstack node in case of invalid providerID format with no region",
+			providerID: "openstack://us-east-1-testInstanceID",
+			wantResult: false,
+		},
+		{
+			name:       "openstack node, it parses instanceID has empty protocol & no region",
+			providerID: "/testInstanceID",
+			wantResult: false,
+		},
+		{
+			name:       "openstack node, it parses correct instanceID in case the region name is the empty string",
+			providerID: "openstack:///testInstanceID",
+			wantResult: false,
+		},
+		{
+			name:       "openstack node, it parses correct instanceID with region name",
+			providerID: "openstack://region/testInstanceID",
+			wantResult: false,
+		},
+		{
+			name:       "openstack node in case of missing protocol in providerID",
+			providerID: "us-east-1/testInstanceID",
+			wantResult: false,
+		},
+		{
+			name:       "non openstack node, providerID has non openstack protocol",
+			providerID: "provider:///us-east-1-testInstanceID",
+			wantResult: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := isNodeUnmanaged(tt.providerID)
+			assert.Equal(t, tt.wantResult, res)
+		})
+	}
+}


### PR DESCRIPTION
We cannot definitively determine whether a node exists within our zone without the provider ID string.

**What this PR does / why we need it**:

It affects if `OS_CCM_REGIONAL` is `true`
The node trying to join to the cluster. It has non ready status and uninitialized taint.
The `cloud-node` controller is attempting to initialize the node simultaneously with the `node-lifecycle` controller's attempt to delete the node, as the node is located in another region

So we need to skip nodes without ProviderID in `OS_CCM_REGIONAL` mode.
Azure does the same [az.IsNodeUnmanaged](https://github.com/kubernetes-sigs/cloud-provider-azure/blob/master/pkg/provider/azure_instances_v2.go#L37) -> [IsNodeUnmanagedByProviderID] (https://github.com/kubernetes-sigs/cloud-provider-azure/blob/master/pkg/provider/azure_wrap.go#L86) - if ProviderID is not azure string (or empty) - set it as unmanaged node.

**Which issue this PR fixes(if applicable)**:

part of #1924

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

`OS_CCM_REGIONAL` is alpha feature, we do not need to update release note.
Feature flag was introduced here #1909 

```release-note
NONE
```
