### PR TITLE
[cinder-csi-plugin] implement structured logging

### DIFF
--- a/pkg/csi/cinder/identityserver.go
+++ b/pkg/csi/cinder/identityserver.go
@@ -30,7 +30,7 @@ type identityServer struct {
 }
 
 func (ids *identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
-	klog.V(5).Infof("Using default GetPluginInfo")
+	klog.V(5).InfoS("GetPluginInfo() called", "args", *req)
 
 	if ids.Driver.name == "" {
 		return nil, status.Error(codes.Unavailable, "Driver name not configured")
@@ -51,7 +51,8 @@ func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*c
 }
 
 func (ids *identityServer) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
-	klog.V(5).Infof("GetPluginCapabilities called with req %+v", req)
+	klog.V(5).InfoS("GetPluginCapabilities() called", "args", *req)
+
 	return &csi.GetPluginCapabilitiesResponse{
 		Capabilities: []*csi.PluginCapability{
 			{

--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -165,7 +165,7 @@ func TestNodePublishVolumeEphemeral(t *testing.T) {
 
 	// Invoke NodePublishVolume
 	_, err := fakeNs.NodePublishVolume(FakeCtx, fakeReq)
-	assert.Equal(status.Error(codes.Unimplemented, "CSI inline ephemeral volumes support is removed in 1.31 release."), err)
+	assert.Equal(status.Error(codes.Unimplemented, "[NodePublishVolume] CSI inline ephemeral volumes support is removed in 1.31 release."), err)
 }
 
 // Test NodeStageVolume

--- a/pkg/csi/cinder/utils.go
+++ b/pkg/csi/cinder/utils.go
@@ -86,7 +86,7 @@ func ParseEndpoint(ep string) (string, string, error) {
 			return s[0], s[1], nil
 		}
 	}
-	return "", "", fmt.Errorf("Invalid endpoint: %v", ep)
+	return "", "", fmt.Errorf("invalid endpoint: %v", ep)
 }
 
 func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

implement [structured logging KEP 1602](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/1602-structured-logging/README.md#new-klog-methods)

CSI plugins often use common values like node name, volume name, volume ID, and instance ID in unstructured error and log messages. This makes it hard to group and sort them. I want to change these logs to structured logs, as the core Kubernetes team has decided to move in this direction

Current logs:

```
CreateVolume: Successfully created volume 47d323fd-b06c-424e-b27b-d27db2fb2c5c in Availability Zone: nova of size 10 GiB
```

Structured logs

```
"Successfully created volume" func="CreateVolume" volumeID="228d4464-48a2-4a45-81a7-24d3d0a1862a" size=10 zone="nova"
"Successfully detached volume" func="ControllerUnpublishVolume" volumeID="228d4464-48a2-4a45-81a7-24d3d0a1862a" instanceID="89e33913-0cce-4c1a-be2f-4e6a39d32b51"
"Successfully deleted volume" func="DeleteVolume" volumeID="228d4464-48a2-4a45-81a7-24d3d0a1862a" cloud=""
```

Default log keys:

* `func`- name of function, example `CreateVolume`
* `size` - volume size
* `volume` - volume name
* `volumeID` - volume ID
* `snapshotID` - snapshot ID
* `instanceID` -  instance ID
* `zone` - availability zone
* `cloud` - cloud config

**Which issue this PR fixes(if applicable)**:

make sense after  #2640

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
