### PR TITLE
Bump CSI test timeouts

### DIFF
--- a/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
@@ -190,12 +190,12 @@
         --ginkgo.v \
         --ginkgo.noColor \
         --ginkgo.progress \
-        --ginkgo.timeout=1h30m \
+        --ginkgo.timeout=1h45m \
         -test.timeout=0 \
         -report-dir="/var/log/csi-pod" | tee "/var/log/csi-pod/cinder-csi-e2e.log"
   register: functional_test_result
   ignore_errors: true
-  async: 5700 # wait 1h35m (i.e. 5 mins longer than the ginkgo timeout) then fail and fetch the logs
+  async: 6600 # wait 1h50m (i.e. 5 mins longer than the ginkgo timeout) then fail and fetch the logs
   poll: 15
 
 - name: Collect pod logs for debug purpose

--- a/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
@@ -237,12 +237,12 @@
         --ginkgo.v \
         --ginkgo.noColor \
         --ginkgo.progress \
-        --ginkgo.timeout=1h30m \
+        --ginkgo.timeout=1h45m \
         -timeout=0 \
         -report-dir /var/log/csi-pod | tee "/var/log/csi-pod/manila-csi-e2e.log"
   register: functional_test_result
   ignore_errors: true
-  async: 5700 # wait 1h35m (i.e. 5 mins longer than the ginkgo timeout) then fail and fetch the logs
+  async: 6600 # wait 1h50m (i.e. 5 mins longer than the ginkgo timeout) then fail and fetch the logs
   poll: 15
 
 - name: Collect pod logs for debug purpose

--- a/tests/playbooks/roles/install-devstack/tasks/main.yml
+++ b/tests/playbooks/roles/install-devstack/tasks/main.yml
@@ -115,3 +115,19 @@
         cmd: |
           set -ex
           sudo -u {{ user }} -H ./stack.sh
+
+    # FIXME(stephenfin): We should remove this as soon as [1] merges and we
+    # bump our dependencies to include it.
+    # [1] https://github.com/gophercloud/gophercloud/pull/3435
+    - name: Delete legacy manila endpoint
+      shell:
+        executable: /bin/bash
+        chdir: "{{ workdir }}"
+        cmd: |
+          set -ex
+          export OS_CLOUD=devstack-admin
+
+          # delete legacy manila API endpoints
+          if openstack service show manila > /dev/null 2>&1; then
+            openstack service delete manila
+          fi


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

We have worked around Nova bug #2119114 by lowering the device detach threshold to 1 second. Unfortunately this still leaves us with a N seconds of additional runtime, where N is the number of device detaches incurred by our test suite (since we run tests serially). This has put us right on the cusp of timeouts, meaning our jobs occasionally pass and occasionally fail, depending on the node we end up on. Add a bit more breathing room for the jobs while we wait for the Nova fix.

Note that we do this for both Cinder and Manila to try keep those jobs consistent where possible.

[1] https://bugs.launchpad.net/nova/+bug/2119114

**Which issue this PR fixes(if applicable)**:

n/a

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
