### PR TITLE
[occm] passthrough context to gophercloud calls

### DIFF
--- a/pkg/openstack/loadbalancer_subnet_match_test.go
+++ b/pkg/openstack/loadbalancer_subnet_match_test.go
@@ -103,7 +103,7 @@ func runTag(t *testing.T, subnet *subnets.Subnet, spec floatingSubnetSpec, expec
 }
 
 func runMatch(t *testing.T, subnet *subnets.Subnet, spec floatingSubnetSpec, expected bool) {
-	m, err := spec.Matcher(true)
+	m, err := spec.matcher(true)
 	assert.NoError(t, err)
 	assert.Equal(t, m(subnet), expected)
 }

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -456,13 +456,14 @@ func (os *OpenStack) GetZoneByNodeName(ctx context.Context, nodeName types.NodeN
 func (os *OpenStack) Routes() (cloudprovider.Routes, bool) {
 	klog.V(4).Info("openstack.Routes() called")
 
+	ctx := context.TODO()
 	network, err := client.NewNetworkV2(os.provider, os.epOpts)
 	if err != nil {
 		klog.Errorf("Failed to create an OpenStack Network client: %v", err)
 		return nil, false
 	}
 
-	netExts, err := openstackutil.GetNetworkExtensions(network)
+	netExts, err := openstackutil.GetNetworkExtensions(ctx, network)
 	if err != nil {
 		klog.Warningf("Failed to list neutron extensions: %v", err)
 		return nil, false


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This is a yet another code cleanup and #2692 follow-up. This PR removes unused arguments in functions, uses `SplitTrim` helper, where it's needed, and adds context passthrough.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
