### PR TITLE
[occm] add a node selector support for loadbalancer services

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -236,6 +236,12 @@ Request Body:
   This annotation is automatically added and it contains the floating ip address of the load balancer service.
   When using `loadbalancer.openstack.org/hostname` annotation it is the only place to see the real address of the load balancer.
 
+- `loadbalancer.openstack.org/node-selector`
+
+  A set of key=value annotations used to filter nodes for targeting by the load balancer. When defined, only nodes that match all the specified key=value annotations will be targeted. If an annotation includes only a key without a value, the filter will check only for the existence of the key on the node. If the value is not set, the `node-selector` value defined in the OCCM configuration is applied.
+
+  Example: To filter nodes with the labels `env=production` and `region=default`, set the `loadbalancer.openstack.org/node-selector` annotation to `env=production, region=default`
+
 ### Switching between Floating Subnets by using preconfigured Classes
 
 If you have multiple `FloatingIPPools` and/or `FloatingIPSubnets` it might be desirable to offer the user logical meanings for `LoadBalancers` like `internetFacing` or `DMZ` instead of requiring the user to select a dedicated network or subnet ID at the service object level as an annotation.

--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -207,7 +207,7 @@ Although the openstack-cloud-controller-manager was initially implemented with N
     * `ROUND_ROBIN` (default)
     * `LEAST_CONNECTIONS`
     * `SOURCE_IP`
-    
+
   If `lb-provider` is set to "ovn" the value must be set to `SOURCE_IP_PORT`.
 
 * `lb-provider`
@@ -247,6 +247,23 @@ Although the openstack-cloud-controller-manager was initially implemented with N
 
 * `internal-lb`
   Determines whether or not to create an internal load balancer (no floating IP) by default. Default: false.
+
+* `node-selector`
+  A comma separated list of key=value annotations used to filter nodes for targeting by the load balancer. When defined, only nodes that match all the specified key=value annotations will be targeted. If an annotation includes only a key without a value, the filter will check only for the existence of the key on the node. When node-selector is not set (default value), all nodes will be added as members to a load balancer pool.
+
+  Note: This configuration option can be overridden with the `loadbalancer.openstack.org/node-selector` service annotation. Refer to [Exposing applications using services of LoadBalancer type](./expose-applications-using-loadbalancer-type-service.md)
+
+  Example: To filter nodes with the labels `env=production` and `region=default`, set the `node-selector` as follows:
+
+  ```
+  node-selector="env=production, region=default"
+  ```
+
+  Example: To filter nodes that have the key `env` with any value and the key `region` specifically set to `default`, set the `node-selector` as follows:
+
+  ```
+  node-selector="env, region=default"
+  ```
 
 * `cascade-delete`
   Determines whether or not to perform cascade deletion of load balancers. Default: true.

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -120,7 +120,7 @@ type serviceConfig struct {
 	lbMemberSubnetID            string
 	lbPublicNetworkID           string
 	lbPublicSubnetSpec          *floatingSubnetSpec
-	targetNodeLabels            string
+	targetNodeLabels            map[string]string
 	keepClientIP                bool
 	enableProxyProtocol         bool
 	timeoutClientData           int
@@ -405,6 +405,38 @@ func nodeAddressForLB(node *corev1.Node, preferredIPFamily corev1.IPFamily) (str
 	}
 
 	return "", cpoerrors.ErrNoAddressFound
+}
+
+// getKeyValuePropertiesFromAnnotation converts the comma separated list of key-value
+// pairs from the specified annotation and returns it as a map.
+func getKeyValuePropertiesFromServiceAnnotation(service *corev1.Service, annotationKey string, defaultSetting map[string]string) map[string]string {
+	klog.V(4).Infof("getStringFromServiceAnnotation") //(%s/%s, %v, %v)", service.Namespace, service.Name, annotationKey, defaultSetting)
+	if additionalTagsList, ok := service.Annotations[annotationKey]; ok {
+		additionalTags := make(map[string]string)
+		additionalTagsList = strings.TrimSpace(additionalTagsList)
+
+		// Break up list of "Key1=Val,Key2=Val2"
+		tagList := strings.Split(additionalTagsList, ",")
+
+		// Break up "Key=Val"
+		for _, tagSet := range tagList {
+			tag := strings.Split(strings.TrimSpace(tagSet), "=")
+
+			// Accept "Key=val" or "Key=" or just "Key"
+			if len(tag) >= 2 && len(tag[0]) != 0 {
+				// There is a key and a value, so save it
+				additionalTags[tag[0]] = tag[1]
+			} else if len(tag) == 1 && len(tag[0]) != 0 {
+				// Just "Key"
+				additionalTags[tag[0]] = ""
+			}
+		}
+		return additionalTags
+	}
+
+	// TODO: print default setting to log
+	klog.V(4).Infof("Could not find a Service Annotation; falling back on cloud-config setting")
+	return defaultSetting
 }
 
 // getStringFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's value or a specified defaultSetting
