### PR TITLE
fix typo in the multi-region documentation

### DIFF
--- a/docs/cinder-csi-plugin/multi-region-clouds.md
+++ b/docs/cinder-csi-plugin/multi-region-clouds.md
@@ -138,7 +138,7 @@ Daemonsets should deploy pods on nodes from proper openstack context. We suppose
 
 Do as follows:
 - Use nodeSelector to match proper nodes labels
-- Add cli argument `--additionnal-topology topology.kubernetes.io/region=region-one`, which should match node labels, to container cinder-csi-plugin
+- Add cli argument `--additional-topology topology.kubernetes.io/region=region-one`, which should match node labels, to container cinder-csi-plugin
 - Add cli argument `--cloud-name="region-one"`, which should match configuration file subsection name, to container cinder-csi-plugin.
 
 ```yaml
@@ -168,7 +168,7 @@ spec:
         - --endpoint=$(CSI_ENDPOINT)
         - --cloud-config=$(CLOUD_CONFIG)
         - --cloud-name="region-one"
-        - --additionnal-topology
+        - --additional-topology
         - topology.kubernetes.io/region=region-one
         env:
         - name: CSI_ENDPOINT
@@ -218,7 +218,7 @@ spec:
         - --endpoint=$(CSI_ENDPOINT)
         - --cloud-config=$(CLOUD_CONFIG)
         - --cloud-name="region-two"
-        - --additionnal-topology
+        - --additional-topology
         - topology.kubernetes.io/region=region-two
         env:
         - name: CSI_ENDPOINT


### PR DESCRIPTION
Simple typo fix on the multi-region documentation. 
I was getting "Error: unknown flag: --additionnal-topology" errors because I copy/pasted the examples in the documentation. 
Indeed, the correct option is  "--additional-topology", with a single N

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```