### PR TITLE
[cinder-csi-plugin][manila-csi-plugin] Bump sidecar image versions

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.33.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.33.0
+version: 2.33.1
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -8,7 +8,7 @@ csi:
   attacher:
     image:
       repository: registry.k8s.io/sig-storage/csi-attacher
-      tag: v4.7.0
+      tag: v4.10.0
       pullPolicy: IfNotPresent
     resources: {}
     extraArgs: {}
@@ -17,7 +17,7 @@ csi:
     topology: "true"
     image:
       repository: registry.k8s.io/sig-storage/csi-provisioner
-      tag: v5.1.0
+      tag: v5.3.0
       pullPolicy: IfNotPresent
     resources: {}
     extraArgs: {}
@@ -25,7 +25,7 @@ csi:
   snapshotter:
     image:
       repository: registry.k8s.io/sig-storage/csi-snapshotter
-      tag: v8.1.0
+      tag: v8.3.0
       pullPolicy: IfNotPresent
     resources: {}
     extraArgs: {}
@@ -41,7 +41,7 @@ csi:
   resizer:
     image:
       repository: registry.k8s.io/sig-storage/csi-resizer
-      tag: v1.12.0
+      tag: v1.14.0
       pullPolicy: IfNotPresent
     resources: {}
     extraArgs: {}
@@ -55,7 +55,7 @@ csi:
   livenessprobe:
     image:
       repository: registry.k8s.io/sig-storage/livenessprobe
-      tag: v2.14.0
+      tag: v2.17.0
       pullPolicy: IfNotPresent
     failureThreshold: 5
     initialDelaySeconds: 10
@@ -67,7 +67,7 @@ csi:
   nodeDriverRegistrar:
     image:
       repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
-      tag: v2.12.0
+      tag: v2.15.0
       pullPolicy: IfNotPresent
     resources: {}
     extraArgs: {}

--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.33.0
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 2.33.0
+version: 2.33.1
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -60,7 +60,7 @@ nodeplugin:
   registrar:
     image:
       repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
-      tag: v2.12.0
+      tag: v2.15.0
       pullPolicy: IfNotPresent
     resources: {}
     extraEnv: []
@@ -90,7 +90,7 @@ controllerplugin:
   provisioner:
     image:
       repository: registry.k8s.io/sig-storage/csi-provisioner
-      tag: v5.1.0
+      tag: v5.3.0
       pullPolicy: IfNotPresent
     resources: {}
     extraEnv: []
@@ -100,7 +100,7 @@ controllerplugin:
   snapshotter:
     image:
       repository: registry.k8s.io/sig-storage/csi-snapshotter
-      tag: v8.1.0
+      tag: v8.3.0
       pullPolicy: IfNotPresent
     resources: {}
     extraEnv: []
@@ -108,7 +108,7 @@ controllerplugin:
   resizer:
     image:
       repository: registry.k8s.io/sig-storage/csi-resizer
-      tag: v1.12.0
+      tag: v1.14.0
       pullPolicy: IfNotPresent
     resources: {}
     extraEnv: []

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccount: csi-cinder-controller-sa
       containers:
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.10.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -39,7 +39,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -55,7 +55,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.3.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -69,7 +69,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -83,7 +83,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.14.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
           args:
             - "--csi-address=$(ADDRESS)"
           env:

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -21,7 +21,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
@@ -41,7 +41,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.14.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/manifests/manila-csi-plugin/csi-controllerplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-controllerplugin.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: openstack-manila-csi-controllerplugin
       containers:
         - name: provisioner
-          image: "registry.k8s.io/sig-storage/csi-provisioner:v5.1.0"
+          image: "registry.k8s.io/sig-storage/csi-provisioner:v5.3.0"
           args:
             - "--csi-address=$(ADDRESS)"
             - "--extra-create-metadata"
@@ -50,7 +50,7 @@ spec:
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
         - name: snapshotter
-          image: "registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0"
+          image: "registry.k8s.io/sig-storage/csi-snapshotter:v8.3.0"
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -61,7 +61,7 @@ spec:
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
         - name: resizer
-          image: "registry.k8s.io/sig-storage/csi-resizer:v1.12.0"
+          image: "registry.k8s.io/sig-storage/csi-resizer:v1.14.0"
           args:
             - "--csi-address=$(ADDRESS)"
             - "--handle-volume-inuse-error=false"

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -21,7 +21,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: registrar
-          image: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0"
+          image: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0"
           args:
             - "--csi-address=/csi/csi.sock"
             - "--kubelet-registration-path=/var/lib/kubelet/plugins/manila.csi.openstack.org/csi.sock"


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump the images to the latest version in both the manifests and Helm charts. Per https://github.com/kubernetes/cloud-provider-openstack/pull/3004#issuecomment-3377610731, this should resolve the issues we are seeing with https://github.com/kubernetes/cloud-provider-openstack/pull/3004 and allow us to merge that and cut a new release.

**Which issue this PR fixes(if applicable)**:

(none)

**Special notes for reviewers**:

(none)

**Release note**:

```release-note
NONE
```
