### PR TITLE
[cinder-csi-plugin] Rationalise all things topology

### DIFF
--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -1082,7 +1082,7 @@ func getCreateVolumeResponse(vol *volumes.Volume, volCtx map[string]string, igno
 		if accessibleTopologyReq != nil {
 			accessibleTopology = accessibleTopologyReq.GetPreferred()
 		}
-	} else {
+	} else if vol.AvailabilityZone != "" {
 		accessibleTopology = []*csi.Topology{
 			{
 				Segments: map[string]string{topologyKey: vol.AvailabilityZone},

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -86,21 +86,21 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	// Volume Type
 	volType := volParams["type"]
 
+	// Volume AZ
+
+	accessibleTopologyReq := req.GetAccessibilityRequirements()
+	ignoreVolumeAZ := cloud.GetBlockStorageOpts().IgnoreVolumeAZ
+
+	// First check if volAvailability is already specified, if not get preferred from Topology
+	// Required, in case vol AZ is different from node AZ
 	var volAvailability string
 	if cs.Driver.withTopology {
-		// First check if volAvailability is already specified, if not get preferred from Topology
-		// Required, incase vol AZ is different from node AZ
-		volAvailability = volParams["availability"]
-		if volAvailability == "" {
-			accessibleTopologyReq := req.GetAccessibilityRequirements()
-			// Check from Topology
-			if accessibleTopologyReq != nil {
-				volAvailability = sharedcsi.GetAZFromTopology(topologyKey, accessibleTopologyReq)
-			}
+		if volParams["availability"] != "" {
+			volAvailability = volParams["availability"]
+		} else if accessibleTopologyReq != nil {
+			volAvailability = sharedcsi.GetAZFromTopology(topologyKey, accessibleTopologyReq)
 		}
 	}
-
-	ignoreVolumeAZ := cloud.GetBlockStorageOpts().IgnoreVolumeAZ
 
 	// get the PVC annotation
 	pvcAnnotations := sharedcsi.GetPVCAnnotations(cs.Driver.pvcLister, volParams)
@@ -120,8 +120,11 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 			return nil, status.Error(codes.AlreadyExists, "Volume Already exists with same name and different capacity")
 		}
 		klog.V(4).Infof("Volume %s already exists in Availability Zone: %s of size %d GiB", vols[0].ID, vols[0].AvailabilityZone, vols[0].Size)
-		return getCreateVolumeResponse(&vols[0], nil, ignoreVolumeAZ, req.GetAccessibilityRequirements()), nil
-	} else if len(vols) > 1 {
+		accessibleTopology := getTopology(&vols[0], accessibleTopologyReq, ignoreVolumeAZ)
+		return getCreateVolumeResponse(&vols[0], nil, accessibleTopology), nil
+	}
+
+	if len(vols) > 1 {
 		klog.V(3).Infof("found multiple existing volumes with selected name (%s) during create", volName)
 		return nil, status.Error(codes.Internal, "Multiple volumes reported by Cinder with same name")
 	}
@@ -247,7 +250,9 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 
 	klog.V(4).Infof("CreateVolume: Successfully created volume %s in Availability Zone: %s of size %d GiB", vol.ID, vol.AvailabilityZone, vol.Size)
 
-	return getCreateVolumeResponse(vol, volCtx, ignoreVolumeAZ, req.GetAccessibilityRequirements()), nil
+	accessibleTopology := getTopology(vol, accessibleTopologyReq, ignoreVolumeAZ)
+
+	return getCreateVolumeResponse(vol, volCtx, accessibleTopology), nil
 }
 
 func (d *controllerServer) ControllerModifyVolume(ctx context.Context, req *csi.ControllerModifyVolumeRequest) (*csi.ControllerModifyVolumeResponse, error) {
@@ -1035,7 +1040,24 @@ func (cs *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 	}, nil
 }
 
-func getCreateVolumeResponse(vol *volumes.Volume, volCtx map[string]string, ignoreVolumeAZ bool, accessibleTopologyReq *csi.TopologyRequirement) *csi.CreateVolumeResponse {
+func getTopology(vol *volumes.Volume, topologyReq *csi.TopologyRequirement, ignoreVolumeAZ bool) []*csi.Topology {
+	var accessibleTopology []*csi.Topology
+	if ignoreVolumeAZ {
+		if topologyReq != nil {
+			accessibleTopology = topologyReq.GetPreferred()
+		}
+	} else if vol.AvailabilityZone != "" {
+		// NOTE(stephenfin): We retrieve the AZ from the created volume rather than
+		// using the value we provided in our request since these can differ due to
+		// Cinder's '[DEFAULT] allow_availability_zone_fallback' option.
+		accessibleTopology = []*csi.Topology{
+			{Segments: map[string]string{topologyKey: vol.AvailabilityZone}},
+		}
+	}
+	return accessibleTopology
+}
+
+func getCreateVolumeResponse(vol *volumes.Volume, volCtx map[string]string, accessibleTopology []*csi.Topology) *csi.CreateVolumeResponse {
 	var volsrc *csi.VolumeContentSource
 	volCnx := map[string]string{}
 
@@ -1071,21 +1093,6 @@ func getCreateVolumeResponse(vol *volumes.Volume, volCtx map[string]string, igno
 				Snapshot: &csi.VolumeContentSource_SnapshotSource{
 					SnapshotId: *vol.BackupID,
 				},
-			},
-		}
-	}
-
-	var accessibleTopology []*csi.Topology
-	// If ignore-volume-az is true , dont set the accessible topology to volume az,
-	// use from preferred topologies instead.
-	if ignoreVolumeAZ {
-		if accessibleTopologyReq != nil {
-			accessibleTopology = accessibleTopologyReq.GetPreferred()
-		}
-	} else if vol.AvailabilityZone != "" {
-		accessibleTopology = []*csi.Topology{
-			{
-				Segments: map[string]string{topologyKey: vol.AvailabilityZone},
 			},
 		}
 	}

--- a/pkg/csi/cinder/openstack/openstack_mock.go
+++ b/pkg/csi/cinder/openstack/openstack_mock.go
@@ -521,7 +521,8 @@ func (_m *OpenStackMock) GetMetadataOpts() metadata.Opts {
 
 // GetBlockStorageOpts provides a mock function to return BlockStorageOpts
 func (_m *OpenStackMock) GetBlockStorageOpts() BlockStorageOpts {
-	return BlockStorageOpts{}
+	args := _m.Called()
+	return args.Get(0).(BlockStorageOpts)
 }
 
 // ResolveVolumeListToUUIDs provides a mock function to return volume UUIDs


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This is a patch that came out of my work on https://github.com/kubernetes/cloud-provider-openstack/issues/2861. Currently, generation of the topology request for the Cinder Volume is logically separated from the generation of the topology request for the CSI Volume. This makes things harder to understand. Move some things around to resolve this and make everything a little easier to grok. This is kept separate from https://github.com/kubernetes/cloud-provider-openstack/pull/2862 since I don't expect we'll want to backport this.

**Which issue this PR fixes(if applicable)**:

n/a

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

I have a decoder of the logic embedded in the commit message. Hopefully this helps with review, but please don't assume the decoder itself is correct! :sweat_smile: I have also added additional unit tests that should capture any changes in logic.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
