### PR TITLE
[manila-csi-plugin] helm: support additional volumes in manila csi chart

### DIFF
--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.32.0
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 2.33.0-alpha.2
+version: 2.33.0-alpha.3
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -132,6 +132,9 @@ spec:
               mountPath: /runtimeconfig
               readOnly: true
             {{- end }}
+            {{- with .Values.controllerplugin.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
 {{ toYaml $.Values.controllerplugin.nodeplugin.resources | indent 12 }}
         {{- end }}
@@ -155,6 +158,9 @@ spec:
           hostPath:
             path: /var/lib/kubelet/pods
             type: Directory
+        {{- with .Values.controllerplugin.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     {{- if .Values.controllerplugin.affinity }}
       affinity: {{ toYaml .Values.controllerplugin.affinity | nindent 8 }}
     {{- end }}

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -132,7 +132,7 @@ spec:
               mountPath: /runtimeconfig
               readOnly: true
             {{- end }}
-            {{- with .Values.controllerplugin.volumeMounts }}
+            {{- with $.Values.controllerplugin.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -87,7 +87,7 @@ spec:
               mountPath: /runtimeconfig
               readOnly: true
             {{- end }}
-            {{- with .Values.nodeplugin.volumeMounts }}
+            {{- with $.Values.nodeplugin.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -87,6 +87,9 @@ spec:
               mountPath: /runtimeconfig
               readOnly: true
             {{- end }}
+            {{- with .Values.nodeplugin.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
 {{ toYaml $.Values.nodeplugin.nodeplugin.resources | indent 12 }}
         {{- end }}
@@ -109,6 +112,9 @@ spec:
           configMap:
             name: manila-csi-runtimeconf-cm
         {{- end }}
+        {{- end }}
+        {{- with .Values.nodeplugin.volumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
     {{- if .Values.nodeplugin.affinity }}
       affinity: {{ toYaml .Values.nodeplugin.affinity | nindent 8 }}

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -76,6 +76,8 @@ nodeplugin:
   # Use fullnameOverride to fully override the name of this component
   # fullnameOverride: some-other-name
   podSecurityContext: {}
+  volumes: []
+  volumeMounts: []
 
 # StatefulSet deployment
 controllerplugin:
@@ -121,6 +123,17 @@ controllerplugin:
   # Use fullnameOverride to fully override the name of this component
   # fullnameOverride: some-other-name
   podSecurityContext: {}
+  volumes: []
+    # - name: cacert
+    #   hostPath:
+    #     path: /etc/cacert
+  volumeMounts: []
+    # - name: cacert
+    #   mountPath: /etc/cacert
+    #   readOnly: true
+    # - name: cloud-config
+    #   mountPath: /etc/kubernetes
+    #   readOnly: true
 
 # Log verbosity level.
 # See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
This PR supports additional volumes in manila csi chart. Typical use case is to mount ca cert of openstack api.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[manila-csi-plugin] add support for additional volumes in helm chart. 
Typical use case is to mount ca cert of openstack api.
```
