### PR TITLE
[cinder-csi-plugin] Refactor list volumes

### DIFF
--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
 	sharedcsi "k8s.io/cloud-provider-openstack/pkg/csi"
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack"
 	"k8s.io/cloud-provider-openstack/pkg/util"

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -406,7 +406,6 @@ func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 type CloudsStartingToken struct {
 	CloudName string `json:"cloud"`
 	Token     string `json:"token"`
-	isEmpty   bool
 }
 
 func (cs *controllerServer) extractNodeIDs(attachments []volumes.Attachment) []string {
@@ -482,16 +481,11 @@ func (cs *controllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 	switch {
 	// if we have not finished listing all volumes from this cloud, we will continue on next call.
 	case nextPageToken != "":
-		cloudsToken.CloudName = currentCloudName
 		// if we listed all volumes from this cloud but more clouds exist, return a token of the next cloud.
 	case idx+1 < len(cloudsNames):
 		cloudsToken.CloudName = cloudsNames[idx+1]
 	default:
 		// work is done.
-		cloudsToken.CloudName = ""
-	}
-
-	if cloudsToken.Token == "" && cloudsToken.CloudName == "" {
 		klog.V(4).Infof("ListVolumes: completed with %d entries and %q next token", len(volumeEntries), "")
 		return &csi.ListVolumesResponse{
 			Entries:   volumeEntries,

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -452,7 +452,7 @@ func (cs *controllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 	}
 
 	var volumeList []volumes.Volume
-	volumeList, token, err = cs.Clouds[cloudsNames[idx]].ListVolumes(ctx, maxEntries, token)
+	volumeList, token, err = cs.Clouds[cloudName].ListVolumes(ctx, maxEntries, token)
 	if err != nil {
 		klog.Errorf("Failed to ListVolumes: %v", err)
 		if cpoerrors.IsInvalidError(err) {
@@ -461,7 +461,7 @@ func (cs *controllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 		return nil, status.Errorf(codes.Internal, "ListVolumes failed with error %v", err)
 	}
 	volumeEntries := cs.createVolumeEntries(volumeList)
-	klog.V(4).Infof("ListVolumes: retrieved %d entries and %q next token from cloud %q", len(volumeEntries), token, cloudsNames[idx])
+	klog.V(4).Infof("ListVolumes: retrieved %d entries and %q next token from cloud %q", len(volumeEntries), token, cloudName)
 
 	switch {
 	// if we have not finished listing all volumes from this cloud, we will continue on next call.

--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -24,8 +24,9 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
 	sharedcsi "k8s.io/cloud-provider-openstack/pkg/csi"
-	openstack "k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack"
+	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack"
 )
 
 var fakeCs *controllerServer
@@ -473,7 +474,7 @@ func TestListVolumes(t *testing.T) {
 }
 
 type ListVolumeTestOSMock struct {
-	//name           string
+	// name           string
 	mockCloud      *openstack.OpenStackMock
 	mockMaxEntries int
 	mockVolumes    []volumes.Volume
@@ -481,6 +482,7 @@ type ListVolumeTestOSMock struct {
 	mockTokenCall  string
 }
 type ListVolumesTest struct {
+	name          string
 	volumeSet     map[string]ListVolumeTestOSMock
 	maxEntries    int
 	StartingToken string
@@ -492,12 +494,12 @@ type ListVolumesTestResult struct {
 }
 
 func TestGlobalListVolumesMultipleClouds(t *testing.T) {
-	//osmock.On("ListVolumes", 2, "").Return([]volumes.Volume{FakeVol1}, "", nil)
-	//osmockRegionX.On("ListVolumes", 1, "").Return([]volumes.Volume{FakeVol2}, FakeVol2.ID, nil)
+	// osmock.On("ListVolumes", 2, "").Return([]volumes.Volume{FakeVol1}, "", nil)
+	// osmockRegionX.On("ListVolumes", 1, "").Return([]volumes.Volume{FakeVol2}, FakeVol2.ID, nil)
 
 	tests := []*ListVolumesTest{
 		{
-			// no pagination, no clouds has volumes
+			name:          "no pagination, no clouds has volumes",
 			maxEntries:    0,
 			StartingToken: "",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -524,7 +526,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 			},
 		},
 		{
-			// no pagination, all clouds has volumes
+			name:          "no pagination, all clouds has volumes",
 			maxEntries:    0,
 			StartingToken: "",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -553,9 +555,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 				},
 			},
 			Result: ListVolumesTestResult{
-				ExpectedToken: CloudsStartingToken{
-					isEmpty: true,
-				},
+				ExpectedToken: CloudsStartingToken{},
 				Entries: genFakeVolumeEntries([]volumes.Volume{
 					{ID: "vol1"},
 					{ID: "vol2"},
@@ -568,7 +568,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 			},
 		},
 		{
-			// no pagination, only first cloud have volumes
+			name:          "no pagination, only first cloud have volumes",
 			maxEntries:    0,
 			StartingToken: "",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -593,9 +593,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 				},
 			},
 			Result: ListVolumesTestResult{
-				ExpectedToken: CloudsStartingToken{
-					isEmpty: true,
-				},
+				ExpectedToken: CloudsStartingToken{},
 				Entries: genFakeVolumeEntries([]volumes.Volume{
 					{ID: "vol1"},
 					{ID: "vol2"},
@@ -605,7 +603,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 			},
 		},
 		{
-			// no pagination, first cloud without volumes
+			name:          "no pagination, first cloud without volumes",
 			maxEntries:    0,
 			StartingToken: "",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -630,9 +628,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 				},
 			},
 			Result: ListVolumesTestResult{
-				ExpectedToken: CloudsStartingToken{
-					isEmpty: true,
-				},
+				ExpectedToken: CloudsStartingToken{},
 				Entries: genFakeVolumeEntries([]volumes.Volume{
 					{ID: "vol1"},
 					{ID: "vol2"},
@@ -643,7 +639,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 		},
 		// PAGINATION
 		{
-			// no volmues
+			name:          "no volumes",
 			maxEntries:    2,
 			StartingToken: "",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -663,14 +659,12 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 				},
 			},
 			Result: ListVolumesTestResult{
-				ExpectedToken: CloudsStartingToken{
-					isEmpty: true,
-				},
-				Entries: genFakeVolumeEntries([]volumes.Volume{}),
+				ExpectedToken: CloudsStartingToken{},
+				Entries:       genFakeVolumeEntries([]volumes.Volume{}),
 			},
 		},
 		{
-			// cloud1: 1 volume, cloud2: 0 volume
+			name:          "cloud1: 1 volume, cloud2: 0 volume",
 			maxEntries:    2,
 			StartingToken: "",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -692,16 +686,14 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 				},
 			},
 			Result: ListVolumesTestResult{
-				ExpectedToken: CloudsStartingToken{
-					isEmpty: true,
-				},
+				ExpectedToken: CloudsStartingToken{},
 				Entries: genFakeVolumeEntries([]volumes.Volume{
 					{ID: "vol1"},
 				}),
 			},
 		},
 		{
-			// cloud1: 0 volume, cloud2: 1 volume
+			name:          "cloud1: 0 volume, cloud2: 1 volume",
 			maxEntries:    2,
 			StartingToken: "",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -723,16 +715,14 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 				},
 			},
 			Result: ListVolumesTestResult{
-				ExpectedToken: CloudsStartingToken{
-					isEmpty: true,
-				},
+				ExpectedToken: CloudsStartingToken{},
 				Entries: genFakeVolumeEntries([]volumes.Volume{
 					{ID: "vol1"},
 				}),
 			},
 		},
 		{
-			// cloud1: 2 volume, cloud2: 0 volume
+			name:          "cloud1: 2 volume, cloud2: 0 volume",
 			maxEntries:    2,
 			StartingToken: "",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -755,9 +745,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 				},
 			},
 			Result: ListVolumesTestResult{
-				ExpectedToken: CloudsStartingToken{
-					isEmpty: true,
-				},
+				ExpectedToken: CloudsStartingToken{},
 				Entries: genFakeVolumeEntries([]volumes.Volume{
 					{ID: "vol1"},
 					{ID: "vol2"},
@@ -765,7 +753,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 			},
 		},
 		{
-			// cloud1: 0 volume, cloud2: 2 volume
+			name:          "cloud1: 0 volume, cloud2: 2 volume",
 			maxEntries:    2,
 			StartingToken: "",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -788,9 +776,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 				},
 			},
 			Result: ListVolumesTestResult{
-				ExpectedToken: CloudsStartingToken{
-					isEmpty: true,
-				},
+				ExpectedToken: CloudsStartingToken{},
 				Entries: genFakeVolumeEntries([]volumes.Volume{
 					{ID: "vol1"},
 					{ID: "vol2"},
@@ -798,7 +784,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 			},
 		},
 		{
-			// cloud1: 2 volume, cloud2: 1 volume : 1st call
+			name:          "cloud1: 2 volume, cloud2: 1 volume : 1st call",
 			maxEntries:    2,
 			StartingToken: "",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -835,7 +821,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 			},
 		},
 		{
-			// cloud1: 2 volume, cloud2: 1 volume : 2nd call
+			name:          "cloud1: 2 volume, cloud2: 1 volume : 2nd call",
 			maxEntries:    2,
 			StartingToken: "{\"cloud\":\"\",\"token\":\"\"}",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -869,7 +855,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 			},
 		},
 		{
-			// cloud1: 1 volume, cloud2: 2 volume : 1st call
+			name:          "cloud1: 1 volume, cloud2: 2 volume : 1st call",
 			maxEntries:    2,
 			StartingToken: "",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -938,7 +924,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 			},
 		},
 		{
-			// cloud1: 2 volume, cloud2: 2 volume : 1st call
+			name:          "cloud1: 2 volume, cloud2: 2 volume : 1st call",
 			maxEntries:    2,
 			StartingToken: "",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -975,7 +961,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 			},
 		},
 		{
-			// cloud1: 2 volume, cloud2: 2 volume : 2nd call
+			name:          "cloud1: 2 volume, cloud2: 2 volume : 2nd call",
 			maxEntries:    2,
 			StartingToken: "{\"cloud\":\"\",\"token\":\"\"}",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -1013,7 +999,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 			},
 		},
 		{
-			// cloud1: 3 volume, cloud2: 2 volume : 1st call
+			name:          "cloud1: 3 volume, cloud2: 2 volume : 1st call",
 			maxEntries:    2,
 			StartingToken: "",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -1051,7 +1037,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 			},
 		},
 		{
-			// cloud1: 3 volume, cloud2: 2 volume : 2nd call
+			name:          "cloud1: 3 volume, cloud2: 2 volume : 2nd call",
 			maxEntries:    2,
 			StartingToken: "{\"cloud\":\"\",\"token\":\"vol2\"}",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -1087,7 +1073,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 			},
 		},
 		{
-			// cloud1: 3 volume, cloud2: 2 volume : 3rd call
+			name:          "cloud1: 3 volume, cloud2: 2 volume : 3rd call",
 			maxEntries:    2,
 			StartingToken: "{\"cloud\":\"region-x\",\"token\":\"vol4\"}",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -1122,7 +1108,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 			},
 		},
 		{
-			// cloud1: 2 volume, cloud2: 3 volume : 1st call
+			name:          "cloud1: 2 volume, cloud2: 3 volume : 1st call",
 			maxEntries:    2,
 			StartingToken: "",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -1159,7 +1145,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 			},
 		},
 		{
-			// cloud1: 3 volume, cloud2: 2 volume : 2nd call
+			name:          "cloud1: 3 volume, cloud2: 2 volume : 2nd call",
 			maxEntries:    2,
 			StartingToken: "{\"cloud\":\"\",\"token\":\"\"}",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -1196,7 +1182,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 			},
 		},
 		{
-			// cloud1: 2 volume, cloud2: 3 volume : 3rd call
+			name:          "cloud1: 2 volume, cloud2: 3 volume : 3rd call",
 			maxEntries:    2,
 			StartingToken: "{\"cloud\":\"region-x\",\"token\":\"vol4\"}",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -1231,7 +1217,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 			},
 		},
 		{
-			// cloud1: 3 volume, cloud2: 1 volume : 2rd call
+			name:          "cloud1: 3 volume, cloud2: 1 volume : 2rd call",
 			maxEntries:    2,
 			StartingToken: "{\"cloud\":\"\",\"token\":\"vol2\"}",
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -1266,52 +1252,54 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 		},
 	}
 
