### PR TITLE
fix bump scripts

### DIFF
--- a/hack/bump-charts.sh
+++ b/hack/bump-charts.sh
@@ -21,4 +21,15 @@ TO_MINOR="${3:?TO_MINOR (3rd arg) not set or empty}"
 # example usage: hack/bump-release.sh 28 28 1
 # should replace 1.28.x with 1.28.1 / 2.28.x with 2.28.1
 
-find charts -type f -exec sed -i -re 's/((ersion)?: ?v?)?([1-2]\.)'${FROM_MAJOR}'\.([0-9][0-9a-zA-Z.-]*)/\1\3'${TO_MAJOR}'.'${TO_MINOR}'/g' "{}" \;
+# Use portable sed syntax that works on both Linux (GNU sed) and macOS (BSD sed)
+if sed --version >/dev/null 2>&1; then
+  # GNU sed (Linux)
+  SED_INPLACE=(-i)
+  SED_EXTENDED=(-r)
+else
+  # BSD sed (macOS)
+  SED_INPLACE=(-i '')
+  SED_EXTENDED=(-E)
+fi
+
+find charts -type f -exec sed "${SED_INPLACE[@]}" "${SED_EXTENDED[@]}" -e 's/((ersion)?: ?v?)?([1-2]\.)'${FROM_MAJOR}'\.([0-9][0-9a-zA-Z.-]*)/\1\3'${TO_MAJOR}'.'${TO_MINOR}'/g' "{}" \;

--- a/hack/bump-release.sh
+++ b/hack/bump-release.sh
@@ -21,4 +21,15 @@ TO_MINOR="${3:?TO_MINOR (3rd arg) not set or empty}"
 # example usage: hack/bump-release.sh 28 28 1
 # should replace 1.28.x with 1.28.1 / 2.28.x with 2.28.1
 
-find docs manifests tests examples -type f -exec sed -i -re 's/((ersion)?: ?v?)?([1-2]\.)'${FROM_MAJOR}'\.([0-9][0-9a-zA-Z.-]*)/\1\3'${TO_MAJOR}'.'${TO_MINOR}'/g' "{}" \;
+# Use portable sed syntax that works on both Linux (GNU sed) and macOS (BSD sed)
+if sed --version >/dev/null 2>&1; then
+  # GNU sed (Linux)
+  SED_INPLACE=(-i)
+  SED_EXTENDED=(-r)
+else
+  # BSD sed (macOS)
+  SED_INPLACE=(-i '')
+  SED_EXTENDED=(-E)
+fi
+
+find docs manifests tests examples -type f -exec sed "${SED_INPLACE[@]}" "${SED_EXTENDED[@]}" -e 's/((ersion)?: ?v?)?([1-2]\.)'${FROM_MAJOR}'\.([0-9][0-9a-zA-Z.-]*)/\1\3'${TO_MAJOR}'.'${TO_MINOR}'/g' "{}" \;


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
