### PR TITLE
[cinder-csi-plugin] Add extraEnv support on cinder-csi-plugin and manila-csi-plugin helm charts

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.30.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.30.0
+version: 2.30.1-alpha.1
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -53,6 +53,9 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            {{- if .Values.csi.attacher.extraEnv }}
+              {{- toYaml .Values.csi.attacher.extraEnv | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -78,6 +81,9 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            {{- if .Values.csi.provisioner.extraEnv }}
+              {{- toYaml .Values.csi.provisioner.extraEnv | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -100,6 +106,9 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            {{- if .Values.csi.snapshotter.extraEnv }}
+              {{- toYaml .Values.csi.snapshotter.extraEnv | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
@@ -123,6 +132,9 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            {{- if .Values.csi.resizer.extraEnv }}
+              {{- toYaml .Values.csi.resizer.extraEnv | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -143,6 +155,9 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            {{- if .Values.csi.livenessprobe.extraEnv }}
+              {{- toYaml .Values.csi.livenessprobe.extraEnv | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
@@ -173,6 +188,9 @@ spec:
               value: /etc/kubernetes/{{ .Values.secret.filename }}
             - name: CLUSTER_NAME
               value: "{{ .Values.clusterID }}"
+            {{- if .Values.csi.plugin.extraEnv }}
+              {{- toYaml .Values.csi.plugin.extraEnv | nindent 12 }}
+            {{- end }}
           ports:
             - containerPort: 9808
               name: healthz

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -49,6 +49,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if .Values.csi.nodeDriverRegistrar.extraEnv }}
+              {{- toYaml .Values.csi.nodeDriverRegistrar.extraEnv | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -67,6 +70,10 @@ spec:
             {{- with .Values.csi.livenessprobe.extraArgs }}
             {{- tpl . $ | trim | nindent 12 }}
             {{- end }}
+            {{- end }}
+          env:
+            {{- if .Values.csi.livenessprobe.extraEnv }}
+              {{- toYaml .Values.csi.livenessprobe.extraEnv | nindent 12 }}
             {{- end }}
           volumeMounts:
             - name: socket-dir
@@ -95,6 +102,9 @@ spec:
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
               value: /etc/kubernetes/{{ .Values.secret.filename }}
+            {{- if .Values.csi.plugin.extraEnv }}
+              {{- toYaml .Values.csi.plugin.extraEnv | nindent 12 }}
+            {{- end }}
           ports:
             - containerPort: 9808
               name: healthz

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -12,6 +12,7 @@ csi:
       pullPolicy: IfNotPresent
     resources: {}
     extraArgs: {}
+    extraEnv: []
   provisioner:
     topology: "true"
     image:
@@ -20,6 +21,7 @@ csi:
       pullPolicy: IfNotPresent
     resources: {}
     extraArgs: {}
+    extraEnv: []
   snapshotter:
     image:
       repository: registry.k8s.io/sig-storage/csi-snapshotter
@@ -27,6 +29,7 @@ csi:
       pullPolicy: IfNotPresent
     resources: {}
     extraArgs: {}
+    extraEnv: []
   resizer:
     image:
       repository: registry.k8s.io/sig-storage/csi-resizer
@@ -34,6 +37,7 @@ csi:
       pullPolicy: IfNotPresent
     resources: {}
     extraArgs: {}
+    extraEnv: []
   livenessprobe:
     image:
       repository: registry.k8s.io/sig-storage/livenessprobe
@@ -45,6 +49,7 @@ csi:
     periodSeconds: 60
     resources: {}
     extraArgs: {}
+    extraEnv: []
   nodeDriverRegistrar:
     image:
       repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
@@ -52,6 +57,7 @@ csi:
       pullPolicy: IfNotPresent
     resources: {}
     extraArgs: {}
+    extraEnv: []
   plugin:
     image:
       repository: registry.k8s.io/provider-os/cinder-csi-plugin
@@ -131,6 +137,7 @@ csi:
     podMonitor:
       enabled: false
     extraArgs: {}
+    extraEnv: []
 
 # Log verbosity level.
 # See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md

--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.30.0
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 2.30.0
+version: 2.30.1-alpha.1
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -32,6 +32,9 @@ spec:
           env:
             - name: ADDRESS
               value: "unix:///var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}/csi-controllerplugin.sock"
+            {{- if $.Values.controllerplugin.provisioner.extraEnv }}
+              {{- toYaml $.Values.controllerplugin.provisioner.extraEnv | nindent 12 }}
+            {{- end }}
           imagePullPolicy: {{ $.Values.controllerplugin.provisioner.image.pullPolicy }}
           volumeMounts:
             - name: {{ .protocolSelector | lower }}-plugin-dir
@@ -46,6 +49,9 @@ spec:
           env:
             - name: ADDRESS
               value: "unix:///var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}/csi-controllerplugin.sock"
+            {{- if $.Values.controllerplugin.snapshotter.extraEnv }}
+              {{- toYaml $.Values.controllerplugin.snapshotter.extraEnv | nindent 12 }}
+            {{- end }}
           imagePullPolicy: {{ $.Values.controllerplugin.snapshotter.image.pullPolicy }}
           volumeMounts:
             - name: {{ .protocolSelector | lower }}-plugin-dir
@@ -61,6 +67,9 @@ spec:
           env:
             - name: ADDRESS
               value: "unix:///var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}/csi-controllerplugin.sock"
+            {{- if $.Values.controllerplugin.resizer.extraEnv }}
+              {{- toYaml $.Values.controllerplugin.resizer.extraEnv | nindent 12 }}
+            {{- end }}
           imagePullPolicy: {{ $.Values.controllerplugin.resizer.image.pullPolicy }}
           volumeMounts:
             - name: {{ .protocolSelector | lower }}-plugin-dir
@@ -107,6 +116,9 @@ spec:
               value: "unix://{{ .fwdNodePluginEndpoint.dir }}/{{ .fwdNodePluginEndpoint.sockFile }}"
             - name: MANILA_SHARE_PROTO
               value: "{{ .protocolSelector }}"
+            {{- if $.Values.controllerplugin.nodeplugin.extraEnv }}
+              {{- toYaml $.Values.controllerplugin.nodeplugin.extraEnv | nindent 12 }}
+            {{- end }}
           imagePullPolicy: {{ $.Values.csimanila.image.pullPolicy }}
           volumeMounts:
             - name: {{ .protocolSelector | lower }}-plugin-dir

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -29,6 +29,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if $.Values.nodeplugin.registrar.extraEnv }}
+              {{- toYaml $.Values.nodeplugin.registrar.extraEnv | nindent 12 }}
+            {{- end }}
           imagePullPolicy: {{ $.Values.nodeplugin.registrar.image.pullPolicy }}
           volumeMounts:
             - name: {{ .protocolSelector | lower }}-plugin-dir
@@ -74,6 +77,9 @@ spec:
               value: "unix://{{ .fwdNodePluginEndpoint.dir }}/{{ .fwdNodePluginEndpoint.sockFile }}"
             - name: MANILA_SHARE_PROTO
               value: "{{ .protocolSelector }}"
+            {{- if $.Values.nodeplugin.nodeplugin.extraEnv }}
+              {{- toYaml $.Values.nodeplugin.nodeplugin.extraEnv | nindent 12 }}
+            {{- end }}
           imagePullPolicy: {{ $.Values.csimanila.image.pullPolicy }}
           volumeMounts:
             - name: {{ .protocolSelector | lower }}-plugin-dir

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -56,7 +56,7 @@ nodeplugin:
   # CSI Manila container compute resources constraints
   nodeplugin:
     resources: {}
-    # extraEnv: []
+    extraEnv: []
   # csi-node-driver-registrar
   registrar:
     image:
@@ -64,7 +64,7 @@ nodeplugin:
       tag: v2.4.0
       pullPolicy: IfNotPresent
     resources: {}
-    # extraEnv: []
+    extraEnv: []
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -83,7 +83,7 @@ controllerplugin:
   # CSI Manila container compute resources constraints
   nodeplugin:
     resources: {}
-    # extraEnv: []
+    extraEnv: []
   # CSI external-provisioner container spec
   provisioner:
     image:
@@ -91,7 +91,7 @@ controllerplugin:
       tag: v3.0.0
       pullPolicy: IfNotPresent
     resources: {}
-    # extraEnv: []
+    extraEnv: []
     # Whether to pass --extra-create-metadata flag to csi-provisioner.
     extraCreateMetadata: false
   # CSI external-snapshotter container spec
@@ -101,7 +101,7 @@ controllerplugin:
       tag: v5.0.1
       pullPolicy: IfNotPresent
     resources: {}
-    # extraEnv: []
+    extraEnv: []
   # CSI external-resizer container spec
   resizer:
     image:
@@ -109,7 +109,7 @@ controllerplugin:
       tag: v1.8.0
       pullPolicy: IfNotPresent
     resources: {}
-    # extraEnv: []
+    extraEnv: []
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -56,6 +56,7 @@ nodeplugin:
   # CSI Manila container compute resources constraints
   nodeplugin:
     resources: {}
+    # extraEnv: []
   # csi-node-driver-registrar
   registrar:
     image:
@@ -63,6 +64,7 @@ nodeplugin:
       tag: v2.4.0
       pullPolicy: IfNotPresent
     resources: {}
+    # extraEnv: []
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -81,6 +83,7 @@ controllerplugin:
   # CSI Manila container compute resources constraints
   nodeplugin:
     resources: {}
+    # extraEnv: []
   # CSI external-provisioner container spec
   provisioner:
     image:
@@ -88,6 +91,7 @@ controllerplugin:
       tag: v3.0.0
       pullPolicy: IfNotPresent
     resources: {}
+    # extraEnv: []
     # Whether to pass --extra-create-metadata flag to csi-provisioner.
     extraCreateMetadata: false
   # CSI external-snapshotter container spec
@@ -97,6 +101,7 @@ controllerplugin:
       tag: v5.0.1
       pullPolicy: IfNotPresent
     resources: {}
+    # extraEnv: []
   # CSI external-resizer container spec
   resizer:
     image:
@@ -104,6 +109,7 @@ controllerplugin:
       tag: v1.8.0
       pullPolicy: IfNotPresent
     resources: {}
+    # extraEnv: []
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Add `extraEnv` support on the cinder-csi-plugin helm chart.

**Which issue this PR fixes(if applicable)**:

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->
 
One example use case of extraEnv:  In some of our private customer cloud, cinder-csi-plugin must access the openstack API endpoint with following env variable  `http_proxy, https_proxy, no_proxy`.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
