### PR TITLE
[cinder-csi-plugin]: do not allow DetachVolume when status is detaching

### DIFF
--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -43,6 +43,7 @@ import (
 const (
 	VolumeAvailableStatus    = "available"
 	VolumeInUseStatus        = "in-use"
+	VolumeDetachingStatus    = "detaching"
 	operationFinishInitDelay = 1 * time.Second
 	operationFinishFactor    = 1.1
 	operationFinishSteps     = 10
@@ -305,6 +306,11 @@ func (os *OpenStack) DetachVolume(ctx context.Context, instanceID, volumeID stri
 	}
 	if volume.Status == VolumeAvailableStatus {
 		klog.V(2).Infof("volume: %s has been detached from compute: %s ", volume.ID, instanceID)
+		return nil
+	}
+	// If the volume is already in detaching state, we can return nil
+	if volume.Status == VolumeDetachingStatus {
+		klog.V(2).Infof("volume: %s is already in detaching state from compute %s  ", volume.ID, instanceID)
 		return nil
 	}
 


### PR DESCRIPTION


<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This PR updates the `DetachVolume` logic to check if a disk is already in the `detaching` state before attempting to detach it again. If the disk is in the `detaching` state, the function now returns early with an appropriate message, preventing repeated detach attempts and unnecessary error loops. This helps avoid situations where `WaitDiskDetached` fails and the detach operation is retried in a loop.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:

- Ensures that volumes in the `detaching` state are not subject to repeated detach attempts.
- Improves error handling and reduces unnecessary API calls during detach failures.
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Prevent repeated detach attempts for volumes already in 'detaching' state, improving stability and error handling during volume detach operations.
```
