### PR TITLE
upgrade test dependency versions

### DIFF
--- a/tests/playbooks/roles/install-k3s/defaults/main.yaml
+++ b/tests/playbooks/roles/install-k3s/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-k3s_release: v1.31.2+k3s1
+k3s_release: v1.32.2-rc3+k3s1
 worker_node_count: 1
 cluster_token: "K1039d1cf76d1f8b0e8b0d48e7c60d9c4a43c2e7a56de5d86f346f2288a2677f1d7::server:2acba4e60918c0e2d1f1d1a7c4e81e7b"
 devstack_workdir: "{{ ansible_user_dir }}/devstack"

--- a/tests/playbooks/test-csi-cinder-e2e.yaml
+++ b/tests/playbooks/test-csi-cinder-e2e.yaml
@@ -4,7 +4,7 @@
   gather_facts: true
 
   vars:
-    e2e_test_version: v1.31.2
+    e2e_test_version: v1.32.2
     user: stack
     devstack_workdir: /home/{{ user }}/devstack
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