-	// Init assert
-	assert := assert.New(t)
 	for _, test := range tests {
-		// Setup Mock
-		for _, volumeSet := range test.volumeSet {
-			cloud := volumeSet.mockCloud
-			cloud.On(
-				"ListVolumes",
-				volumeSet.mockMaxEntries,
-				volumeSet.mockTokenCall,
-			).Return(
-				volumeSet.mockVolumes,
-				volumeSet.mockToken,
-				nil,
-			).Once()
-		}
-		fakeReq := &csi.ListVolumesRequest{MaxEntries: int32(test.maxEntries), StartingToken: test.StartingToken}
-		expectedToken, _ := json.Marshal(test.Result.ExpectedToken)
-		if test.Result.ExpectedToken.isEmpty {
-			expectedToken = []byte("")
-		}
-		expectedRes := &csi.ListVolumesResponse{
-			Entries:   test.Result.Entries,
-			NextToken: string(expectedToken),
-		}
-		// Invoke ListVolumes
-		actualRes, err := fakeCsMultipleClouds.ListVolumes(FakeCtx, fakeReq)
-		if err != nil {
-			t.Errorf("failed to ListVolumes: %v", err)
-		}
-		// Assert
-		assert.Equal(expectedRes, actualRes)
+		t.Run(test.name, func(t *testing.T) {
+			// Init assert
+			assert := assert.New(t)
+			// Setup Mock
+			for _, volumeSet := range test.volumeSet {
+				cloud := volumeSet.mockCloud
+				cloud.On(
+					"ListVolumes",
+					volumeSet.mockMaxEntries,
+					volumeSet.mockTokenCall,
+				).Return(
+					volumeSet.mockVolumes,
+					volumeSet.mockToken,
+					nil,
+				).Once()
+			}
+			fakeReq := &csi.ListVolumesRequest{MaxEntries: int32(test.maxEntries), StartingToken: test.StartingToken}
+			expectedToken, _ := json.Marshal(test.Result.ExpectedToken)
+			if test.Result.ExpectedToken.isEmpty {
+				expectedToken = []byte("")
+			}
+			expectedRes := &csi.ListVolumesResponse{
+				Entries:   test.Result.Entries,
+				NextToken: string(expectedToken),
+			}
+			// Invoke ListVolumes
+			actualRes, err := fakeCsMultipleClouds.ListVolumes(FakeCtx, fakeReq)
+			if err != nil {
+				t.Errorf("failed to ListVolumes: %v", err)
+			}
+			// Assert
+			assert.Equal(expectedRes, actualRes)
 
-		// Unset Mock
-		for _, volumeSet := range test.volumeSet {
-			cloud := volumeSet.mockCloud
-			cloud.On(
-				"ListVolumes",
-				volumeSet.mockMaxEntries,
-				volumeSet.mockTokenCall,
-			).Return(
-				volumeSet.mockVolumes,
-				volumeSet.mockToken,
-				nil,
-			).Unset()
-		}
+			// Unset Mock
+			for _, volumeSet := range test.volumeSet {
+				cloud := volumeSet.mockCloud
+				cloud.On(
+					"ListVolumes",
+					volumeSet.mockMaxEntries,
+					volumeSet.mockTokenCall,
+				).Return(
+					volumeSet.mockVolumes,
+					volumeSet.mockToken,
+					nil,
+				).Unset()
+			}
+		})
 	}
 }
 

