### PR TITLE
Add missing release namespace for manila charts

### DIFF
--- a/charts/manila-csi-plugin/templates/controllerplugin-role.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-role.yaml
@@ -2,6 +2,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "openstack-manila-csi.controllerplugin.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "openstack-manila-csi.controllerplugin.labels" .  | nindent 4 }}
 rules:

--- a/charts/manila-csi-plugin/templates/controllerplugin-rolebinding.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-rolebinding.yaml
@@ -2,6 +2,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "openstack-manila-csi.controllerplugin.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "openstack-manila-csi.controllerplugin.labels" .  | nindent 4 }}
 subjects:

--- a/charts/manila-csi-plugin/templates/controllerplugin-service.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-service.yaml
@@ -2,6 +2,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ include "openstack-manila-csi.controllerplugin.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "openstack-manila-csi.controllerplugin.labels" .  | nindent 4 }}
 spec:

--- a/charts/manila-csi-plugin/templates/controllerplugin-serviceaccount.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-serviceaccount.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "openstack-manila-csi.serviceAccountName.controllerplugin" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "openstack-manila-csi.controllerplugin.labels" .  | nindent 4 }}

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -2,6 +2,7 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: {{ include "openstack-manila-csi.controllerplugin.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "openstack-manila-csi.controllerplugin.labels" .  | nindent 4 }}
 spec:

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -2,6 +2,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: {{ include "openstack-manila-csi.nodeplugin.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "openstack-manila-csi.nodeplugin.labels" .  | nindent 4 }}
 spec:

--- a/charts/manila-csi-plugin/templates/nodeplugin-rules-clusterrole.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-rules-clusterrole.yaml
@@ -2,6 +2,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "openstack-manila-csi.nodeplugin.fullname" . }}-rules
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "openstack-manila-csi.nodeplugin.labels" .  | nindent 4 }}
     rbac.manila.csi.openstack.org/aggregate-to-nodeplugin-{{ include "openstack-manila-csi.name" . }}: "true"

--- a/charts/manila-csi-plugin/templates/nodeplugin-serviceaccount.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-serviceaccount.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "openstack-manila-csi.serviceAccountName.nodeplugin" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "openstack-manila-csi.nodeplugin.labels" .  | nindent 4 }}

--- a/charts/manila-csi-plugin/templates/runtimeconfig-cm.yaml
+++ b/charts/manila-csi-plugin/templates/runtimeconfig-cm.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: manila-csi-runtimeconf-cm
+  namespace: {{ .Release.Namespace }}
 data:
   runtimeconfig.json: |-
 {{ .Values.csimanila.runtimeConfig.jsonData | indent 4 }}


### PR DESCRIPTION
The manila charts are missing the namespace and when templating
things with Helm, it will omit it and be problematic.  The cinder
chart has the namespaces set everywhere and its better to be
explicit so this adds it to the manila chart.

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
