### PR TITLE
tests: create volumev3 service type

### DIFF
--- a/tests/playbooks/roles/install-devstack/tasks/main.yml
+++ b/tests/playbooks/roles/install-devstack/tasks/main.yml
@@ -115,3 +115,13 @@
         cmd: |
           set -ex
           sudo -u {{ user }} -H ./stack.sh
+
+    - name: Create volumev3 service type
+      shell:
+        executable: /bin/bash
+        chdir: "{{ workdir }}"
+        cmd: |
+          set -ex
+          source openrc admin admin
+          openstack service create --name cinder volumev3
+          openstack endpoint create --region $OS_REGION_NAME volumev3 public `openstack endpoint list --service block-storage -f value -c URL`


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Devstack starting from epoxy renamed cinder volume types

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
