### PR TITLE
Stop setting GOPROXY in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,6 @@ RUN apk add --no-cache ca-certificates
 # builder itself is always amd64
 FROM --platform=${BUILDPLATFORM} ${GOLANG_IMAGE} AS builder
 
-ARG GOPROXY=https://goproxy.io,direct
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION

--- a/tests/playbooks/roles/install-cpo-occm/README.md
+++ b/tests/playbooks/roles/install-cpo-occm/README.md
@@ -5,6 +5,5 @@ Prerequisites:
 * The playbook is running on a host with devstack installed.
 * golang, docker and kubectl should be installed.
 * docker registry is up and running.
-* GOPATH should be configured in {{ global_env }}
-* KUBECONFIG should be configured in {{ global_env }}
 * k8s cluster is running inside VMs on the devstack host.
+* `~/.kube/config` exists and is pointing at the k8s cluster

--- a/tests/playbooks/roles/install-cpo-occm/tasks/main.yaml
+++ b/tests/playbooks/roles/install-cpo-occm/tasks/main.yaml
@@ -1,18 +1,18 @@
 ---
-- name: Ensure CPO source folder
+- name: Ensure CPO source folder is present
   shell:
     executable: /bin/bash
     cmd: |
-      if [ ! -d $GOPATH/src/k8s.io/cloud-provider-openstack ]; then
-        mkdir -p $GOPATH/src/k8s.io; cd $_
-        git clone https://github.com/kubernetes/cloud-provider-openstack
+      if [ ! -d "{{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack" ]; then
+        echo "{{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack should exist but does not"
+        exit 1
       fi
 
 - name: Build and upload openstack-cloud-controller-manager image
   shell:
     executable: /bin/bash
     cmd: |
