### PR TITLE
[tests] bump devstack branch to stable/2023.2, fix python issues

### DIFF
--- a/tests/playbooks/roles/install-devstack/defaults/main.yaml
+++ b/tests/playbooks/roles/install-devstack/defaults/main.yaml
@@ -1,7 +1,7 @@
 ---
 user: "stack"
 workdir: "/home/{{ user }}/devstack"
-branch: "stable/2023.1"
+branch: "stable/2023.2"
 enable_services:
   - nova
   - glance

--- a/tests/playbooks/roles/install-devstack/tasks/main.yml
+++ b/tests/playbooks/roles/install-devstack/tasks/main.yml
@@ -97,21 +97,6 @@
         src: local.conf.j2
         dest: "{{ workdir }}/local.conf"
 
-    - name: Fix localhost
-      shell:
-        executable: /bin/bash
-        cmd: |
-          # https://bugs.launchpad.net/devstack/+bug/1891694
-          rm -rf /usr/lib/python3/dist-packages/PyYAML-*.egg-info
-          # https://bugs.launchpad.net/devstack/+bug/1906322
-          sed -i 's|$cmd_pip $upgrade |$cmd_pip $upgrade --ignore-installed |g' {{ workdir }}/inc/python
-          python3 -m pip install --upgrade pip==23.0
-          python3 -m pip install --upgrade keystoneauth1==5.1.1
-          python3 -m pip install --upgrade setuptools
-          python3 -m pip install --upgrade python-debian
-          python3 -m pip install --upgrade distro-info
-          python3 -m pip install --upgrade SecretStorage
-
     - name: Change devstack directory owner
       file:
         path: "{{ item }}"

--- a/tests/playbooks/roles/install-devstack/templates/local.conf.j2
+++ b/tests/playbooks/roles/install-devstack/templates/local.conf.j2
@@ -122,6 +122,15 @@ MANILA_DEFAULT_SHARE_TYPE_EXTRA_SPECS='snapshot_support=True create_share_from_s
 MANILA_CONFIGURE_DEFAULT_TYPES=True
 {% endif %}
 
+# Add a pre-install script to upgrade pip and setuptools
+[[local|pre-install]]
+# Activate the virtual environment and upgrade pip and setuptools
+if [ -f /opt/stack/data/venv/bin/activate ]; then
+    source /opt/stack/data/venv/bin/activate
+    pip install --upgrade pip setuptools
+    deactivate
+fi
+
 {% if "glance" in enable_services %}
 [[post-config|$GLANCE_API_CONF]]
 [glance_store]


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

the `stable/2023.1` was removed in some openstack repos, now the `stable/2023.2` is the stable one. also we need to update pip and setuptools

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
