### PR TITLE
[occm]: exit on unreachable loadbalancer endpoint

### DIFF
--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -349,13 +349,13 @@ func (os *OpenStack) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 
 	network, err := client.NewNetworkV2(os.provider, os.epOpts)
 	if err != nil {
-		klog.Errorf("Failed to create an OpenStack Network client: %v", err)
+		klog.Fatalf("Failed to create an OpenStack Network client: %v", err)
 		return nil, false
 	}
 
 	lb, err := client.NewLoadBalancerV2(os.provider, os.epOpts)
 	if err != nil {
-		klog.Errorf("Failed to create an OpenStack LoadBalancer client: %v", err)
+		klog.Fatalf("Failed to create an OpenStack LoadBalancer client: %v", err)
 		return nil, false
 	}
 
@@ -369,7 +369,7 @@ func (os *OpenStack) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 	// Currently kubernetes OpenStack cloud provider just support LBaaS v2.
 	lbVersion := os.lbOpts.LBVersion
 	if lbVersion != "" && lbVersion != "v2" {
-		klog.Warningf("Config error: currently only support LBaaS v2, unrecognised lb-version \"%v\"", lbVersion)
+		klog.Fatalf("Config error: currently only support LBaaS v2, unrecognised lb-version \"%v\"", lbVersion)
 		return nil, false
 	}
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This PR stops OCCM controller, when a loadbalancer config was provided, but the endpoint is absent or not reachable.

**Which issue this PR fixes(if applicable)**:
fixes #2704

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[occm] exit on unreachable loadbalancer endpoint
```
