### PR TITLE
[cinder-csi-plugin] retry mount operation with rescan incase of failure

### DIFF
--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -398,7 +398,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 			options = append(options, collectMountOptions(fsType, mountFlags)...)
 		}
 		// Mount
-		err = m.Mounter().FormatAndMount(devicePath, stagingTarget, fsType, options)
+		err = ns.formatAndMountRetry(devicePath, stagingTarget, fsType, options)
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
@@ -424,6 +424,25 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	}
 
 	return &csi.NodeStageVolumeResponse{}, nil
+}
+
+// formatAndMountRetry attempts to format and mount a device at the given path.
+// If the initial mount fails, it rescans the device and retries the mount operation.
+func (ns *nodeServer) formatAndMountRetry(devicePath, stagingTarget, fsType string, options []string) error {
+	m := ns.Mount
+	err := m.Mounter().FormatAndMount(devicePath, stagingTarget, fsType, options)
+	if err != nil {
+		klog.Infof("Initial format and mount failed: %v. Attempting rescan.", err)
+		// Attempting rescan if the initial mount fails
+		rescanErr := blockdevice.RescanDevice(devicePath)
+		if rescanErr != nil {
+			klog.Infof("Rescan failed: %v. Returning original mount error.", rescanErr)
+			return err
+		}
+		klog.Infof("Rescan succeeded, retrying format and mount")
+		err = m.Mounter().FormatAndMount(devicePath, stagingTarget, fsType, options)
+	}
+	return err
 }
 
 func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {


### PR DESCRIPTION
If the initial formatting and mounting fails in NodeStageVolume try to rescan the device and retry the operation.

### What this PR does / why we need it:

This prevents failures if the device information is reported wrongly which would otherwise be blocking the mounting.

### Which issue this PR fixes(if applicable):
fixes #2588 

### Special notes for reviewers:

Hi, I thought I would add this as a retry mechanism in case the mounting has already failed to minimize the impact on the current flow, also do not think this rescan should be causing any issues. If there is other ideas or concerns I am all ears, thanks!


```release-notes
None
```
