### PR TITLE
[occm] Update ServiceMonitor to use common labels

### DIFF
--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.34.1
+version: 2.34.2
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/templates/servicemonitor.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/servicemonitor.yaml
@@ -24,5 +24,5 @@ spec:
   jobLabel: component
   selector:
     matchLabels:
-      {{- include "occm.controllermanager.matchLabels" . | nindent 6 }}
+      {{- include "common.labels.standard" . | nindent 6 }}
 {{- end }}


### PR DESCRIPTION


**What this PR does / why we need it**:
service monitor doesn't have the controller manager labels, use the service's labels as the selector for servicemonitor

**Which issue this PR fixes(if applicable)**:
none
**Special notes for reviewers**:
<!-- e.g. How to test this PR -->
Set serviceMonitor.enabled: true in the helm chart

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fixed label selector in occm service monitor
```
