### PR TITLE
[occm] docs: remove deprecated apiserver flag from kubeadm.conf

### DIFF
--- a/manifests/controller-manager/kubeadm.conf
+++ b/manifests/controller-manager/kubeadm.conf
@@ -11,9 +11,6 @@ kind: ClusterConfiguration
 kubernetesVersion: v1.17.0
 networking:
   podSubnet: 192.168.0.0/16
-apiServer:
-  extraArgs:
-    cloud-provider: "external"
 controllerManager:
   extraArgs:
     cloud-provider: "external"


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**: Removes `cloud-provider: "external"` flag from the example `kubeadm.conf` [file](https://github.com/kubernetes/cloud-provider-openstack/blob/master/manifests/controller-manager/kubeadm.conf) as its removed from kube-apiserver.

**Which issue this PR fixes(if applicable)**:
fixes #2898

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
