### PR TITLE
fix instructions

### DIFF
--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -31,11 +31,12 @@ critical bug fixes.
 4. Once the PR is merged, make a tag and push it to the upstream repository.
 
     ```bash
-    $ git checkout -b release-X.Y upstream master
-    $ git pull upstream release-X.Y --tags
-    $ git tag -m "Release for cloud-provider-openstack to support Kubernetes release x" vX.Y.Z
+    $ git checkout master
+    $ git pull upstream master
+    $ git tag vX.Y.Z
     $ git push upstream vX.Y.Z
-    $ git push upstream release-X.Y
+    $ git checkout -b release-X.Y
+    $ git push origin release-X.Y
     ```
 
 5. [Github Actions](https://github.com/kubernetes/cloud-provider-openstack/actions/workflows/release-cpo.yaml) will create new [Docker images](https://console.cloud.google.com/gcr/images/k8s-staging-provider-os) and generate a [new draft release](https://github.com/kubernetes/cloud-provider-openstack/releases) in the repository.


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
