### PR TITLE
migrate away from gcr.io/k8s-testimages

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,7 +9,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: gcr.io/k8s-testimages/gcb-docker-gcloud
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud
     entrypoint: bash
     env:
     # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx


### PR DESCRIPTION
**What this PR does / why we need it**:


**Which issue this PR fixes(if applicable)**:

fixes #2904

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
