### PR TITLE
release 1.32.0

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: v1.31.2
+appVersion: v1.32.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.32.0-alpha.0
+version: 2.32.0
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: v1.31.2
+appVersion: v1.32.0
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 2.32.0-alpha.0
+version: 2.32.0
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
-appVersion: v1.31.2
+appVersion: v1.32.0
 description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.32.0-alpha.0
+version: 2.32.0
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/docs/cinder-csi-plugin/multi-region-clouds.md
+++ b/docs/cinder-csi-plugin/multi-region-clouds.md
@@ -166,7 +166,7 @@ spec:
       - name: liveness-probe
         ...
       - name: cinder-csi-plugin
-        image: docker.io/k8scloudprovider/cinder-csi-plugin:v1.31.2
+        image: docker.io/k8scloudprovider/cinder-csi-plugin:v1.32.0
         args:
         - /bin/cinder-csi-plugin
         - --endpoint=$(CSI_ENDPOINT)
@@ -216,7 +216,7 @@ spec:
       - name: liveness-probe
         ...
       - name: cinder-csi-plugin
-        image: docker.io/k8scloudprovider/cinder-csi-plugin:v1.31.2
+        image: docker.io/k8scloudprovider/cinder-csi-plugin:v1.32.0
         args:
         - /bin/cinder-csi-plugin
         - --endpoint=$(CSI_ENDPOINT)
@@ -282,7 +282,7 @@ spec:
         - Topology=true
         ...
       - name: cinder-csi-plugin
-        image: docker.io/k8scloudprovider/cinder-csi-plugin:v1.31.2
+        image: docker.io/k8scloudprovider/cinder-csi-plugin:v1.32.0
         args:
         - /bin/cinder-csi-plugin
         - --endpoint=$(CSI_ENDPOINT)

--- a/docs/keystone-auth/using-keystone-webhook-authenticator-and-authorizer.md
+++ b/docs/keystone-auth/using-keystone-webhook-authenticator-and-authorizer.md
@@ -252,7 +252,7 @@ it as a service. There are several things we need to notice in the
 deployment manifest:
 
 - We are using image
-  `registry.k8s.io/provider-os/k8s-keystone-auth:v1.31.2`
+  `registry.k8s.io/provider-os/k8s-keystone-auth:v1.32.0`
 - We use `k8s-auth-policy` configmap created above.
 - The pod uses service account `keystone-auth` created above.
 - We use `keystone-auth-certs` secret created above to inject the

--- a/docs/magnum-auto-healer/using-magnum-auto-healer.md
+++ b/docs/magnum-auto-healer/using-magnum-auto-healer.md
@@ -73,7 +73,7 @@ user_id=ceb61464a3d341ebabdf97d1d4b97099
 user_project_id=b23a5e41d1af4c20974bf58b4dff8e5a
 password=password
 region=RegionOne
-image=registry.k8s.io/provider-os/magnum-auto-healer:v1.31.2
+image=registry.k8s.io/provider-os/magnum-auto-healer:v1.32.0
 
 cat <<EOF | kubectl apply -f -
 ---

--- a/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
+++ b/docs/octavia-ingress-controller/using-octavia-ingress-controller.md
@@ -172,7 +172,7 @@ Here are several other config options are not included in the example configurat
 ### Deploy octavia-ingress-controller
 
 ```shell
-image="registry.k8s.io/provider-os/octavia-ingress-controller:v1.31.2"
+image="registry.k8s.io/provider-os/octavia-ingress-controller:v1.32.0"
 
 cat <<EOF > /etc/kubernetes/octavia-ingress-controller/deployment.yaml
 ---

--- a/examples/webhook/keystone-deployment.yaml
+++ b/examples/webhook/keystone-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: k8s-keystone
       containers:
         - name: k8s-keystone-auth
-          image: registry.k8s.io/provider-os/k8s-keystone-auth:v1.31.2
+          image: registry.k8s.io/provider-os/k8s-keystone-auth:v1.32.0
           args:
             - ./bin/k8s-keystone-auth
             - --tls-cert-file

--- a/manifests/barbican-kms/ds.yaml
+++ b/manifests/barbican-kms/ds.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: barbican-kms
-          image: registry.k8s.io/provider-os/barbican-kms-plugin:v1.31.2
+          image: registry.k8s.io/provider-os/barbican-kms-plugin:v1.32.0
           args:
             - /bin/barbican-kms-plugin
             - --socketpath=$(KMS_ENDPOINT)

--- a/manifests/barbican-kms/pod.yaml
+++ b/manifests/barbican-kms/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: barbican-kms
-      image: registry.k8s.io/provider-os/barbican-kms-plugin:v1.31.2
+      image: registry.k8s.io/provider-os/barbican-kms-plugin:v1.32.0
       args:
         - "--socketpath=/kms/kms.sock"
         - "--cloud-config=/etc/kubernetes/cloud-config"

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -93,7 +93,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: cinder-csi-plugin
-          image: registry.k8s.io/provider-os/cinder-csi-plugin:v1.31.2
+          image: registry.k8s.io/provider-os/cinder-csi-plugin:v1.32.0
           args:
             - /bin/cinder-csi-plugin
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -53,7 +53,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: registry.k8s.io/provider-os/cinder-csi-plugin:v1.31.2
+          image: registry.k8s.io/provider-os/cinder-csi-plugin:v1.32.0
           args:
             - /bin/cinder-csi-plugin
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -38,7 +38,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: openstack-cloud-controller-manager
-          image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.31.2
+          image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.32.0
           args:
             - /bin/openstack-cloud-controller-manager
             - --v=1

--- a/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   containers:
     - name: openstack-cloud-controller-manager
-      image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.31.2
+      image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.32.0
       args:
         - /bin/openstack-cloud-controller-manager
         - --v=1

--- a/manifests/magnum-auto-healer/magnum-auto-healer.yaml
+++ b/manifests/magnum-auto-healer/magnum-auto-healer.yaml
@@ -88,7 +88,7 @@ spec:
         node-role.kubernetes.io/control-plane: ""
       containers:
         - name: magnum-auto-healer
-          image: registry.k8s.io/provider-os/magnum-auto-healer:v1.31.2
+          image: registry.k8s.io/provider-os/magnum-auto-healer:v1.32.0
           imagePullPolicy: Always
           args:
             - /bin/magnum-auto-healer

--- a/manifests/manila-csi-plugin/csi-controllerplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-controllerplugin.yaml
@@ -78,7 +78,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: registry.k8s.io/provider-os/manila-csi-plugin:v1.31.2
+          image: registry.k8s.io/provider-os/manila-csi-plugin:v1.32.0
           command: ["/bin/sh", "-c",
             '/bin/manila-csi-plugin
             --endpoint=$(CSI_ENDPOINT)

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -50,7 +50,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: registry.k8s.io/provider-os/manila-csi-plugin:v1.31.2
+          image: registry.k8s.io/provider-os/manila-csi-plugin:v1.32.0
           command: ["/bin/sh", "-c",
             '/bin/manila-csi-plugin
             --endpoint=$(CSI_ENDPOINT)


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
