### PR TITLE
Add weekly govulncheck workflow

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -1,0 +1,30 @@
+name: Weekly security scan
+
+on:
+  schedule:
+  # Cron for every Monday at 4:12 UTC.
+  - cron: "12 4 * * 1"
+
+# Remove all permissions from GITHUB_TOKEN except metadata.
+permissions: {}
+
+jobs:
+  scan:
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [main, release-1.32, release-1.31, release-1.30]
+    name: Verify security
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
+      with:
+        ref: ${{ matrix.branch }}
+    - name: Set up Go
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # tag=v5.4.0
+      with:
+        # Keep this in sync with the go version in the Dockerfile.
+        go-version: 1.23.6
+    - name: Run verify security target
+      run: make verify-security

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,9 @@ vet: check
 cover: work
 	go test -tags=unit $(shell go list ./...) -cover
 
+verify-security: work
+	go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
+
 docs:
 	@echo "$@ not yet implemented"
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This adds a github workflow for weekly security scanning using govulncheck. It was inspired by what [CAPI has](https://github.com/kubernetes-sigs/cluster-api/blob/main/.github/workflows/weekly-security-scan.yaml) but adapted quite heavily and limited to govulncheck for now. (CAPI also runs Trivy to scan the images.)
I have been doing the same in CAPO and ORC with the goal of having better insights into when new patch releases would be needed to fix vulnerabilities (and of course when dependencies need to be updated).

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
