### PR TITLE
[manila-csi-plugin] support muilple share rules

### DIFF
--- a/pkg/csi/manila/shareadapters/cephfs.go
+++ b/pkg/csi/manila/shareadapters/cephfs.go
@@ -19,6 +19,7 @@ package shareadapters
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gophercloud/gophercloud/v2"
@@ -32,82 +33,81 @@ type Cephfs struct{}
 
 var _ ShareAdapter = &Cephfs{}
 
-func (Cephfs) GetOrGrantAccess(ctx context.Context, args *GrantAccessArgs) (accessRight *shares.AccessRight, err error) {
+func (Cephfs) GetOrGrantAccesses(ctx context.Context, args *GrantAccessArgs) ([]shares.AccessRight, error) {
 	// First, check if the access right exists or needs to be created
 
-	var rights []shares.AccessRight
-
-	accessTo := args.Options.CephfsClientID
-	if accessTo == "" {
-		accessTo = args.Share.Name
-	}
-
-	rights, err = args.ManilaClient.GetAccessRights(ctx, args.Share.ID)
+	rights, err := args.ManilaClient.GetAccessRights(ctx, args.Share.ID)
 	if err != nil {
 		if _, ok := err.(gophercloud.ErrResourceNotFound); !ok {
 			return nil, fmt.Errorf("failed to list access rights: %v", err)
 		}
-	} else {
+	}
+
+	accessToList := []string{args.Share.Name}
+	if args.Options.CephfsClientID != "" {
+		accessToList = strings.Split(args.Options.CephfsClientID, ",")
+	}
+
+	created := false
+	for _, at := range accessToList {
 		// Try to find the access right
-
+		found := false
 		for _, r := range rights {
-			if r.AccessTo == accessTo && r.AccessType == "cephx" && r.AccessLevel == "rw" {
+			if r.AccessTo == at && r.AccessType == "cephx" && r.AccessLevel == "rw" {
 				klog.V(4).Infof("cephx access right for share %s already exists", args.Share.Name)
-
-				accessRight = &r
+				found = true
 				break
 			}
 		}
-	}
 
-	if accessRight == nil {
 		// Not found, create it
-
-		accessRight, err = args.ManilaClient.GrantAccess(ctx, args.Share.ID, shares.GrantAccessOpts{
-			AccessType:  "cephx",
-			AccessLevel: "rw",
-			AccessTo:    accessTo,
-		})
-
-		if err != nil {
-			return
+		if !found {
+			result, err := args.ManilaClient.GrantAccess(ctx, args.Share.ID, shares.GrantAccessOpts{
+				AccessType:  "cephx",
+				AccessLevel: "rw",
+				AccessTo:    at,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to grant access right: %v", err)
+			}
+			if result.AccessKey == "" {
+				// Wait till a ceph key is assigned to the access right
+				backoff := wait.Backoff{
+					Duration: time.Second * 5,
+					Factor:   1.2,
+					Steps:    10,
+				}
+				wait.ExponentialBackoff(backoff, func() (bool, error) {
+					rights, err := args.ManilaClient.GetAccessRights(ctx, args.Share.ID)
+					if err != nil {
+						return false, fmt.Errorf("error get access rights for share %s: %v", args.Share.ID, err)
+					}
+					if len(rights) == 0 {
+						return false, fmt.Errorf("cannot find the access right we've just created")
+					}
+					for _, r := range rights {
+						if r.AccessTo == at && r.AccessKey != "" {
+							return true, nil
+						}
+					}
+					klog.V(4).Infof("Access key for %s is not set yet, retrying...", at)
+					return false, nil
+				})
+			}
+			created = true
 		}
 	}
 
-	if accessRight.AccessKey != "" {
-		// The access right is ready
-		return
-	}
-
-	// Wait till a ceph key is assigned to the access right
-
-	backoff := wait.Backoff{
-		Duration: time.Second * 5,
-		Factor:   1.2,
-		Steps:    10,
-	}
-
-	return accessRight, wait.ExponentialBackoff(backoff, func() (bool, error) {
-		rights, err := args.ManilaClient.GetAccessRights(ctx, args.Share.ID)
+	// Search again because access rights have changed
+	if created {
+		rights, err = args.ManilaClient.GetAccessRights(ctx, args.Share.ID)
 		if err != nil {
-			return false, err
-		}
-
-		var accessRight *shares.AccessRight
-
-		for i := range rights {
-			if rights[i].AccessTo == accessTo {
-				accessRight = &rights[i]
-				break
+			if _, ok := err.(gophercloud.ErrResourceNotFound); !ok {
+				return nil, fmt.Errorf("failed to list access rights: %v", err)
 			}
 		}
-
-		if accessRight == nil {
-			return false, fmt.Errorf("cannot find the access right we've just created")
-		}
-
-		return accessRight.AccessKey != "", nil
-	})
+	}
+	return rights, nil
 }
 
 func (Cephfs) BuildVolumeContext(args *VolumeContextArgs) (volumeContext map[string]string, err error) {

--- a/pkg/csi/manila/shareadapters/nfs.go
+++ b/pkg/csi/manila/shareadapters/nfs.go
@@ -33,7 +33,7 @@ type NFS struct{}
 
 var _ ShareAdapter = &NFS{}
 
-func (NFS) GetOrGrantAccess(ctx context.Context, args *GrantAccessArgs) (*shares.AccessRight, error) {
+func (NFS) GetOrGrantAccesses(ctx context.Context, args *GrantAccessArgs) ([]shares.AccessRight, error) {
 	// First, check if the access right exists or needs to be created
 
 	rights, err := args.ManilaClient.GetAccessRights(ctx, args.Share.ID)
@@ -43,22 +43,43 @@ func (NFS) GetOrGrantAccess(ctx context.Context, args *GrantAccessArgs) (*shares
 		}
 	}
 
-	// Try to find the access right
+	accessToList := strings.Split(args.Options.NFSShareClient, ",")
 
-	for _, r := range rights {
-		if r.AccessTo == args.Options.NFSShareClient && r.AccessType == "ip" && r.AccessLevel == "rw" {
-			klog.V(4).Infof("IP access right for share %s already exists", args.Share.Name)
-			return &r, nil
+	created := false
+	for _, at := range accessToList {
+		// Try to find the access right
+		found := false
+		for _, r := range rights {
+			if r.AccessTo == at && r.AccessType == "ip" && r.AccessLevel == "rw" {
+				klog.V(4).Infof("IP access right %s for share %s already exists", at, args.Share.Name)
+				found = true
+				break
+			}
+		}
+		// Not found, create it
+		if !found {
+			_, err = args.ManilaClient.GrantAccess(ctx, args.Share.ID, shares.GrantAccessOpts{
+				AccessType:  "ip",
+				AccessLevel: "rw",
+				AccessTo:    at,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to grant access right: %v", err)
+			}
+			created = true
 		}
 	}
 
-	// Not found, create it
-
-	return args.ManilaClient.GrantAccess(ctx, args.Share.ID, shares.GrantAccessOpts{
-		AccessType:  "ip",
-		AccessLevel: "rw",
-		AccessTo:    args.Options.NFSShareClient,
-	})
+	// Search again because access rights have changed
+	if created {
+		rights, err = args.ManilaClient.GetAccessRights(ctx, args.Share.ID)
+		if err != nil {
+			if _, ok := err.(gophercloud.ErrResourceNotFound); !ok {
+				return nil, fmt.Errorf("failed to list access rights: %v", err)
+			}
+		}
+	}
+	return rights, nil
 }
 
 func (NFS) BuildVolumeContext(args *VolumeContextArgs) (volumeContext map[string]string, err error) {

--- a/pkg/csi/manila/shareadapters/shareadapter.go
+++ b/pkg/csi/manila/shareadapters/shareadapter.go
@@ -46,7 +46,7 @@ type ShareAdapter interface {
 	// GetOrGrantAccess first tries to retrieve an access right for args.Share.
 	// An access right is created for the share in case it doesn't exist yet.
 	// Returns an existing or new access right for args.Share.
-	GetOrGrantAccess(ctx context.Context, args *GrantAccessArgs) (accessRight *shares.AccessRight, err error)
+	GetOrGrantAccesses(ctx context.Context, args *GrantAccessArgs) (accessRights []shares.AccessRight, err error)
 
 	// BuildVolumeContext builds a volume context map that's passed to NodeStageVolumeRequest and NodePublishVolumeRequest
 	BuildVolumeContext(args *VolumeContextArgs) (volumeContext map[string]string, err error)


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Manila currently supports only setting a single access rule, making it difficult to have multiple access rules to a shared file system, which is a common scenario in a cloud where we need to have multiple clients being able to mount the shares simultaneously. This PR introduces support for multiple share access rules by accepting a list of IPs/Cephx users instead of a single string.

**Which issue this PR fixes(if applicable)**:
fixes #2725 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->
Author of the change stated that they didn't have a CephFS environment, so could not test it with CephFS.
Another pull request was proposed for this issue [1], but due to maintainers not being able to update and rebase the original author's PR, we opened a new PR.
[1] https://github.com/kubernetes/cloud-provider-openstack/pull/2727

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[manila-csi-plugin] Added support for configuring multiple share access rules to a shared filesystem.
```
