### PR TITLE
[cinder-csi-plugin] add POSIX shell to docker image

### DIFF
--- a/tools/csi-deps-check.sh
+++ b/tools/csi-deps-check.sh
@@ -21,6 +21,7 @@ set -o errexit
 
 # This utils are using by
 # go mod k8s.io/mount-utils
+/bin/sh -c true
 /bin/mount -V
 /bin/umount -V
 /sbin/blkid -V

--- a/tools/csi-deps.sh
+++ b/tools/csi-deps.sh
@@ -62,6 +62,10 @@ else
   mkdir -p ${DEST}/lib64 && cp -Lv /lib64/ld-linux-*.so.* ${DEST}/lib64/
 fi
 
+# Copy POSIX shell
+copy_deps /bin/dash
+copy_deps /bin/sh
+
 # To collect dmesg logs
 copy_deps /usr/bin/dmesg || true
 copy_deps /bin/dmesg || true


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #2875

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[cinder-csi-plugin] add POSIX shell to docker image
```
