### PR TITLE
[occm] Fix floating IP allocation for shared internal load balancers

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -670,6 +670,12 @@ func (lbaas *LbaasV2) ensureFloatingIP(ctx context.Context, clusterName string, 
 		return lb.VipAddress, nil
 	}
 
+	// For shared internal load balancers, don't attempt to create/manage floating IPs
+	if svcConf.internal && !isLBOwner {
+		klog.V(4).Infof("Skipping floating IP management for shared internal load balancer service %s", serviceName)
+		return lb.VipAddress, nil
+	}
+
 	// first attempt: if we've found a FIP attached to LBs VIP port, we'll be using that.
 
 	// we cannot add a FIP to a shared LB when we're a secondary Service or we risk adding it to an internal


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Fixes an issue where the OpenStack Cloud Controller Manager incorrectly attempts to allocate floating IPs when sharing internal load balancers between services. This causes spurious warnings and potential failures when using the load balancer sharing feature with internal services.

**What happened:**
When sharing an internal load balancer (marked with `service.beta.kubernetes.io/openstack-internal-load-balancer: "true"`), the controller would still try to attach a floating IP to the shared load balancer, even though internal load balancers should not have floating IPs by design.

**What this PR does:**
- Adds a check in `ensureFloatingIP` to skip floating IP operations for shared internal load balancers
- Returns the VIP address directly for internal load balancers when the service is not the load balancer owner
- Prevents unnecessary floating IP allocation attempts while preserving existing behavior for all other scenarios


**Which issue this PR fixes(if applicable)**:
fixes #2891

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->
This change only affects the code path for services that are both internal (`svcConf.internal = true`) and not the load balancer owner (`isLBOwner = false`). All existing behavior for external load balancers and load balancer owners remains unchanged.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
