### PR TITLE
[occm] LoadBalancer ProxyProtocol v2 feature

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -136,7 +136,11 @@ Request Body:
 
 - `loadbalancer.openstack.org/proxy-protocol`
 
-  If 'true', the loadbalancer pool protocol will be set as `PROXY`. Default is 'false'.
+  Enable the ProxyProtocol on all listeners. Default is 'false'.
+
+  Values:
+  - `v1`, `true`: enable the ProxyProtocol version 1
+  - `v2`: enable the ProxyProtocol version 2
 
   Not supported when `lb-provider=ovn` is configured in openstack-cloud-controller-manager.
 
@@ -402,6 +406,8 @@ To enable PROXY protocol support, the either the openstack-cloud-controller-mana
        app: nginx-ingress
    ```
 
+> To use the ProxyProtocol's version 2, set the annotation's value to `v2`. By default, ProxyProtocol's version 1 is used.
+
    Wait until the service gets an external IP.
 
    ```bash
@@ -499,6 +505,8 @@ To enable PROXY protocol support, the either the openstack-cloud-controller-mana
    Request Body:
            -no body in request-
    ```
+
+> Note: the Proxy Protocol is only available with TCP services.
 
 ### Sharing load balancer with multiple Services
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
The PR brings the ability of choosing the ProxProtocol in version 2 (instead of v1).

Two new values are supported for `loadbalancer.openstack.org/proxy-protocol`
```yaml
loadbalancer.openstack.org/proxy-protocol: "true" # Enable ProxyProtocolv1
loadbalancer.openstack.org/proxy-protocol: "false" # Default value, no proxy protocol enable 
loadbalancer.openstack.org/proxy-protocol: "v1" # NEW - Enable ProxyProtocolv1
loadbalancer.openstack.org/proxy-protocol: "v2" # NEW - Enable ProxyProtocolv2
```

**Which issue this PR fixes(if applicable)**:
fixes #2585

**Special notes for reviewers**:
N/A

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] Support LoadBalancer ProxyProtocol v2 feature
```
