### PR TITLE
[occm] Support Octavia/Amphora Prometheus endpoint creation using annotations

### DIFF
--- a/pkg/openstack/events.go
+++ b/pkg/openstack/events.go
@@ -24,4 +24,5 @@ const (
 	eventLBFloatingIPSkipped           = "LoadBalancerFloatingIPSkipped"
 	eventLBRename                      = "LoadBalancerRename"
 	eventLBLbMethodUnknown             = "LoadBalancerLbMethodUnknown"
+	eventLBMetricListenerIgnored       = "LoadBalancerMetricListenerIgnored"
 )

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -73,6 +73,9 @@ const (
 	ServiceAnnotationLoadBalancerSubnetID             = "loadbalancer.openstack.org/subnet-id"
 	ServiceAnnotationLoadBalancerNetworkID            = "loadbalancer.openstack.org/network-id"
 	ServiceAnnotationLoadBalancerMemberSubnetID       = "loadbalancer.openstack.org/member-subnet-id"
+	ServiceAnnotationLoadBalancerMetricsEnabled       = "loadbalancer.openstack.org/metrics-enable"
+	ServiceAnnotationLoadBalancerMetricsPort          = "loadbalancer.openstack.org/metrics-port"
+	ServiceAnnotationLoadBalancerMetricsAllowCidrs    = "loadbalancer.openstack.org/metrics-allow-cidrs"
 	ServiceAnnotationLoadBalancerTimeoutClientData    = "loadbalancer.openstack.org/timeout-client-data"
 	ServiceAnnotationLoadBalancerTimeoutMemberConnect = "loadbalancer.openstack.org/timeout-member-connect"
 	ServiceAnnotationLoadBalancerTimeoutMemberData    = "loadbalancer.openstack.org/timeout-member-data"
@@ -89,6 +92,7 @@ const (
 	ServiceAnnotationLoadBalancerHealthMonitorMaxRetriesDown = "loadbalancer.openstack.org/health-monitor-max-retries-down"
 	ServiceAnnotationLoadBalancerLoadbalancerHostname        = "loadbalancer.openstack.org/hostname"
 	ServiceAnnotationLoadBalancerAddress                     = "loadbalancer.openstack.org/load-balancer-address"
+	ServiceAnnotationLoadBalancerVIPAddress                  = "loadbalancer.openstack.org/load-balancer-vip-address"
 	// revive:disable:var-naming
 	ServiceAnnotationTlsContainerRef = "loadbalancer.openstack.org/default-tls-container-ref"
 	// revive:enable:var-naming
@@ -97,14 +101,15 @@ const (
 	ServiceAnnotationLoadBalancerID = "loadbalancer.openstack.org/load-balancer-id"
 
 	// Octavia resources name formats
-	servicePrefix  = "kube_service_"
-	lbFormat       = "%s%s_%s_%s"
-	listenerPrefix = "listener_"
-	listenerFormat = listenerPrefix + "%d_%s"
-	poolPrefix     = "pool_"
-	poolFormat     = poolPrefix + "%d_%s"
-	monitorPrefix  = "monitor_"
-	monitorFormat  = monitorPrefix + "%d_%s"
+	servicePrefix        = "kube_service_"
+	lbFormat             = "%s%s_%s_%s"
+	listenerPrefix       = "listener_"
+	listenerFormat       = listenerPrefix + "%d_%s"
+	listenerFormatMetric = listenerPrefix + "metric_%s"
+	poolPrefix           = "pool_"
+	poolFormat           = poolPrefix + "%d_%s"
+	monitorPrefix        = "monitor_"
+	monitorFormat        = monitorPrefix + "%d_%s"
 )
 
 // LbaasV2 is a LoadBalancer implementation based on Octavia
@@ -145,6 +150,9 @@ type serviceConfig struct {
 	healthMonitorTimeout        int
 	healthMonitorMaxRetries     int
 	healthMonitorMaxRetriesDown int
+	metricAllowedCIDRs          []string
+	metricEnabled               bool
+	metricPort                  int
 	preferredIPFamily           corev1.IPFamily // preferred (the first) IP family indicated in service's `spec.ipFamilies`
 }
 
@@ -423,13 +431,13 @@ func getKeyValueFromServiceAnnotation(service *corev1.Service, annotationKey str
 func getStringFromServiceAnnotation(service *corev1.Service, annotationKey string, defaultSetting string) string {
 	klog.V(4).Infof("getStringFromServiceAnnotation(%s/%s, %v, %v)", service.Namespace, service.Name, annotationKey, defaultSetting)
 	if annotationValue, ok := service.Annotations[annotationKey]; ok {
-		//if there is an annotation for this setting, set the "setting" var to it
+		// if there is an annotation for this setting, set the "setting" var to it
 		// annotationValue can be empty, it is working as designed
 		// it makes possible for instance provisioning loadbalancer without floatingip
 		klog.V(4).Infof("Found a Service Annotation: %v = %v", annotationKey, annotationValue)
 		return annotationValue
 	}
-	//if there is no annotation, set "settings" var to the value from cloud config
+	// if there is no annotation, set "settings" var to the value from cloud config
 	if defaultSetting != "" {
 		klog.V(4).Infof("Could not find a Service Annotation; falling back on cloud-config setting: %v = %v", annotationKey, defaultSetting)
 	}
@@ -450,6 +458,22 @@ func getIntFromServiceAnnotation(service *corev1.Service, annotationKey string, 
 		return returnValue
 	}
 	klog.V(4).Infof("Could not find a Service Annotation; falling back to default setting: %v = %v", annotationKey, defaultSetting)
+	return defaultSetting
+}
+
+// getStringArrayFromServiceAnnotationSeparatedByComma  searches a given v1.Service for a specific annotationKey
+// and either returns the annotation's string array value (using comma as separator), or the specified defaultSetting.
+// Each value of the array is TrimSpaced. After the trim, if the string is empty, remove it.
+func getStringArrayFromServiceAnnotationSeparatedByComma(service *corev1.Service, annotationKey string, defaultSetting []string) []string {
+	klog.V(4).Infof("getStringArrayFromServiceAnnotationSeparatedByComma(%s/%s, %v, %q)", service.Namespace, service.Name, annotationKey, defaultSetting)
+	if annotationValue, ok := service.Annotations[annotationKey]; ok {
+		returnValue := cpoutil.SplitTrim(annotationValue, ',')
+
+		klog.V(4).Infof("Found a Service Annotation: %v = %q", annotationKey, returnValue)
+		return returnValue
+	}
+
+	klog.V(4).Infof("Could not find a Service Annotation; falling back to default setting: %v = %q", annotationKey, defaultSetting)
 	return defaultSetting
 }
 
@@ -1076,16 +1100,39 @@ func (lbaas *LbaasV2) buildCreateMemberOpts(ctx context.Context, port corev1.Ser
 }
 
 // Make sure the listener is created for Service
-func (lbaas *LbaasV2) ensureOctaviaListener(ctx context.Context, lbID string, name string, curListenerMapping map[listenerKey]*listeners.Listener, port corev1.ServicePort, svcConf *serviceConfig) (*listeners.Listener, error) {
-	listener, isPresent := curListenerMapping[listenerKey{
-		Protocol: getListenerProtocol(port.Protocol, svcConf),
-		Port:     int(port.Port),
-	}]
-	if !isPresent {
-		listenerCreateOpt := lbaas.buildListenerCreateOpt(ctx, port, svcConf, name)
-		listenerCreateOpt.LoadbalancerID = lbID
+func (lbaas *LbaasV2) ensureOctaviaListener(ctx context.Context, lbID string, name string, curListenerMapping map[listenerKey]*listeners.Listener, port corev1.ServicePort, svcConf *serviceConfig, isMetricListener bool) (*listeners.Listener, error) {
+	var listener *listeners.Listener
+	var isListenerPresent bool
 
-		klog.V(2).Infof("Creating listener for port %d using protocol %s", int(port.Port), listenerCreateOpt.Protocol)
+	if isMetricListener {
+		listener, isListenerPresent = curListenerMapping[listenerKey{
+			Protocol: listeners.ProtocolPrometheus,
+			Port:     svcConf.metricPort,
+		}]
+	} else {
+		listener, isListenerPresent = curListenerMapping[listenerKey{
+			Protocol: getListenerProtocol(port.Protocol, svcConf),
+			Port:     int(port.Port),
+		}]
+	}
+
+	if !isListenerPresent {
+		var listenerCreateOpt listeners.CreateOpts
+		if isMetricListener {
+			listenerCreateOpt = listeners.CreateOpts{
+				Name:           name,
+				Protocol:       listeners.ProtocolPrometheus,
+				ProtocolPort:   svcConf.metricPort,
+				AllowedCIDRs:   svcConf.metricAllowedCIDRs,
+				LoadbalancerID: lbID,
+				Tags:           []string{svcConf.lbName},
+			}
+		} else {
+			listenerCreateOpt = lbaas.buildListenerCreateOpt(ctx, port, svcConf, name)
+			listenerCreateOpt.LoadbalancerID = lbID
+		}
+
+		klog.V(2).Infof("Creating listener for port %d using protocol %s", listenerCreateOpt.ProtocolPort, listenerCreateOpt.Protocol)
 
 		var err error
 		listener, err = openstackutil.CreateListener(ctx, lbaas.lb, lbID, listenerCreateOpt)
@@ -1108,53 +1155,59 @@ func (lbaas *LbaasV2) ensureOctaviaListener(ctx context.Context, lbID string, na
 			}
 		}
 
-		if svcConf.connLimit != listener.ConnLimit {
-			updateOpts.ConnLimit = &svcConf.connLimit
-			listenerChanged = true
-		}
+		if isMetricListener {
+			if !cpoutil.StringListEqual(svcConf.metricAllowedCIDRs, listener.AllowedCIDRs) {
+				updateOpts.AllowedCIDRs = &svcConf.metricAllowedCIDRs
+				listenerChanged = true
+			}
+		} else {
+			if svcConf.connLimit != listener.ConnLimit {
+				updateOpts.ConnLimit = &svcConf.connLimit
+				listenerChanged = true
+			}
 
-		listenerKeepClientIP := listener.InsertHeaders[annotationXForwardedFor] == "true"
-		if svcConf.keepClientIP != listenerKeepClientIP {
-			updateOpts.InsertHeaders = &listener.InsertHeaders
-			if svcConf.keepClientIP {
-				if *updateOpts.InsertHeaders == nil {
-					*updateOpts.InsertHeaders = make(map[string]string)
+			listenerKeepClientIP := listener.InsertHeaders[annotationXForwardedFor] == "true"
+			if svcConf.keepClientIP != listenerKeepClientIP {
+				updateOpts.InsertHeaders = &listener.InsertHeaders
+				if svcConf.keepClientIP {
+					if *updateOpts.InsertHeaders == nil {
+						*updateOpts.InsertHeaders = make(map[string]string)
+					}
+					(*updateOpts.InsertHeaders)[annotationXForwardedFor] = "true"
+				} else {
+					delete(*updateOpts.InsertHeaders, annotationXForwardedFor)
 				}
-				(*updateOpts.InsertHeaders)[annotationXForwardedFor] = "true"
-			} else {
-				delete(*updateOpts.InsertHeaders, annotationXForwardedFor)
-			}
-			listenerChanged = true
-		}
-		if svcConf.tlsContainerRef != listener.DefaultTlsContainerRef {
-			updateOpts.DefaultTlsContainerRef = &svcConf.tlsContainerRef
-			listenerChanged = true
-		}
-		if openstackutil.IsOctaviaFeatureSupported(ctx, lbaas.lb, openstackutil.OctaviaFeatureTimeout, lbaas.opts.LBProvider) {
-			if svcConf.timeoutClientData != listener.TimeoutClientData {
-				updateOpts.TimeoutClientData = &svcConf.timeoutClientData
 				listenerChanged = true
 			}
-			if svcConf.timeoutMemberConnect != listener.TimeoutMemberConnect {
-				updateOpts.TimeoutMemberConnect = &svcConf.timeoutMemberConnect
+			if svcConf.tlsContainerRef != listener.DefaultTlsContainerRef {
+				updateOpts.DefaultTlsContainerRef = &svcConf.tlsContainerRef
 				listenerChanged = true
 			}
-			if svcConf.timeoutMemberData != listener.TimeoutMemberData {
-				updateOpts.TimeoutMemberData = &svcConf.timeoutMemberData
-				listenerChanged = true
+			if openstackutil.IsOctaviaFeatureSupported(ctx, lbaas.lb, openstackutil.OctaviaFeatureTimeout, lbaas.opts.LBProvider) {
+				if svcConf.timeoutClientData != listener.TimeoutClientData {
+					updateOpts.TimeoutClientData = &svcConf.timeoutClientData
+					listenerChanged = true
+				}
+				if svcConf.timeoutMemberConnect != listener.TimeoutMemberConnect {
+					updateOpts.TimeoutMemberConnect = &svcConf.timeoutMemberConnect
+					listenerChanged = true
+				}
+				if svcConf.timeoutMemberData != listener.TimeoutMemberData {
+					updateOpts.TimeoutMemberData = &svcConf.timeoutMemberData
+					listenerChanged = true
+				}
+				if svcConf.timeoutTCPInspect != listener.TimeoutTCPInspect {
+					updateOpts.TimeoutTCPInspect = &svcConf.timeoutTCPInspect
+					listenerChanged = true
+				}
 			}
-			if svcConf.timeoutTCPInspect != listener.TimeoutTCPInspect {
-				updateOpts.TimeoutTCPInspect = &svcConf.timeoutTCPInspect
-				listenerChanged = true
-			}
-		}
-		if openstackutil.IsOctaviaFeatureSupported(ctx, lbaas.lb, openstackutil.OctaviaFeatureVIPACL, lbaas.opts.LBProvider) {
-			if !cpoutil.StringListEqual(svcConf.allowedCIDR, listener.AllowedCIDRs) {
-				updateOpts.AllowedCIDRs = &svcConf.allowedCIDR
-				listenerChanged = true
+			if openstackutil.IsOctaviaFeatureSupported(ctx, lbaas.lb, openstackutil.OctaviaFeatureVIPACL, lbaas.opts.LBProvider) {
+				if !cpoutil.StringListEqual(svcConf.allowedCIDR, listener.AllowedCIDRs) {
+					updateOpts.AllowedCIDRs = &svcConf.allowedCIDR
+					listenerChanged = true
+				}
 			}
 		}
-
 		if listenerChanged {
 			klog.InfoS("Updating listener", "listenerID", listener.ID, "lbID", lbID, "updateOpts", updateOpts)
 			if err := openstackutil.UpdateListener(ctx, lbaas.lb, lbID, listener.ID, updateOpts); err != nil {
@@ -1163,7 +1216,6 @@ func (lbaas *LbaasV2) ensureOctaviaListener(ctx context.Context, lbID string, na
 			klog.InfoS("Updated listener", "listenerID", listener.ID, "lbID", lbID)
 		}
 	}
-
 	return listener, nil
 }
 
@@ -1452,6 +1504,12 @@ func (lbaas *LbaasV2) checkService(ctx context.Context, service *corev1.Service,
 		svcConf.lbMemberSubnetID = memberSubnetID
 	}
 
+	svcConf.metricEnabled = getBoolFromServiceAnnotation(service, ServiceAnnotationLoadBalancerMetricsEnabled, false)
+	if svcConf.metricEnabled {
+		svcConf.metricPort = getIntFromServiceAnnotation(service, ServiceAnnotationLoadBalancerMetricsPort, 9100)
+		svcConf.metricAllowedCIDRs = getStringArrayFromServiceAnnotationSeparatedByComma(service, ServiceAnnotationLoadBalancerMetricsAllowCidrs, []string{})
+	}
+
 	if !svcConf.internal {
 		var lbClass *LBClass
 		var floatingNetworkID string
@@ -1609,7 +1667,15 @@ func (lbaas *LbaasV2) makeSvcConf(ctx context.Context, serviceName string, servi
 }
 
 // checkListenerPorts checks if there is conflict for ports.
-func (lbaas *LbaasV2) checkListenerPorts(service *corev1.Service, curListenerMapping map[listenerKey]*listeners.Listener, isLBOwner bool, lbName string) error {
+func (lbaas *LbaasV2) checkListenerPorts(service *corev1.Service, curListenerMapping map[listenerKey]*listeners.Listener, isLBOwner bool, lbName string, extraPorts []corev1.ServicePort) error {
+	// Create a set of service ports for faster lookup
+	servicePortSet := make(map[listenerKey]struct{}, len(service.Spec.Ports))
+	for _, svcPort := range service.Spec.Ports {
+		key := listenerKey{Protocol: listeners.Protocol(svcPort.Protocol), Port: int(svcPort.Port)}
+		servicePortSet[key] = struct{}{}
+	}
+
+	// Check existing listeners for conflicts
 	for _, svcPort := range service.Spec.Ports {
 		key := listenerKey{Protocol: listeners.Protocol(svcPort.Protocol), Port: int(svcPort.Port)}
 
@@ -1621,6 +1687,26 @@ func (lbaas *LbaasV2) checkListenerPorts(service *corev1.Service, curListenerMap
 			} else {
 				return fmt.Errorf("the listener port %d already exists", svcPort.Port)
 			}
+		}
+	}
+
+	// Create a map for quick lookup of extra ports
+	extraPortMap := make(map[listenerKey]string, len(extraPorts))
+	for _, extraPort := range extraPorts {
+		key := listenerKey{Protocol: listeners.Protocol(extraPort.Protocol), Port: int(extraPort.Port)}
+		if _, isPresent := extraPortMap[key]; isPresent {
+			// Duplicate extra port detected
+			return fmt.Errorf("some extraPorts (%s/%s) are in conflicts: %d/%s", extraPortMap[key], extraPort.Name, extraPort.Port, string(extraPort.Protocol))
+		}
+		extraPortMap[key] = extraPort.Name
+	}
+
+	// Check for conflicts between service ports and extra ports
+	for key := range servicePortSet {
+		if _, isPresent := extraPortMap[key]; isPresent {
+			// Conflict found between service port and extra port
+			extraPortName := extraPortMap[key]
+			return fmt.Errorf("an extraPort (%s) conflicts with a Service Port %d/%s", extraPortName, key.Port, string(key.Protocol))
 		}
 	}
 
@@ -1778,13 +1864,24 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 		}
 		klog.V(4).InfoS("Existing listeners", "portProtocolMapping", curListenerMapping)
 
+		// setup extra ports list to check if there are no conflicts with Service's ones
+		var extraPortsList []corev1.ServicePort
+		if svcConf.metricEnabled && openstackutil.IsOctaviaFeatureSupported(ctx, lbaas.lb, openstackutil.OctaviaFeaturePrometheusListener, lbaas.opts.LBProvider) {
+			extraPortsList = append(extraPortsList,
+				corev1.ServicePort{
+					Name:     "octavia-metric-endpoint",
+					Protocol: corev1.ProtocolTCP,
+					Port:     int32(svcConf.metricPort),
+				})
+		}
+
 		// Check port conflicts
-		if err := lbaas.checkListenerPorts(service, curListenerMapping, isLBOwner, lbName); err != nil {
+		if err := lbaas.checkListenerPorts(service, curListenerMapping, isLBOwner, lbName, extraPortsList); err != nil {
 			return nil, err
 		}
 
 		for portIndex, port := range service.Spec.Ports {
-			listener, err := lbaas.ensureOctaviaListener(ctx, loadbalancer.ID, cpoutil.Sprintf255(listenerFormat, portIndex, lbName), curListenerMapping, port, svcConf)
+			listener, err := lbaas.ensureOctaviaListener(ctx, loadbalancer.ID, cpoutil.Sprintf255(listenerFormat, portIndex, lbName), curListenerMapping, port, svcConf, false)
 			if err != nil {
 				return nil, err
 			}
@@ -1804,6 +1901,22 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 			curListeners = popListener(curListeners, listener.ID)
 		}
 
+		// Check if we need to expose the metric endpoint
+		if svcConf.metricEnabled && openstackutil.IsOctaviaFeatureSupported(ctx, lbaas.lb, openstackutil.OctaviaFeaturePrometheusListener, lbaas.opts.LBProvider) {
+			// Only a LB owner can add the prometheus listener (to avoid conflict with a shared loadbalancer)
+			if isLBOwner {
+				lbaas.updateServiceAnnotation(service, ServiceAnnotationLoadBalancerMetricsPort, strconv.Itoa(svcConf.metricPort))
+				listener, err := lbaas.ensureOctaviaListener(ctx, loadbalancer.ID, cpoutil.Sprintf255(listenerFormatMetric, lbName), curListenerMapping, corev1.ServicePort{}, svcConf, true)
+				if err != nil {
+					return nil, err
+				}
+				curListeners = popListener(curListeners, listener.ID)
+			} else {
+				msg := "Metric Listener cannot be deployed on Service %s, only owner Service can do that"
+				lbaas.eventRecorder.Eventf(service, corev1.EventTypeWarning, eventLBMetricListenerIgnored, msg, serviceName)
+				klog.Warningf(msg, serviceName)
+			}
+		}
 		// Deal with the remaining listeners, delete the listener if it was created by this Service previously.
 		if err := lbaas.deleteOctaviaListeners(ctx, loadbalancer.ID, curListeners, isLBOwner, lbName); err != nil {
 			return nil, err
@@ -1823,8 +1936,9 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 		}
 	}
 
-	// save address into the annotation
+	// save addresses into the annotations
 	lbaas.updateServiceAnnotation(service, ServiceAnnotationLoadBalancerAddress, addr)
+	lbaas.updateServiceAnnotation(service, ServiceAnnotationLoadBalancerVIPAddress, loadbalancer.VipAddress)
 
 	// add LB name to load balancer tags.
 	if svcConf.supportLBTags {

--- a/pkg/util/openstack/loadbalancer.go
+++ b/pkg/util/openstack/loadbalancer.go
@@ -40,12 +40,13 @@ import (
 )
 
 const (
-	OctaviaFeatureTags              = 0
-	OctaviaFeatureVIPACL            = 1
-	OctaviaFeatureFlavors           = 2
-	OctaviaFeatureTimeout           = 3
-	OctaviaFeatureAvailabilityZones = 4
-	OctaviaFeatureHTTPMonitorsOnUDP = 5
+	OctaviaFeatureTags               = 0
+	OctaviaFeatureVIPACL             = 1
+	OctaviaFeatureFlavors            = 2
+	OctaviaFeatureTimeout            = 3
+	OctaviaFeatureAvailabilityZones  = 4
+	OctaviaFeatureHTTPMonitorsOnUDP  = 5
+	OctaviaFeaturePrometheusListener = 6
 
 	waitLoadbalancerInitDelay   = 1 * time.Second
 	waitLoadbalancerFactor      = 1.2
@@ -143,6 +144,14 @@ func IsOctaviaFeatureSupported(ctx context.Context, client *gophercloud.ServiceC
 		}
 		verHTTPMonitorsOnUDP, _ := version.NewVersion("v2.16")
 		if currentVer.GreaterThanOrEqual(verHTTPMonitorsOnUDP) {
+			return true
+		}
+	case OctaviaFeaturePrometheusListener:
+		if lbProvider == "ovn" {
+			return false
+		}
+		verACL, _ := version.NewVersion("v2.25")
+		if currentVer.GreaterThanOrEqual(verACL) {
 			return true
 		}
 	default:

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -47,3 +47,70 @@ func TestStringToMap(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitTrim(t *testing.T) {
+	type args struct {
+		s   string
+		sep rune
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "csv style",
+			args: args{
+				s:   "10.0.0.0/8, my-string-data",
+				sep: ',',
+			},
+			want: []string{
+				"10.0.0.0/8",
+				"my-string-data",
+			},
+		},
+		{
+			name: "csv with (with a trim space separation)",
+			args: args{
+				s:   "10.0.0.0/8 my-string-data",
+				sep: ',',
+			},
+			want: []string{
+				"10.0.0.0/8",
+				"my-string-data",
+			},
+		},
+		{
+			name: "double comma",
+			args: args{
+				s:   ",10.0.0.0/8, , 192.168.0.0/24,,",
+				sep: ',',
+			},
+			want: []string{
+				"10.0.0.0/8",
+				"192.168.0.0/24",
+			},
+		},
+		{
+			name: "empty string with comma",
+			args: args{
+				s:   " , ",
+				sep: ',',
+			},
+			want: []string{},
+		},
+		{
+			name: "empty string",
+			args: args{
+				s:   "",
+				sep: ',',
+			},
+			want: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, SplitTrim(tt.args.s, tt.args.sep), "SplitTrim(%v, %v)", tt.args.s, tt.args.sep)
+		})
+	}
+}

--- a/tests/e2e/cloudprovider/test-lb-service.sh
+++ b/tests/e2e/cloudprovider/test-lb-service.sh
@@ -801,6 +801,74 @@ EOF
     fi
 }
 
+########################################################################
+## Name: test_metric_endpoint
+## Desc: Create a k8s service and check the metric endpoint exposition
+## Params: None
+########################################################################
+function test_metric_endpoint {
+    local service="test-metric-endpoint"
+    local metric_port="9101"
+    local allowed_cidrs_expected='"0.0.0.0/0"'
+
+    if [[ ${OCTAVIA_PROVIDER} == "ovn" ]]; then
+        printf "\n>>>>>>> Skipping Service ${service} test for OVN provider\n"
+        return 0
+    fi
+
+    printf "\n>>>>>>> Create Service ${service}\n"
+    cat <<EOF | kubectl apply -f -
+kind: Service
+apiVersion: v1
+metadata:
+  annotations:
+    loadbalancer.openstack.org/metrics-enable: "true"
+    loadbalancer.openstack.org/metrics-port: "${metric_port}"
+    loadbalancer.openstack.org/metrics-allow-cidrs: ${allowed_cidrs_expected}
+  name: ${service}
+  namespace: $NAMESPACE
+spec:
+  type: LoadBalancer
+  selector:
+    run: echoserver
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+EOF
+
+    printf "\n>>>>>>> Waiting for the Service ${service} creation finished\n"
+    wait_for_service_address ${service}
+    wait_address_accessible $ipaddr
+
+    lbID=$(openstack loadbalancer list -c id -c name | grep "octavia-lb-test_${service}" | awk '{print $2}')
+
+    printf "\n>>>>>>> Sending request to the Metric endpoint ${service}\n"
+    metricFetch=$(curl -sS http://${ipaddr}:${metric_port}/metrics)
+    # ensure a metric is returned by the endpoint
+    if [[ "$metricFetch" == *"octavia_loadbalancer_cpu"* ]]; then
+        printf "\n>>>>>>> Expected: Get correct response from Service ${service}\n"
+    else
+        printf "\n>>>>>>> FAIL: Get incorrect response from Service ${service}, expected: octavia_loadbalancer_cpu, actual: ${metricFetch}\n"
+        curl -sSv http://${ipaddr}:${metric_port}/metrics
+        exit 1
+    fi
+
+    printf "\n>>>>>>> Checking Metric endpoint's configuration (allowed cidrs)\n"
+    metricListenerId=$(openstack loadbalancer status show ${lbID} | jq -r '.loadbalancer.listeners[] | select(.name | startswith("listener_metric_kube_service")) | .id')
+    cidrs=$(openstack loadbalancer listener show ${metricListenerId} -f json | jq '.allowed_cidrs | join(",")')
+    # ensure allowed cidrs are well filled on octavia side
+    if [[ "$cidrs" == "$allowed_cidrs_expected" ]] ; then
+      printf "\n>>>>>>> Expected: Get correct response from Metric endpoint's configuration\n"
+    else
+      printf "\n>>>>>>> FAIL: Get incorrect Metric's configuration, expected: ${allowed_cidrs_expected}, actual: ${cidrs}\n"
+      exit 1
+    fi
+
+    printf "\n>>>>>>> Delete Service ${service}\n"
+    kubectl -n $NAMESPACE delete service ${service}
+}
+
 create_namespace
 create_deployment
 set_openstack_credentials
@@ -810,3 +878,4 @@ test_forwarded
 test_update_port
 test_shared_lb
 test_shared_user_lb
+test_metric_endpoint


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Adds the ability to add a Prometheus listener on the Octavia LoadBalancer in order to fetch it with any Prometheus scrapper to get metrics from the LoadBalancer.

This PR brings 4 new annotations:
```yaml
loadbalancer.openstack.org/metrics-enable: "true" # Enable the listener endpoint on the Octavia LoadBalancer (default false)
loadbalancer.openstack.org/metrics-port: "9101" # Listener's port (default 9100)
loadbalancer.openstack.org/metrics-allow-cidrs: "10.0.0.0/8" # Listener's allowed cidrs (default none) - see below
loadbalancer.openstack.org/load-balancer-vip-address: "10.4.2.3" #  Auto-computed field based on Octavia VIP
```
**Why you should have to use `loadbalancer.openstack.org/metrics-allow-cidrs`**

It's strongly recommended to apply an allowed cidrs on the listener. If a Floating IP is attached to the Octavia, the metric endpoint **will be exposed publicly**. Apply a restriction to the K8S's subnet is recommended.

More detail on the Prometheus listener:
https://docs.openstack.org/octavia/latest/user/guides/monitoring.html#monitoring-with-prometheus

**Which issue this PR fixes(if applicable)**:
fixes #2465

**Special notes for reviewers**:
A new E2E test has been added.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] Support Octavia/Amphora Prometheus endpoint creation using annotations
```