@@ -1317,10 +1349,16 @@ func (lbaas *LbaasV2) checkService(service *corev1.Service, nodes []*corev1.Node
 	svcConf.supportLBTags = openstackutil.IsOctaviaFeatureSupported(lbaas.lb, openstackutil.OctaviaFeatureTags, lbaas.opts.LBProvider)
 
 	// If in the config file internal-lb=true, user is not allowed to create external service.
-	// TODO: try mershal
-	svcConf.targetNodeLabels = getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerTargetNodeLabels, lbaas.opts.TargetNodeLabels)
-	if svcConf.targetNodeLabels != "" {
-		klog.V(3).InfoS("Target node labels %s are set", svcConf.targetNodeLabels)
+	svcConf.targetNodeLabels = getKeyValuePropertiesFromServiceAnnotation(service, ServiceAnnotationLoadBalancerTargetNodeLabels, lbaas.opts.TargetNodeLabels)
+	if len(svcConf.targetNodeLabels) > 0 {
+		for key, value := range svcConf.targetNodeLabels {
+			if value == "" {
+				klog.V(3).InfoS("Target node label key=%s is set to LoadBalancer service %s", key, serviceName)
+			} else {
+				klog.V(3).InfoS("Target node label key=%s,value=%s is set to LoadBalancer service %s", key, value, serviceName)
+			}
+		}
+
 	}
 	// TODO: review if needed?
 	// test again
@@ -1834,7 +1872,7 @@ func (lbaas *LbaasV2) updateOctaviaLoadBalancer(ctx context.Context, clusterName
 		return err
 	}
 
-	targetNodes := filterTargetNodes(nodes, svcConf.TargetNodeLabels)
+	targetNodes := filterTargetNodes(nodes, svcConf.targetNodeLabels)
 
 	serviceName := fmt.Sprintf("%s/%s", service.Namespace, service.Name)
 	klog.V(2).Infof("Updating %d nodes for Service %s in cluster %s", len(targetNodes), serviceName, clusterName)
@@ -2205,9 +2243,7 @@ func PreserveGopherError(rawError error) error {
 
 // filterTargetNodes uses node labels to filter the nodes that should be targeted by the LB,
 // checking if all the labels provided in an annotation are present in the nodes
-func filterTargetNodes(nodes []*corev1.Node, annotations map[string]string) []*corev1.Node {
-
-	targetNodeLabels := getKeyValuePropertiesFromAnnotation(annotations, ServiceAnnotationLoadBalancerTargetNodeLabels)
+func filterTargetNodes(nodes []*corev1.Node, targetNodeLabels map[string]string) []*corev1.Node {
 
 	if len(targetNodeLabels) == 0 {
 		return nodes

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -120,6 +120,7 @@ type serviceConfig struct {
 	lbMemberSubnetID            string
 	lbPublicNetworkID           string
 	lbPublicSubnetSpec          *floatingSubnetSpec
+	targetNodeLabels            string
 	keepClientIP                bool
 	enableProxyProtocol         bool
 	timeoutClientData           int
@@ -2204,7 +2205,7 @@ func PreserveGopherError(rawError error) error {
 
 // filterTargetNodes uses node labels to filter the nodes that should be targeted by the LB,
 // checking if all the labels provided in an annotation are present in the nodes
-func filterTargetNodes(nodes []*v1.Node, annotations map[string]string) []*v1.Node {
+func filterTargetNodes(nodes []*corev1.Node, annotations map[string]string) []*corev1.Node {
 
 	targetNodeLabels := getKeyValuePropertiesFromAnnotation(annotations, ServiceAnnotationLoadBalancerTargetNodeLabels)
 
@@ -2212,7 +2213,7 @@ func filterTargetNodes(nodes []*v1.Node, annotations map[string]string) []*v1.No
 		return nodes
 	}
 
-	targetNodes := make([]*v1.Node, 0, len(nodes))
+	targetNodes := make([]*corev1.Node, 0, len(nodes))
 
 	for _, node := range nodes {
 		if node.Labels != nil && len(node.Labels) > 0 {

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -114,8 +114,8 @@ type LoadBalancerOpts struct {
 	MonitorMaxRetries              uint                `gcfg:"monitor-max-retries"`
 	MonitorMaxRetriesDown          uint                `gcfg:"monitor-max-retries-down"`
 	ManageSecurityGroups           bool                `gcfg:"manage-security-groups"`
-	InternalLB                     bool                `gcfg:"internal-lb"` // default false
-	TargetNodeLabels               map[string]string   `gcfg:"target-node-labels"`   // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
+	InternalLB                     bool                `gcfg:"internal-lb"`        // default false
+	TargetNodeLabels               map[string]string   `gcfg:"target-node-labels"` // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
 	CascadeDelete                  bool                `gcfg:"cascade-delete"`
 	FlavorID                       string              `gcfg:"flavor-id"`
 	AvailabilityZone               string              `gcfg:"availability-zone"`
@@ -223,7 +223,7 @@ func ReadConfig(config io.Reader) (Config, error) {
 	// Set default values explicitly
 	cfg.LoadBalancer.Enabled = true
 	cfg.LoadBalancer.InternalLB = false
-    cfg.LoadBalancer.TargetNodeLabels = make(map[string]string)
+	cfg.LoadBalancer.TargetNodeLabels = make(map[string]string)
 	cfg.LoadBalancer.LBProvider = "amphora"
 	cfg.LoadBalancer.LBMethod = "ROUND_ROBIN"
 	cfg.LoadBalancer.CreateMonitor = false

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -114,8 +114,8 @@ type LoadBalancerOpts struct {
 	MonitorMaxRetries              uint                `gcfg:"monitor-max-retries"`
 	MonitorMaxRetriesDown          uint                `gcfg:"monitor-max-retries-down"`
 	ManageSecurityGroups           bool                `gcfg:"manage-security-groups"`
-	InternalLB                     bool                `gcfg:"internal-lb"`        // default false
-	TargetNodeLabels               map[string]string   `gcfg:"target-node-labels"` // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
+	InternalLB                     bool                `gcfg:"internal-lb"`   // default false
+	NodeSelector                   string              `gcfg:"node-selector"` // If specified, the loadbalancer members will be assined only from nodes list filtered by node-selector labels
 	CascadeDelete                  bool                `gcfg:"cascade-delete"`
 	FlavorID                       string              `gcfg:"flavor-id"`
 	AvailabilityZone               string              `gcfg:"availability-zone"`
@@ -223,7 +223,7 @@ func ReadConfig(config io.Reader) (Config, error) {
 	// Set default values explicitly
 	cfg.LoadBalancer.Enabled = true
 	cfg.LoadBalancer.InternalLB = false
-	cfg.LoadBalancer.TargetNodeLabels = make(map[string]string)
+	cfg.LoadBalancer.NodeSelector = ""
 	cfg.LoadBalancer.LBProvider = "amphora"
 	cfg.LoadBalancer.LBMethod = "ROUND_ROBIN"
 	cfg.LoadBalancer.CreateMonitor = false

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -115,7 +115,7 @@ type LoadBalancerOpts struct {
 	MonitorMaxRetriesDown          uint                `gcfg:"monitor-max-retries-down"`
 	ManageSecurityGroups           bool                `gcfg:"manage-security-groups"`
 	InternalLB                     bool                `gcfg:"internal-lb"` // default false
-	TargetNodeLabels               string              `gcfg:"target-node-labels"`   // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
+	TargetNodeLabels               map[string]string   `gcfg:"target-node-labels"`   // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
 	CascadeDelete                  bool                `gcfg:"cascade-delete"`
 	FlavorID                       string              `gcfg:"flavor-id"`
 	AvailabilityZone               string              `gcfg:"availability-zone"`
@@ -223,7 +223,7 @@ func ReadConfig(config io.Reader) (Config, error) {
 	// Set default values explicitly
 	cfg.LoadBalancer.Enabled = true
 	cfg.LoadBalancer.InternalLB = false
-    cfg.LoadBalancer.TargetNodeLabels = ""
+    cfg.LoadBalancer.TargetNodeLabels = make(map[string]string)
 	cfg.LoadBalancer.LBProvider = "amphora"
 	cfg.LoadBalancer.LBMethod = "ROUND_ROBIN"
 	cfg.LoadBalancer.CreateMonitor = false

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -115,6 +115,7 @@ type LoadBalancerOpts struct {
 	MonitorMaxRetriesDown          uint                `gcfg:"monitor-max-retries-down"`
 	ManageSecurityGroups           bool                `gcfg:"manage-security-groups"`
 	InternalLB                     bool                `gcfg:"internal-lb"` // default false
+	TargetNodeLabels               string              `gcfg:"target-node-labels"`   // If specified, will create floating ip for loadbalancer in one of the matching floating pool subnetworks.
 	CascadeDelete                  bool                `gcfg:"cascade-delete"`
 	FlavorID                       string              `gcfg:"flavor-id"`
 	AvailabilityZone               string              `gcfg:"availability-zone"`
@@ -222,6 +223,7 @@ func ReadConfig(config io.Reader) (Config, error) {
 	// Set default values explicitly
 	cfg.LoadBalancer.Enabled = true
 	cfg.LoadBalancer.InternalLB = false
+    cfg.LoadBalancer.TargetNodeLabels = ""
 	cfg.LoadBalancer.LBProvider = "amphora"
 	cfg.LoadBalancer.LBMethod = "ROUND_ROBIN"
 	cfg.LoadBalancer.CreateMonitor = false

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -75,6 +76,31 @@ func Contains(list []string, strToSearch string) bool {
 		}
 	}
 	return false
+}
+
+// StringToMap converts a string of comma-separated key-values into a map
+func StringToMap(str string) map[string]string {
+	// break up a "key1=val,key2=val2,key3=,key4" string into a list
+	values := strings.Split(strings.TrimSpace(str), ",")
+	keyValues := make(map[string]string, len(values))
+
+	for _, kv := range values {
+		kv := strings.SplitN(strings.TrimSpace(kv), "=", 2)
+
+		k := kv[0]
+		if len(kv) == 1 {
+			if k != "" {
+				// process "key=" or "key"
+				keyValues[k] = ""
+			}
+			continue
+		}
+
+		// process "key=val" or "key=val=foo"
+		keyValues[k] = kv[1]
+	}
+
+	return keyValues
 }
 
 // RoundUpSize calculates how many allocation units are needed to accommodate

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringToMap(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		out  map[string]string
+	}{
+		{
+			name: "test1",
+			in:   "k1=v1,k2=v2",
+			out:  map[string]string{"k1": "v1", "k2": "v2"},
+		},
+		{
+			name: "test2",
+			in:   "k1=v1,k2=v2=true",
+			out:  map[string]string{"k1": "v1", "k2": "v2=true"},
+		},
+		{
+			name: "test3",
+			in:   "k1,k2",
+			out:  map[string]string{"k1": "", "k2": ""},
+		},
+		{
+			name: "test4",
+			in:   " k1=v1, k2 ",
+			out:  map[string]string{"k1": "v1", "k2": ""},
+		},
+		{
+			name: "test5",
+			in:   "k3=v3,=emptykey",
+			out:  map[string]string{"k3": "v3", "": "emptykey"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out := StringToMap(test.in)
+
+			assert.Equal(t, test.out, out)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds an ability to specify loadbalancer service with a node selector.

Big thanks to @ririko-nakamura for the [initial code](https://github.com/ririko-nakamura/cloud-provider-openstack/tree/target-node-labels-selector).

A new OCCM `node-selector` option is added into the `[LoadBalancer]` config section.
And a new `loadbalancer.openstack.org/node-selector` service annotation support is added.

**Which issue this PR fixes(if applicable)**:
fixes #1770

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
added a node selector support for loadbalancer services
```
