### PR TITLE
[occm]: remove InstancesV1 Zones method

### DIFF
--- a/pkg/openstack/openstack_test.go
+++ b/pkg/openstack/openstack_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
 	neutronports "github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports"
 	"github.com/spf13/pflag"
@@ -935,45 +934,6 @@ func TestLoadBalancer(t *testing.T) {
 		if exists {
 			t.Fatalf("GetLoadBalancer(\"noexist\") returned exists")
 		}
-	}
-}
-
-var FakeMetadata = metadata.Metadata{
-	UUID:             "83679162-1378-4288-a2d4-70e13ec132aa",
-	Name:             "test",
-	AvailabilityZone: "nova",
-}
-
-func TestZones(t *testing.T) {
-	metadata.Set(&FakeMetadata)
-	defer metadata.Clear()
-
-	os := OpenStack{
-		provider: &gophercloud.ProviderClient{
-			IdentityBase: "http://auth.url/",
-		},
-		epOpts: &gophercloud.EndpointOpts{
-			Region:       "myRegion",
-			Availability: gophercloud.AvailabilityPublic,
-		},
-	}
-
-	z, ok := os.Zones()
-	if !ok {
-		t.Fatalf("Zones() returned false")
-	}
-
-	zone, err := z.GetZone(context.TODO())
-	if err != nil {
-		t.Fatalf("GetZone() returned error: %v", err)
-	}
-
-	if zone.Region != "myRegion" {
-		t.Fatalf("GetZone() returned wrong region (%s)", zone.Region)
-	}
-
-	if zone.FailureDomain != "nova" {
-		t.Fatalf("GetZone() returned wrong failure domain (%s)", zone.FailureDomain)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Since InstancesV1 was removed, we need to clean up the zone methods.
Zones() uses only if InstancesV1 interface exists. https://github.com/kubernetes/cloud-provider/blob/master/controllers/node/node_controller.go#L579-L606

All zone information expose by InstancesV2 in InstanceMetadata()
And

https://github.com/kubernetes/cloud-provider/blob/master/cloud.go#L274

```go
// DEPRECATED: Zones is deprecated in favor of retrieving zone/region information from InstancesV2.
// This interface will not be called if InstancesV2 is enabled.
type Zones interface {
```

**Which issue this PR fixes(if applicable)**:

#2692

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
