### PR TITLE
[manila-csi-plugin] Update manila dev doc regarding implemented features

### DIFF
--- a/docs/manila-csi-plugin/developers-csi-manila.md
+++ b/docs/manila-csi-plugin/developers-csi-manila.md
@@ -43,9 +43,7 @@ Usually, shares / share adapters offer a set of options which users may want to 
 
 **Controller Service:**
 * `CREATE_DELETE_VOLUME`
-* `CREATE_DELETE_SNAPSHOT` (snapshotting CephFS shares is not supported yet - planned as a part of GSoC 2019)
-
-Availability Zones are not supported yet.
+* `CREATE_DELETE_SNAPSHOT`
 
 **Node Service:**
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Snapshotting and cloning CephFS shares is supported (#2299) so is Topology via Manila AZs (#939, #2255)

```release-note
NONE
```