-      cd $GOPATH/src/k8s.io/cloud-provider-openstack
+      cd {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack
       VERSION="v0.0.99" # Fake version, but in proper format.
 
       make push-multiarch-image-openstack-cloud-controller-manager \
@@ -71,7 +71,7 @@
     cmd: |
       VERSION="v0.0.99" # Fake version, but in proper format.
 
-      cd $GOPATH/src/k8s.io/cloud-provider-openstack
+      cd {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack
       # replace image with built image
       sed -i "s#registry.k8s.io/provider-os/openstack-cloud-controller-manager:[^'\"]\+#{{ remote_registry_host }}/openstack-cloud-controller-manager:${VERSION}#" manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
       sed -i "s#node-role.kubernetes.io/control-plane: \"\"#node-role.kubernetes.io/control-plane: \"true\"#" manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -82,7 +82,7 @@
   shell:
     executable: /bin/bash
     cmd: |
-      cd $GOPATH/src/k8s.io/cloud-provider-openstack
+      cd {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack
 
       kubectl apply -f manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
       kubectl apply -f manifests/controller-manager/cloud-controller-manager-roles.yaml
@@ -133,7 +133,7 @@
   shell:
     executable: /bin/bash
     cmd: |
-      cd $GOPATH/src/k8s.io/cloud-provider-openstack
+      cd {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack
 
       # GATEWAY_IP is the default value in devstack
       GATEWAY_IP=172.24.5.1 \

--- a/tests/playbooks/roles/install-csi-cinder/README.md
+++ b/tests/playbooks/roles/install-csi-cinder/README.md
@@ -5,6 +5,5 @@ Prerequisites:
 * The playbook is running on a host with devstack installed.
 * golang, docker and kubectl should be installed.
 * docker registry is up and running.
-* GOPATH should be configured in {{ global_env }}
-* KUBECONFIG should be configured in {{ global_env }}
 * k8s cluster is running inside VMs on the devstack host.
+* `~/.kube/config` exists and is pointing at the k8s cluster

--- a/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
@@ -1,18 +1,18 @@
 ---
-- name: Ensure CPO source folder
+- name: Ensure CPO source folder is present
   shell:
     executable: /bin/bash
     cmd: |
-      if [ ! -d $GOPATH/src/k8s.io/cloud-provider-openstack ]; then
-        mkdir -p $GOPATH/src/k8s.io; cd $_
-        git clone https://github.com/kubernetes/cloud-provider-openstack
+      if [ ! -d "{{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack" ]; then
+        echo "{{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack should exist but does not"
+        exit 1
       fi
 
 - name: Build and upload cinder-csi-plugin image
   shell:
     executable: /bin/bash
     cmd: |
-      cd $GOPATH/src/k8s.io/cloud-provider-openstack
+      cd {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack
       VERSION="v0.0.99" # Fake version, but in proper format.
 
       make push-multiarch-image-cinder-csi-plugin \
@@ -59,7 +59,7 @@
       # replace manifest cloud secret file
 
       b64data=`cat {{ ansible_user_dir }}/cloud.conf | base64 -w 0`
-      cd $GOPATH/src/k8s.io/cloud-provider-openstack
+      cd {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack
 
       sed -i "/cloud\.conf/c\  cloud.conf: $b64data" manifests/cinder-csi-plugin/csi-secret-cinderplugin.yaml
 
@@ -74,7 +74,7 @@
   shell:
     executable: /bin/bash
     cmd: |
-      cd $GOPATH/src/k8s.io/cloud-provider-openstack
+      cd {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack
       kubectl apply -f manifests/cinder-csi-plugin
   ignore_errors: true
 
@@ -180,7 +180,7 @@
       set -e
       set -o pipefail
 
-      cd $GOPATH/src/k8s.io/cloud-provider-openstack
+      cd {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack
       mkdir -p /var/log/csi-pod
       # TODO(chrigl): No idea why both tests fail in CI. On a real OpenStack both pass.
       /tmp/kubernetes/test/bin/e2e.test \

--- a/tests/playbooks/roles/install-csi-manila/README.md
+++ b/tests/playbooks/roles/install-csi-manila/README.md
@@ -5,5 +5,5 @@ Prerequisites:
 * The playbook is running on a host with devstack installed.
 * golang, docker and kubectl should be installed.
 * docker registry is up and running.
-* KUBECONFIG should be configured in {{ global_env }}
 * k8s cluster is running inside VMs on the devstack host.
+* `~/.kube/config` exists and is pointing at the k8s cluster

--- a/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
@@ -1,18 +1,18 @@
 ---
-- name: Ensure CPO source folder
+- name: Ensure CPO source folder is present
   shell:
     executable: /bin/bash
     cmd: |
-      if [ ! -d $GOPATH/src/k8s.io/cloud-provider-openstack ]; then
-        mkdir -p $GOPATH/src/k8s.io; cd $_
-        git clone https://github.com/kubernetes/cloud-provider-openstack
+      if [ ! -d "{{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack" ]; then
+        echo "{{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack should exist but does not"
+        exit 1
       fi
 
 - name: Build and upload manila-csi-plugin image
   shell:
     executable: /bin/bash
     cmd: |
-      cd $GOPATH/src/k8s.io/cloud-provider-openstack
+      cd {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack
       VERSION="v0.0.99" # Fake version, but in proper format.
 
       make push-multiarch-image-manila-csi-plugin \

--- a/tests/playbooks/roles/install-golang/tasks/main.yml
+++ b/tests/playbooks/roles/install-golang/tasks/main.yml
@@ -26,12 +26,16 @@
   when:
     - curr_go_version.stdout != go_version
 
-- name: Set golang env vars
-  set_fact:
-    golang_env:
-      GOPATH: '{{ ansible_user_dir }}'
-      PATH: '/usr/local/go/bin:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}'
+- name: Set GOPATH
+  lineinfile:
+    path: ~/.bashrc
+    line: 'export GOPATH=$HOME'
+    create: true
+    state: present
 
-- name: Merge golang env vars into global env
-  set_fact:
-    global_env: '{{ global_env | combine(golang_env) }}'
+- name: Add go binary path to PATH
+  lineinfile:
+    path: ~/.bashrc
+    line: 'export PATH=/usr/local/go/bin:{{ ansible_user_dir }}/bin:$PATH'
+    create: true
+    state: present

--- a/tests/playbooks/roles/install-k3s-bare-single/tasks/main.yaml
+++ b/tests/playbooks/roles/install-k3s-bare-single/tasks/main.yaml
@@ -45,10 +45,13 @@
   retries: 12
   delay: 10
 
-- name: Set kubeconfig env
-  set_fact:
-    kubeconfig: "/etc/rancher/k3s/k3s.yaml"
+- name: Create ~/.kube directory
+  ansible.builtin.file:
+    path: ~/.kube
+    state: directory
 
-- name: Merge KUBECONFIG env vars into global env
-  set_fact:
-    global_env: "{{ global_env | combine({'KUBECONFIG': kubeconfig}) }}"
+- name: Copy kubeconfig to ~/.kube
+  ansible.builtin.copy:
+    src: /etc/rancher/k3s/k3s.yaml
+    dest: ~/.kube/config
+    remote_src: true

--- a/tests/playbooks/roles/install-k3s/tasks/main.yaml
+++ b/tests/playbooks/roles/install-k3s/tasks/main.yaml
@@ -175,11 +175,3 @@
   until: result.stdout == (worker_node_count + 1)|string
   retries: 12
   delay: 10
-
-- name: Set kubeconfig env
-  set_fact:
-    kubeconfig: "{{ ansible_user_dir }}/.kube/config"
-
-- name: Merge KUBECONFIG env vars into global env
-  set_fact:
-    global_env: "{{ global_env | combine({'KUBECONFIG': kubeconfig}) }}"

--- a/tests/playbooks/test-csi-cinder-e2e.yaml
+++ b/tests/playbooks/test-csi-cinder-e2e.yaml
@@ -24,3 +24,7 @@
     - role: install-cpo-occm
       run_e2e: false
     - role: install-csi-cinder
+      environment:
+        GOPATH: '{{ ansible_user_dir }}'
+        PATH: '/usr/local/go/bin:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}'
+        KUBECONFIG: '{{ ansible_user_dir }}/.kube/config'

--- a/tests/playbooks/test-csi-cinder-e2e.yaml
+++ b/tests/playbooks/test-csi-cinder-e2e.yaml
@@ -6,7 +6,6 @@
   vars:
     e2e_test_version: v1.31.2
     user: stack
-    global_env: {}
     devstack_workdir: /home/{{ user }}/devstack
 
   roles:
@@ -24,6 +23,4 @@
       worker_node_count: 0
     - role: install-cpo-occm
       run_e2e: false
-      environment: "{{ global_env }}"
     - role: install-csi-cinder
-      environment: "{{ global_env }}"

--- a/tests/playbooks/test-csi-manila-e2e.yaml
+++ b/tests/playbooks/test-csi-manila-e2e.yaml
@@ -24,3 +24,7 @@
       run_e2e: false
     - role: install-helm
     - role: install-csi-manila
+      environment:
+        GOPATH: '{{ ansible_user_dir }}'
+        PATH: '/usr/local/go/bin:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}'
+        KUBECONFIG: '{{ ansible_user_dir }}/.kube/config'

--- a/tests/playbooks/test-csi-manila-e2e.yaml
+++ b/tests/playbooks/test-csi-manila-e2e.yaml
@@ -5,7 +5,6 @@
 
   vars:
     user: stack
-    global_env: {}
     devstack_workdir: /home/{{ user }}/devstack
 
   roles:
@@ -25,4 +24,3 @@
       run_e2e: false
     - role: install-helm
     - role: install-csi-manila
-      environment: "{{ global_env }}"

--- a/tests/playbooks/test-occm-e2e.yaml
+++ b/tests/playbooks/test-occm-e2e.yaml
@@ -5,7 +5,6 @@
 
   vars:
     user: stack
-    global_env: {}
     devstack_workdir: /home/{{ user }}/devstack
     octavia_provider: ""
 
@@ -28,4 +27,3 @@
     - role: install-cpo-occm
       run_e2e: "{{ run_e2e }}"
       octavia_provider: "{{ octavia_provider }}"
-      environment: "{{ global_env }}"


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

We're seeing failures in CI related to goproxy.io. There's no need to set this so simply don't. Doing this highlights a couple of issues with our jobs: namely that we're not actually testing code in the PR due to a missing `GOPATH` env var. This is mitigated with a temporary fix, but a larger fix that involves building the controllers locally before pushing them to the cluster should and will be done separately.

**Which issue this PR fixes(if applicable)**:

none.

**Special notes for reviewers**:

Discussed this on Slack [here](https://kubernetes.slack.com/archives/C0LSA3T7C/p1733405450278309).

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
