### PR TITLE
[occm] fix node internal/external IP order

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -387,22 +387,22 @@ func nodeAddressForLB(node *corev1.Node, preferredIPFamily corev1.IPFamily) (str
 	}
 
 	allowedAddrTypes := []corev1.NodeAddressType{corev1.NodeInternalIP, corev1.NodeExternalIP}
-	for _, addr := range addrs {
-		if !slices.Contains(allowedAddrTypes, addr.Type) {
-			// Skip the address type that is not allowed
-			continue
-		}
-		switch preferredIPFamily {
-		case corev1.IPv4Protocol:
-			if netutils.IsIPv4String(addr.Address) {
-				return addr.Address, nil
+	for _, allowedAddrType := range allowedAddrTypes {
+		for _, addr := range addrs {
+			if addr.Type == allowedAddrType {
+				switch preferredIPFamily {
+				case corev1.IPv4Protocol:
+					if netutils.IsIPv4String(addr.Address) {
+						return addr.Address, nil
+					}
+				case corev1.IPv6Protocol:
+					if netutils.IsIPv6String(addr.Address) {
+						return addr.Address, nil
+					}
+				default:
+					return addr.Address, nil
+				}
 			}
-		case corev1.IPv6Protocol:
-			if netutils.IsIPv6String(addr.Address) {
-				return addr.Address, nil
-			}
-		default:
-			return addr.Address, nil
 		}
 	}
 

--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -1524,12 +1524,12 @@ func Test_nodeAddressForLB(t *testing.T) {
 					Status: corev1.NodeStatus{
 						Addresses: []corev1.NodeAddress{
 							{
-								Type:    corev1.NodeInternalIP,
-								Address: "192.168.1.1",
-							},
-							{
 								Type:    corev1.NodeExternalIP,
 								Address: "192.168.1.2",
+							},
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.1.1",
 							},
 						},
 					},
@@ -1546,12 +1546,12 @@ func Test_nodeAddressForLB(t *testing.T) {
 					Status: corev1.NodeStatus{
 						Addresses: []corev1.NodeAddress{
 							{
-								Type:    corev1.NodeInternalIP,
-								Address: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
-							},
-							{
 								Type:    corev1.NodeExternalIP,
 								Address: "2001:0db8:85a3:3333:1111:8a2e:9999:8888",
+							},
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
 							},
 						},
 					},


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This PR fixes a regression introduced in #2688, unit tests ensure that the internal/external IP order works as expected.

**Which issue this PR fixes(if applicable)**:
fixes #2718 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
