### PR TITLE
Make cloud config optional in cinder-csi-plugin

### DIFF
--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -177,7 +177,7 @@ func CreateOpenStackProvider(cloudName string, noClient bool) (IOpenStack, error
 	}
 	logcfg(cfg)
 	_, cloudNameDefined := cfg.Global[cloudName]
-	if !cloudNameDefined {
+	if !cloudNameDefined && !noClient {
 		return nil, fmt.Errorf("GetConfigFromFiles cloud name \"%s\" not found in configuration files: %s", cloudName, configFiles)
 	}
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```


it is now possible to run nodeplugin without providing cloud config at all

```
        - /bin/cinder-csi-plugin
        - --endpoint=$(CSI_ENDPOINT)
        - --http-endpoint=:9809
        - --provide-controller-service=false
        - --node-service-no-os-client=true
```