### PR TITLE
Fix CSI tests

### DIFF
--- a/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
@@ -26,7 +26,9 @@
     cmd: |
       kubectl -n kube-system get secret cloud-config >/dev/null 2>&1
       if [ $? -eq 0 ]; then
-        exit 0
+        kubectl -n kube-system get secrets cloud-config -o json | jq -r '.data."cloud.conf"' | base64 -d
+        # replacing a cloud-config, created by the OCCM role
+        kubectl -n kube-system delete secret cloud-config
       fi
 
       set -ex
@@ -43,9 +45,12 @@
       tenant-id=$tenant_id
       domain-id=default
 
+      [LoadBalancer]
+      enabled=false
       EOF
 
       kubectl create secret -n kube-system generic cloud-config --from-file={{ ansible_user_dir }}/cloud.conf
+      kubectl -n kube-system get secrets cloud-config -o json | jq -r '.data."cloud.conf"' | base64 -d
 
 - name: Replace manifests
   shell:
@@ -139,11 +144,21 @@
           set -x
           set -e
 
+          mkdir -p /var/log/csi-pod
           kubectl logs deployment/csi-cinder-controllerplugin -n kube-system -c cinder-csi-plugin
           kubectl logs daemonset/csi-cinder-nodeplugin -n kube-system -c cinder-csi-plugin
 
           kubectl logs deployment/csi-cinder-controllerplugin -n kube-system -c cinder-csi-plugin > /var/log/csi-pod/csi-cinder-controllerplugin.log
-          kubectl logs daemonset/csi-cinder-nodeplugin -n kube-system -c cinder-csi-plugin > /var/log/csi-pod/csi-cinder-nodeplugin.log 
+          kubectl logs daemonset/csi-cinder-nodeplugin -n kube-system -c cinder-csi-plugin > /var/log/csi-pod/csi-cinder-nodeplugin.log
+
+    - name: Show openstack-cloud-controller-manager pod logs
+      shell:
+        executable: /bin/bash
+        cmd: |
+          kubectl -n kube-system logs ds/openstack-cloud-controller-manager
+
+          kubectl -n kube-system logs ds/openstack-cloud-controller-manager > /var/log/csi-pod/occm.log
+
     - name: &failmsg Stop due to prior failure of csi-cinder-plugin
       fail:
         msg: *failmsg

--- a/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
@@ -26,7 +26,9 @@
     cmd: |
       kubectl -n kube-system get secret cloud-config >/dev/null 2>&1
       if [ $? -eq 0 ]; then
-        exit 0
+        kubectl -n kube-system get secrets cloud-config -o json | jq -r '.data."cloud.conf"' | base64 -d
+        # replacing a cloud-config, created by the OCCM role
+        kubectl -n kube-system delete secret cloud-config
       fi
 
       set -ex
@@ -42,9 +44,13 @@
       region=${OS_REGION_NAME}
       tenant-id=$tenant_id
       domain-id=default
+
+      [LoadBalancer]
+      enabled=false
       EOF
 
       kubectl create secret -n kube-system generic cloud-config --from-file={{ ansible_user_dir }}/cloud.conf
+      kubectl -n kube-system get secrets cloud-config -o json | jq -r '.data."cloud.conf"' | base64 -d
 
 - name: Deploy Kubernetes VolumeSnapshot CRDs and snapshot controller
   shell:
@@ -170,6 +176,12 @@
           kubectl describe pod -l app=openstack-manila-csi,component=nodeplugin
       register: describe_csi
       changed_when: false
+
+    - name: Show openstack-cloud-controller-manager pod logs
+      shell:
+        executable: /bin/bash
+        cmd: |
+          kubectl -n kube-system logs ds/openstack-cloud-controller-manager
 
     - name: Log failed manila-csi-plugin deployment
       debug:


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Add more logging capabilities, fix collecting the cinder CSI logs on error, disable LBaaS support in CSI tests (due to #2706)

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
