### PR TITLE
Revert "[tests] bump ubuntu to 24.04 noble"

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -43,7 +43,7 @@ Choose the one you are familiar with and easy to customize. Config the cluster w
 Using kubeadm, openstack-cloud-controller-manager can be deployed easily with predefined manifests, see the [deployment guide with kubeadm](openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#deploy-a-kubernetes-cluster-with-openstack-cloud-controller-manager-using-kubeadm).
 
 ### DevStack-based testing environment
-You can also use our CI scripts to setup a simple development environment based on DevStack and k3s. To do so you need a fresh VM with Ubuntu 24.04. We've tested this with 4 vCPUs and 16 GB of RAM and that's recommended, but we never tested the lower bound, so feel free to try with less resources.
+You can also use our CI scripts to setup a simple development environment based on DevStack and k3s. To do so you need a fresh VM with Ubuntu 22.04. We've tested this with 4 vCPUs and 16 GB of RAM and that's recommended, but we never tested the lower bound, so feel free to try with less resources.
 
 Once the VM is up make sure your SSH keys allow logging in as `ubuntu` user and from your PC and cloud-provider-openstack directory run:
 
@@ -133,11 +133,11 @@ make unit
 
 End-to-end or _e2e_ tests are more complex to run as they require a functioning OpenStack cloud and Kubernetes (well, k3s) deployment. Fortunately, you can rely on the infrastructure used for CI to run this on your own machines.
 
-For example, to run the Cinder CSI e2e tests, the CI calls the `tests/ci-csi-cinder-e2e.sh` script. Inspecting this, you'll note that a lot of the commands in here are simply provisioning an instance on GCE, using [Boskos](https://github.com/kubernetes-sigs/boskos) to manage static resources (projects, in this case) if needed. If you have a set of GCE credentials, then in theory you could run this script as-is. However, all you need is a VM with sufficient resources and network connectivity running the correct image (Ubuntu 24.04 cloud image as of writing - check `tests/scripts/create-gce-vm.sh` for the latest info). For example, using OpenStack:
+For example, to run the Cinder CSI e2e tests, the CI calls the `tests/ci-csi-cinder-e2e.sh` script. Inspecting this, you'll note that a lot of the commands in here are simply provisioning an instance on GCE, using [Boskos](https://github.com/kubernetes-sigs/boskos) to manage static resources (projects, in this case) if needed. If you have a set of GCE credentials, then in theory you could run this script as-is. However, all you need is a VM with sufficient resources and network connectivity running the correct image (Ubuntu 20.04 cloud image as of writing - check `tests/scripts/create-gce-vm.sh` for the latest info). For example, using OpenStack:
 
 ```
 openstack server create \
-  --image ubuntu2404 \
+  --image ubuntu2004 \
   --flavor m1.large \
   --key-name <key-name> \
   --network <network> \

--- a/tests/playbooks/roles/install-docker/defaults/main.yml
+++ b/tests/playbooks/roles/install-docker/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-docker_version: 5:27.3.1-1~ubuntu.24.04~noble
+docker_version: 5:20.10.18~3-0~ubuntu-focal

--- a/tests/playbooks/roles/install-k3s/defaults/main.yaml
+++ b/tests/playbooks/roles/install-k3s/defaults/main.yaml
@@ -1,11 +1,11 @@
 ---
-k3s_release: v1.31.2+k3s1
+k3s_release: v1.31.0+k3s1
 worker_node_count: 1
 cluster_token: "K1039d1cf76d1f8b0e8b0d48e7c60d9c4a43c2e7a56de5d86f346f2288a2677f1d7::server:2acba4e60918c0e2d1f1d1a7c4e81e7b"
 devstack_workdir: "{{ ansible_user_dir }}/devstack"
 flavor_name: "ds2G"
 sg_name: "k3s_sg"
 keypair_name: "k3s_keypair"
-image_url: "https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img"
-image_name: "ubuntu-noble"
+image_url: "https://cloud-images.ubuntu.com/releases/jammy/release/ubuntu-22.04-server-cloudimg-amd64.img"
+image_name: "ubuntu-jammy"
 master_port_name: "k3s_master"

--- a/tests/scripts/create-gce-vm.sh
+++ b/tests/scripts/create-gce-vm.sh
@@ -94,7 +94,7 @@ main() {
     if ! gcloud compute disks describe devstack-${FLAVOR} --zone "${GCP_ZONE}" > /dev/null 2>&1;
     then
       gcloud compute disks create devstack-${FLAVOR} \
-        --image-project ubuntu-os-cloud --image-family ubuntu-2404-lts-amd64 \
+        --image-project ubuntu-os-cloud --image-family ubuntu-2204-lts \
         --zone "${GCP_ZONE}"
     fi
 


### PR DESCRIPTION
Reverts kubernetes/cloud-provider-openstack#2721

Let's roll this back to 22.04 jammy, since devstack starts to complain
