### PR TITLE
k8s-keystone-auth: properly handle token with no project scope

### DIFF
--- a/pkg/identity/keystone/authenticator.go
+++ b/pkg/identity/keystone/authenticator.go
@@ -66,6 +66,9 @@ func (k *Keystoner) GetTokenInfo(ctx context.Context, token string) (*tokenInfo,
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract project information from Keystone response: %v", err)
 	}
+	if project == nil {
+		return nil, fmt.Errorf("failed to extract project information from Keystone response")
+	}
 
 	roles, err := ret.ExtractRoles()
 	if err != nil {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Don't panic in case, when a token doesn't contain a project scope. Return a proper error message instead.

**Which issue this PR fixes(if applicable)**:
fixes #2760

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
k8s-keystone-auth: properly handle tokens with no project scope
```
