### PR TITLE
occm: add a new batch pools members update endpoint support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 
 // the below fixes the "go list -m all" execution
 replace (
+	github.com/gophercloud/gophercloud/v2 => github.com/kayrus/gophercloud/v2 v2.9.1-0.20260112125525-25600003eb41
 	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.36.0
 	k8s.io/cri-client => k8s.io/cri-client v0.36.0
 	k8s.io/cri-streaming => k8s.io/cri-streaming v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -151,8 +151,6 @@ github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 h1:EwtI+Al+DeppwYX2oX
 github.com/google/pprof v0.0.0-20260402051712-545e8a4df936/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gophercloud/gophercloud/v2 v2.12.0 h1:Gxmc/Bog1UDKkxTcQW7MSPTDviJXpLeEgVeN5KrxoCo=
-github.com/gophercloud/gophercloud/v2 v2.12.0/go.mod h1:H7TTOxbLy8RIaHSNhI2GCrWIzw4Xpw8Xn2mBhCUT5kA=
 github.com/gophercloud/utils/v2 v2.0.0-20260424064311-2eeed4ceb3e9 h1:WEPhYFzYmpfWHq+YPaP3+8pYf4wKQuJMkgPiiI4g7CY=
 github.com/gophercloud/utils/v2 v2.0.0-20260424064311-2eeed4ceb3e9/go.mod h1:bIEH+wgvnxfegUewFuGi0u/L+ji5uiEuVVQMNKQASEY=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
@@ -173,6 +171,8 @@ github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE
 github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/kayrus/gophercloud/v2 v2.9.1-0.20260112125525-25600003eb41 h1:XVoMzOJQNH6tN7hnm48lny1u9A/xzmxm+eBDfckY/kc=
+github.com/kayrus/gophercloud/v2 v2.9.1-0.20260112125525-25600003eb41/go.mod h1:Ki/ILhYZr/5EPebrPL9Ej+tUg4lqx71/YH2JWVeU+Qk=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1021,13 +1021,16 @@ func (lbaas *LbaasV2) ensureOctaviaPool(ctx context.Context, lbID string, name s
 		return nil, err
 	}
 
-	if !curMembers.Equal(newMembers) {
+	if !curMembers.Equal(newMembers) && !lbaas.opts.BatchPoolsMembersUpdate {
 		klog.V(2).Infof("Updating %d members for pool %s", len(members), pool.ID)
 		if err := openstackutil.BatchUpdatePoolMembers(ctx, lbaas.lb, lbID, pool.ID, members); err != nil {
 			return nil, err
 		}
 		klog.V(2).Infof("Successfully updated %d members for pool %s", len(members), pool.ID)
 	}
+
+	// set the updated members to the pool for further batch update
+	pool.Members = batchUpdateMemberOptsToMembers(members)
 
 	return pool, nil
 }
@@ -1110,6 +1113,20 @@ func (lbaas *LbaasV2) buildBatchUpdateMemberOpts(ctx context.Context, port corev
 		}
 	}
 	return members, newMembers, nil
+}
+
+func batchUpdateMemberOptsToMembers(opts []v2pools.BatchUpdateMemberOpts) []v2pools.Member {
+	members := make([]v2pools.Member, len(opts))
+	for i := range opts {
+		members[i] = v2pools.Member{
+			Address:      opts[i].Address,
+			ProtocolPort: opts[i].ProtocolPort,
+			Name:         ptr.Deref(opts[i].Name, ""),
+			SubnetID:     ptr.Deref(opts[i].SubnetID, ""),
+			MonitorPort:  ptr.Deref(opts[i].MonitorPort, 0),
+		}
+	}
+	return members
 }
 
 func (lbaas *LbaasV2) buildCreateMemberOpts(ctx context.Context, port corev1.ServicePort, nodes []*corev1.Node, svcConf *serviceConfig) ([]v2pools.CreateMemberOpts, sets.Set[string], error) {
@@ -1851,6 +1868,8 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 			return nil, err
 		}
 
