### PR TITLE
[docs] add missing parameters to StorageClass in multi-region-clouds.md

### DIFF
--- a/docs/cinder-csi-plugin/multi-region-clouds.md
+++ b/docs/cinder-csi-plugin/multi-region-clouds.md
@@ -17,7 +17,7 @@ stringData:
     [BlockStorage]
     bs-version=v3
     ignore-volume-az=True
-    
+
     [Global]
     auth-url="https://auth.cloud.openstackcluster.region-default.local/v3"
     username="region-default-username"
@@ -26,7 +26,7 @@ stringData:
     tenant-id="region-default-tenant-id"
     tenant-name="region-default-tenant-name"
     domain-name="Default"
-    
+
     [Global "region-one"]
     auth-url="https://auth.cloud.openstackcluster.region-one.local/v3"
     username="region-one-username"
@@ -35,7 +35,7 @@ stringData:
     tenant-id="region-one-tenant-id"
     tenant-name="region-one-tenant-name"
     domain-name="Default"
-    
+
     [Global "region-two"]
     auth-url="https://auth.cloud.openstackcluster.region-two.local/v3"
     username="region-two-username"
@@ -101,6 +101,8 @@ parameters:
   csi.storage.k8s.io/node-stage-secret-namespace: kube-system
   csi.storage.k8s.io/provisioner-secret-name: openstack-config-region-one
   csi.storage.k8s.io/provisioner-secret-namespace: kube-system
+  csi.storage.k8s.io/controller-expand-secret-name: openstack-config-region-one
+  csi.storage.k8s.io/controller-expand-secret-namespace: kube-system
 provisioner: cinder.csi.openstack.org
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
@@ -127,6 +129,8 @@ parameters:
   csi.storage.k8s.io/node-stage-secret-namespace: kube-system
   csi.storage.k8s.io/provisioner-secret-name: openstack-config-region-two
   csi.storage.k8s.io/provisioner-secret-namespace: kube-system
+  csi.storage.k8s.io/controller-expand-secret-name: openstack-config-region-two
+  csi.storage.k8s.io/controller-expand-secret-namespace: kube-system
 provisioner: cinder.csi.openstack.org
 reclaimPolicy: Delete
 volumeBindingMode: Immediate


### PR DESCRIPTION
Added missing parameters csi.storage.k8s.io/controller-expand-secret-name and csi.storage.k8s.io/controller-expand-secret-namespace to the StorageClass configuration in the Multi-AZ/Region/OpenStack documentation. These parameters were missing, causing issues with PVC expansion. After some time spent troubleshooting, I found these parameters in the [Kubernetes CSI documentation on StorageClass secrets](https://kubernetes-csi.github.io/docs/secrets-and-credentials-storage-class.html#storageclass-secrets). After adding them, PVC expansion works as expected.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```