### PR TITLE
Add stephenfin to approvers, reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,9 +6,11 @@ emeritus_approvers:
 approvers:
 - dulek
 - kayrus
+- stephenfin
 - zetaab
 reviewers:
 - dulek
 - kayrus
 - mdbooth
+- stephenfin
 - zetaab


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

As discussed [on Slack](https://kubernetes.slack.com/archives/C0LSA3T7C/p1744287140817049?thread_ts=1741621902.079559&cid=C0LSA3T7C), I'd like to step up and help with the maintenance of CPO. I expect my focus to mainly be maintenance of CI and occasional bug fixes to cloud-provider and the CSI drivers (though I'd like to explore the other components as time allows). I have contributed sporadically in the past, but I have been very active in
upstream OpenStack for over a decade and have also been involved in Gophercloud and to a lesser degree CAPO in recent times, so rest assured I am "vouched for" and won't be self-approving things or ignoring CI failures on PRs 😄

**Which issue this PR fixes(if applicable)**:

None.

**Special notes for reviewers**:

None.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
