### PR TITLE
[occm] Target control-plane nodes and tolerate CriticalAddonsOnly taint

### DIFF
--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -24,10 +24,14 @@ spec:
         k8s-app: openstack-cloud-controller-manager
     spec:
       nodeSelector:
-        node-role.kubernetes.io/control-plane: ""
+        node-role.kubernetes.io/control-plane: "true"
       securityContext:
         runAsUser: 1001
       tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Equal"
+        value: "true"
+        effect: "NoExecute"
       - key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
         effect: NoSchedule


### PR DESCRIPTION
**What this PR does / why we need it**:
The OpenStack Cloud Controller Manager is a critical component of the Kubernetes control plane when running on OpenStack. It should ideally run on control-plane nodes for better isolation, security, and to fulfill its role effectively. These changes ensure that OCCM pods:
- Are scheduled on the intended control-plane nodes.
- Can operate on nodes protected by the CriticalAddonsOnly=true:NoExecute taint, as OCCM is considered a critical add-on.
- This leads to a more robust and correctly configured deployment of OCCM.

**Which issue this PR fixes(if applicable)**:
fixes #2093 
Addresses an issue where OCCM may fail to schedule on control-plane nodes due to the CriticalAddonsOnly taint.

**Special notes for reviewers**:

- Please verify that the updated nodeSelector (node-role.kubernetes.io/control-plane: "true") aligns with the common labeling scheme for control-plane nodes in your environments.
- The added toleration for **CriticalAddonsOnly=true:NoExecute** is based on taints commonly found on control-plane nodes in various Kubernetes distributions (like RKE2). If other NoExecute taints specific to control-plane nodes are present in a particular setup, they might also need corresponding tolerations.
- This PR assumes that deploying OCCM on control-plane nodes is the desired architecture.


**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

1. [occm] Fixed OCCM scheduling on control-plane nodes by correcting the nodeSelector and adding toleration for the `CriticalAddonsOnly=true:NoExecute` taint.

```
