### PR TITLE
[occm] Multi region openstack cluster

### DIFF
--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -113,7 +113,9 @@ The options in `Global` section are used for openstack-cloud-controller-manager 
 * `password`
   Keystone user password. If you are using [Keystone application credential](https://docs.openstack.org/keystone/latest/user/application_credentials.html), this option is not required.
 * `region`
-  Required. Keystone region name.
+  Required. Keystone region name. The name of region will be set in the `topology.kubernetes.io/region` label of the node.
+* `regions`
+  Optional. Keystone region name, which is used to specify regions for the cloud provider where the instance is running. Can be specified multiple times.The region name may or may not be the same as the region name in the `region` option. They merge together at runtime.
 * `domain-id`
   Keystone user domain ID. If you are using [Keystone application credential](https://docs.openstack.org/keystone/latest/user/application_credentials.html), this option is not required.
 * `domain-name`
@@ -317,7 +319,7 @@ Although the openstack-cloud-controller-manager was initially implemented with N
   call](https://docs.openstack.org/api-ref/load-balancer/v2/?expanded=create-a-load-balancer-detail#creating-a-fully-populated-load-balancer).
   Setting this option to true will create loadbalancers using serial API calls which first create an unpopulated
   loadbalancer, then populate its listeners, pools and members. This is a compatibility option at the expense of
-  increased load on the OpenStack API. Default: false 
+  increased load on the OpenStack API. Default: false
 
 NOTE:
 

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"slices"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack"
@@ -126,7 +127,7 @@ func GetConfigFromFiles(configFilePaths []string) (Config, error) {
 		}
 	}
 
-	for _, global := range cfg.Global {
+	for idx, global := range cfg.Global {
 		// Update the config with data from clouds.yaml if UseClouds is enabled
 		if global.UseClouds {
 			if global.CloudsFile != "" {
@@ -138,6 +139,15 @@ func GetConfigFromFiles(configFilePaths []string) (Config, error) {
 			}
 			klog.V(5).Infof("Credentials are loaded from %s:", global.CloudsFile)
 		}
+
+		regions := []string{global.Region}
+		for _, region := range cfg.Global[idx].Regions {
+			if !slices.Contains(regions, region) {
+				regions = append(regions, region)
+			}
+		}
+
+		cfg.Global[idx].Regions = regions
 	}
 
 	return cfg, nil

--- a/pkg/csi/cinder/openstack/openstack_test.go
+++ b/pkg/csi/cinder/openstack/openstack_test.go
@@ -68,6 +68,7 @@ tenant-id=` + fakeTenantID + `
 domain-id=` + fakeDomainID + `
 ca-file=` + fakeCAfile + `
 region=` + fakeRegion + `
+regions=` + fakeRegion + `
 [Global "cloud2"]
 username=` + fakeUserName_cloud2 + `
 password=` + fakePassword_cloud2 + `
@@ -76,6 +77,8 @@ tenant-id=` + fakeTenantID_cloud2 + `
 domain-id=` + fakeDomainID_cloud2 + `
 ca-file=` + fakeCAfile_cloud2 + `
 region=` + fakeRegion_cloud2 + `
+regions=` + fakeRegion_cloud2 + `
+regions=` + fakeRegion_cloud2 + `
 [Global "cloud3"]
 username=` + fakeUserName_cloud3 + `
 password=` + fakePassword_cloud3 + `
@@ -112,6 +115,7 @@ rescan-on-resize=true`
 		CAFile:   fakeCAfile,
 		TenantID: fakeTenantID,
 		Region:   fakeRegion,
+		Regions:  []string{fakeRegion},
 	}
 	expectedOpts.Global["cloud2"] = &client.AuthOpts{
 		Username: fakeUserName_cloud2,
@@ -121,6 +125,7 @@ rescan-on-resize=true`
 		CAFile:   fakeCAfile_cloud2,
 		TenantID: fakeTenantID_cloud2,
 		Region:   fakeRegion_cloud2,
+		Regions:  []string{fakeRegion_cloud2},
 	}
 	expectedOpts.Global["cloud3"] = &client.AuthOpts{
 		Username: fakeUserName_cloud3,
@@ -130,6 +135,7 @@ rescan-on-resize=true`
 		CAFile:   fakeCAfile_cloud3,
 		TenantID: fakeTenantID_cloud3,
 		Region:   fakeRegion_cloud3,
+		Regions:  []string{fakeRegion_cloud3},
 	}
 
 	expectedOpts.BlockStorage.RescanOnResize = true
@@ -224,6 +230,7 @@ rescan-on-resize=true`
 		CAFile:       fakeCAfile,
 		TenantID:     fakeTenantID,
 		Region:       fakeRegion,
+		Regions:      []string{fakeRegion},
 		EndpointType: gophercloud.AvailabilityPublic,
 		UseClouds:    true,
 		CloudsFile:   wd + "/fixtures/clouds.yaml",
@@ -237,6 +244,7 @@ rescan-on-resize=true`
 		CAFile:       fakeCAfile_cloud2,
 		TenantID:     fakeTenantID_cloud2,
 		Region:       fakeRegion_cloud2,
+		Regions:      []string{fakeRegion_cloud2},
 		EndpointType: gophercloud.AvailabilityPublic,
 		UseClouds:    true,
 		CloudsFile:   wd + "/fixtures/clouds.yaml",
@@ -250,6 +258,7 @@ rescan-on-resize=true`
 		CAFile:       fakeCAfile_cloud3,
 		TenantID:     fakeTenantID_cloud3,
 		Region:       fakeRegion_cloud3,
+		Regions:      []string{fakeRegion_cloud3},
 		EndpointType: gophercloud.AvailabilityPublic,
 		UseClouds:    true,
 		CloudsFile:   wd + "/fixtures/clouds.yaml",


### PR DESCRIPTION
**What this PR does / why we need it**:

Openstack CCM multi region support, if it has one Identity provider.
The OpenStack cluster includes a single Keystone service and multiple Nova, Cinder, and Neutron services grouped by region.

<img width="586" alt="openstack-regional" src="https://github.com/user-attachments/assets/cb6aae27-7971-4538-ab46-e67a587b0ee1" />

**Which issue this PR fixes(if applicable)**:
fixes #1924

**Special notes for reviewers**:

CCM config changes:
The `region` is required param (as was before) and it uses as default region in cluster.
The `regions` can set multiple times, they will merge with `region` param.  So the value of the `region` may or may not exist in the list of defined regions.

```cfg
[Global]
auth-url=https://auth.openstack.example.com/v3/
region=REGION1
# new param 'regions' can be specified multiple times
regions=REGION1
regions=REGION2
regions=REGION3
```

Optionally can be set in cloud.conf, it supports only one auth service (Keystone)
```yaml
clouds:
  kubernetes:
    auth:
      auth_url: https://auth.openstack.example.com/v3
    region_name: "REGION1"
    regions:
      - REGION1
      - REGION2
      - REGION3
```

During the initialization process, OCCM checks for the existence of providerID. If providerID does not exist, it defaults to using `node.name`, as it did previously. Additionally, if the node has the label `topology.kubernetes.io/region`, OCCM will prioritize using this region as the first one to check. This approach ensures that in the event of a region outage, OCCM can continue to function.

In addition, we can assist CCM in locating the node by providing `kubelet` parameters:
* `--provider-id=openstack:///$InstanceID` - InstanceID exists in [metadata](https://docs.openstack.org/nova/latest/admin/metadata-service.html)
* `--provider-id=openstack://$REGION/$InstanceID` - if you can define the region (by default [meta server](https://docs.openstack.org/nova/latest/admin/metadata-service.html) does not have this information)
* `--node-labels=topology.kubernetes.io/region=$REGION` set preferred REGION in label, OCCM will then prioritize searching for the node in this specified region

The OCCM sets `ProviderID`:
* openstack:///$InstanceID - default behavior 
* openstack://$REGION/$InstanceID if env.OS_CCM_REGIONAL is sets to true (https://github.com/kubernetes/cloud-provider-openstack/pull/1909)

OCCM with multi regions can work with/without `env.OS_CCM_REGIONAL=true`

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[OCCM] support multi regional cluster with one keystone deployment
```
