### PR TITLE
[cinder-csi-plugin] fix global config requirement for node-service

### DIFF
--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -176,8 +176,8 @@ func CreateOpenStackProvider(cloudName string, noClient bool) (IOpenStack, error
 		return nil, err
 	}
 	logcfg(cfg)
-	_, cloudNameDefined := cfg.Global[cloudName]
-	if !cloudNameDefined {
+	global := cfg.Global[cloudName]
+	if global == nil && !noClient {
 		return nil, fmt.Errorf("GetConfigFromFiles cloud name \"%s\" not found in configuration files: %s", cloudName, configFiles)
 	}
 
@@ -196,14 +196,14 @@ func CreateOpenStackProvider(cloudName string, noClient bool) (IOpenStack, error
 		return NoopInstances[cloudName], nil
 	}
 
-	provider, err := client.NewOpenStackClient(cfg.Global[cloudName], "cinder-csi-plugin", userAgentData...)
+	provider, err := client.NewOpenStackClient(global, "cinder-csi-plugin", userAgentData...)
 	if err != nil {
 		return nil, err
 	}
 
 	epOpts := gophercloud.EndpointOpts{
-		Region:       cfg.Global[cloudName].Region,
-		Availability: cfg.Global[cloudName].EndpointType,
+		Region:       global.Region,
+		Availability: global.EndpointType,
 	}
 
 	// Init Nova ServiceClient


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #2677

**Special notes for reviewers**:


**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[cinder-csi-plugin] fix global config requirement for node-service
```
