### PR TITLE
[occm] [cinder-csi-plugin] Sanitize AZ name

### DIFF
--- a/pkg/openstack/instancesv2.go
+++ b/pkg/openstack/instancesv2.go
@@ -27,6 +27,7 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/cloud-provider-openstack/pkg/client"
 	"k8s.io/cloud-provider-openstack/pkg/metrics"
+	"k8s.io/cloud-provider-openstack/pkg/util"
 	"k8s.io/cloud-provider-openstack/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
@@ -133,11 +134,13 @@ func (i *InstancesV2) InstanceMetadata(ctx context.Context, node *v1.Node) (*clo
 		return nil, err
 	}
 
+	availabilityZone := util.SanitizeLabel(server.AvailabilityZone)
+
 	return &cloudprovider.InstanceMetadata{
 		ProviderID:    i.makeInstanceID(&server),
 		InstanceType:  instanceType,
 		NodeAddresses: addresses,
-		Zone:          server.AvailabilityZone,
+		Zone:          availabilityZone,
 		Region:        i.region,
 	}, nil
 }

--- a/pkg/util/metadata/metadata.go
+++ b/pkg/util/metadata/metadata.go
@@ -306,7 +306,7 @@ func (m *metadataService) GetAvailabilityZone() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return md.AvailabilityZone, nil
+	return util.SanitizeLabel(md.AvailabilityZone), nil
 }
 
 func CheckMetadataSearchOrder(order string) error {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -166,4 +167,20 @@ func GetAZFromTopology(topologyKey string, requirement *csi.TopologyRequirement)
 	}
 
 	return zone
+}
+
+func SanitizeLabel(input string) string {
+	// Replace non-alphanumeric characters (except '-', '_', '.') with '-'
+	reg := regexp.MustCompile(`[^-a-zA-Z0-9_.]+`)
+	sanitized := reg.ReplaceAllString(input, "-")
+
+	// Ensure the label starts and ends with an alphanumeric character
+	sanitized = strings.Trim(sanitized, "-_.")
+
+	// Ensure the label is not longer than 63 characters
+	if len(sanitized) > 63 {
+		sanitized = sanitized[:63]
+	}
+
+	return sanitized
 }


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**: AZ names can contain unicode characters, for example "Württemberg". The current behaviour is that this causes the occm pod to crash: 
```
$ crictl logs a358b0388996d (openstack-cloud-controller-manager)
error syncing 'test-hshu2jf73dym-default-worker-6s4mq-s9swb': Node "test-hshu2jf73dym-default-worker-6s4mq-s9swb" is invalid: metadata.labels: Invalid value: "Württemberg Test": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'), requeuing
```
This PR sanitizes the label value before it is applied. 
We also see the same problem in cinder-csi-plugin: 
```
$ kubectl logs -n openstack-system openstack-cinder-csi-nodeplugin-cl5tc
...
I0822 14:53:22.576401       1 main.go:101] Received NotifyRegistrationStatus call: &RegistrationStatus{PluginRegistered:false,Error:RegisterPlugin error -- plugin registration failed with err: error updating Node object with CSI driver node info: error updating node: timed out waiting for the condition; caused by: failed to patch status "{\"metadata\":{\"annotations\":{\"csi.volume.kubernetes.io/nodeid\":\"{\\\"cinder.csi.openstack.org\\\":\\\"0699b10e-b4bc-4129-9280-5b7c8556418f\\\",\\\"csi.tigera.io\\\":\\\"sst-yde-test-1-yt3243sf6os5-control-plane-m4hpg\\\"}\"},\"labels\":{\"topology.cinder.csi.openstack.org/zone\":\"Düdingen Test\"}}}" for node "sst-yde-test-1-yt3243sf6os5-control-plane-m4hpg": Node "sst-yde-test-1-yt3243sf6os5-control-plane-m4hpg" is invalid: metadata.labels: Invalid value: "Düdingen Test": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'),}
```

So this change also sanitises the label coming from the metadata service. 
**Special notes for reviewers**:
<!-- e.g. How to test this PR -->
I believe a similar fix is needed for cinder-csi-plugin
**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes a bug where unicode characters in the openstack availability zone can crash the OCCM or cinder-csi-plugin pods.
```
