### PR TITLE
[manila-csi-plugin] Trivial fixups

### DIFF
--- a/pkg/csi/manila/driver.go
+++ b/pkg/csi/manila/driver.go
@@ -130,15 +130,10 @@ func NewDriver(o *DriverOpts) (*Driver, error) {
 	klog.Info("Driver: ", d.name)
 	klog.Info("Driver version: ", d.fqVersion)
 	klog.Info("CSI spec version: ", specVersion)
+	klog.Infof("Topology awareness: %T", d.withTopology)
 
 	getShareAdapter(d.shareProto) // The program will terminate with a non-zero exit code if the share protocol selector is wrong
 	klog.Infof("Operating on %s shares", d.shareProto)
-
-	if d.withTopology {
-		klog.Infof("Topology awareness enabled")
-	} else {
-		klog.Info("Topology awareness disabled")
-	}
 
 	serverProto, serverAddr, err := parseGRPCEndpoint(o.ServerCSIEndpoint)
 	if err != nil {

--- a/pkg/csi/manila/nodeserver.go
+++ b/pkg/csi/manila/nodeserver.go
@@ -335,15 +335,17 @@ func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 		NodeId: nodeID,
 	}
 
-	if ns.d.withTopology {
-		zone, err := ns.metadata.GetAvailabilityZone()
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "[NodeGetInfo] Unable to retrieve availability zone of node %v", err)
-		}
+	if !ns.d.withTopology {
+		return nodeInfo, nil
+	}
 
-		nodeInfo.AccessibleTopology = &csi.Topology{
-			Segments: map[string]string{topologyKey: zone},
-		}
+	zone, err := ns.metadata.GetAvailabilityZone()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "[NodeGetInfo] Unable to retrieve availability zone of node %v", err)
+	}
+
+	nodeInfo.AccessibleTopology = &csi.Topology{
+		Segments: map[string]string{topologyKey: zone},
 	}
 
 	return nodeInfo, nil


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Trivial fixes for things highlighted in https://github.com/kubernetes/cloud-provider-openstack/pull/2743

**Which issue this PR fixes(if applicable)**:

(none)

**Special notes for reviewers**:

(none)

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
