### PR TITLE
[occm] add dnsPolicy feature 

### DIFF
--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.30.0
+version: 2.30.1
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -107,6 +107,7 @@ spec:
       {{- if .Values.extraInitContainers }}
       initContainers: {{ toYaml .Values.extraInitContainers | nindent 6 }}
       {{- end }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
       hostNetwork: true
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -46,6 +46,8 @@ livenessProbe: {}
 # Set readinessProbe in the same way like livenessProbe
 readinessProbe: {}
 
+dnsPolicy: ClusterFirstWithHostNet
+
 # Set nodeSelector where the controller should run, i.e. controlplane nodes
 nodeSelector:
   node-role.kubernetes.io/control-plane: ""

--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -65,6 +65,7 @@ spec:
               value: /etc/config/cloud.conf
             - name: CLUSTER_NAME
               value: kubernetes
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       volumes:
       - hostPath:

--- a/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
@@ -38,6 +38,7 @@ spec:
           value: /etc/config/cloud.conf
         - name: CLUSTER_NAME
           value: kubernetes
+  dnsPolicy: ClusterFirstWithHostNet
   hostNetwork: true
   securityContext:
     runAsUser: 1001


### PR DESCRIPTION
**What this PR does / why we need it**:
this PR adds dnsPolicy configuration to occm which should be changed if deployed in a cluster with a custom coredns configuration like internal dns domain.
**Which issue this PR fixes(if applicable)**:
fixes #2592

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] Add dnsPolicy configuration to manifests and charts
```
