### PR TITLE
[cinder-csi-plugin] Don't report topology capability when --with-topology=False

### DIFF
--- a/pkg/csi/cinder/driver.go
+++ b/pkg/csi/cinder/driver.go
@@ -101,7 +101,7 @@ func NewDriver(o *DriverOpts) *Driver {
 	klog.Info("Driver: ", d.name)
 	klog.Info("Driver version: ", d.fqVersion)
 	klog.Info("CSI Spec version: ", specVersion)
-	klog.Infof("Topology awareness: %T", d.withTopology)
+	klog.Infof("Topology awareness: %t", d.withTopology)
 
 	d.AddControllerServiceCapabilities(
 		[]csi.ControllerServiceCapability_RPC_Type{

--- a/pkg/csi/cinder/identityserver.go
+++ b/pkg/csi/cinder/identityserver.go
@@ -53,36 +53,39 @@ func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*c
 
 func (ids *identityServer) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
 	klog.V(5).Infof("GetPluginCapabilities called with req %+v", req)
-	return &csi.GetPluginCapabilitiesResponse{
-		Capabilities: []*csi.PluginCapability{
-			{
-				Type: &csi.PluginCapability_Service_{
-					Service: &csi.PluginCapability_Service{
-						Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,
-					},
-				},
-			},
-			{
-				Type: &csi.PluginCapability_Service_{
-					Service: &csi.PluginCapability_Service{
-						Type: csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS,
-					},
-				},
-			},
-			{
-				Type: &csi.PluginCapability_VolumeExpansion_{
-					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
-						Type: csi.PluginCapability_VolumeExpansion_ONLINE,
-					},
-				},
-			},
-			{
-				Type: &csi.PluginCapability_VolumeExpansion_{
-					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
-						Type: csi.PluginCapability_VolumeExpansion_OFFLINE,
-					},
+	caps := []*csi.PluginCapability{
+		{
+			Type: &csi.PluginCapability_Service_{
+				Service: &csi.PluginCapability_Service{
+					Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,
 				},
 			},
 		},
-	}, nil
+		{
+			Type: &csi.PluginCapability_VolumeExpansion_{
+				VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
+					Type: csi.PluginCapability_VolumeExpansion_ONLINE,
+				},
+			},
+		},
+		{
+			Type: &csi.PluginCapability_VolumeExpansion_{
+				VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
+					Type: csi.PluginCapability_VolumeExpansion_OFFLINE,
+				},
+			},
+		},
+	}
+
+	if ids.Driver.withTopology {
+		caps = append(caps, &csi.PluginCapability{
+			Type: &csi.PluginCapability_Service_{
+				Service: &csi.PluginCapability_Service{
+					Type: csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS,
+				},
+			},
+		})
+	}
+
+	return &csi.GetPluginCapabilitiesResponse{Capabilities: caps}, nil
 }

--- a/pkg/csi/manila/driver.go
+++ b/pkg/csi/manila/driver.go
@@ -130,7 +130,7 @@ func NewDriver(o *DriverOpts) (*Driver, error) {
 	klog.Info("Driver: ", d.name)
 	klog.Info("Driver version: ", d.fqVersion)
 	klog.Info("CSI spec version: ", specVersion)
-	klog.Infof("Topology awareness: %T", d.withTopology)
+	klog.Infof("Topology awareness: %t", d.withTopology)
 
 	getShareAdapter(d.shareProto) // The program will terminate with a non-zero exit code if the share protocol selector is wrong
 	klog.Infof("Operating on %s shares", d.shareProto)

--- a/pkg/csi/manila/identityserver.go
+++ b/pkg/csi/manila/identityserver.go
@@ -22,6 +22,7 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2"
 )
 
 type identityServer struct {
@@ -30,8 +31,14 @@ type identityServer struct {
 }
 
 func (ids *identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
+	klog.V(5).Infof("Using default GetPluginInfo")
+
 	if ids.d.name == "" {
 		return nil, status.Error(codes.Unavailable, "Driver name not configured")
+	}
+
+	if ids.d.fqVersion == "" {
+		return nil, status.Error(codes.Unavailable, "Driver is missing version")
 	}
 
 	return &csi.GetPluginInfoResponse{
@@ -51,6 +58,7 @@ func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*c
 }
 
 func (ids *identityServer) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
+	klog.V(5).Infof("GetPluginCapabilities called with req %+v", req)
 	caps := []*csi.PluginCapability{
 		{
 			Type: &csi.PluginCapability_Service_{


### PR DESCRIPTION
**What this PR does / why we need it**:

The `PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS` capability flag determines whether the provisioner attempts to look up topology information from the node or not [1][1] [2][2]. If we report it but don't return topology information from the node, we end up with failures to provision [3][3]. Fix the issue by optionally reporting the capability, like Manila already does.

In addition to the main fix, we also duplicate some helpful logs from Cinder to Manila, plus we fix a minor issue in the startup logging for both. More information on all these changes is provided in [the commits](https://github.com/kubernetes/cloud-provider-openstack/pull/2862/commits).

[1]: https://github.com/kubernetes-csi/external-provisioner/blob/17e2429e9f/pkg/controller/controller.go#L685-L700
[2]: https://github.com/kubernetes-csi/external-provisioner/blob/17e2429e9f/pkg/controller/controller.go#L994-L996
[3]: https://github.com/kubernetes-csi/external-provisioner/blob/17e2429e9f/pkg/controller/topology.go#L177

**Which issue this PR fixes(if applicable)**:

fixes #2861

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
