### PR TITLE
[occm] Add node affinity to schedule cloud controller manager only on control plane nodes.

### DIFF
--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -23,8 +23,13 @@ spec:
       labels:
         k8s-app: openstack-cloud-controller-manager
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/control-plane: "true"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
       securityContext:
         runAsUser: 1001
       tolerations:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the OpenStack Cloud Controller Manager (OCCM) scheduling configuration by replacing the nodeSelector with more flexible nodeAffinity. The change:
- Replaces nodeSelector: node-role.kubernetes.io/control-plane: "true" with nodeAffinity using operator: Exists
- Provides better compatibility across different Kubernetes distributions where control-plane nodes might have the label with different values (empty string "", "true", "yes", etc.)

**Which issue this PR fixes(if applicable)**:
Not related.

**Special notes for reviewers**:
- The nodeAffinity with operator: Exists only checks for the presence of the node-role.kubernetes.io/control-plane label, regardless of its value
- This approach is more compatible with various Kubernetes distributions (kubeadm, RKE2, k3s, minikube, etc.) that might set different values for the control-plane label
- The scheduling behavior remains the same - OCCM will still only run on control-plane nodes
- nodeAffinity is the recommended modern approach over nodeSelector for more complex scheduling requirements

**Release note**:
```
[occm] Improved OCCM scheduling robustness by replacing nodeSelector with nodeAffinity for better compatibility across Kubernetes distributions.
```