### PR TITLE
[occm] Support Octavia load balancing method via annotation

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -152,6 +152,14 @@ Request Body:
 
   Not supported when `lb-provider=ovn` is configured in openstack-cloud-controller-manager.
 
+- `loadbalancer.openstack.org/lb-method`
+
+  Load balancing algorithm to use when distributed to members. [OpenStack Pool Creation | lb_algorithm](https://docs.openstack.org/api-ref/load-balancer/v2/#create-pool)
+
+  Default value: defined in your OCCM configuration
+
+  Possible values: `ROUND_ROBIN`, `LEAST_CONNECTIONS`, `SOURCE_IP`, `SOURCE_IP_PORT`
+
 - `loadbalancer.openstack.org/timeout-client-data`
 
   Frontend client inactivity timeout in milliseconds for the load balancer.

--- a/pkg/openstack/events.go
+++ b/pkg/openstack/events.go
@@ -23,4 +23,5 @@ const (
 	eventLBAZIgnored                   = "LoadBalancerAvailabilityZonesIgnored"
 	eventLBFloatingIPSkipped           = "LoadBalancerFloatingIPSkipped"
 	eventLBRename                      = "LoadBalancerRename"
+	eventLBLbMethodUnknown             = "LoadBalancerLbMethodUnknown"
 )

--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -1155,6 +1155,29 @@ func Test_buildPoolCreateOpt(t *testing.T) {
 				Persistence: &pools.SessionPersistence{Type: "SOURCE_IP"},
 			},
 		},
+		{
+			name: "test for loadbalancing method",
+			args: args{
+				protocol: "TCP",
+				svcConf: &serviceConfig{
+					poolLbMethod: "ROUND_ROBIN",
+				},
+				lbaasV2: &LbaasV2{
+					LoadBalancer{
+						opts: LoadBalancerOpts{
+							LBProvider: "ovn",
+							LBMethod:   "SOURCE_IP_PORT",
+						},
+					},
+				},
+				service: &corev1.Service{},
+			},
+			want: pools.CreateOpts{
+				Name:     "test for loadbalancing method",
+				Protocol: pools.ProtocolTCP,
+				LBMethod: "ROUND_ROBIN",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Adds the ability to change the LB Algorithm of an Octavia using an annotation.

This PR brings a new annotation:
```yaml
loadbalancer.openstack.org/lb-method: "" # Default value: the one defined in the OCCM configuration file
```

**Special notes for reviewers**:
N/A

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[occm] Octavia - ability to change the load balancing method using an annotation.
```
