### PR TITLE
[release-1.33][manila-csi-plugin] Add support for authentication via clouds.yaml

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -37,7 +37,7 @@ import (
 )
 
 type AuthOpts struct {
-	AuthURL          string                   `gcfg:"auth-url" mapstructure:"auth-url" name:"os-authURL" dependsOn:"os-password|os-trustID|os-applicationCredentialSecret|os-clientCertPath"`
+	AuthURL          string                   `gcfg:"auth-url" mapstructure:"auth-url" name:"os-authURL" value:"optional" dependsOn:"os-password|os-trustID|os-applicationCredentialSecret|os-clientCertPath"`
 	UserID           string                   `gcfg:"user-id" mapstructure:"user-id" name:"os-userID" value:"optional" dependsOn:"os-password"`
 	Username         string                   `name:"os-userName" value:"optional" dependsOn:"os-password"`
 	Password         string                   `name:"os-password" value:"optional" dependsOn:"os-domainID|os-domainName,os-projectID|os-projectName,os-userID|os-userName"`
@@ -52,7 +52,7 @@ type AuthOpts struct {
 	TenantDomainName string                   `gcfg:"tenant-domain-name" mapstructure:"project-domain-name" name:"os-projectDomainName" value:"optional"`
 	UserDomainID     string                   `gcfg:"user-domain-id" mapstructure:"user-domain-id" name:"os-userDomainID" value:"optional"`
 	UserDomainName   string                   `gcfg:"user-domain-name" mapstructure:"user-domain-name" name:"os-userDomainName" value:"optional"`
-	Region           string                   `name:"os-region"`
+	Region           string                   `name:"os-region" value:"optional" dependsOn:"os-password|os-applicationCredentialSecret|os-trusteePassword"`
 	EndpointType     gophercloud.Availability `gcfg:"os-endpoint-type" mapstructure:"os-endpoint-type" name:"os-endpointType" value:"optional"`
 	CAFile           string                   `gcfg:"ca-file" mapstructure:"ca-file" name:"os-certAuthorityPath" value:"optional"`
 	TLSInsecure      string                   `gcfg:"tls-insecure" mapstructure:"tls-insecure" name:"os-TLSInsecure" value:"optional" matches:"^true|false$"`

--- a/pkg/csi/manila/manilaclient/builder.go
+++ b/pkg/csi/manila/manilaclient/builder.go
@@ -48,6 +48,14 @@ func (cb *ClientBuilder) New(ctx context.Context, o *client.AuthOpts) (Interface
 
 func New(ctx context.Context, o *client.AuthOpts, userAgent string, extraUserAgentData []string) (*Client, error) {
 	// Authenticate and create Manila v2 client
+	// If UseClouds is set, read clouds.yaml file
+	if o.UseClouds {
+		err := client.ReadClouds(o)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read clouds.yaml: %v", err)
+		}
+	}
+
 	provider, err := client.NewOpenStackClient(o, userAgent, extraUserAgentData...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to authenticate: %v", err)

--- a/pkg/csi/manila/validator/validator.go
+++ b/pkg/csi/manila/validator/validator.go
@@ -19,6 +19,7 @@ package validator
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 )
 
 // Validator validates input data and stores it in the output struct.
@@ -113,10 +114,24 @@ func (v *Validator) Populate(data map[string]string, out interface{}) error {
 				return fmt.Errorf("parameter '%s' cannot be empty", fName)
 			}
 
-			// The value is present, populate the field and continue with the next one
+			field := vOut.Field(int(fIdx))
 
-			vOut.Field(int(fIdx)).SetString(value)
-			continue
+			switch field.Kind() {
+			case reflect.Bool:
+				boolValue, err := strconv.ParseBool(value)
+				if err != nil {
+					return fmt.Errorf("invalid boolean value for parameter '%s': %v", fName, err)
+				}
+				field.SetBool(boolValue)
+				continue
+
+			case reflect.String:
+				field.SetString(value)
+				continue
+
+			default:
+				return fmt.Errorf("unsupported field type for parameter '%s'", fName)
+			}
 		}
 
 		// Value not present, determine whether this field is required

--- a/pkg/csi/manila/validator/validator_test.go
+++ b/pkg/csi/manila/validator/validator_test.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package validator
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2"
+)
 
 func TestValueRequired(t *testing.T) {
 	type s1 struct {
@@ -222,5 +226,66 @@ func TestFieldNames(t *testing.T) {
 		if !findElem(v.Fields[i], expected) {
 			t.Error("found unexpected field", v.Fields[i], "; expected fields", expected, "actual fields", v.Fields)
 		}
+	}
+}
+
+func TestBooleanField(t *testing.T) {
+	type s struct {
+		A bool `name:"a"`
+	}
+
+	v := New(&s{})
+
+	// Test with a valid boolean string "true"
+	obj := &s{}
+	err := v.Populate(map[string]string{"a": "true"}, obj)
+	if err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+	if obj.A != true {
+		t.Errorf("expected A to be true, got: %v", obj.A)
+	}
+
+	// Test with a valid boolean string "false"
+	obj = &s{}
+	err = v.Populate(map[string]string{"a": "false"}, obj)
+	if err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+	if obj.A != false {
+		t.Errorf("expected A to be false, got: %v", obj.A)
+	}
+
+	// Test with a invalid boolean string "foo"
+	obj = &s{}
+	err = v.Populate(map[string]string{"a": "foo"}, obj)
+	if err == nil {
+		t.Errorf("Populate with 'foo': expected an error, but got nil")
+	}
+
+}
+
+func TestAvailabilityField(t *testing.T) {
+	type s struct {
+		Avail gophercloud.Availability `name:"avail"`
+	}
+
+	v := New(&s{})
+
+	// Test with a valid availability string
+	obj := &s{}
+	err := v.Populate(map[string]string{"avail": "public"}, obj)
+	if err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+	if obj.Avail != gophercloud.Availability("public") {
+		t.Errorf("expected Avail to be 'public', got: %v", obj.Avail)
+	}
+
+	// Test with empty value
+	obj = &s{}
+	err = v.Populate(map[string]string{"avail": ""}, obj)
+	if err == nil {
+		t.Errorf("expected error for empty value, got nil")
 	}
 }

--- a/pkg/csi/manila/validator/validator_test.go
+++ b/pkg/csi/manila/validator/validator_test.go
@@ -262,7 +262,6 @@ func TestBooleanField(t *testing.T) {
 	if err == nil {
 		t.Errorf("Populate with 'foo': expected an error, but got nil")
 	}
-
 }
 
 func TestAvailabilityField(t *testing.T) {


### PR DESCRIPTION
This is a manual cherry-pick of [#2883](https://github.com/kubernetes/cloud-provider-openstack/pull/2883)

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```