### PR TITLE
Update tests to use 2025.1 openstack, disable zswap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/container-storage-interface/spec v1.11.0
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/google/uuid v1.6.0
-	github.com/gophercloud/gophercloud/v2 v2.5.0
+	github.com/gophercloud/gophercloud/v2 v2.7.0
 	github.com/gophercloud/utils/v2 v2.0.0-20250212084022-725b94822eeb
 	github.com/hashicorp/go-version v1.7.0
 	github.com/kubernetes-csi/csi-lib-utils v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gophercloud/gophercloud/v2 v2.5.0 h1:DubPfC43gsZiGZ9LT1IJflVMm+0rck0ejoPsH8D5rqk=
-github.com/gophercloud/gophercloud/v2 v2.5.0/go.mod h1:Ki/ILhYZr/5EPebrPL9Ej+tUg4lqx71/YH2JWVeU+Qk=
+github.com/gophercloud/gophercloud/v2 v2.7.0 h1:o0m4kgVcPgHlcXiWAjoVxGd8QCmvM5VU+YM71pFbn0E=
+github.com/gophercloud/gophercloud/v2 v2.7.0/go.mod h1:Ki/ILhYZr/5EPebrPL9Ej+tUg4lqx71/YH2JWVeU+Qk=
 github.com/gophercloud/utils/v2 v2.0.0-20250212084022-725b94822eeb h1:TQTXVYXL3d0zRAybRUKKboO0z/XAsXEfU6Oax8n00kc=
 github.com/gophercloud/utils/v2 v2.0.0-20250212084022-725b94822eeb/go.mod h1:tIUw/gFHOB6lFV9LhzNZg5jfCLYMxI2lC1dZUa7NlHM=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -189,7 +189,7 @@ func CreateOpenStackProvider(cloudName string) (IOpenStack, error) {
 
 	provider, err := client.NewOpenStackClient(global, "cinder-csi-plugin", userAgentData...)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create OpenStack client: %w", err)
 	}
 
 	epOpts := gophercloud.EndpointOpts{
@@ -200,13 +200,13 @@ func CreateOpenStackProvider(cloudName string) (IOpenStack, error) {
 	// Init Nova ServiceClient
 	computeclient, err := openstack.NewComputeV2(provider, epOpts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create Nova client: %w", err)
 	}
 
 	// Init Cinder ServiceClient
 	blockstorageclient, err := openstack.NewBlockStorageV3(provider, epOpts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create Cinder client: %w", err)
 	}
 
 	// Init OpenStack

--- a/tests/playbooks/roles/install-devstack/defaults/main.yaml
+++ b/tests/playbooks/roles/install-devstack/defaults/main.yaml
@@ -1,7 +1,7 @@
 ---
 user: "stack"
 workdir: "/home/{{ user }}/devstack"
-branch: "stable/2023.2"
+branch: "stable/2025.1"
 enable_services:
   - nova
   - glance
@@ -10,6 +10,6 @@ enable_services:
   - octavia
   - ovn-octavia
   - barbican
-octavia_amphora_url: "https://tarballs.opendev.org/openstack/octavia/test-images/test-only-amphora-x64-haproxy-ubuntu-jammy.qcow2"
+octavia_amphora_url: "https://tarballs.opendev.org/openstack/octavia/test-images/test-only-amphora-x64-haproxy-ubuntu-noble.qcow2"
 octavia_amphora_dir: /opt/octavia-amphora
 octavia_amphora_filename: amphora-x64-haproxy.qcow2

--- a/tests/playbooks/roles/install-devstack/tasks/main.yml
+++ b/tests/playbooks/roles/install-devstack/tasks/main.yml
@@ -48,6 +48,7 @@
           - python3-pip
           - build-essential
           - python3-dev
+          - python3-venv
           - python3-setuptools
           - libffi-dev
           - libxslt1-dev
@@ -58,6 +59,27 @@
           - unzip
           - jq
           - net-tools
+          - ca-certificates
+          - python3-openstackclient
+          - python3-cinderclient
+          - python3-glanceclient
+          - python3-keystoneclient
+          - python3-neutronclient
+          - python3-novaclient
+          - python3-swiftclient
+          - python3-heatclient
+          - python3-octaviaclient
+          - python3-manilaclient
+          - python3-barbicanclient
+
+    - name: Verify OpenStack CLI installation
+      ansible.builtin.command: openstack --version
+      register: openstack_version
+      changed_when: false
+
+    - name: Display OpenStack CLI version
+      ansible.builtin.debug:
+        msg: "OpenStack CLI installed successfully: {{ openstack_version.stdout }}"
 
     - name: Git checkout devstack
       git:

--- a/tests/playbooks/roles/install-devstack/templates/local.conf.j2
+++ b/tests/playbooks/roles/install-devstack/templates/local.conf.j2
@@ -39,7 +39,7 @@ ENABLE_SYSCTL_NET_TUNING=true
 # increase in swap performance by reducing the amount of data
 # written to disk. the overall speedup is porportional to the
 # compression ratio and the speed of the swap device.
-ENABLE_ZSWAP=true
+ENABLE_ZSWAP=false
 
 {% if "nova" in enable_services %}
 # Nova

--- a/tests/playbooks/roles/install-golang/defaults/main.yml
+++ b/tests/playbooks/roles/install-golang/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-go_version: '1.22.2'
+go_version: '1.24.3'
 arch: 'amd64'
 go_tarball: 'go{{ go_version }}.linux-{{ arch }}.tar.gz'
 go_download_location: 'https://go.dev/dl/{{ go_tarball }}'


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
