### PR TITLE
[occm] Support keystone token for openstack auth

### DIFF
--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -156,6 +156,8 @@ The options in `Global` section are used for openstack-cloud-controller-manager 
   The secret of an application credential to authenticate with.
 * `tls-insecure`
   If set to `true`, then the server’s certificate will not be verified. Default is `false`.
+* `token`
+  Keystone token.
 
 ###  Networking
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -56,6 +56,7 @@ type AuthOpts struct {
 	EndpointType     gophercloud.Availability `gcfg:"os-endpoint-type" mapstructure:"os-endpoint-type" name:"os-endpointType" value:"optional"`
 	CAFile           string                   `gcfg:"ca-file" mapstructure:"ca-file" name:"os-certAuthorityPath" value:"optional"`
 	TLSInsecure      string                   `gcfg:"tls-insecure" mapstructure:"tls-insecure" name:"os-TLSInsecure" value:"optional" matches:"^true|false$"`
+	Token            string                   `name:"os-token" value:"optional"`
 
 	// TLS client auth
 	CertFile string `gcfg:"cert-file" mapstructure:"cert-file" name:"os-clientCertPath" value:"optional" dependsOn:"os-clientKeyPath"`
@@ -150,6 +151,7 @@ func (authOpts AuthOpts) ToAuthOptions() gophercloud.AuthOptions {
 			ApplicationCredentialID:     authOpts.ApplicationCredentialID,
 			ApplicationCredentialName:   authOpts.ApplicationCredentialName,
 			ApplicationCredentialSecret: authOpts.ApplicationCredentialSecret,
+			Token:                       authOpts.Token,
 		},
 	}
 
@@ -231,6 +233,7 @@ func ReadClouds(authOpts *AuthOpts) error {
 	authOpts.ApplicationCredentialID = replaceEmpty(authOpts.ApplicationCredentialID, cloud.AuthInfo.ApplicationCredentialID)
 	authOpts.ApplicationCredentialName = replaceEmpty(authOpts.ApplicationCredentialName, cloud.AuthInfo.ApplicationCredentialName)
 	authOpts.ApplicationCredentialSecret = replaceEmpty(authOpts.ApplicationCredentialSecret, cloud.AuthInfo.ApplicationCredentialSecret)
+	authOpts.Token = replaceEmpty(authOpts.Token, cloud.AuthInfo.Token)
 
 	return nil
 }


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Support keystone token for openstack auth in occm

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
