### PR TITLE
tests: Temporarily unblock gate with use of EOL Bobcat tags

### DIFF
--- a/tests/playbooks/roles/install-devstack/defaults/main.yaml
+++ b/tests/playbooks/roles/install-devstack/defaults/main.yaml
@@ -1,7 +1,7 @@
 ---
 user: "stack"
 workdir: "/home/{{ user }}/devstack"
-branch: "stable/2023.2"
+branch: "2023.2-eol"
 enable_services:
   - nova
   - glance

--- a/tests/playbooks/roles/install-devstack/templates/local.conf.j2
+++ b/tests/playbooks/roles/install-devstack/templates/local.conf.j2
@@ -101,7 +101,6 @@ enable_service o-hk
 enable_service o-da
 enable_service o-api
 
-LIBS_FROM_GIT+=,python-octaviaclient
 DIB_REPOLOCATION_amphora_agent=https://github.com/openstack/octavia.git
 DIB_REPOLOCATION_octavia_lib=https://github.com/openstack/octavia-lib.git
 
@@ -121,8 +120,6 @@ enable_plugin ovn-octavia-provider https://opendev.org/openstack/ovn-octavia-pro
 # Barbican
 enable_plugin barbican ${GIT_BASE}/openstack/barbican.git {{ branch }}
 enable_service barbican-vault
-
-LIBS_FROM_GIT+=,python-barbicanclient
 {% endif %}
 
 {% if "manila" in enable_services %}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

We currently have no less than three PRs in-flight attempting to bump the DevStack version used in the gate (and a possible forth one need for Epoxy):

* https://github.com/kubernetes/cloud-provider-openstack/pull/2888
* https://github.com/kubernetes/cloud-provider-openstack/pull/2742
* https://github.com/kubernetes/cloud-provider-openstack/pull/2903

While we continue work on these and investigate the performance regressions seen in Dalmatian (and possibly Caracal), unblock the gate by relying on the `2023.2-eol` tags rather than the (now deleted) `stable/2023.2` branches.

Note that `python-barbicanclient` does not have a `2023.2-eol` tag so we can't use install from Git. Since we're not hacking on though there's no good reason to be installing from Git, so we remove both this and `python-octaviaclient` from the list.

**Which issue this PR fixes(if applicable)**:

None.

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->
This should be considered a temporary bandaid. I'm actively investigating these test timeouts locally now that the Gophercloud CI bump is completed (and I think @zetaab is doing the same).

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
