### PR TITLE
[cinder-csi-plugin]: helm-charts: use /etc/config/ for cloud.conf

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.32.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.33.0-alpha.1
+version: 2.33.0-alpha.2
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -192,7 +192,7 @@ spec:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
-              value: /etc/kubernetes/{{ .Values.secret.filename }}
+              value: /etc/config/{{ .Values.secret.filename }}
             - name: CLUSTER_NAME
               value: "{{ .Values.clusterID }}"
             {{- if .Values.csi.plugin.extraEnv }}
@@ -233,7 +233,7 @@ spec:
         {{- else if .Values.secret.hostMount }}
         - name: cloud-config
           hostPath:
-            path: /etc/kubernetes
+            path: /etc/config
         {{- end }}
         {{- with .Values.csi.plugin.volumes }}
           {{- toYaml . | nindent 8 }}

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -105,7 +105,7 @@ spec:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
-              value: /etc/kubernetes/{{ .Values.secret.filename }}
+              value: /etc/config/{{ .Values.secret.filename }}
             {{- if .Values.csi.plugin.extraEnv }}
               {{- toYaml .Values.csi.plugin.extraEnv | nindent 12 }}
             {{- end }}
@@ -163,7 +163,7 @@ spec:
         {{- else if .Values.secret.hostMount }}
         - name: cloud-config
           hostPath:
-            path: /etc/kubernetes
+            path: /etc/config
         {{- end }}
         {{- with .Values.csi.plugin.volumes }}
           {{- toYaml . | nindent 8 }}

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -86,7 +86,7 @@ csi:
         mountPath: /etc/cacert
         readOnly: true
       - name: cloud-config
-        mountPath: /etc/kubernetes
+        mountPath: /etc/config
         readOnly: true
     nodePlugin:
       dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
[cinder-csi-plugin] helm charts: Use /etc/config/ for cloud.conf
This path is used by default in the deployment manifests for cinder-csi as well as in manifests and helm charts for occm.
It does not matter much until you reference another file via ca-file=/etc/config/cacert
in your cloud.conf and assume that to work.

So better align the volumeMount location everywhere. As there is a canonical location where most artifacts already agree on, let's use it in cinder-csi helm charts as well.

**What this PR does / why we need it**:
Make the cinder-csi-plugin helm charts work if we pass a secret with `cloud.conf` and a `cacert` referenced from there assuming the `/etc/config` path.
This works with occm (deployment manifests and helm charts) and cinder-csi deployment manifests, but not currently with the cinder-csi helm charts due to using `/etc/kubernetes` there.
This PR aligns cinder-csi helm charts to also use the canonical path.

Reference: 
https://github.com/SovereignCloudStack/cluster-stacks/issues/188#issuecomment-2898122614

**Release note**:
```release-note
* [cinder-csi-plugin] Use `/etc/config` in helm charts rather than `/etc/kubernetes` for `cloud.conf`, so any referenced file (e.g. `cacert`) is found.
```
(Feel free to not add this if determined not to be significant enough.)