### PR TITLE
[core] improved readability of lb funcs, switch to slices.Contains

### DIFF
--- a/pkg/identity/keystone/sync.go
+++ b/pkg/identity/keystone/sync.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 
@@ -32,8 +33,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
-
-	cpoutil "k8s.io/cloud-provider-openstack/pkg/util"
 )
 
 const (
@@ -314,7 +313,7 @@ func (s *Syncer) syncRoles(user *userInfo) *userInfo {
 
 	if roles, isPresent := user.Extra[Roles]; isPresent {
 		for _, roleMap := range s.syncConfig.RoleMaps {
-			if roleMap.KeystoneRole != "" && cpoutil.Contains(roles, roleMap.KeystoneRole) {
+			if roleMap.KeystoneRole != "" && slices.Contains(roles, roleMap.KeystoneRole) {
 				if len(roleMap.Groups) > 0 {
 					user.Groups = append(user.Groups, roleMap.Groups...)
 				}

--- a/pkg/openstack/instances.go
+++ b/pkg/openstack/instances.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	sysos "os"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -41,7 +42,6 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/cloud-provider-openstack/pkg/client"
 	"k8s.io/cloud-provider-openstack/pkg/metrics"
-	"k8s.io/cloud-provider-openstack/pkg/util"
 	"k8s.io/cloud-provider-openstack/pkg/util/errors"
 	"k8s.io/cloud-provider-openstack/pkg/util/metadata"
 )
@@ -677,7 +677,7 @@ func nodeAddresses(srv *servers.Server, ports []PortWithTrunkDetails, client *go
 			var addressType v1.NodeAddressType
 			if props.IPType == "floating" {
 				addressType = v1.NodeExternalIP
-			} else if util.Contains(networkingOpts.PublicNetworkName, network) {
+			} else if slices.Contains(networkingOpts.PublicNetworkName, network) {
 				addressType = v1.NodeExternalIP
 				// removing already added address to avoid listing it as both ExternalIP and InternalIP
 				// may happen due to listing "private" network as "public" in CCM's config
@@ -687,7 +687,7 @@ func nodeAddresses(srv *servers.Server, ports []PortWithTrunkDetails, client *go
 					},
 				)
 			} else {
-				if len(networkingOpts.InternalNetworkName) == 0 || util.Contains(networkingOpts.InternalNetworkName, network) {
+				if len(networkingOpts.InternalNetworkName) == 0 || slices.Contains(networkingOpts.InternalNetworkName, network) {
 					addressType = v1.NodeInternalIP
 				} else {
 					klog.V(5).Infof("Node '%s' address '%s' ignored due to 'internal-network-name' option", srv.Name, props.Addr)

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -258,11 +259,11 @@ func ReadConfig(config io.Reader) (Config, error) {
 		cfg.Metadata.SearchOrder = fmt.Sprintf("%s,%s", metadata.ConfigDriveID, metadata.MetadataID)
 	}
 
-	if !util.Contains(supportedLBProvider, cfg.LoadBalancer.LBProvider) {
+	if !slices.Contains(supportedLBProvider, cfg.LoadBalancer.LBProvider) {
 		klog.Warningf("Unsupported LoadBalancer Provider: %s", cfg.LoadBalancer.LBProvider)
 	}
 
-	if !util.Contains(supportedContainerStore, cfg.LoadBalancer.ContainerStore) {
+	if !slices.Contains(supportedContainerStore, cfg.LoadBalancer.ContainerStore) {
 		klog.Warningf("Unsupported Container Store: %s", cfg.LoadBalancer.ContainerStore)
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -69,16 +69,6 @@ func StringListEqual(list1, list2 []string) bool {
 	return s1.Equal(s2)
 }
 
-// Contains searches if a string list contains the given string or not.
-func Contains(list []string, strToSearch string) bool {
-	for _, item := range list {
-		if item == strToSearch {
-			return true
-		}
-	}
-	return false
-}
-
 // StringToMap converts a string of comma-separated key-values into a map
 func StringToMap(str string) map[string]string {
 	// break up a "key1=val,key2=val2,key3=,key4" string into a list


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Fixed nested conditions logic and switched to `slices.Contains`, removed `Contains` func from util package.

**Which issue this PR fixes(if applicable)**:

n/a

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
