### PR TITLE
[cinder-csi-plugin]: ResourceExhausted code for CreateVolume

### DIFF
--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -146,8 +146,10 @@ func GetConfigFromFiles(configFilePaths []string) (Config, error) {
 
 const defaultMaxVolAttachLimit int64 = 256
 
-var OsInstances map[string]IOpenStack
-var configFiles = []string{"/etc/cloud.conf"}
+var (
+	OsInstances map[string]IOpenStack
+	configFiles = []string{"/etc/cloud.conf"}
+)
 
 func InitOpenStackProvider(cfgFiles []string, httpEndpoint string) {
 	OsInstances = make(map[string]IOpenStack)

--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -23,6 +23,9 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 )
 
+// ErrQuotaExceeded is used when openstack runs in to quota limits
+var ErrQuotaExceeded = errors.New("quota exceeded")
+
 // ErrNotFound is used to inform that the object is missing
 var ErrNotFound = errors.New("failed to find object")
 


### PR DESCRIPTION

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
If OpenStack quotas for volumes are exceeded, the driver currently returns the gRPC call with code `Internal`. This is not propagated to the PVC as an event and is not traceable very easily.
Cinder returns with a HTTP 413 response code if the quota for volumes is exceeded:
https://github.com/openstack/cinder/blob/c4f61c11ef9b590606a2a276bdf256622516181f/cinder/quota_utils.py#L130-L140

CSI spec defines that on a quota limit error, the driver should return a `ResourceExhausted` grpc error code:
https://github.com/container-storage-interface/spec/blob/master/spec.md#createvolume-errors

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Updated the error code to ResourceExhausted for CreateVolume calls if the volume quota is exceeded.
```
