### PR TITLE
tests: Bump DevStack to Caracal (2024.1)

### DIFF
--- a/tests/ci-csi-cinder-e2e.sh
+++ b/tests/ci-csi-cinder-e2e.sh
@@ -41,6 +41,24 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Install Ansible from Trixie (Debian Testing) to allow us to talk to a host
+# running Python 3.12 like Ubuntu 24.04
+#
+# https://woju.eu/blog/2025/03/ansible-bookworm/
+cat << EOF > /etc/apt/sources.list.d/trixie.list
+deb https://deb.debian.org/debian trixie main
+EOF
+
+cat << EOF > /etc/apt/preferences.d/ansible.pref
+Package: *
+Pin: release n=trixie
+Pin-Priority: -10
+
+Package: ansible* python3-netaddr
+Pin: release n=trixie
+Pin-Priority: 990
+EOF
+
 apt-get update
 apt-get install -y python3-requests ansible
 

--- a/tests/ci-csi-manila-e2e.sh
+++ b/tests/ci-csi-manila-e2e.sh
@@ -41,6 +41,24 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Install Ansible from Trixie (Debian Testing) to allow us to talk to a host
+# running Python 3.12 like Ubuntu 24.04
+#
+# https://woju.eu/blog/2025/03/ansible-bookworm/
+cat << EOF > /etc/apt/sources.list.d/trixie.list
+deb https://deb.debian.org/debian trixie main
+EOF
+
+cat << EOF > /etc/apt/preferences.d/ansible.pref
+Package: *
+Pin: release n=trixie
+Pin-Priority: -10
+
+Package: ansible* python3-netaddr
+Pin: release n=trixie
+Pin-Priority: 990
+EOF
+
 apt-get update
 apt-get install -y python3-requests ansible
 

--- a/tests/ci-occm-e2e.sh
+++ b/tests/ci-occm-e2e.sh
@@ -42,6 +42,24 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Install Ansible from Trixie (Debian Testing) to allow us to talk to a host
+# running Python 3.12 like Ubuntu 24.04
+#
+# https://woju.eu/blog/2025/03/ansible-bookworm/
+cat << EOF > /etc/apt/sources.list.d/trixie.list
+deb https://deb.debian.org/debian trixie main
+EOF
+
+cat << EOF > /etc/apt/preferences.d/ansible.pref
+Package: *
+Pin: release n=trixie
+Pin-Priority: -10
+
+Package: ansible* python3-netaddr
+Pin: release n=trixie
+Pin-Priority: 990
+EOF
+
 apt-get update
 apt-get install -y python3-requests ansible
 

--- a/tests/playbooks/roles/install-cpo-occm/tasks/main.yaml
+++ b/tests/playbooks/roles/install-cpo-occm/tasks/main.yaml
@@ -128,7 +128,7 @@
         msg: *failmsg
 
 - name: Run functional tests for openstack-cloud-controller-manager
-  when: run_e2e
+  when: run_e2e | bool
   register: run_tests
   shell:
     executable: /bin/bash
@@ -145,7 +145,7 @@
 
 - name: Print logs for debugging
   when:
-    - run_e2e
+    - run_e2e | bool
     - run_tests.failed
   block:
   - name: Show openstack-cloud-controller-manager pod logs

--- a/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
@@ -190,12 +190,12 @@
         --ginkgo.noColor \
         --ginkgo.progress \
         --ginkgo.v \
-        --ginkgo.timeout=24h \
+        --ginkgo.timeout=1h30m \
         -test.timeout=0 \
         -report-dir="/var/log/csi-pod" | tee "/var/log/csi-pod/cinder-csi-e2e.log"
   register: functional_test_result
   ignore_errors: true
-  async: 5400 # wait 1h30m then fail and fetch the logs
+  async: 6300 # wait 1h45m (i.e. 15 mins longer than the ginkgo timeout) then fail and fetch the logs
   poll: 15
 
 - name: Collect pod logs for debug purpose

--- a/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
@@ -187,9 +187,9 @@
         -storage.testdriver=tests/e2e/csi/cinder/test-driver.yaml \
         --ginkgo.focus='External.Storage' \
         --ginkgo.skip='\[Disruptive\]|\[Testpattern:\s+Dynamic\s+PV\s+\(default\s+fs\)\]\s+provisioning\s+should\s+mount\s+multiple\s+PV\s+pointing\s+to\s+the\s+same\s+storage\s+on\s+the\s+same\s+node|\[Testpattern:\s+Dynamic\s+PV\s+\(default\s+fs\)\]\s+provisioning\s+should\s+provision\s+storage\s+with\s+any\s+volume\s+data\s+source\s+\[Serial\]|should\s+support\s+expansion\s+of\s+pvcs\s+created\s+for\s+ephemeral\s+pvcs' \
+        --ginkgo.v \
         --ginkgo.noColor \
         --ginkgo.progress \
-        --ginkgo.v \
         --ginkgo.timeout=1h30m \
         -test.timeout=0 \
         -report-dir="/var/log/csi-pod" | tee "/var/log/csi-pod/cinder-csi-e2e.log"

