### PR TITLE
[cinder-csi-plugin] ephemeral volume removal

### DIFF
--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack"
 	"k8s.io/cloud-provider-openstack/pkg/util/metadata"
 	"k8s.io/cloud-provider-openstack/pkg/util/mount"
@@ -129,31 +131,13 @@ func TestNodePublishVolumeEphermeral(t *testing.T) {
 
 	properties := map[string]string{"cinder.csi.openstack.org/cluster": FakeCluster}
 	fvolName := fmt.Sprintf("ephemeral-%s", FakeVolID)
-	tState := []string{"available"}
 
 	omock.On("CreateVolume", fvolName, 2, "test", "nova", "", "", "", properties).Return(&FakeVol, nil)
-
-	omock.On("AttachVolume", FakeNodeID, FakeVolID).Return(FakeVolID, nil)
-	omock.On("WaitDiskAttached", FakeNodeID, FakeVolID).Return(nil)
-	omock.On("WaitVolumeTargetStatus", FakeVolID, tState).Return(nil)
-	mmock.On("GetDevicePath", FakeVolID).Return(FakeDevicePath, nil)
-	mmock.On("IsLikelyNotMountPointAttach", FakeTargetPath).Return(true, nil)
-	metamock.On("GetAvailabilityZone").Return(FakeAvailability, nil)
-
-	mount.MInstance = mmock
-	metadata.MetadataService = metamock
-	openstack.OsInstances = map[string]openstack.IOpenStack{
-		"": omock,
-	}
-
-	d := NewDriver(&DriverOpts{Endpoint: FakeEndpoint, ClusterID: FakeCluster})
-	fakeNse := NewNodeServer(d, mount.MInstance, metadata.MetadataService, openstack.OsInstances[""], map[string]string{})
 
 	// Init assert
 	assert := assert.New(t)
 
 	// Expected Result
-	expectedRes := &csi.NodePublishVolumeResponse{}
 	stdVolCap := &csi.VolumeCapability{
 		AccessType: &csi.VolumeCapability_Mount{
 			Mount: &csi.VolumeCapability_MountVolume{},
@@ -174,13 +158,8 @@ func TestNodePublishVolumeEphermeral(t *testing.T) {
 	}
 
 	// Invoke NodePublishVolume
-	actualRes, err := fakeNse.NodePublishVolume(FakeCtx, fakeReq)
-	if err != nil {
-		t.Errorf("failed to NodePublishVolume: %v", err)
-	}
-
-	// Assert
-	assert.Equal(expectedRes, actualRes)
+	_, err := fakeNs.NodePublishVolume(FakeCtx, fakeReq)
+	assert.Equal(status.Error(codes.Unimplemented, "CSI inline ephemeral volumes support is removed in 1.31 release."), err)
 }
 
 // Test NodeStageVolume


### PR DESCRIPTION
Disable creating new deprecated ephemeral volumes

**What this PR does / why we need it**:

Remove deprecated ephemeral volumes.

**Which issue this PR fixes(if applicable)**:
fixes #2599

**Special notes for reviewers**:

Hi, @dulek i've disabled only ephemeral volume creation stage.
What do you think, we should remove all code or make it in two steps (releases)?

Thanks.

<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
In-line ephemeral is no longer available.
```
