### PR TITLE
group all dependabot updates to one pr

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,50 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     groups:
-      all:
+      # disable, since dependabot doesn't support update of the "replace" directive
+      # k8s.io:
+      #   patterns:
+      #   - "k8s.io/*"
+      k8s-sigs:
         patterns:
-        - "*"
+          - "sigs.k8s.io/*"
+      k8s-csi:
+        - "github.com/kubernetes-csi/*"
+        - "github.com/container-storage-interface/*"
+      system:
+        patterns:
+          - "golang.org/x/*"
+      gopkg:
+        patterns:
+          - "gopkg.in/*"
+      google:
+        patterns:
+          - "google.golang.org/*"
+          - "github.com/google/*"
+      sfp13:
+        patterns:
+          - "github.com/spf13/*"
+      openapi:
+        patterns:
+          - "github.com/go-openapi/*"
+      containerd:
+        patterns:
+          - "github.com/containerd/*"
+      other:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "k8s.io/*"
+          - "golang.org/x/*"
+          - "gopkg.in/*"
+          - "google.golang.org/*"
+          - "github.com/google/*"
+          - "sigs.k8s.io/*"
+          - "github.com/kubernetes-csi/*"
+          - "github.com/container-storage-interface/*"
+          - "github.com/spf13/*"
+          - "github.com/go-openapi/*"
+          - "github.com/containerd/*"
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,29 +7,9 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     groups:
-      k8s.io:
+      all:
         patterns:
-        - "k8s.io/*"
+        - "*"
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
-  - package-ecosystem: "gomod"
-    directory: "/"
-    groups:
-      k8s.io:
-        patterns:
-        - "k8s.io/*"
-    open-pull-requests-limit: 10
-    schedule:
-      interval: "daily"
-    target-branch: release-1.31
-  - package-ecosystem: "gomod"
-    directory: "/"
-    groups:
-      k8s.io:
-        patterns:
-        - "k8s.io/*"
-    open-pull-requests-limit: 10
-    schedule:
-      interval: "daily"
-    target-branch: release-1.30


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
