### PR TITLE
doc: fix typo in keystone sync example

### DIFF
--- a/docs/keystone-auth/using-auth-data-synchronization.md
+++ b/docs/keystone-auth/using-auth-data-synchronization.md
@@ -75,10 +75,10 @@ metadata:
   namespace: kube-system
 data:
   syncConfig: |
-    data_types_to_sync:
+    data-types-to-sync:
       - projects
       - role_assignments
-    namespace_format: "%i"
+    namespace-format: "%i"
     role-mappings:
       - keystone-role: member
         username: myuser


### PR DESCRIPTION
**What this PR does / why we need it**:
* The keystone auth sync doc contains a typo in one of the examples, which may lead to a non-working configuration. The fields were not following the specification on sync struct[1]

[1] https://github.com/kubernetes/cloud-provider-openstack/blob/master/pkg/identity/keystone/sync.go#L54

**Release note**:

```
Fix typo in the keystone authentication sync example docs, which led to a non-working configuration.
```