### PR TITLE
Bump golangci to 1.61

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,10 @@
 run:
+  concurrency: 2
   timeout: 10m0s
 linters:
   enable:
     - gofmt
 output:
-  format: line-number
+  formats:
+￼    - format: line-number
+￼      path: stdout

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ $(BUILD_CMDS): $(SOURCES)
 test: unit functional
 
 check: work
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.0 run ./...
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0 run ./...
 
 unit: work
 	go test -tags=unit $(shell go list ./... | sed -e '/sanity/ { N; d; }' | sed -e '/tests/ {N; d;}') $(TESTARGS)

--- a/cmd/manila-csi-plugin/main.go
+++ b/cmd/manila-csi-plugin/main.go
@@ -71,7 +71,7 @@ func main() {
 		Short: "CSI Manila driver",
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := validateShareProtocolSelector(protoSelector); err != nil {
-				klog.Fatalf(err.Error())
+				klog.Fatal(err.Error())
 			}
 
 			manilaClientBuilder := &manilaclient.ClientBuilder{UserAgent: "manila-csi-plugin", ExtraUserAgentData: userAgentData}

--- a/pkg/util/blockdevice/blockdevice_linux.go
+++ b/pkg/util/blockdevice/blockdevice_linux.go
@@ -41,7 +41,7 @@ func findBlockDeviceRescanPath(path string) (string, error) {
 	if len(parts) == 3 && strings.HasPrefix(parts[1], "dev") {
 		return filepath.EvalSymlinks(filepath.Join("/sys/block", parts[2], "device", "rescan"))
 	}
-	return "", fmt.Errorf("illegal path for device " + devicePath)
+	return "", fmt.Errorf("illegal path for device %s", devicePath)
 }
 
 // IsBlockDevice checks whether device on the path is a block device
@@ -128,13 +128,13 @@ func RescanBlockDeviceGeometry(devicePath string, deviceMountPath string, newSiz
 func RescanDevice(devicePath string) error {
 	blockDeviceRescanPath, err := findBlockDeviceRescanPath(devicePath)
 	if err != nil {
-		return fmt.Errorf("Device does not have rescan path " + devicePath)
+		return fmt.Errorf("Device does not have rescan path %s", devicePath)
 	}
 
 	klog.V(3).Infof("Resolved block device path from %q to %q", devicePath, blockDeviceRescanPath)
 	err = triggerRescan(blockDeviceRescanPath)
 	if err != nil {
-		return fmt.Errorf("Error rescanning new block device geometry " + devicePath)
+		return fmt.Errorf("Error rescanning new block device geometry %s", devicePath)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