+		// a list of pools to update
+		pools := make([]v2pools.Pool, 0, len(service.Spec.Ports))
 		for portIndex, port := range service.Spec.Ports {
 			listener, err := lbaas.ensureOctaviaListener(ctx, loadbalancer.ID, cpoutil.Sprintf255(listenerFormat, portIndex, lbName), curListenerMapping, port, svcConf)
 			if err != nil {
@@ -1861,6 +1880,7 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 			if err != nil {
 				return nil, err
 			}
+			pools = append(pools, *pool)
 
 			if err := lbaas.ensureOctaviaHealthMonitor(ctx, loadbalancer.ID, cpoutil.Sprintf255(monitorFormat, portIndex, lbName), pool, port, svcConf); err != nil {
 				return nil, err
@@ -1870,6 +1890,16 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 			// The remove of the listener must always happen at the end of the loop to avoid wrong assignment.
 			// Modifying the curListeners would also change the mapping.
 			curListeners = popListener(curListeners, listener.ID)
+		}
+
+		if lbaas.opts.BatchPoolsMembersUpdate {
+			err := openstackutil.BatchUpdatePoolsMembers(ctx, lbaas.lb, loadbalancer.ID, pools)
+			if err != nil {
+				err = PreserveGopherError(err)
+				msg := fmt.Sprintf("Error updating batch pools members for LoadBalancer: %v", err)
+				klog.Errorf(msg, "lbID", loadbalancer.ID)
+				return nil, err
+			}
 		}
 
 		// Deal with the remaining listeners, delete the listener if it was created by this Service previously.
@@ -2004,6 +2034,9 @@ func (lbaas *LbaasV2) updateOctaviaLoadBalancer(ctx context.Context, clusterName
 		lbListeners[key] = l
 	}
 
+	// a list of pools to update
+	pools := make([]v2pools.Pool, 0, len(service.Spec.Ports))
+
 	// Update pool members for each listener.
 	for portIndex, port := range service.Spec.Ports {
 		proto := getListenerProtocol(port.Protocol, svcConf)
@@ -2019,9 +2052,20 @@ func (lbaas *LbaasV2) updateOctaviaLoadBalancer(ctx context.Context, clusterName
 		if err != nil {
 			return err
 		}
+		pools = append(pools, *pool)
 
 		err = lbaas.ensureOctaviaHealthMonitor(ctx, loadbalancer.ID, cpoutil.Sprintf255(monitorFormat, portIndex, loadbalancer.Name), pool, port, svcConf)
 		if err != nil {
+			return err
+		}
+	}
+
+	if lbaas.opts.BatchPoolsMembersUpdate {
+		err := openstackutil.BatchUpdatePoolsMembers(ctx, lbaas.lb, loadbalancer.ID, pools)
+		if err != nil {
+			err = PreserveGopherError(err)
+			msg := fmt.Sprintf("Error updating batch pools members for LoadBalancer: %v", err)
+			klog.Errorf(msg, "lbID", loadbalancer.ID)
 			return err
 		}
 	}

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -120,6 +120,7 @@ type LoadBalancerOpts struct {
 	MaxSharedLB                    int                 `gcfg:"max-shared-lb"`                      //  Number of Services in maximum can share a single load balancer. Default 2
 	ContainerStore                 string              `gcfg:"container-store"`                    // Used to specify the store of the tls-container-ref
 	ProviderRequiresSerialAPICalls bool                `gcfg:"provider-requires-serial-api-calls"` // default false, the provider supports the "bulk update" API call
+	BatchPoolsMembersUpdate        bool                `gcfg:"batch-pools-members-update"`         // default false, the controller will update all pools members in batch when possible
 	// revive:disable:var-naming
 	TlsContainerRef string `gcfg:"default-tls-container-ref"` //  reference to a tls container
 	// revive:enable:var-naming


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This PR adds a support for a new potential octavia endpoint that allows to update pool members for multiple pools with one API call.

See https://bugs.launchpad.net/bugs/2125786 and https://github.com/sapcc/octavia/pull/57

**Which issue this PR fixes(if applicable)**:
fixes #2858 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
occm: add a new batch pools members update endpoint support
```
