### PR TITLE
Update openstack-cinder-csi helm chart for multi cloud support

### DIFF
--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -181,6 +181,11 @@ spec:
             {{- tpl . $ | trim | nindent 12 }}
             {{- end }}
             {{- end }}
+            {{- if .Values.csi.plugin.controllerPlugin.extraArgs }}
+            {{- with .Values.csi.plugin.controllerPlugin.extraArgs }}
+            {{- tpl . $ | trim | nindent 12 }}
+            {{- end }}
+            {{- end }}
           env:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock

--- a/charts/cinder-csi-plugin/templates/controllerplugin-rbac.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-rbac.yaml
@@ -97,13 +97,6 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-  # Secret permission is optional.
-  # Enable it if your driver needs secret.
-  # For example, `csi.storage.k8s.io/snapshotter-secret-name` is set in VolumeSnapshotClass.
-  # See https://kubernetes-csi.github.io/docs/secrets-and-credentials.html for more details.
-  #  - apiGroups: [""]
-  #    resources: ["secrets"]
-  #    verbs: ["get", "list"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
@@ -116,6 +109,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+  {{- with .Values.csi.snapshotter.extraRbac }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -135,11 +131,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-resizer-role
 rules:
-  # The following rule should be uncommented for plugins that require secrets
-  # for provisioning.
-  # - apiGroups: [""]
-  #   resources: ["secrets"]
-  #   verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "patch"]
@@ -158,6 +149,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+  {{- with .Values.csi.resizer.extraRbac }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -97,6 +97,11 @@ spec:
             {{- tpl . $ | trim | nindent 12 }}
             {{- end }}
             {{- end }}
+            {{- if .Values.csi.plugin.nodePlugin.extraArgs }}
+            {{- with .Values.csi.plugin.nodePlugin.extraArgs }}
+            {{- tpl . $ | trim | nindent 12 }}
+            {{- end }}
+            {{- end }}
           env:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -30,6 +30,14 @@ csi:
     resources: {}
     extraArgs: {}
     extraEnv: []
+    # Secret permission is optional.
+    # Enable it if your driver needs secret.
+    # For example, `csi.storage.k8s.io/snapshotter-secret-name` is set in VolumeSnapshotClass.
+    # See https://kubernetes-csi.github.io/docs/secrets-and-credentials.html for more details.
+    extraRbac: {}
+    #  - apiGroups: [""]
+    #    resources: ["secrets"]
+    #    verbs: ["get", "list"]
   resizer:
     image:
       repository: registry.k8s.io/sig-storage/csi-resizer
@@ -38,6 +46,12 @@ csi:
     resources: {}
     extraArgs: {}
     extraEnv: []
+    # The following rule should be uncommented for plugins that require secrets
+    # for provisioning.
+    extraRbac: {}
+    # - apiGroups: [""]
+    #   resources: ["secrets"]
+    #   verbs: ["get", "list", "watch"]
   livenessprobe:
     image:
       repository: registry.k8s.io/sig-storage/livenessprobe

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -88,6 +88,7 @@ csi:
       tolerations:
         - operator: Exists
       kubeletDir: /var/lib/kubelet
+      extraArgs: {}
       # Allow for specifying internal IP addresses for multiple hostnames
       # hostAliases:
       #   - ip: "10.0.0.1"
@@ -122,6 +123,7 @@ csi:
       affinity: {}
       nodeSelector: {}
       tolerations: []
+      extraArgs: {}
       # Allow for specifying internal IP addresses for multiple hostnames
       # hostAliases:
       #   - ip: "10.0.0.1"

--- a/docs/cinder-csi-plugin/multi-region-clouds.md
+++ b/docs/cinder-csi-plugin/multi-region-clouds.md
@@ -325,13 +325,28 @@ If you set the extraArgs in `plugin.extraArgs`, the same `extraArgs` will end up
 You will still need to manually create your additionnal daemonsets for your additionnal regions.
 
 ```yaml
-        nodePlugin:
-          extraArgs: |-
-            - --cloud-name=region-one
-            - --additional-topology
-            - topology.kubernetes.io/region=region-one
-        controllerPlugin:
-          extraArgs: |-
-            - --cloud-name=region-one
-            - --cloud-name=region-two
+nodePlugin:
+  extraArgs: |-
+    - --cloud-name=region-one
+    - --additional-topology
+    - topology.kubernetes.io/region=region-one
+controllerPlugin:
+  extraArgs: |-
+    - --cloud-name=region-one
+    - --cloud-name=region-two
+```
+
+In addition, if you use the `resizer` and the `snapshotter`, you will need them to be able to read the secrets you defined in the storage class' annotations in order to determine which cloud to address. You will need to add some `extraRbac` in YAML format, like this: 
+
+```yaml
+snapshotter:
+  extraRbac:
+    - apiGroups: [""]
+      resources: ["secrets"]
+      verbs: ["get", "list"]
+resizer:
+  extraRbac:
+    - apiGroups: [""]
+      resources: ["secrets"]
+      verbs: ["get", "list", "watch"]
 ```

--- a/docs/cinder-csi-plugin/multi-region-clouds.md
+++ b/docs/cinder-csi-plugin/multi-region-clouds.md
@@ -314,3 +314,24 @@ spec:
       ...
 ```
 
+### When using the cinder-csi-plugin helmchart
+
+When runing the cinder-csi-plugin with multi-region, you need to specify different `extraArgs` on the `cinder-csi-plugin` containers of the deployment and the daemonset.
+
+When using the helmchart, you need to set the different `extraArgs` on `plugin.nodePlugin.extraArgs` and `plugin.controllerPlugin.extraArgs`.
+
+If you set the extraArgs in `plugin.extraArgs`, the same `extraArgs` will end up on both the `cinder-csi-plugin` container of both the deployment and the daemonset. 
+
+You will still need to manually create your additionnal daemonsets for your additionnal regions.
+
+```yaml
+        nodePlugin:
+          extraArgs: |-
+            - --cloud-name=region-one
+            - --additional-topology
+            - topology.kubernetes.io/region=region-one
+        controllerPlugin:
+          extraArgs: |-
+            - --cloud-name=region-one
+            - --cloud-name=region-two
+```


### PR DESCRIPTION
**What this PR does / why we need it**:

Hello, this PR modifies the openstack-cinder-csi helm chart to allow to use it with the multi cloud feature: https://github.com/kubernetes/cloud-provider-openstack/pull/2551

It fixes two problems that were preventing to use the chart with multi cloud: 
1) When runing the cinder-csi-plugin with multi-region, you need to specify different `extraArgs` on the `cinder-csi-plugin` containers of the deployment and the daemonset. It wasn't possible with the current version. Now you can, like this:

```yaml
nodePlugin:
  extraArgs: |-
    - --cloud-name=region-one
    - --additional-topology
    - topology.kubernetes.io/region=region-one
controllerPlugin:
  extraArgs: |-
    - --cloud-name=region-one
    - --cloud-name=region-two
```

You still need to create the second daemonset manually, but at least you can use the chart. If this PR is accepted, I'll work on a new one to allow the creation of the second daemonset.

2) If you use the `resizer` and the `snapshotter`, you will need them to be able to read the secrets you defined in the storage class' annotations in order to determine which cloud to address. This was hardcoded in controllerplugin-rbac.yaml, now you can specify it like this: 

```yaml
snapshotter:
  extraRbac:
    - apiGroups: [""]
      resources: ["secrets"]
      verbs: ["get", "list"]
resizer:
  extraRbac:
    - apiGroups: [""]
      resources: ["secrets"]
      verbs: ["get", "list", "watch"]
```
I also moved the comments from controllerplugin-rbac.yaml to the values file. 

I added these info to the multi-region-clouds.md documentation file.