--- a/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
@@ -227,21 +227,23 @@
       set +x; source {{ devstack_workdir }}/openrc demo demo > /dev/null; set -x
 
       cd {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack
-
-      # GATEWAY_IP is the default value in devstack
       mkdir -p /var/log/csi-pod
+      # GATEWAY_IP is the default value in devstack
       GATEWAY_IP=172.24.5.1 \
       OS_RC={{ devstack_workdir }}/openrc \
       go test -v ./cmd/tests/manila-csi-e2e-suite/manila_csi_e2e_suite_test.go \
+        --ginkgo.focus="\[manila-csi-e2e\]" \
+        --ginkgo.skip="\[Disruptive\]|\[sig-storage\]\s+\[manila-csi-e2e\]\s+CSI\s+Volumes\s+\[Driver:\s+nfs.manila.csi.openstack.org\]\s+\[Testpattern:\s+Dynamic\s+PV\s+\(default\s+fs\)\]\s+provisioning\s+should\s+provision\s+storage\s+with\s+any\s+volume\s+data\s+source\s+\[Serial\]|should\s+provision\s+storage\s+with\s+snapshot\s+data\s+source|restoring\s+snapshot\s+to\s+larger\s+size" \
         --ginkgo.v \
         --ginkgo.noColor \
         --ginkgo.progress \
-        --ginkgo.skip="\[Disruptive\]|\[sig-storage\]\s+\[manila-csi-e2e\]\s+CSI\s+Volumes\s+\[Driver:\s+nfs.manila.csi.openstack.org\]\s+\[Testpattern:\s+Dynamic\s+PV\s+\(default\s+fs\)\]\s+provisioning\s+should\s+provision\s+storage\s+with\s+any\s+volume\s+data\s+source\s+\[Serial\]|should\s+provision\s+storage\s+with\s+snapshot\s+data\s+source|restoring\s+snapshot\s+to\s+larger\s+size" \
-        --ginkgo.focus="\[manila-csi-e2e\]" \
-        -report-dir /var/log/csi-pod \
-        -timeout=0 | tee "/var/log/csi-pod/manila-csi-e2e.log"
+        --ginkgo.timeout=1h30m \
+        -timeout=0 \
+        -report-dir /var/log/csi-pod | tee "/var/log/csi-pod/manila-csi-e2e.log"
   register: functional_test_result
   ignore_errors: true
+  async: 6300 # wait 1h45m (i.e. 15 mins longer than the ginkgo timeout) then fail and fetch the logs
+  poll: 15
 
 - name: Collect pod logs for debug purpose
   shell:

--- a/tests/playbooks/roles/install-devstack/defaults/main.yaml
+++ b/tests/playbooks/roles/install-devstack/defaults/main.yaml
@@ -1,7 +1,7 @@
 ---
 user: "stack"
 workdir: "/home/{{ user }}/devstack"
-branch: "stable/2023.2"
+branch: "stable/2024.1"
 enable_services:
   - nova
   - glance

--- a/tests/playbooks/roles/install-devstack/templates/local.conf.j2
+++ b/tests/playbooks/roles/install-devstack/templates/local.conf.j2
@@ -3,7 +3,6 @@ RECLONE=False
 HOST_IP={{ local_ip_address }}
 DEST=/opt/stack
 DATA_DIR=${DEST}/data
-USE_PYTHON3=True
 LOGFILE=$DEST/logs/stack.sh.log
 VERBOSE=True
 LOG_COLOR=False

--- a/tests/playbooks/test-occm-e2e.yaml
+++ b/tests/playbooks/test-occm-e2e.yaml
@@ -25,5 +25,5 @@
     - role: install-k3s
       worker_node_count: 0
     - role: install-cpo-occm
-      run_e2e: "{{ run_e2e }}"
+      run_e2e: "{{ run_e2e | bool }}"
       octavia_provider: "{{ octavia_provider }}"

--- a/tests/scripts/create-gce-vm.sh
+++ b/tests/scripts/create-gce-vm.sh
@@ -91,17 +91,18 @@ main() {
 
   case "${FLAVOR}" in
   "default")
-    if ! gcloud compute disks describe devstack-${FLAVOR} --zone "${GCP_ZONE}" > /dev/null 2>&1;
+    local disk_name="devstack-${FLAVOR}-ubuntu2204"
+    if ! gcloud compute disks describe "${disk_name}" --zone "${GCP_ZONE}" > /dev/null 2>&1;
     then
-      gcloud compute disks create devstack-${FLAVOR} \
-        --image-project ubuntu-os-cloud --image-family ubuntu-2404-lts-amd64 \
+      gcloud compute disks create "${disk_name}" \
+        --image-project ubuntu-os-cloud --image-family ubuntu-2204-lts \
         --zone "${GCP_ZONE}"
     fi
 
-    if ! gcloud compute images describe devstack-${FLAVOR} > /dev/null 2>&1;
+    if ! gcloud compute images describe "${disk_name}" > /dev/null 2>&1;
     then
-      gcloud compute images create devstack-${FLAVOR} \
-        --source-disk devstack-${FLAVOR} --source-disk-zone "${GCP_ZONE}" \
+      gcloud compute images create "${disk_name}" \
+        --source-disk "${disk_name}" --source-disk-zone "${GCP_ZONE}" \
         --licenses "https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
     fi
     ;;
@@ -115,7 +116,7 @@ main() {
   then
     gcloud compute instances create devstack \
       --zone "${GCP_ZONE}" \
-      --image devstack-${FLAVOR} \
+      --image "${disk_name}" \
       --boot-disk-size 30G \
       --boot-disk-type pd-ssd \
       --can-ip-forward \


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump the version of DevStack used in CI from Bobcat (2023.2), which is now EOL, to Caracal (2024.1). A future change will bump this further to Dalmatian (2024.2) and then Epoxy (2025.1).

**Which issue this PR fixes(if applicable)**:

(none)

**Special notes for reviewers**:

(none)

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

