### PR TITLE
cinder-csi-plugin: Tweak behavior of --with-topology flag

### DIFF
--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -265,27 +265,21 @@ func TestCreateVolumeWithTopologyDisabled(t *testing.T) {
 	assert := assert.New(t)
 
 	tests := []struct {
-		name                string
-		volumeParams        map[string]string
-		expectedVolumeAZ    string
-		expectedCSITopology string
+		name             string
+		volumeParams     map[string]string
+		expectedVolumeAZ string
 	}{
 		{
 			name:             "empty paramters",
 			volumeParams:     nil,
 			expectedVolumeAZ: "",
-			// FIXME(stephenfin): This should be unset
-			expectedCSITopology: "nova",
 		},
 		{
 			name: "availability parameter",
 			volumeParams: map[string]string{
 				"availability": "cinder",
 			},
-			// FIXME(stephenfin): This should be "cinder" per the parameter
-			expectedVolumeAZ: "",
-			// ...and this should be unset
-			expectedCSITopology: "nova",
+			expectedVolumeAZ: "cinder",
 		},
 	}
 	for _, tt := range tests {
@@ -324,12 +318,8 @@ func TestCreateVolumeWithTopologyDisabled(t *testing.T) {
 			assert.NotNil(actualRes.Volume)
 			assert.NotNil(actualRes.Volume.CapacityBytes)
 			assert.NotEqual(0, len(actualRes.Volume.VolumeId), "Volume Id is nil")
-			if tt.expectedCSITopology == "" {
-				assert.Nil(actualRes.Volume.AccessibleTopology)
-			} else {
-				assert.GreaterOrEqual(len(actualRes.Volume.AccessibleTopology), 1)
-				assert.Equal(tt.expectedCSITopology, actualRes.Volume.AccessibleTopology[0].GetSegments()[topologyKey])
-			}
+			// This should always be nil if --with-topology=false
+			assert.Nil(actualRes.Volume.AccessibleTopology)
 		})
 	}
 }


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This is currently backwards from what you'd expect when the value is `false`, with the topology information always being ignored for the Cinder requests but never ignored for the k8s CSI requests.
Modify the former so that we respect the 'availability' parameter when set - regardless of the value of `--with-topology` - and ensure that we never set topology requirements on the CSI Volume when `--with-topology=false`.

**Which issue this PR fixes(if applicable)**:

(none)

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The behavior of the `--with-topology` option for `cinder-csi-plugin` has changed.
Previously, when this was `false` and the `availability` parameter was set on a storage class, the `availability` parameter would be ignored.
This is now changed so the parameter is respected regardless of the value of `--with-topology`
```
