### PR TITLE
ci: host tuning in devstack

### DIFF
--- a/tests/playbooks/roles/install-devstack/templates/local.conf.j2
+++ b/tests/playbooks/roles/install-devstack/templates/local.conf.j2
@@ -21,6 +21,26 @@ TARGET_BRANCH={{ branch }}
 
 ENABLED_SERVICES=rabbit,mysql,key
 
+# Host tuning
+# From: https://opendev.org/openstack/devstack/src/commit/05f7d302cfa2da73b2887afcde92ef65b1001194/.zuul.yaml#L645-L662
+# Tune the host to optimize memory usage and hide io latency
+# these setting will configure the kernel to treat the host page
+# cache and swap with equal priority, and prefer deferring writes
+# changing the default swappiness, dirty_ratio and
+# the vfs_cache_pressure
+ENABLE_SYSCTL_MEM_TUNING=true
+# The net tuning optimizes ipv4 tcp fast open and config the default
+# qdisk policy to pfifo_fast which effectively disable all qos.
+# this minimizes the cpu load of the host network stack
+ENABLE_SYSCTL_NET_TUNING=true
+# zswap allows the kernel to compress pages in memory before swapping
+# them to disk. this can reduce the amount of swap used and improve
+# performance. effectivly this trades a small amount of cpu for an
+# increase in swap performance by reducing the amount of data
+# written to disk. the overall speedup is porportional to the
+# compression ratio and the speed of the swap device.
+ENABLE_ZSWAP=true
+
 {% if "nova" in enable_services %}
 # Nova
 enable_service n-api


### PR DESCRIPTION
**What this PR does / why we need it**:

Copy host tuning from:
https://opendev.org/openstack/devstack/src/commit/05f7d302cfa2da73b2887afcde92ef65b1001194/.zuul.yaml#L645-L662

Enable `ENABLE_SYSCTL_MEM_TUNING`, `ENABLE_SYSCTL_NET_TUNING` and
`ENABLE_ZSWAP` for the reasons explained in comments.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
