### PR TITLE
release: add verify-image-digests.sh and release-image-digests.sh scripts

### DIFF
--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -16,13 +16,13 @@ critical bug fixes.
 2. Update the minor version with the expected version.
 
     Make changes in the `docs/manifests/tests/examples` directories using the
-    `hack/bump_release.sh` script by running the following command:
+    `hack/bump-release.sh` script by running the following command:
 
     ```bash
     $ hack/bump-release.sh 28 29 0
     ```
 
-    This will replace `1.28.x`/`2.28.x` with `1.29.0`/`2.29.0` strings in the
+    This will replace `1.28.x` with `1.29.0` strings in the
     `docs/manifests/tests/examples` directories. Ensure that you double-check the
     diff before committing the changes. Non-related changes must not be shipped.
 
@@ -43,8 +43,32 @@ critical bug fixes.
 
 6. Make PR modifying [images.yaml](https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/images/k8s-staging-provider-os/images.yaml) to promote gcr.io images to registry.k8s.io. The point is to copy the proper image sha256 hashes from the staging repository to the images.yaml.
 
-7. Once images are promoted create release notes using the "Generate release notes" button in the GitHub "New release" UI and publish the release.
+    Use `hack/release-image-digests.sh` script and `hack/verify-image-digests.sh` to verify the digests before submitting the PR.
 
-8. Update `kubernetes/test-infra` to add jobs for the new release branch in the [`config/jobs/kubernetes/cloud-provider-openstack`](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes/cloud-provider-openstack) directory.
+    ```bash
+    $ ./hack/release-image-digests.sh ../k8s.io/registry.k8s.io/images/k8s-staging-provider-os/images.yaml vX.Y.Z
+    ```
+
+    Generate a PR with the updated `images.yaml` file. Make sure to review the changes and ensure that the correct images are being promoted.
+
+7. Once images are promoted (takes about 30 minutes) create release notes using the "Generate release notes" button in the GitHub "New release" UI and publish the release.
+
+8. Update the helm chart version with the expected version.
+
+    Make changes in the `charts` directory using the
+    `hack/bump-release.sh` script by running the following command:
+
+    ```bash
+    $ hack/bump-charts.sh 28 29 0
+    ```
+
+    This will replace `1.28.x`/`2.28.x` with `1.29.0`/`2.29.0` strings in the
+    `docs/manifests/tests/examples` directories. Ensure that you double-check the
+    diff before committing the changes. Non-related changes must not be shipped.
+
+    Make a PR to bump the chart version in the `charts` directory. Once the PR is
+    merged, the chart will be automatically published to the repository registry.
+
+9. Update `kubernetes/test-infra` to add jobs for the new release branch in the [`config/jobs/kubernetes/cloud-provider-openstack`](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes/cloud-provider-openstack) directory.
 
     This is generally as simple as copying the `release-master` file to `release-X.Y`, adding `--release-XY` suffixes to the job names and `testgrid-tab-name` annotations, and updating the branch specifiers.

--- a/hack/bump-charts.sh
+++ b/hack/bump-charts.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright 2023 The Kubernetes Authors.
+# Copyright 2025 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,4 +21,4 @@ TO_MINOR="${3:?TO_MINOR (3rd arg) not set or empty}"
 # example usage: hack/bump-release.sh 28 28 1
 # should replace 1.28.x with 1.28.1 / 2.28.x with 2.28.1
 
-find docs manifests tests examples -type f -exec sed -i -re 's/((ersion)?: ?v?)?([1-2]\.)'${FROM_MAJOR}'\.([0-9][0-9a-zA-Z.-]*)/\1\3'${TO_MAJOR}'.'${TO_MINOR}'/g' "{}" \;
+find charts -type f -exec sed -i -re 's/((ersion)?: ?v?)?([1-2]\.)'${FROM_MAJOR}'\.([0-9][0-9a-zA-Z.-]*)/\1\3'${TO_MAJOR}'.'${TO_MINOR}'/g' "{}" \;

