### PR TITLE
[cinder-csi-plugin] enable fs resize for any volume for Stage Volume Step

### DIFF
--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -251,14 +251,6 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, status.Error(codes.InvalidArgument, "NodeStageVolume Volume Capability must be provided")
 	}
 
-	vol, err := ns.Cloud.GetVolume(volumeID)
-	if err != nil {
-		if cpoerrors.IsNotFound(err) {
-			return nil, status.Error(codes.NotFound, "Volume not found")
-		}
-		return nil, status.Errorf(codes.Internal, "GetVolume failed with error %v", err)
-	}
-
 	m := ns.Mount
 	// Do not trust the path provided by cinder, get the real path on node
 	devicePath, err := getDevicePath(volumeID, m)
@@ -296,22 +288,18 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		}
 	}
 
-	// Try expanding the volume if it's created from a snapshot or another volume (see #1539)
-	if vol.SourceVolID != "" || vol.SnapshotID != "" {
+	r := mountutil.NewResizeFs(ns.Mount.Mounter().Exec)
 
-		r := mountutil.NewResizeFs(ns.Mount.Mounter().Exec)
+	needResize, err := r.NeedResize(devicePath, stagingTarget)
 
-		needResize, err := r.NeedResize(devicePath, stagingTarget)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Could not determine if volume %q need to be resized: %v", volumeID, err)
+	}
 
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "Could not determine if volume %q need to be resized: %v", volumeID, err)
-		}
-
-		if needResize {
-			klog.V(4).Infof("NodeStageVolume: Resizing volume %q created from a snapshot/volume", volumeID)
-			if _, err := r.Resize(devicePath, stagingTarget); err != nil {
-				return nil, status.Errorf(codes.Internal, "Could not resize volume %q: %v", volumeID, err)
-			}
+	if needResize {
+		klog.V(4).Infof("NodeStageVolume: Resizing volume %q created from a snapshot/volume", volumeID)
+		if _, err := r.Resize(devicePath, stagingTarget); err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not resize volume %q: %v", volumeID, err)
 		}
 	}
 

--- a/pkg/util/blockdevice/blockdevice_unsupported.go
+++ b/pkg/util/blockdevice/blockdevice_unsupported.go
@@ -34,3 +34,7 @@ func GetBlockDeviceSize(path string) (int64, error) {
 func RescanBlockDeviceGeometry(devicePath string, deviceMountPath string, newSize int64) error {
 	return errors.New("RescanBlockDeviceGeometry is not implemented for this OS")
 }
+
+func RescanDevice(devicePath string) error {
+	return errors.New("RescanDevice is not implemented for this OS")
+}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

enable resize fs for all volumes.


**Which issue this PR fixes(if applicable)**:

I'm in a scenario where the volume source is a block storage device, not a snapshot or another volume. We want to enable filesystem resizing to fully utilize the entire disk in this case.

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
