### PR TITLE
[Barbican][KMS] Fix clouds.yaml authentication

### DIFF
--- a/pkg/kms/barbican/barbican.go
+++ b/pkg/kms/barbican/barbican.go
@@ -2,11 +2,13 @@ package barbican
 
 import (
 	"context"
+	"os"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack"
 	"github.com/gophercloud/gophercloud/v2/openstack/keymanager/v1/secrets"
 	"k8s.io/cloud-provider-openstack/pkg/client"
+	"k8s.io/klog/v2"
 )
 
 type KMSOpts struct {
@@ -26,6 +28,17 @@ type Barbican struct {
 
 // NewBarbicanClient creates new BarbicanClient
 func NewBarbicanClient(cfg Config) (*gophercloud.ServiceClient, error) {
+	if cfg.Global.UseClouds {
+		if cfg.Global.CloudsFile != "" {
+			os.Setenv("OS_CLIENT_CONFIG_FILE", cfg.Global.CloudsFile)
+		}
+		if err := client.ReadClouds(&cfg.Global); err != nil {
+			return nil, err
+		}
+		klog.V(5).Infof("Config, loaded from the %s:", cfg.Global.CloudsFile)
+		client.LogCfg(cfg.Global)
+	}
+
 	provider, err := client.NewOpenStackClient(&cfg.Global, "barbican-kms-plugin")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
With the barbican KMS plugin it's impossible to use clouds.yaml authentication.

**Which issue this PR fixes(if applicable)**:
fixes #2895

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[barbican-kms-plugin] Enable the use of clouds.yaml based authentication
```