--- a/hack/release-image-digests.sh
+++ b/hack/release-image-digests.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# example:
+# ./release-image-digests.sh registry.k8s.io/images/k8s-staging-provider-os/images.yaml [v1.33.0] [v1.33.1]
+
+YAML_FILE=${1:?Usage: $0 <yaml_file> [<tag>...]}
+TAGS="${@:2}"
+
+# fail if file does not exist
+if [ ! -f "${YAML_FILE}" ]; then
+  echo "ERROR: File ${YAML_FILE} does not exist" >&2
+  exit 1
+fi
+
+if [ -z "$TAGS" ]; then
+  echo "Processing existing tags in ${YAML_FILE}..."
+  TAGS=$(yq '[.[] | .dmap | to_entries[] | .value[]] | unique | sort | .[]' "${YAML_FILE}")
+fi
+
+IMAGES=$(yq '.[] | .name' "${YAML_FILE}")
+for TAG in $TAGS; do
+for IMAGE in $IMAGES; do
+  #echo "Processing image: $IMAGE:$TAG)"
+  digest="$(curl -sI "https://gcr.io/v2/k8s-staging-provider-os/${IMAGE}/manifests/${TAG}" | awk '/(i?)docker-content-digest/{ gsub(/\r/, ""); print tolower($NF)}')"
+  if [ -z "$digest" ]; then
+    echo "ERROR: gcr.io/k8s-staging-provider-os/$IMAGE:$TAG digest is empty" >&2
+    continue
+  fi
+
+  # add new digest -> tag mapping
+  yq -i '(.[] | select(.name == "'"${IMAGE}"'") | .dmap["'"${digest}"'" | . style="double"]) = (["'"${TAG}"'" | . style="double"] | . style="flow")' "${YAML_FILE}"
+  # add/replace existing digest -> tag mapping
+  # yq -i '(.[] | select(.name == "'"${IMAGE}"'") | .dmap) |= with_entries(select(.value[] | contains("'"${TAG}"'") | not)) | (.[] | select(.name == "'"${IMAGE}"'") | .dmap["'"${digest}"'" | . style="double"]) = (["'"${TAG}"'" | . style="double"] | . style="flow") ' "${YAML_FILE}"
+done
+done
+
+echo "YAML file updated: $YAML_FILE"

--- a/hack/verify-image-digests.sh
+++ b/hack/verify-image-digests.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# example:
+# ./verify-image-digests.sh 'v1.33.*' registry.k8s.io/images/k8s-staging-provider-os/images.yaml
+
+# default to match all images
+MATCH=${1:-'.*'}
+
+# fail if $2 is not set
+YAML_FILE=${2:?Usage: $0 '<match>' <yaml_file>}
+
+# fail if file does not exist
+if [ ! -f "${YAML_FILE}" ]; then
+  echo "ERROR: File ${YAML_FILE} does not exist" >&2
+  exit 1
+fi
+
+while read -r IMAGE DIGEST TAG; do
+  #echo "image=$IMAGE, digest='$DIGEST', tag=$TAG"
+  digest="$(curl -sI "https://gcr.io/v2/k8s-staging-provider-os/${IMAGE}/manifests/${TAG}" | awk '/(i?)docker-content-digest/{ gsub(/\r/, ""); print tolower($NF)}')"
+  if [ -z "$digest" ]; then
+    echo "ERROR: gcr.io/k8s-staging-provider-os/$IMAGE:$TAG digest is empty" >&2
+    continue
+  fi
+  if [ "$digest" != "$DIGEST" ]; then
+    echo "ERROR: gcr.io/k8s-staging-provider-os/$IMAGE:$TAG digest mismatch: expected $DIGEST, got $digest" >&2
+  fi
+  digest1="$(curl -sIL "https://registry.k8s.io/v2/provider-os/${IMAGE}/manifests/${TAG}" | awk '/(i?)docker-content-digest/{ gsub(/\r/, ""); print tolower($NF)}')"
+  if [ -z "$digest1" ]; then
+    echo "ERROR: registry.k8s.io/provider-os/$IMAGE:$TAG digest is empty" >&2
+    continue
+  fi
+  if [ "$digest1" != "$DIGEST" ]; then
+    echo "ERROR: registry.k8s.io/provider-os/$IMAGE:$TAG digest mismatch: expected $DIGEST, got $digest1" >&2
+  fi
+done <<< `yq '.[] | .name as $name | .dmap | to_entries | sort_by(.value[0]) | reverse | .[] | select(.value[0] | test("'"${MATCH}"'")) | "\($name) \(.key) \(.value[0])"' "${YAML_FILE}"`


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This PR adds a script that checks release images checksums along gcr.io/k8s-staging-provider-os and registry.k8s.io/provider-os registries with a https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/images/k8s-staging-provider-os/images.yaml file contents

**Which issue this PR fixes(if applicable)**:
fixes #2930

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
