### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Bug report
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--
+Please add the affected binary name in the title unless multiple binaries are affected, e.g.
+[cinder-csi-plugin] Cannot delete PV
+For openstack-cloud-controller-manager, you can use [occm] for short.
+
+All the currently maintained binaries are:
+* openstack-cloud-controller-manager (occm)
+* cinder-csi-plugin
+* manila-csi-plugin
+* k8s-keystone-auth
+* client-keystone-auth
+* octavia-ingress-controller
+* magnum-auto-healer
+* barbican-kms-plugin
+-->
+
+/kind bug
+
+**What happened**:
+
+
+**What you expected to happen**:
+
+
+**How to reproduce it**:
+
+
+**Anything else we need to know?**:
+
+
+**Environment**:
+- openstack-cloud-controller-manager(or other related binary) version:
+- OpenStack version:
+- Others:

--- a/.github/ISSUE_TEMPLATE/feature_report.md
+++ b/.github/ISSUE_TEMPLATE/feature_report.md
@@ -1,3 +1,12 @@
+---
+name: Feature report
+about: Feature report
+title: ''
+labels: ''
+assignees: ''
+
+---
+
 <!--
 Please add the affected binary name in the title unless multiple binaries are affected, e.g.
 [cinder-csi-plugin] Cannot delete PV
@@ -14,12 +23,7 @@ All the currently maintained binaries are:
 * barbican-kms-plugin
 -->
 
-**Is this a BUG REPORT or FEATURE REQUEST?**:
-
-> Uncomment only one, leave it on its own line: 
->
-> /kind bug
-> /kind feature
+/kind feature
 
 **What happened**:
 

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ $(BUILD_CMDS): $(SOURCES)
 test: unit functional
 
 check: work
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0 run --timeout=20m ./...
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4 run --timeout=20m ./...
 
 unit: work
 	go test -tags=unit $(shell go list ./... | sed -e '/sanity/ { N; d; }' | sed -e '/tests/ {N; d;}') $(TESTARGS)


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

for some reason this change was implemented too soon https://github.blog/changelog/2025-02-18-github-issues-projects-february-18th-update/#single-issue-templates-issue_template-md-will-be-retired


**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
