### PR TITLE
Revert "[tests] bump openstack branch to stable/2024.2"

### DIFF
--- a/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
@@ -195,7 +195,7 @@
         -report-dir="/var/log/csi-pod" | tee "/var/log/csi-pod/cinder-csi-e2e.log"
   register: functional_test_result
   ignore_errors: true
-  async: 9000 # wait 2h30m then fail and fetch the logs
+  async: 5400 # wait 1h30m then fail and fetch the logs
   poll: 15
 
 - name: Collect pod logs for debug purpose

--- a/tests/playbooks/roles/install-devstack/defaults/main.yaml
+++ b/tests/playbooks/roles/install-devstack/defaults/main.yaml
@@ -1,7 +1,7 @@
 ---
 user: "stack"
 workdir: "/home/{{ user }}/devstack"
-branch: "stable/2024.2"
+branch: "stable/2023.2"
 enable_services:
   - nova
   - glance


### PR DESCRIPTION
Reverts kubernetes/cloud-provider-openstack#2720

tests against the stable/2024.2 are running too slow. we need to analyze [logs](https://gcsweb.k8s.io/gcs/kubernetes-ci-logs/pr-logs/pull/cloud-provider-openstack/2720/openstack-cloud-csi-cinder-e2e-test/1858895961917493248/artifacts/logs/) and clarify why.

```release-note
NONE
```