--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -438,7 +438,7 @@ func genFakeVolumeEntry(fakeVol volumes.Volume) *csi.ListVolumesResponse_Entry {
 	}
 }
 func genFakeVolumeEntries(fakeVolumes []volumes.Volume) []*csi.ListVolumesResponse_Entry {
-	entries := make([]*csi.ListVolumesResponse_Entry, 0)
+	entries := make([]*csi.ListVolumesResponse_Entry, 0, len(fakeVolumes))
 	for _, fakeVol := range fakeVolumes {
 		entries = append(entries, genFakeVolumeEntry(fakeVol))
 	}
@@ -450,7 +450,7 @@ func TestListVolumes(t *testing.T) {
 
 	// Init assert
 	assert := assert.New(t)
-	token := CloudsStartingToken{
+	token := cloudsStartingToken{
 		CloudName: "",
 		Token:     FakeVolID,
 	}
@@ -476,7 +476,7 @@ func TestListVolumes(t *testing.T) {
 type ListVolumesTest struct {
 	name          string
 	maxEntries    int
-	startingToken *CloudsStartingToken
+	startingToken *cloudsStartingToken
 	volumeSet     map[string]ListVolumeTestOSMock
 	result        ListVolumesTestResult
 }
@@ -489,11 +489,11 @@ type ListVolumeTestOSMock struct {
 }
 
 type ListVolumesTestRequest struct {
-	StartingToken CloudsStartingToken
+	StartingToken cloudsStartingToken
 }
 
 type ListVolumesTestResult struct {
-	ExpectedToken *CloudsStartingToken
+	ExpectedToken *cloudsStartingToken
 	Entries       []*csi.ListVolumesResponse_Entry
 }
 
@@ -531,7 +531,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 			},
 
 			result: ListVolumesTestResult{
-				ExpectedToken: &CloudsStartingToken{
+				ExpectedToken: &cloudsStartingToken{
 					Token: "vol2",
 				},
 				Entries: genFakeVolumeEntries([]volumes.Volume{
@@ -586,7 +586,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 				},
 			},
 			result: ListVolumesTestResult{
-				ExpectedToken: &CloudsStartingToken{
+				ExpectedToken: &cloudsStartingToken{
 					CloudName: "region-x",
 				},
 				Entries: genFakeVolumeEntries([]volumes.Volume{}),
@@ -594,7 +594,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 		},
 		{
 			name: "cloud2_no_pagination_no_volumes",
-			startingToken: &CloudsStartingToken{
+			startingToken: &cloudsStartingToken{
 				CloudName: "region-x",
 			},
 			maxEntries: 0,
@@ -645,7 +645,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 				},
 			},
 			result: ListVolumesTestResult{
-				ExpectedToken: &CloudsStartingToken{
+				ExpectedToken: &cloudsStartingToken{
 					CloudName: "region-x",
 				},
 				Entries: genFakeVolumeEntries([]volumes.Volume{
@@ -659,7 +659,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 		{
 			name:       "cloud2_no_pagination_has_volumes",
 			maxEntries: 0,
-			startingToken: &CloudsStartingToken{
+			startingToken: &cloudsStartingToken{
 				CloudName: "region-x",
 			},
 			volumeSet: map[string]ListVolumeTestOSMock{
@@ -713,7 +713,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 				},
 			},
 			result: ListVolumesTestResult{
-				ExpectedToken: &CloudsStartingToken{
+				ExpectedToken: &cloudsStartingToken{
 					CloudName: "region-x",
 				},
 				Entries: genFakeVolumeEntries([]volumes.Volume{}),
@@ -739,7 +739,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 				},
 			},
 			result: ListVolumesTestResult{
-				ExpectedToken: &CloudsStartingToken{
+				ExpectedToken: &cloudsStartingToken{
 					CloudName: "region-x",
 				},
 				Entries: genFakeVolumeEntries([]volumes.Volume{
@@ -767,7 +767,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 				},
 			},
 			result: ListVolumesTestResult{
-				ExpectedToken: &CloudsStartingToken{
+				ExpectedToken: &cloudsStartingToken{
 					CloudName: "region-x",
 				},
 				Entries: genFakeVolumeEntries([]volumes.Volume{}),
@@ -794,7 +794,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 				},
 			},
 			result: ListVolumesTestResult{
-				ExpectedToken: &CloudsStartingToken{
+				ExpectedToken: &cloudsStartingToken{
 					CloudName: "region-x",
 				},
 				Entries: genFakeVolumeEntries([]volumes.Volume{
@@ -826,7 +826,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 				},
 			},
 			result: ListVolumesTestResult{
-				ExpectedToken: &CloudsStartingToken{
+				ExpectedToken: &cloudsStartingToken{
 					CloudName: "",
 					Token:     "vol2",
 				},
@@ -839,7 +839,7 @@ func TestGlobalListVolumesMultipleClouds(t *testing.T) {
 		{
 			name:       "cloud1_3volume_cloud2_1volume_2st_call",
 			maxEntries: 2,
-			startingToken: &CloudsStartingToken{
+			startingToken: &cloudsStartingToken{
 				CloudName: "region-x",
 				Token:     "",
 			},

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -89,9 +89,7 @@ func (os *OpenStack) ListVolumes(ctx context.Context, limit int, startingToken s
 			return nil, "", err
 		}
 		vols, err = volumes.ExtractVolumes(page)
-		if mc.ObserveRequest(err) != nil {
-			return vols, "", err
-		}
+		return vols, "", mc.ObserveRequest(err)
 	}
 
 	opts := volumes.ListOpts{Limit: limit, Marker: startingToken}
@@ -118,11 +116,8 @@ func (os *OpenStack) ListVolumes(ctx context.Context, limit int, startingToken s
 
 		return false, nil
 	})
-	if mc.ObserveRequest(err) != nil {
-		return nil, nextPageToken, err
-	}
 
-	return vols, nextPageToken, nil
+	return vols, nextPageToken, mc.ObserveRequest(err)
 }
 
 // GetVolumesByName is a wrapper around ListVolumes that creates a Name filter to act as a GetByName

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -30,7 +30,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/util/wait"
-
 	"k8s.io/cloud-provider-openstack/pkg/metrics"
 	"k8s.io/cloud-provider-openstack/pkg/util"
 	cpoerrors "k8s.io/cloud-provider-openstack/pkg/util/errors"
@@ -84,9 +83,8 @@ func (os *OpenStack) ListVolumes(ctx context.Context, limit int, startingToken s
 	var vols []volumes.Volume
 
 	mc := metrics.NewMetricContext("volume", "list")
-	opts := volumes.ListOpts{Limit: limit, Marker: startingToken}
 	if limit == 0 {
-		page, err := volumes.List(os.blockstorage, opts).AllPages(ctx)
+		page, err := volumes.List(os.blockstorage, nil).AllPages(ctx)
 		if err != nil {
 			return nil, "", err
 		}
@@ -95,6 +93,8 @@ func (os *OpenStack) ListVolumes(ctx context.Context, limit int, startingToken s
 			return vols, "", err
 		}
 	}
+
+	opts := volumes.ListOpts{Limit: limit, Marker: startingToken}
 	err := volumes.List(os.blockstorage, opts).EachPage(ctx, func(_ context.Context, page pagination.Page) (bool, error) {
 		var err error
 

--- a/pkg/csi/cinder/utils.go
+++ b/pkg/csi/cinder/utils.go
@@ -103,3 +103,19 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 
 	return resp, err
 }
+
+func splitToken(str string) (string, string) {
+	i := strings.Index(str, ":")
+	if i == -1 {
+		return str, ""
+	}
+
+	return str[:i], str[i+1:]
+}
+
+func joinToken(str1, str2 string) string {
+	if str2 == "" {
+		return str1
+	}
+	return str1 + ":" + str2
+}

--- a/pkg/csi/cinder/utils_test.go
+++ b/pkg/csi/cinder/utils_test.go
@@ -146,3 +146,23 @@ func TestLogGRPC(t *testing.T) {
 		})
 	}
 }
+func TestSplitToken(t *testing.T) {
+	tests := []struct {
+		input string
+		token string
+		cloud string
+	}{
+		{input: "foo:bar", token: "foo", cloud: "bar"},
+		{input: "foo", token: "foo", cloud: ""},
+		{input: ":bar", token: "", cloud: "bar"},
+		{input: "foo:bar:baz", token: "foo", cloud: "bar:baz"},
+	}
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			token, cloud := splitToken(test.input)
+
+			assert.Equal(t, test.token, token)
+			assert.Equal(t, test.cloud, cloud)
+		})
+	}
+}

--- a/pkg/csi/cinder/utils_test.go
+++ b/pkg/csi/cinder/utils_test.go
@@ -152,9 +152,11 @@ func TestSplitToken(t *testing.T) {
 		token string
 		cloud string
 	}{
-		{input: "foo:bar", token: "foo", cloud: "bar"},
+		{input: "", token: "", cloud: ""},
 		{input: "foo", token: "foo", cloud: ""},
+		{input: "foo:", token: "foo", cloud: ""},
 		{input: ":bar", token: "", cloud: "bar"},
+		{input: "foo:bar", token: "foo", cloud: "bar"},
 		{input: "foo:bar:baz", token: "foo", cloud: "bar:baz"},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Fixes the linked issue and in addition does a small refactoring simplifying the code for the list volumes. In particular it changes the behavior slightly in 2 ways:
- if the list operation returns any page token even with max-entries == 0, we will respect the token and return it in the response.
- in the case of multiple cloud envs, we will no longer do the discovery for "the first cloud with volumes", instead we return the next cloud env. The discovery costs additional Cinder API calls which are more costly than simply issuing an additional local grpc call from the external-attacher.

Regarding point 2: the external-attacher will continue sending requests to list volumes while the response contains a token:

https://github.com/kubernetes-csi/external-attacher/blob/e5ae92e87bb6c3d99061ca515285c5c9e76e0414/pkg/attacher/lister.go#L63-L65

With this change, we will expect the csi-attacher to issue a request per cloud in our configuration. 

**Which issue this PR fixes(if applicable)**:
fixes https://github.com/kubernetes/cloud-provider-openstack/issues/2764

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix an issue with the `ListVolumes` not respecting pagination tokens from Cinder API with `req.maxEntries` is set to 0.
```
