### PR TITLE
[occm] Add support for x-forwarded-port and x-forwarded-proto annotations

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -152,6 +152,24 @@ Request Body:
 
   Not supported when `lb-provider=ovn` is configured in openstack-cloud-controller-manager.
 
+- `loadbalancer.openstack.org/x-forwarded-port`
+
+  If 'true', `X-Forwarded-Port` is inserted into the HTTP headers which contains the original destination port used by the client (for example `443` for HTTPS traffic), allowing the backend HTTP service to reconstruct the original request port. Please note that the cloud provider will force the creation of an Octavia listener of type `HTTP` if this option is set. Only applies when using Octavia.
+
+  This annotation also works in conjunction with the `loadbalancer.openstack.org/default-tls-container-ref` annotation. In this case the cloud provider will create an Octavia listener of type `TERMINATED_HTTPS` instead of an `HTTP` listener.
+
+  Not supported when `lb-provider=ovn` is configured in openstack-cloud-controller-manager.
+
+- `loadbalancer.openstack.org/x-forwarded-proto`
+
+  If 'true', `X-Forwarded-Proto` is inserted into the HTTP headers which contains the original protocol used by the client (for example `http` or `https`), allowing the backend HTTP service to correctly determine the original request scheme when TLS termination occurs at the load balancer. Please note that the cloud provider will force the creation of an Octavia listener of type `HTTP` if this option is set. Only applies when using Octavia.
+
+  This annotation also works in conjunction with the `loadbalancer.openstack.org/default-tls-container-ref` annotation. In this case the cloud provider will create an Octavia listener of type `TERMINATED_HTTPS` instead of an `HTTP` listener.
+
+  Not supported when `lb-provider=ovn` is configured in openstack-cloud-controller-manager.
+
+  The `x-forwarded-for`, `x-forwarded-port`, and `x-forwarded-proto` annotations are independent and can be enabled separately depending on application requirements.
+
 - `loadbalancer.openstack.org/lb-method`
 
   Load balancing algorithm to use when distributed to members. [OpenStack Pool Creation | lb_algorithm](https://docs.openstack.org/api-ref/load-balancer/v2/#create-pool)

--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -146,11 +146,19 @@ Request Body:
 
 - `loadbalancer.openstack.org/x-forwarded-for`
 
-  If 'true', `X-Forwarded-For` is inserted into the HTTP headers which contains the original client IP address so that the backend HTTP service is able to get the real source IP of the request. Please note that the cloud provider will force the creation of an Octavia listener of type `HTTP` if this option is set. Only applies when using Octavia.
+  If set to `true`, adds an `X-Forwarded-For` request header containing the client IP address. Default is `false`.
 
-  This annotation also works in conjunction with the `loadbalancer.openstack.org/default-tls-container-ref` annotation. In this case the cloud provider will create an Octavia listener of type `TERMINATED_HTTPS` instead of an `HTTP` listener.
+- `loadbalancer.openstack.org/x-forwarded-port`
 
-  Not supported when `lb-provider=ovn` is configured in openstack-cloud-controller-manager.
+  If set to `true`, adds an `X-Forwarded-Port` request header containing the listener port on which the request was received. Default is `false`.
+
+- `loadbalancer.openstack.org/x-forwarded-proto`
+
+  If set to `true`, adds an `X-Forwarded-Proto` request header. The value is `http` for an `HTTP` listener and `https` for a `TERMINATED_HTTPS` listener. Default is `false`. This header requires Octavia API version 2.1 or later.
+
+The three X-Forwarded annotations are independent and apply to every listener created for the Service. All Service ports must use `TCP`. Without TLS termination, enabling any of them forces both the listener and pool protocols to `HTTP`. When `loadbalancer.openstack.org/default-tls-container-ref` is configured, the listener protocol is `TERMINATED_HTTPS` and the pool protocol remains `HTTP`. Enabling the first X-Forwarded annotation or disabling the last one on an existing non-TLS Service recreates its listeners because the Octavia listener protocol is immutable.
+
+The X-Forwarded annotations cannot be combined with `loadbalancer.openstack.org/proxy-protocol`. They are supported by the Octavia Amphora provider, but not by the OVN provider. Support by other provider drivers depends on the driver. See the [Octavia supported HTTP header insertions](https://docs.openstack.org/api-ref/load-balancer/v2/#supported-http-header-insertions) for details.
 
 - `loadbalancer.openstack.org/lb-method`
 

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"regexp"
 	"slices"
@@ -56,7 +57,9 @@ const (
 	defaultLoadBalancerSourceRangesIPv6 = "::/0"
 	activeStatus                        = "ACTIVE"
 	errorStatus                         = "ERROR"
-	annotationXForwardedFor             = "X-Forwarded-For"
+	xForwardedForHeader                 = "X-Forwarded-For"
+	xForwardedPortHeader                = "X-Forwarded-Port"
+	xForwardedProtoHeader               = "X-Forwarded-Proto"
 
 	ServiceAnnotationLoadBalancerInternal             = "service.beta.kubernetes.io/openstack-internal-load-balancer"
 	ServiceAnnotationLoadBalancerNodeSelector         = "loadbalancer.openstack.org/node-selector"
@@ -78,6 +81,8 @@ const (
 	ServiceAnnotationLoadBalancerTimeoutMemberData    = "loadbalancer.openstack.org/timeout-member-data"
 	ServiceAnnotationLoadBalancerTimeoutTCPInspect    = "loadbalancer.openstack.org/timeout-tcp-inspect"
 	ServiceAnnotationLoadBalancerXForwardedFor        = "loadbalancer.openstack.org/x-forwarded-for"
+	ServiceAnnotationLoadBalancerXForwardedPort       = "loadbalancer.openstack.org/x-forwarded-port"
+	ServiceAnnotationLoadBalancerXForwardedProto      = "loadbalancer.openstack.org/x-forwarded-proto"
 	ServiceAnnotationLoadBalancerFlavorID             = "loadbalancer.openstack.org/flavor-id"
 	ServiceAnnotationLoadBalancerAvailabilityZone     = "loadbalancer.openstack.org/availability-zone"
 	// ServiceAnnotationLoadBalancerEnableHealthMonitor defines whether to create health monitor for the load balancer
@@ -132,7 +137,9 @@ type serviceConfig struct {
 	lbPublicNetworkID           string
 	lbPublicSubnetSpec          *floatingSubnetSpec
 	nodeSelectors               map[string]string
-	keepClientIP                bool
+	xForwardedFor               bool
+	xForwardedPort              bool
+	xForwardedProto             bool
 	poolLbMethod                string
 	proxyProtocolVersion        *v2pools.Protocol
 	timeoutClientData           int
@@ -254,12 +261,44 @@ func popListener(existingListeners []listeners.Listener, id string) []listeners.
 	return newListeners
 }
 
+func isListenerOwnedByService(listener listeners.Listener, isLBOwner bool, lbName string) bool {
+	return slices.Contains(listener.Tags, lbName) || (isLBOwner && len(listener.Tags) == 0)
+}
+
+func getListenersOwnedByService(currentListeners []listeners.Listener, isLBOwner bool, lbName string) []listeners.Listener {
+	var ownedListeners []listeners.Listener
+	for _, listener := range currentListeners {
+		if isListenerOwnedByService(listener, isLBOwner, lbName) {
+			ownedListeners = append(ownedListeners, listener)
+		}
+	}
+	return ownedListeners
+}
+
+func listenerProtocolFamily(protocol listeners.Protocol) listeners.Protocol {
+	switch protocol {
+	case listeners.ProtocolTCP,
+		listeners.ProtocolHTTP,
+		listeners.ProtocolHTTPS,
+		listeners.ProtocolTerminatedHTTPS,
+		listeners.ProtocolPROXY,
+		listeners.ProtocolPrometheus:
+		return listeners.ProtocolTCP
+	default:
+		return protocol
+	}
+}
+
+func listenerProtocolsConflict(protocolA, protocolB listeners.Protocol) bool {
+	return listenerProtocolFamily(protocolA) == listenerProtocolFamily(protocolB)
+}
+
 func getListenerProtocol(protocol corev1.Protocol, svcConf *serviceConfig) listeners.Protocol {
-	// Make neutron-lbaas code work
 	if svcConf != nil {
 		if svcConf.tlsContainerRef != "" {
 			return listeners.ProtocolTerminatedHTTPS
-		} else if svcConf.keepClientIP {
+		}
+		if hasXForwardedHeaders(svcConf) {
 			return listeners.ProtocolHTTP
 		}
 	}
@@ -272,6 +311,46 @@ func getListenerProtocol(protocol corev1.Protocol, svcConf *serviceConfig) liste
 	default:
 		return listeners.Protocol(protocol)
 	}
+}
+
+// planListenerReplacements validates listener port ownership and returns listeners
+// whose immutable protocol must change before their replacements can be created.
+func planListenerReplacements(service *corev1.Service, svcConf *serviceConfig, currentListeners []listeners.Listener, isLBOwner bool, lbName string) ([]listeners.Listener, error) {
+	var listenersToReplace []listeners.Listener
+
+	for _, listener := range currentListeners {
+		currentProtocol := listeners.Protocol(listener.Protocol)
+		for _, servicePort := range service.Spec.Ports {
+			desiredProtocol := getListenerProtocol(servicePort.Protocol, svcConf)
+			if listener.ProtocolPort != int(servicePort.Port) || !listenerProtocolsConflict(currentProtocol, desiredProtocol) {
+				continue
+			}
+
+			if !isListenerOwnedByService(listener, isLBOwner, lbName) {
+				return nil, fmt.Errorf("the listener port %d already exists with protocol %s", servicePort.Port, listener.Protocol)
+			}
+
+			if currentProtocol != desiredProtocol {
+				listenersToReplace = append(listenersToReplace, listener)
+			}
+			break
+		}
+	}
+
+	return listenersToReplace, nil
+}
+
+func getPoolProtocol(listenerProtocol string, svcConf *serviceConfig) v2pools.Protocol {
+	if svcConf != nil && svcConf.proxyProtocolVersion != nil {
+		return *svcConf.proxyProtocolVersion
+	}
+
+	protocol := v2pools.Protocol(listenerProtocol)
+	if svcConf != nil && (hasXForwardedHeaders(svcConf) || svcConf.tlsContainerRef != "") && protocol != v2pools.ProtocolHTTP {
+		return v2pools.ProtocolHTTP
+	}
+
+	return protocol
 }
 
 func (lbaas *LbaasV2) createOctaviaLoadBalancer(ctx context.Context, name, clusterName string, service *corev1.Service, nodes []*corev1.Node, svcConf *serviceConfig) (*loadbalancers.LoadBalancer, error) {
@@ -607,7 +686,7 @@ func (lbaas *LbaasV2) deleteListeners(ctx context.Context, lbID string, listener
 func (lbaas *LbaasV2) deleteOctaviaListeners(ctx context.Context, lbID string, listenerList []listeners.Listener, isLBOwner bool, lbName string) error {
 	for _, listener := range listenerList {
 		// If the listener was created by this Service before or after supporting shared LB.
-		if (isLBOwner && len(listener.Tags) == 0) || slices.Contains(listener.Tags, lbName) {
+		if isListenerOwnedByService(listener, isLBOwner, lbName) {
 			klog.InfoS("Deleting listener", "listenerID", listener.ID, "lbID", lbID)
 
 			pool, err := openstackutil.GetPoolByListener(ctx, lbaas.lb, lbID, listener.ID)
@@ -929,14 +1008,7 @@ func (lbaas *LbaasV2) ensureOctaviaPool(ctx context.Context, lbID string, name s
 	if err != nil && err != cpoerrors.ErrNotFound {
 		return nil, fmt.Errorf("error getting pool for listener %s: %v", listener.ID, err)
 	}
-
-	// By default, use the protocol of the listener
-	poolProto := v2pools.Protocol(listener.Protocol)
-	if svcConf.proxyProtocolVersion != nil {
-		poolProto = *svcConf.proxyProtocolVersion
-	} else if (svcConf.keepClientIP || svcConf.tlsContainerRef != "") && poolProto != v2pools.ProtocolHTTP {
-		poolProto = v2pools.ProtocolHTTP
-	}
+	poolProto := getPoolProtocol(listener.Protocol, svcConf)
 
 	// Delete the pool and its members if it already exists and has the wrong protocol
 	if pool != nil && v2pools.Protocol(pool.Protocol) != poolProto {
@@ -1033,19 +1105,9 @@ func (lbaas *LbaasV2) ensureOctaviaPool(ctx context.Context, lbID string, name s
 }
 
 func (lbaas *LbaasV2) buildPoolCreateOpt(listenerProtocol string, service *corev1.Service, svcConf *serviceConfig, name string) v2pools.CreateOpts {
-	// By default, use the protocol of the listener
-	poolProto := v2pools.Protocol(listenerProtocol)
-	if svcConf.proxyProtocolVersion != nil {
-		poolProto = *svcConf.proxyProtocolVersion
-	} else if (svcConf.keepClientIP || svcConf.tlsContainerRef != "") && poolProto != v2pools.ProtocolHTTP {
-		if svcConf.keepClientIP && svcConf.tlsContainerRef != "" {
-			klog.V(4).Infof("Forcing to use %q protocol for pool because annotations %q %q are set", v2pools.ProtocolHTTP, ServiceAnnotationLoadBalancerXForwardedFor, ServiceAnnotationTlsContainerRef)
-		} else if svcConf.keepClientIP {
-			klog.V(4).Infof("Forcing to use %q protocol for pool because annotation %q is set", v2pools.ProtocolHTTP, ServiceAnnotationLoadBalancerXForwardedFor)
-		} else {
-			klog.V(4).Infof("Forcing to use %q protocol for pool because annotations %q is set", v2pools.ProtocolHTTP, ServiceAnnotationTlsContainerRef)
-		}
-		poolProto = v2pools.ProtocolHTTP
+	poolProto := getPoolProtocol(listenerProtocol, svcConf)
+	if svcConf.proxyProtocolVersion == nil && poolProto != v2pools.Protocol(listenerProtocol) {
+		klog.V(4).InfoS("Forcing pool protocol", "poolProtocol", poolProto, "listenerProtocol", listenerProtocol, "xForwardedAnnotations", enabledXForwardedAnnotations(svcConf), "tlsTermination", svcConf.tlsContainerRef != "")
 	}
 
 	affinity := service.Spec.SessionAffinity
@@ -1175,17 +1237,9 @@ func (lbaas *LbaasV2) ensureOctaviaListener(ctx context.Context, lbID string, na
 			listenerChanged = true
 		}
 
-		listenerKeepClientIP := listener.InsertHeaders[annotationXForwardedFor] == "true"
-		if svcConf.keepClientIP != listenerKeepClientIP {
-			updateOpts.InsertHeaders = &listener.InsertHeaders
-			if svcConf.keepClientIP {
-				if *updateOpts.InsertHeaders == nil {
-					*updateOpts.InsertHeaders = make(map[string]string)
-				}
-				(*updateOpts.InsertHeaders)[annotationXForwardedFor] = "true"
-			} else {
-				delete(*updateOpts.InsertHeaders, annotationXForwardedFor)
-			}
+		desiredHeaders := buildXForwardedHeaders(svcConf)
+		if insertHeaders, changed := reconcileXForwardedHeaders(listener.InsertHeaders, desiredHeaders); changed {
+			updateOpts.InsertHeaders = &insertHeaders
 			listenerChanged = true
 		}
 		if svcConf.tlsContainerRef != listener.DefaultTlsContainerRef {
@@ -1250,21 +1304,16 @@ func (lbaas *LbaasV2) buildListenerCreateOpt(ctx context.Context, port corev1.Se
 		listenerCreateOpt.TimeoutTCPInspect = &svcConf.timeoutTCPInspect
 	}
 
-	if svcConf.keepClientIP {
-		listenerCreateOpt.InsertHeaders = map[string]string{annotationXForwardedFor: "true"}
-	}
+	listenerCreateOpt.InsertHeaders = buildXForwardedHeaders(svcConf)
 
 	if svcConf.tlsContainerRef != "" {
 		listenerCreateOpt.DefaultTlsContainerRef = svcConf.tlsContainerRef
 	}
 
-	// protocol selection
-	if svcConf.tlsContainerRef != "" && listenerCreateOpt.Protocol != listeners.ProtocolTerminatedHTTPS {
-		klog.V(4).Infof("Forcing to use %q protocol for listener because %q annotation is set", listeners.ProtocolTerminatedHTTPS, ServiceAnnotationTlsContainerRef)
-		listenerCreateOpt.Protocol = listeners.ProtocolTerminatedHTTPS
-	} else if svcConf.keepClientIP && listenerCreateOpt.Protocol != listeners.ProtocolHTTP {
-		klog.V(4).Infof("Forcing to use %q protocol for listener because %q annotation is set", listeners.ProtocolHTTP, ServiceAnnotationLoadBalancerXForwardedFor)
-		listenerCreateOpt.Protocol = listeners.ProtocolHTTP
+	desiredProtocol := getListenerProtocol(port.Protocol, svcConf)
+	if desiredProtocol != listenerCreateOpt.Protocol {
+		klog.V(4).InfoS("Forcing listener protocol", "listenerProtocol", desiredProtocol, "xForwardedAnnotations", enabledXForwardedAnnotations(svcConf), "tlsTermination", svcConf.tlsContainerRef != "")
+		listenerCreateOpt.Protocol = desiredProtocol
 	}
 
 	if openstackutil.IsOctaviaFeatureSupported(ctx, lbaas.lb, openstackutil.OctaviaFeatureVIPACL, lbaas.opts.LBProvider) {
@@ -1410,7 +1459,9 @@ func (lbaas *LbaasV2) checkServiceDelete(ctx context.Context, service *corev1.Se
 	svcConf.supportLBTags = openstackutil.IsOctaviaFeatureSupported(ctx, lbaas.lb, openstackutil.OctaviaFeatureTags, lbaas.opts.LBProvider)
 
 	// This affects the protocol of listener and pool
-	svcConf.keepClientIP = getBoolFromServiceAnnotation(service, ServiceAnnotationLoadBalancerXForwardedFor, false)
+	svcConf.xForwardedFor = getBoolFromServiceAnnotation(service, ServiceAnnotationLoadBalancerXForwardedFor, false)
+	svcConf.xForwardedPort = getBoolFromServiceAnnotation(service, ServiceAnnotationLoadBalancerXForwardedPort, false)
+	svcConf.xForwardedProto = getBoolFromServiceAnnotation(service, ServiceAnnotationLoadBalancerXForwardedProto, false)
 	svcConf.proxyProtocolVersion = getProxyProtocolFromServiceAnnotation(service)
 	svcConf.tlsContainerRef = getStringFromServiceAnnotation(service, ServiceAnnotationTlsContainerRef, lbaas.opts.TlsContainerRef)
 
@@ -1621,12 +1672,16 @@ func (lbaas *LbaasV2) makeSvcConf(ctx context.Context, serviceName string, servi
 		}
 	}
 
-	keepClientIP := getBoolFromServiceAnnotation(service, ServiceAnnotationLoadBalancerXForwardedFor, false)
+	svcConf.xForwardedFor = getBoolFromServiceAnnotation(service, ServiceAnnotationLoadBalancerXForwardedFor, false)
+	svcConf.xForwardedPort = getBoolFromServiceAnnotation(service, ServiceAnnotationLoadBalancerXForwardedPort, false)
+	svcConf.xForwardedProto = getBoolFromServiceAnnotation(service, ServiceAnnotationLoadBalancerXForwardedProto, false)
 	svcConf.proxyProtocolVersion = getProxyProtocolFromServiceAnnotation(service)
-	if svcConf.proxyProtocolVersion != nil && keepClientIP {
-		return fmt.Errorf("annotation %s and %s cannot be used together", ServiceAnnotationLoadBalancerProxyEnabled, ServiceAnnotationLoadBalancerXForwardedFor)
+	if err := validateXForwardedAnnotations(service, svcConf, lbaas.opts.LBProvider); err != nil {
+		return err
 	}
-	svcConf.keepClientIP = keepClientIP
+	if svcConf.xForwardedProto && !openstackutil.IsOctaviaFeatureSupported(ctx, lbaas.lb, openstackutil.OctaviaFeatureXForwardedProto, lbaas.opts.LBProvider) {
+		return fmt.Errorf("annotation %q requires Octavia API version 2.1 or later", ServiceAnnotationLoadBalancerXForwardedProto)
+	}
 
 	if openstackutil.IsOctaviaFeatureSupported(ctx, lbaas.lb, openstackutil.OctaviaFeatureTimeout, lbaas.opts.LBProvider) {
 		svcConf.timeoutClientData = getIntFromServiceAnnotation(service, ServiceAnnotationLoadBalancerTimeoutClientData, 50000)
@@ -1673,25 +1728,6 @@ func (lbaas *LbaasV2) makeSvcConf(ctx context.Context, serviceName string, servi
 	svcConf.healthMonitorTimeout = getIntFromServiceAnnotation(service, ServiceAnnotationLoadBalancerHealthMonitorTimeout, int(lbaas.opts.MonitorTimeout.Seconds()))
 	svcConf.healthMonitorMaxRetries = getIntFromServiceAnnotation(service, ServiceAnnotationLoadBalancerHealthMonitorMaxRetries, int(lbaas.opts.MonitorMaxRetries))
 	svcConf.healthMonitorMaxRetriesDown = getIntFromServiceAnnotation(service, ServiceAnnotationLoadBalancerHealthMonitorMaxRetriesDown, int(lbaas.opts.MonitorMaxRetriesDown))
-	return nil
-}
-
-// checkListenerPorts checks if there is conflict for ports.
-func (lbaas *LbaasV2) checkListenerPorts(service *corev1.Service, curListenerMapping map[listenerKey]*listeners.Listener, isLBOwner bool, lbName string) error {
-	for _, svcPort := range service.Spec.Ports {
-		key := listenerKey{Protocol: listeners.Protocol(svcPort.Protocol), Port: int(svcPort.Port)}
-
-		if listener, isPresent := curListenerMapping[key]; isPresent {
-			// The listener is used by this Service if LB name is in the tags, or
-			// the listener was created by this Service.
-			if slices.Contains(listener.Tags, lbName) || (len(listener.Tags) == 0 && isLBOwner) {
-				continue
-			} else {
-				return fmt.Errorf("the listener port %d already exists", svcPort.Port)
-			}
-		}
-	}
-
 	return nil
 }
 
@@ -1839,17 +1875,26 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 	// a newly created, unpopulated loadbalancer that needs populating.
 	if !createNewLB || (lbaas.opts.ProviderRequiresSerialAPICalls && createNewLB) {
 		curListeners := loadbalancer.Listeners
+		listenersToReplace, err := planListenerReplacements(service, svcConf, curListeners, isLBOwner, lbName)
+		if err != nil {
+			return nil, err
+		}
+		for _, listener := range listenersToReplace {
+			klog.V(4).InfoS("Replacing listener to change its protocol", "listenerID", listener.ID, "listenerProtocol", listener.Protocol, "listenerPort", listener.ProtocolPort)
+		}
+		if err := lbaas.deleteListeners(ctx, loadbalancer.ID, listenersToReplace); err != nil {
+			return nil, err
+		}
+		for _, listener := range listenersToReplace {
+			curListeners = popListener(curListeners, listener.ID)
+		}
+
 		curListenerMapping := make(map[listenerKey]*listeners.Listener)
 		for i, l := range curListeners {
 			key := listenerKey{Protocol: listeners.Protocol(l.Protocol), Port: l.ProtocolPort}
 			curListenerMapping[key] = &curListeners[i]
 		}
 		klog.V(4).InfoS("Existing listeners", "portProtocolMapping", curListenerMapping)
-
-		// Check port conflicts
-		if err := lbaas.checkListenerPorts(service, curListenerMapping, isLBOwner, lbName); err != nil {
-			return nil, err
-		}
 
 		for portIndex, port := range service.Spec.Ports {
 			listener, err := lbaas.ensureOctaviaListener(ctx, loadbalancer.ID, cpoutil.Sprintf255(listenerFormat, portIndex, lbName), curListenerMapping, port, svcConf)
@@ -2089,24 +2134,9 @@ func (lbaas *LbaasV2) deleteLoadBalancer(ctx context.Context, loadbalancer *load
 		}
 
 		if !needDeleteLB {
-			var listenersToDelete []listeners.Listener
-			curListenerMapping := make(map[listenerKey]*listeners.Listener)
-			for i, l := range listenerList {
-				key := listenerKey{Protocol: listeners.Protocol(l.Protocol), Port: l.ProtocolPort}
-				curListenerMapping[key] = &listenerList[i]
-			}
-
-			for _, port := range service.Spec.Ports {
-				proto := getListenerProtocol(port.Protocol, svcConf)
-				listener, isPresent := curListenerMapping[listenerKey{
-					Protocol: proto,
-					Port:     int(port.Port),
-				}]
-				if isPresent && slices.Contains(listener.Tags, svcConf.lbName) {
-					listenersToDelete = append(listenersToDelete, *listener)
-				}
-			}
-			listenerList = listenersToDelete
+			// Ownership tags are the source of truth here. The Service ports may
+			// already differ if a preceding update did not finish successfully.
+			listenerList = getListenersOwnedByService(listenerList, false, svcConf.lbName)
 		}
 
 		// get all pools (and health monitors) associated with this loadbalancer
@@ -2367,4 +2397,83 @@ func matchNodeLabels(node *corev1.Node, filterLabels map[string]string) bool {
 	}
 
 	return true
+}
+
+func hasXForwardedHeaders(svcConf *serviceConfig) bool {
+	return svcConf != nil && (svcConf.xForwardedFor || svcConf.xForwardedPort || svcConf.xForwardedProto)
+}
+
+func validateXForwardedAnnotations(service *corev1.Service, svcConf *serviceConfig, lbProvider string) error {
+	if !hasXForwardedHeaders(svcConf) {
+		return nil
+	}
+
+	annotations := enabledXForwardedAnnotations(svcConf)
+	if svcConf.proxyProtocolVersion != nil {
+		return fmt.Errorf("annotation %q cannot be used with any of the following annotations: %s", ServiceAnnotationLoadBalancerProxyEnabled, strings.Join(annotations, ", "))
+	}
+	if lbProvider == "ovn" {
+		return fmt.Errorf("annotations %s are not supported by the OVN provider", strings.Join(annotations, ", "))
+	}
+	for _, port := range service.Spec.Ports {
+		if port.Protocol != corev1.ProtocolTCP {
+			return fmt.Errorf("annotations %s require TCP Service ports, but port %d uses protocol %s", strings.Join(annotations, ", "), port.Port, port.Protocol)
+		}
+	}
+
+	return nil
+}
+
+func enabledXForwardedAnnotations(svcConf *serviceConfig) []string {
+	var annotations []string
+	if svcConf == nil {
+		return annotations
+	}
+	if svcConf.xForwardedFor {
+		annotations = append(annotations, ServiceAnnotationLoadBalancerXForwardedFor)
+	}
+	if svcConf.xForwardedPort {
+		annotations = append(annotations, ServiceAnnotationLoadBalancerXForwardedPort)
+	}
+	if svcConf.xForwardedProto {
+		annotations = append(annotations, ServiceAnnotationLoadBalancerXForwardedProto)
+	}
+	return annotations
+}
+
+func buildXForwardedHeaders(svcConf *serviceConfig) map[string]string {
+	if !hasXForwardedHeaders(svcConf) {
+		return nil
+	}
+
+	headers := make(map[string]string, 3)
+	if svcConf.xForwardedFor {
+		headers[xForwardedForHeader] = "true"
+	}
+	if svcConf.xForwardedPort {
+		headers[xForwardedPortHeader] = "true"
+	}
+	if svcConf.xForwardedProto {
+		headers[xForwardedProtoHeader] = "true"
+	}
+	return headers
+}
+
+// reconcileXForwardedHeaders returns a copy of currentHeaders with the
+// OCCM-managed X-Forwarded headers reconciled and all other headers preserved
+// when the listener can be updated in place.
+func reconcileXForwardedHeaders(currentHeaders, desiredHeaders map[string]string) (map[string]string, bool) {
+	updatedHeaders := maps.Clone(currentHeaders)
+	for _, header := range []string{xForwardedForHeader, xForwardedPortHeader, xForwardedProtoHeader} {
+		if value, ok := desiredHeaders[header]; ok {
+			if updatedHeaders == nil {
+				updatedHeaders = make(map[string]string, len(desiredHeaders))
+			}
+			updatedHeaders[header] = value
+		} else {
+			delete(updatedHeaders, header)
+		}
+	}
+
+	return updatedHeaders, !maps.Equal(currentHeaders, updatedHeaders)
 }

--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -560,7 +560,7 @@ func Test_getListenerProtocol(t *testing.T) {
 			name: "not nil svcConf and keepClientIP is true",
 			testArg: testArg{
 				svcConf: &serviceConfig{
-					keepClientIP: true,
+					xForwardedFor: true,
 				},
 			},
 			expected: listeners.ProtocolHTTP,
@@ -594,7 +594,7 @@ func Test_getListenerProtocol(t *testing.T) {
 			testArg: testArg{
 				svcConf: &serviceConfig{
 					tlsContainerRef: "tls-container-ref",
-					keepClientIP:    true,
+					xForwardedFor:   true,
 				},
 			},
 			expected: listeners.ProtocolTerminatedHTTPS,
@@ -609,172 +609,6 @@ func Test_getListenerProtocol(t *testing.T) {
 	}
 }
 
-func TestLbaasV2_checkListenerPorts(t *testing.T) {
-	type args struct {
-		service            *corev1.Service
-		curListenerMapping map[listenerKey]*listeners.Listener
-		isLBOwner          bool
-		lbName             string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
-	}{
-		{
-			name: "error is not thrown if loadbalancer matches & if port is already in use by a lb",
-			args: args{
-				service: &corev1.Service{
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name:     "service",
-								Protocol: "https",
-								Port:     9090,
-							},
-						},
-					},
-				},
-				curListenerMapping: map[listenerKey]*listeners.Listener{
-					{
-						Protocol: "https",
-						Port:     9090,
-					}: {
-						ID:   "listenerid",
-						Tags: []string{"test-lb"},
-					},
-				},
-				isLBOwner: false,
-				lbName:    "test-lb",
-			},
-			wantErr: false,
-		},
-		{
-			name: "error is thrown if loadbalancer doesn't matches & if port is already in use by a service",
-			args: args{
-				service: &corev1.Service{
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name:     "service",
-								Protocol: "https",
-								Port:     9090,
-							},
-						},
-					},
-				},
-				curListenerMapping: map[listenerKey]*listeners.Listener{
-					{
-						Protocol: "https",
-						Port:     9090,
-					}: {
-						ID:   "listenerid",
-						Tags: []string{"test-lb", "test-lb1"},
-					},
-				},
-				isLBOwner: false,
-				lbName:    "test-lb2",
-			},
-			wantErr: true,
-		},
-		{
-			name: "error is not thrown if lbOwner is present & no tags on service",
-			args: args{
-				service: &corev1.Service{
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name:     "service",
-								Protocol: "https",
-								Port:     9090,
-							},
-						},
-					},
-				},
-				curListenerMapping: map[listenerKey]*listeners.Listener{
-					{
-						Protocol: "https",
-						Port:     9090,
-					}: {
-						ID: "listenerid",
-					},
-				},
-				isLBOwner: true,
-				lbName:    "test-lb",
-			},
-			wantErr: false,
-		},
-		{
-			name: "error is not thrown if lbOwner is true & there are tags on service",
-			args: args{
-				service: &corev1.Service{
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name:     "service",
-								Protocol: "http",
-								Port:     9091,
-							},
-						},
-					},
-				},
-				curListenerMapping: map[listenerKey]*listeners.Listener{
-					{
-						Protocol: "https",
-						Port:     9090,
-					}: {
-						ID:   "listenerid",
-						Tags: []string{"test-lb"},
-					},
-				},
-				isLBOwner: true,
-				lbName:    "test-lb",
-			},
-			wantErr: false,
-		},
-		{
-			name: "error is not thrown if listener key doesn't match port & protocol",
-			args: args{
-				service: &corev1.Service{
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name:     "service",
-								Protocol: "http",
-								Port:     9091,
-							},
-						},
-					},
-				},
-				curListenerMapping: map[listenerKey]*listeners.Listener{
-					{
-						Protocol: "https",
-						Port:     9090,
-					}: {
-						ID:   "listenerid",
-						Tags: []string{"test-lb"},
-					},
-				},
-				isLBOwner: false,
-				lbName:    "test-lb",
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			lbaas := &LbaasV2{
-				LoadBalancer: LoadBalancer{},
-			}
-			err := lbaas.checkListenerPorts(tt.args.service, tt.args.curListenerMapping, tt.args.isLBOwner, tt.args.lbName)
-			if tt.wantErr == true {
-				assert.ErrorContains(t, err, "already exists")
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}
 func TestLbaasV2_createLoadBalancerStatus(t *testing.T) {
 	ipmodeProxy := corev1.LoadBalancerIPModeProxy
 	ipmodeVIP := corev1.LoadBalancerIPModeVIP
@@ -1048,7 +882,7 @@ func Test_buildPoolCreateOpt(t *testing.T) {
 			args: args{
 				protocol: "TCP",
 				svcConf: &serviceConfig{
-					keepClientIP:         true,
+					xForwardedFor:        true,
 					tlsContainerRef:      "tls-container-ref",
 					proxyProtocolVersion: ptr.To(pools.ProtocolPROXY),
 				},
@@ -1078,7 +912,7 @@ func Test_buildPoolCreateOpt(t *testing.T) {
 			args: args{
 				protocol: "HTTP",
 				svcConf: &serviceConfig{
-					keepClientIP:         true,
+					xForwardedFor:        true,
 					tlsContainerRef:      "tls-container-ref",
 					proxyProtocolVersion: nil,
 				},
@@ -1108,7 +942,7 @@ func Test_buildPoolCreateOpt(t *testing.T) {
 			args: args{
 				protocol: "UDP",
 				svcConf: &serviceConfig{
-					keepClientIP:         true,
+					xForwardedFor:        true,
 					tlsContainerRef:      "tls-container-ref",
 					proxyProtocolVersion: nil,
 				},
@@ -1138,7 +972,7 @@ func Test_buildPoolCreateOpt(t *testing.T) {
 			args: args{
 				protocol: "TCP",
 				svcConf: &serviceConfig{
-					keepClientIP:    true,
+					xForwardedFor:   true,
 					tlsContainerRef: "tls-container-ref",
 				},
 				lbaasV2: &LbaasV2{
@@ -1167,7 +1001,7 @@ func Test_buildPoolCreateOpt(t *testing.T) {
 			args: args{
 				protocol: "TCP",
 				svcConf: &serviceConfig{
-					keepClientIP:    true,
+					xForwardedFor:   true,
 					tlsContainerRef: "tls-container-ref",
 				},
 				lbaasV2: &LbaasV2{
@@ -1196,7 +1030,7 @@ func Test_buildPoolCreateOpt(t *testing.T) {
 			args: args{
 				protocol: "TCP",
 				svcConf: &serviceConfig{
-					keepClientIP:         true,
+					xForwardedFor:        true,
 					tlsContainerRef:      "tls-container-ref",
 					proxyProtocolVersion: ptr.To(pools.ProtocolPROXYV2),
 				},
@@ -2473,7 +2307,7 @@ func TestBuildListenerCreateOpt(t *testing.T) {
 				connLimit:       100,
 				lbName:          "my-lb",
 				tlsContainerRef: "tls-container-ref",
-				keepClientIP:    true,
+				xForwardedFor:   true,
 			},
 			expectedCreateOpt: listeners.CreateOpts{
 				Name:                   "Test with TLSContainerRef and X-Forwarded-For",
@@ -2495,7 +2329,7 @@ func TestBuildListenerCreateOpt(t *testing.T) {
 				connLimit:       100,
 				lbName:          "my-lb",
 				tlsContainerRef: "tls-container-ref",
-				keepClientIP:    false,
+				xForwardedFor:   false,
 			},
 			expectedCreateOpt: listeners.CreateOpts{
 				Name:                   "Test with TLSContainerRef but without X-Forwarded-For",
@@ -2516,7 +2350,7 @@ func TestBuildListenerCreateOpt(t *testing.T) {
 				connLimit:       100,
 				lbName:          "my-lb",
 				tlsContainerRef: "tls-container-ref",
-				keepClientIP:    true,
+				xForwardedFor:   true,
 				allowedCIDR:     []string{"192.168.1.0/24", "10.0.0.0/8"},
 			},
 			expectedCreateOpt: listeners.CreateOpts{
@@ -2539,7 +2373,7 @@ func TestBuildListenerCreateOpt(t *testing.T) {
 			svcConf: &serviceConfig{
 				connLimit:       100,
 				lbName:          "my-lb",
-				keepClientIP:    true,
+				xForwardedFor:   true,
 				tlsContainerRef: "",
 			},
 			expectedCreateOpt: listeners.CreateOpts{

--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"k8s.io/utils/ptr"
-	"reflect"
+	"maps"
 	"sort"
 	"testing"
 
@@ -536,7 +536,7 @@ func TestGetRulesToCreateAndDelete(t *testing.T) {
 	}
 }
 
-func Test_getListenerProtocol(t *testing.T) {
+func TestGetListenerProtocol(t *testing.T) {
 	type testArg struct {
 		protocol corev1.Protocol
 		svcConf  *serviceConfig
@@ -557,10 +557,28 @@ func Test_getListenerProtocol(t *testing.T) {
 			expected: listeners.ProtocolTerminatedHTTPS,
 		},
 		{
-			name: "not nil svcConf and keepClientIP is true",
+			name: "X-Forwarded-For uses HTTP",
 			testArg: testArg{
 				svcConf: &serviceConfig{
 					xForwardedFor: true,
+				},
+			},
+			expected: listeners.ProtocolHTTP,
+		},
+		{
+			name: "X-Forwarded-Port uses HTTP",
+			testArg: testArg{
+				svcConf: &serviceConfig{
+					xForwardedPort: true,
+				},
+			},
+			expected: listeners.ProtocolHTTP,
+		},
+		{
+			name: "X-Forwarded-Proto uses HTTP",
+			testArg: testArg{
+				svcConf: &serviceConfig{
+					xForwardedProto: true,
 				},
 			},
 			expected: listeners.ProtocolHTTP,
@@ -590,7 +608,7 @@ func Test_getListenerProtocol(t *testing.T) {
 			expected: listeners.ProtocolSCTP,
 		},
 		{
-			name: "passing a svcConf tls container ref with a keep client IP",
+			name: "TLS termination takes precedence over X-Forwarded headers",
 			testArg: testArg{
 				svcConf: &serviceConfig{
 					tlsContainerRef: "tls-container-ref",
@@ -602,9 +620,301 @@ func Test_getListenerProtocol(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getListenerProtocol(tt.testArg.protocol, tt.testArg.svcConf); !reflect.DeepEqual(got, tt.expected) {
-				t.Errorf("getListenerProtocol() = %v, expected %v", got, tt.expected)
+			assert.Equal(t, tt.expected, getListenerProtocol(tt.testArg.protocol, tt.testArg.svcConf))
+		})
+	}
+}
+
+func TestGetPoolProtocol(t *testing.T) {
+	tests := []struct {
+		name             string
+		listenerProtocol string
+		svcConf          *serviceConfig
+		expected         pools.Protocol
+	}{
+		{
+			name:             "nil configuration uses listener protocol",
+			listenerProtocol: "TCP",
+			expected:         pools.ProtocolTCP,
+		},
+		{
+			name:             "empty configuration uses listener protocol",
+			listenerProtocol: "TCP",
+			svcConf:          &serviceConfig{},
+			expected:         pools.ProtocolTCP,
+		},
+		{
+			name:             "X-Forwarded-Port uses HTTP",
+			listenerProtocol: "TCP",
+			svcConf:          &serviceConfig{xForwardedPort: true},
+			expected:         pools.ProtocolHTTP,
+		},
+		{
+			name:             "X-Forwarded-Proto uses HTTP",
+			listenerProtocol: "TCP",
+			svcConf:          &serviceConfig{xForwardedProto: true},
+			expected:         pools.ProtocolHTTP,
+		},
+		{
+			name:             "TLS termination uses an HTTP pool",
+			listenerProtocol: string(listeners.ProtocolTerminatedHTTPS),
+			svcConf:          &serviceConfig{tlsContainerRef: "tls-container-ref"},
+			expected:         pools.ProtocolHTTP,
+		},
+		{
+			name:             "proxy protocol takes precedence",
+			listenerProtocol: "TCP",
+			svcConf:          &serviceConfig{proxyProtocolVersion: ptr.To(pools.ProtocolPROXYV2)},
+			expected:         pools.ProtocolPROXYV2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, getPoolProtocol(tt.listenerProtocol, tt.svcConf))
+		})
+	}
+}
+
+func TestValidateXForwardedAnnotations(t *testing.T) {
+	tests := []struct {
+		name          string
+		ports         []corev1.ServicePort
+		svcConf       *serviceConfig
+		lbProvider    string
+		errorContains string
+	}{
+		{
+			name:    "disabled annotations allow UDP",
+			ports:   []corev1.ServicePort{{Protocol: corev1.ProtocolUDP, Port: 53}},
+			svcConf: &serviceConfig{},
+		},
+		{
+			name:    "enabled annotation allows TCP",
+			ports:   []corev1.ServicePort{{Protocol: corev1.ProtocolTCP, Port: 80}},
+			svcConf: &serviceConfig{xForwardedPort: true},
+		},
+		{
+			name:          "proxy protocol is mutually exclusive",
+			ports:         []corev1.ServicePort{{Protocol: corev1.ProtocolTCP, Port: 80}},
+			svcConf:       &serviceConfig{xForwardedProto: true, proxyProtocolVersion: ptr.To(pools.ProtocolPROXYV2)},
+			errorContains: ServiceAnnotationLoadBalancerProxyEnabled,
+		},
+		{
+			name:          "OVN provider is unsupported",
+			ports:         []corev1.ServicePort{{Protocol: corev1.ProtocolTCP, Port: 80}},
+			svcConf:       &serviceConfig{xForwardedFor: true},
+			lbProvider:    "ovn",
+			errorContains: "OVN provider",
+		},
+		{
+			name:          "UDP port is unsupported",
+			ports:         []corev1.ServicePort{{Protocol: corev1.ProtocolUDP, Port: 53}},
+			svcConf:       &serviceConfig{xForwardedPort: true},
+			errorContains: "require TCP Service ports",
+		},
+		{
+			name:          "SCTP port is unsupported",
+			ports:         []corev1.ServicePort{{Protocol: corev1.ProtocolSCTP, Port: 3868}},
+			svcConf:       &serviceConfig{xForwardedProto: true},
+			errorContains: "require TCP Service ports",
+		},
+		{
+			name: "mixed TCP and UDP ports are unsupported",
+			ports: []corev1.ServicePort{
+				{Protocol: corev1.ProtocolTCP, Port: 53},
+				{Protocol: corev1.ProtocolUDP, Port: 53},
+			},
+			svcConf:       &serviceConfig{xForwardedFor: true},
+			errorContains: "require TCP Service ports",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &corev1.Service{Spec: corev1.ServiceSpec{Ports: tt.ports}}
+			err := validateXForwardedAnnotations(service, tt.svcConf, tt.lbProvider)
+			if tt.errorContains == "" {
+				assert.NoError(t, err)
+				return
 			}
+			assert.ErrorContains(t, err, tt.errorContains)
+		})
+	}
+}
+
+func TestListenerProtocolFamily(t *testing.T) {
+	tests := []struct {
+		protocol listeners.Protocol
+		expected listeners.Protocol
+	}{
+		{protocol: listeners.ProtocolTCP, expected: listeners.ProtocolTCP},
+		{protocol: listeners.ProtocolHTTP, expected: listeners.ProtocolTCP},
+		{protocol: listeners.ProtocolHTTPS, expected: listeners.ProtocolTCP},
+		{protocol: listeners.ProtocolTerminatedHTTPS, expected: listeners.ProtocolTCP},
+		{protocol: listeners.ProtocolPROXY, expected: listeners.ProtocolTCP},
+		{protocol: listeners.ProtocolPrometheus, expected: listeners.ProtocolTCP},
+		{protocol: listeners.ProtocolUDP, expected: listeners.ProtocolUDP},
+		{protocol: listeners.ProtocolSCTP, expected: listeners.ProtocolSCTP},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.protocol), func(t *testing.T) {
+			assert.Equal(t, tt.expected, listenerProtocolFamily(tt.protocol))
+		})
+	}
+}
+
+func TestGetListenersOwnedByService(t *testing.T) {
+	const lbName = "test-lb"
+	currentListeners := []listeners.Listener{
+		{ID: "old-port", Protocol: string(listeners.ProtocolTCP), ProtocolPort: 80, Tags: []string{lbName}},
+		{ID: "old-protocol", Protocol: string(listeners.ProtocolHTTP), ProtocolPort: 443, Tags: []string{lbName}},
+		{ID: "foreign", Protocol: string(listeners.ProtocolTCP), ProtocolPort: 81, Tags: []string{"other-lb"}},
+		{ID: "legacy", Protocol: string(listeners.ProtocolTCP), ProtocolPort: 82},
+	}
+
+	tests := []struct {
+		name        string
+		isLBOwner   bool
+		expectedIDs []string
+	}{
+		{
+			name:        "shared load balancer includes every tagged listener",
+			expectedIDs: []string{"old-port", "old-protocol"},
+		},
+		{
+			name:        "load balancer owner also includes legacy untagged listeners",
+			isLBOwner:   true,
+			expectedIDs: []string{"old-port", "old-protocol", "legacy"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := getListenersOwnedByService(currentListeners, tt.isLBOwner, lbName)
+			actualIDs := make([]string, 0, len(actual))
+			for _, listener := range actual {
+				actualIDs = append(actualIDs, listener.ID)
+			}
+			assert.ElementsMatch(t, tt.expectedIDs, actualIDs)
+		})
+	}
+}
+
+func TestPlanListenerReplacements(t *testing.T) {
+	const lbName = "test-lb"
+	tests := []struct {
+		name             string
+		ports            []corev1.ServicePort
+		svcConf          *serviceConfig
+		currentListeners []listeners.Listener
+		isLBOwner        bool
+		expectedIDs      []string
+		wantErr          bool
+	}{
+		{
+			name:    "unchanged owned listener is reused",
+			ports:   []corev1.ServicePort{{Protocol: corev1.ProtocolTCP, Port: 80}},
+			svcConf: &serviceConfig{},
+			currentListeners: []listeners.Listener{{
+				ID: "tcp", Protocol: string(listeners.ProtocolTCP), ProtocolPort: 80, Tags: []string{lbName},
+			}},
+		},
+		{
+			name:    "foreign listener with the desired protocol conflicts",
+			ports:   []corev1.ServicePort{{Protocol: corev1.ProtocolTCP, Port: 80}},
+			svcConf: &serviceConfig{xForwardedFor: true},
+			currentListeners: []listeners.Listener{{
+				ID: "http", Protocol: string(listeners.ProtocolHTTP), ProtocolPort: 80, Tags: []string{"other-lb"},
+			}},
+			wantErr: true,
+		},
+		{
+			name:    "foreign listener in the same L4 protocol family conflicts",
+			ports:   []corev1.ServicePort{{Protocol: corev1.ProtocolTCP, Port: 80}},
+			svcConf: &serviceConfig{xForwardedPort: true},
+			currentListeners: []listeners.Listener{{
+				ID: "tcp", Protocol: string(listeners.ProtocolTCP), ProtocolPort: 80, Tags: []string{"other-lb"},
+			}},
+			wantErr: true,
+		},
+		{
+			name:    "foreign listener in a different L4 protocol family is allowed",
+			ports:   []corev1.ServicePort{{Protocol: corev1.ProtocolTCP, Port: 80}},
+			svcConf: &serviceConfig{xForwardedProto: true},
+			currentListeners: []listeners.Listener{{
+				ID: "udp", Protocol: string(listeners.ProtocolUDP), ProtocolPort: 80, Tags: []string{"other-lb"},
+			}},
+		},
+		{
+			name:    "owned TCP listener is replaced with HTTP",
+			ports:   []corev1.ServicePort{{Protocol: corev1.ProtocolTCP, Port: 80}},
+			svcConf: &serviceConfig{xForwardedFor: true},
+			currentListeners: []listeners.Listener{{
+				ID: "tcp", Protocol: string(listeners.ProtocolTCP), ProtocolPort: 80, Tags: []string{lbName},
+			}},
+			expectedIDs: []string{"tcp"},
+		},
+		{
+			name:    "owned HTTP listener is replaced with TCP",
+			ports:   []corev1.ServicePort{{Protocol: corev1.ProtocolTCP, Port: 80}},
+			svcConf: &serviceConfig{},
+			currentListeners: []listeners.Listener{{
+				ID: "http", Protocol: string(listeners.ProtocolHTTP), ProtocolPort: 80, Tags: []string{lbName},
+			}},
+			expectedIDs: []string{"http"},
+		},
+		{
+			name:      "untagged listener is replaced for the load balancer owner",
+			ports:     []corev1.ServicePort{{Protocol: corev1.ProtocolTCP, Port: 80}},
+			svcConf:   &serviceConfig{xForwardedFor: true},
+			isLBOwner: true,
+			currentListeners: []listeners.Listener{{
+				ID: "tcp", Protocol: string(listeners.ProtocolTCP), ProtocolPort: 80,
+			}},
+			expectedIDs: []string{"tcp"},
+		},
+		{
+			name:    "untagged listener conflicts for a shared load balancer user",
+			ports:   []corev1.ServicePort{{Protocol: corev1.ProtocolTCP, Port: 80}},
+			svcConf: &serviceConfig{xForwardedFor: true},
+			currentListeners: []listeners.Listener{{
+				ID: "tcp", Protocol: string(listeners.ProtocolTCP), ProtocolPort: 80,
+			}},
+			wantErr: true,
+		},
+		{
+			name: "all ports are validated before replacements are returned",
+			ports: []corev1.ServicePort{
+				{Protocol: corev1.ProtocolTCP, Port: 80},
+				{Protocol: corev1.ProtocolTCP, Port: 81},
+			},
+			svcConf: &serviceConfig{xForwardedFor: true},
+			currentListeners: []listeners.Listener{
+				{ID: "owned-tcp", Protocol: string(listeners.ProtocolTCP), ProtocolPort: 80, Tags: []string{lbName}},
+				{ID: "foreign-tcp", Protocol: string(listeners.ProtocolTCP), ProtocolPort: 81, Tags: []string{"other-lb"}},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &corev1.Service{Spec: corev1.ServiceSpec{Ports: tt.ports}}
+			actual, err := planListenerReplacements(service, tt.svcConf, tt.currentListeners, tt.isLBOwner, lbName)
+			if tt.wantErr {
+				assert.ErrorContains(t, err, "already exists")
+				assert.Nil(t, actual)
+				return
+			}
+
+			assert.NoError(t, err)
+			actualIDs := make([]string, 0, len(actual))
+			for _, listener := range actual {
+				actualIDs = append(actualIDs, listener.ID)
+			}
+			assert.ElementsMatch(t, tt.expectedIDs, actualIDs)
 		})
 	}
 }
@@ -882,14 +1192,12 @@ func Test_buildPoolCreateOpt(t *testing.T) {
 			args: args{
 				protocol: "TCP",
 				svcConf: &serviceConfig{
-					xForwardedFor:        true,
-					tlsContainerRef:      "tls-container-ref",
 					proxyProtocolVersion: ptr.To(pools.ProtocolPROXY),
 				},
 				lbaasV2: &LbaasV2{
 					LoadBalancer{
 						opts: LoadBalancerOpts{
-							LBProvider: "ovn",
+							LBProvider: "amphora",
 							LBMethod:   "SOURCE_IP_PORT",
 						},
 					},
@@ -911,15 +1219,11 @@ func Test_buildPoolCreateOpt(t *testing.T) {
 			name: "test for pool protocol http with proxy protocol disabled",
 			args: args{
 				protocol: "HTTP",
-				svcConf: &serviceConfig{
-					xForwardedFor:        true,
-					tlsContainerRef:      "tls-container-ref",
-					proxyProtocolVersion: nil,
-				},
+				svcConf:  &serviceConfig{},
 				lbaasV2: &LbaasV2{
 					LoadBalancer{
 						opts: LoadBalancerOpts{
-							LBProvider: "ovn",
+							LBProvider: "amphora",
 							LBMethod:   "SOURCE_IP_PORT",
 						},
 					},
@@ -938,18 +1242,16 @@ func Test_buildPoolCreateOpt(t *testing.T) {
 			},
 		},
 		{
-			name: "test for pool protocol UDP with proxy protocol disabled",
+			name: "test for X-Forwarded headers forcing the pool protocol to HTTP",
 			args: args{
-				protocol: "UDP",
+				protocol: "TCP",
 				svcConf: &serviceConfig{
-					xForwardedFor:        true,
-					tlsContainerRef:      "tls-container-ref",
-					proxyProtocolVersion: nil,
+					xForwardedFor: true,
 				},
 				lbaasV2: &LbaasV2{
 					LoadBalancer{
 						opts: LoadBalancerOpts{
-							LBProvider: "ovn",
+							LBProvider: "amphora",
 							LBMethod:   "SOURCE_IP_PORT",
 						},
 					},
@@ -961,7 +1263,7 @@ func Test_buildPoolCreateOpt(t *testing.T) {
 				},
 			},
 			want: pools.CreateOpts{
-				Name:        "test for pool protocol UDP with proxy protocol disabled",
+				Name:        "test for X-Forwarded headers forcing the pool protocol to HTTP",
 				Protocol:    pools.ProtocolHTTP,
 				LBMethod:    "SOURCE_IP_PORT",
 				Persistence: &pools.SessionPersistence{Type: "SOURCE_IP"},
@@ -970,15 +1272,12 @@ func Test_buildPoolCreateOpt(t *testing.T) {
 		{
 			name: "test for session affinity none",
 			args: args{
-				protocol: "TCP",
-				svcConf: &serviceConfig{
-					xForwardedFor:   true,
-					tlsContainerRef: "tls-container-ref",
-				},
+				protocol: "HTTP",
+				svcConf:  &serviceConfig{},
 				lbaasV2: &LbaasV2{
 					LoadBalancer{
 						opts: LoadBalancerOpts{
-							LBProvider: "ovn",
+							LBProvider: "amphora",
 							LBMethod:   "SOURCE_IP_PORT",
 						},
 					},
@@ -999,15 +1298,12 @@ func Test_buildPoolCreateOpt(t *testing.T) {
 		{
 			name: "test for session affinity client ip",
 			args: args{
-				protocol: "TCP",
-				svcConf: &serviceConfig{
-					xForwardedFor:   true,
-					tlsContainerRef: "tls-container-ref",
-				},
+				protocol: "HTTP",
+				svcConf:  &serviceConfig{},
 				lbaasV2: &LbaasV2{
 					LoadBalancer{
 						opts: LoadBalancerOpts{
-							LBProvider: "ovn",
+							LBProvider: "amphora",
 							LBMethod:   "SOURCE_IP_PORT",
 						},
 					},
@@ -1030,14 +1326,12 @@ func Test_buildPoolCreateOpt(t *testing.T) {
 			args: args{
 				protocol: "TCP",
 				svcConf: &serviceConfig{
-					xForwardedFor:        true,
-					tlsContainerRef:      "tls-container-ref",
 					proxyProtocolVersion: ptr.To(pools.ProtocolPROXYV2),
 				},
 				lbaasV2: &LbaasV2{
 					LoadBalancer{
 						opts: LoadBalancerOpts{
-							LBProvider: "ovn",
+							LBProvider: "amphora",
 							LBMethod:   "SOURCE_IP_PORT",
 						},
 					},
@@ -2320,7 +2614,7 @@ func TestBuildListenerCreateOpt(t *testing.T) {
 			},
 		},
 		{
-			name: "Test with TLSContainerRef but without X-Forwarded-For",
+			name: "Test with TLSContainerRef and X-Forwarded-Proto",
 			port: corev1.ServicePort{
 				Protocol: "TCP",
 				Port:     443,
@@ -2329,10 +2623,31 @@ func TestBuildListenerCreateOpt(t *testing.T) {
 				connLimit:       100,
 				lbName:          "my-lb",
 				tlsContainerRef: "tls-container-ref",
-				xForwardedFor:   false,
+				xForwardedProto: true,
 			},
 			expectedCreateOpt: listeners.CreateOpts{
-				Name:                   "Test with TLSContainerRef but without X-Forwarded-For",
+				Name:                   "Test with TLSContainerRef and X-Forwarded-Proto",
+				Protocol:               listeners.ProtocolTerminatedHTTPS,
+				ProtocolPort:           443,
+				ConnLimit:              &svcConf.connLimit,
+				DefaultTlsContainerRef: "tls-container-ref",
+				InsertHeaders:          map[string]string{"X-Forwarded-Proto": "true"},
+				Tags:                   nil,
+			},
+		},
+		{
+			name: "Test with TLSContainerRef but without X-Forwarded-*",
+			port: corev1.ServicePort{
+				Protocol: "TCP",
+				Port:     443,
+			},
+			svcConf: &serviceConfig{
+				connLimit:       100,
+				lbName:          "my-lb",
+				tlsContainerRef: "tls-container-ref",
+			},
+			expectedCreateOpt: listeners.CreateOpts{
+				Name:                   "Test with TLSContainerRef but without X-Forwarded-*",
 				Protocol:               listeners.ProtocolTerminatedHTTPS,
 				ProtocolPort:           443,
 				ConnLimit:              &svcConf.connLimit,
@@ -2382,6 +2697,27 @@ func TestBuildListenerCreateOpt(t *testing.T) {
 				ProtocolPort:  80,
 				ConnLimit:     &svcConf.connLimit,
 				InsertHeaders: map[string]string{"X-Forwarded-For": "true"},
+				Tags:          nil,
+			},
+		},
+		{
+			name: "Test with Protocol forced to HTTP with X-Forwarded-Port",
+			port: corev1.ServicePort{
+				Protocol: "TCP",
+				Port:     80,
+			},
+			svcConf: &serviceConfig{
+				connLimit:       100,
+				lbName:          "my-lb",
+				xForwardedPort:  true,
+				tlsContainerRef: "",
+			},
+			expectedCreateOpt: listeners.CreateOpts{
+				Name:          "Test with Protocol forced to HTTP with X-Forwarded-Port",
+				Protocol:      listeners.ProtocolHTTP,
+				ProtocolPort:  80,
+				ConnLimit:     &svcConf.connLimit,
+				InsertHeaders: map[string]string{"X-Forwarded-Port": "true"},
 				Tags:          nil,
 			},
 		},
@@ -2482,6 +2818,174 @@ func TestBuildListenerCreateOpt(t *testing.T) {
 			createOpt := lbaas.buildListenerCreateOpt(context.TODO(), tc.port, tc.svcConf, tc.name)
 			assert.Equal(t, tc.expectedCreateOpt, createOpt)
 
+		})
+	}
+}
+
+func TestBuildXForwardedHeaders(t *testing.T) {
+	tests := []struct {
+		name     string
+		svcConf  *serviceConfig
+		expected map[string]string
+	}{
+		{
+			name:     "all annotations disabled",
+			svcConf:  &serviceConfig{},
+			expected: nil,
+		},
+		{
+			name:     "X-Forwarded-For enabled",
+			svcConf:  &serviceConfig{xForwardedFor: true},
+			expected: map[string]string{xForwardedForHeader: "true"},
+		},
+		{
+			name:     "X-Forwarded-Port enabled",
+			svcConf:  &serviceConfig{xForwardedPort: true},
+			expected: map[string]string{xForwardedPortHeader: "true"},
+		},
+		{
+			name:     "X-Forwarded-Proto enabled",
+			svcConf:  &serviceConfig{xForwardedProto: true},
+			expected: map[string]string{xForwardedProtoHeader: "true"},
+		},
+		{
+			name: "all annotations enabled",
+			svcConf: &serviceConfig{
+				xForwardedFor:   true,
+				xForwardedPort:  true,
+				xForwardedProto: true,
+			},
+			expected: map[string]string{
+				xForwardedForHeader:   "true",
+				xForwardedPortHeader:  "true",
+				xForwardedProtoHeader: "true",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, buildXForwardedHeaders(tt.svcConf))
+		})
+	}
+}
+
+func TestReconcileXForwardedHeaders(t *testing.T) {
+	tests := []struct {
+		name           string
+		currentHeaders map[string]string
+		desiredHeaders map[string]string
+		expected       map[string]string
+		changed        bool
+	}{
+		{
+			name:           "no headers and all annotations disabled",
+			currentHeaders: nil,
+			desiredHeaders: nil,
+			expected:       nil,
+			changed:        false,
+		},
+		{
+			name:           "empty headers and all annotations disabled",
+			currentHeaders: map[string]string{},
+			desiredHeaders: nil,
+			expected:       map[string]string{},
+			changed:        false,
+		},
+		{
+			name:           "add X-Forwarded-For",
+			desiredHeaders: map[string]string{xForwardedForHeader: "true"},
+			expected:       map[string]string{xForwardedForHeader: "true"},
+			changed:        true,
+		},
+		{
+			name:           "add X-Forwarded-Port",
+			desiredHeaders: map[string]string{xForwardedPortHeader: "true"},
+			expected:       map[string]string{xForwardedPortHeader: "true"},
+			changed:        true,
+		},
+		{
+			name:           "add X-Forwarded-Proto",
+			desiredHeaders: map[string]string{xForwardedProtoHeader: "true"},
+			expected:       map[string]string{xForwardedProtoHeader: "true"},
+			changed:        true,
+		},
+		{
+			name:           "remove X-Forwarded-For",
+			currentHeaders: map[string]string{xForwardedForHeader: "true"},
+			expected:       map[string]string{},
+			changed:        true,
+		},
+		{
+			name:           "remove X-Forwarded-Port",
+			currentHeaders: map[string]string{xForwardedPortHeader: "true"},
+			expected:       map[string]string{},
+			changed:        true,
+		},
+		{
+			name:           "remove X-Forwarded-Proto",
+			currentHeaders: map[string]string{xForwardedProtoHeader: "true"},
+			expected:       map[string]string{},
+			changed:        true,
+		},
+		{
+			name: "add and remove multiple headers",
+			currentHeaders: map[string]string{
+				xForwardedForHeader:  "true",
+				xForwardedPortHeader: "true",
+			},
+			desiredHeaders: map[string]string{
+				xForwardedPortHeader:  "true",
+				xForwardedProtoHeader: "true",
+			},
+			expected: map[string]string{
+				xForwardedPortHeader:  "true",
+				xForwardedProtoHeader: "true",
+			},
+			changed: true,
+		},
+		{
+			name: "preserve unrelated headers during in-place reconciliation",
+			currentHeaders: map[string]string{
+				"X-SSL-Client-Verify": "true",
+				xForwardedForHeader:   "true",
+			},
+			desiredHeaders: map[string]string{xForwardedProtoHeader: "true"},
+			expected: map[string]string{
+				"X-SSL-Client-Verify": "true",
+				xForwardedProtoHeader: "true",
+			},
+			changed: true,
+		},
+		{
+			name: "unchanged headers are a no-op",
+			currentHeaders: map[string]string{
+				"X-SSL-Client-Verify": "true",
+				xForwardedPortHeader:  "true",
+			},
+			desiredHeaders: map[string]string{xForwardedPortHeader: "true"},
+			expected: map[string]string{
+				"X-SSL-Client-Verify": "true",
+				xForwardedPortHeader:  "true",
+			},
+			changed: false,
+		},
+		{
+			name:           "remove a disabled managed header value",
+			currentHeaders: map[string]string{xForwardedForHeader: "false"},
+			expected:       map[string]string{},
+			changed:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalHeaders := maps.Clone(tt.currentHeaders)
+			actual, changed := reconcileXForwardedHeaders(tt.currentHeaders, tt.desiredHeaders)
+
+			assert.Equal(t, tt.expected, actual)
+			assert.Equal(t, tt.changed, changed)
+			assert.Equal(t, originalHeaders, tt.currentHeaders, "current headers must not be mutated")
 		})
 	}
 }

--- a/pkg/util/openstack/loadbalancer.go
+++ b/pkg/util/openstack/loadbalancer.go
@@ -46,6 +46,7 @@ const (
 	OctaviaFeatureTimeout           = 3
 	OctaviaFeatureAvailabilityZones = 4
 	OctaviaFeatureHTTPMonitorsOnUDP = 5
+	OctaviaFeatureXForwardedProto   = 6
 
 	waitLoadbalancerInitDelay   = 1 * time.Second
 	waitLoadbalancerFactor      = 1.2
@@ -143,6 +144,14 @@ func IsOctaviaFeatureSupported(ctx context.Context, client *gophercloud.ServiceC
 		}
 		verHTTPMonitorsOnUDP, _ := version.NewVersion("v2.16")
 		if currentVer.GreaterThanOrEqual(verHTTPMonitorsOnUDP) {
+			return true
+		}
+	case OctaviaFeatureXForwardedProto:
+		if lbProvider == "ovn" {
+			return false
+		}
+		verXForwardedProto, _ := version.NewVersion("v2.1")
+		if currentVer.GreaterThanOrEqual(verXForwardedProto) {
 			return true
 		}
 	default:

--- a/tests/e2e/cloudprovider/test-lb-service.sh
+++ b/tests/e2e/cloudprovider/test-lb-service.sh
@@ -283,13 +283,19 @@ EOF
 
 ########################################################################
 ## Name: test_forwarded
-## Desc: Create a k8s service that gets the original client IP
+## Desc: Create a k8s service that adds the X-Forwarded headers
 ## Params: None
 ########################################################################
 function test_forwarded {
-    local service="test-x-forwarded-for"
-    local public_ip=$(curl -sS ifconfig.me)
-    local local_ip=$(ip route get 8.8.8.8 | head -1 | awk '{print $7}')
+    local service="test-x-forwarded-headers"
+    local public_ip
+    local local_ip
+    local response
+    local ip_in_header
+    local port_in_header
+    local proto_in_header
+    public_ip=$(curl -sS ifconfig.me)
+    local_ip=$(ip route get 8.8.8.8 | head -1 | awk '{print $7}')
 
     if [[ ${OCTAVIA_PROVIDER} == "ovn" ]]; then
         printf "\n>>>>>>> Skipping Service ${service} test for OVN provider\n"
@@ -305,6 +311,8 @@ metadata:
   namespace: $NAMESPACE
   annotations:
     loadbalancer.openstack.org/x-forwarded-for: "true"
+    loadbalancer.openstack.org/x-forwarded-port: "true"
+    loadbalancer.openstack.org/x-forwarded-proto: "true"
 spec:
   type: LoadBalancer
   loadBalancerIP: ${FLOATING_IP}
@@ -321,14 +329,26 @@ EOF
     wait_address_accessible $ipaddr
 
     printf "\n>>>>>>> Sending request to the Service ${service}\n"
-    ip_in_header=$(curl -sS http://${ipaddr} | grep  x-forwarded-for | awk -F'=' '{print $2}')
+    response=$(curl -sS http://${ipaddr})
+    ip_in_header=$(printf '%s\n' "${response}" | grep x-forwarded-for | awk -F'=' '{print $2}')
+    port_in_header=$(printf '%s\n' "${response}" | grep x-forwarded-port | awk -F'=' '{print $2}')
+    proto_in_header=$(printf '%s\n' "${response}" | grep x-forwarded-proto | awk -F'=' '{print $2}')
     if [[ "${ip_in_header}" != "${local_ip}" && "${ip_in_header}" != "${public_ip}" && "${ip_in_header}" != "${GATEWAY_IP}" ]]; then
         printf "\n>>>>>>> FAIL: Get incorrect response from Service ${service}, ip_in_header: ${ip_in_header}, local_ip: ${local_ip}, gateway_ip: ${GATEWAY_IP}, public_ip: ${public_ip}\n"
-        curl -sS http://${ipaddr}
+        printf '%s\n' "${response}"
         exit 1
-    else
-        printf "\n>>>>>>> Expected: Get correct response from Service ${service}\n"
     fi
+    if [[ "${port_in_header}" != "80" ]]; then
+        printf "\n>>>>>>> FAIL: Get incorrect response from Service ${service}, port_in_header: ${port_in_header}, expected: 80\n"
+        printf '%s\n' "${response}"
+        exit 1
+    fi
+    if [[ "${proto_in_header}" != "http" ]]; then
+        printf "\n>>>>>>> FAIL: Get incorrect response from Service ${service}, proto_in_header: ${proto_in_header}, expected: http\n"
+        printf '%s\n' "${response}"
+        exit 1
+    fi
+    printf "\n>>>>>>> Expected: Get correct response from Service ${service}\n"
 
     printf "\n>>>>>>> Delete Service ${service}\n"
     kubectl -n $NAMESPACE delete service ${service}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This PR adds support for the `x-forwarded-port` and `x-forwarded-proto` Service annotations in cloud-provider-openstack (OCCM).

OCCM already supports the `loadbalancer.openstack.org/x-forwarded-for` Service annotation, and this PR extends octavia listener header insertion with two independent annotations below:

- `loadbalancer.openstack.org/x-forwarded-port` adds `X-Forwarded-Port` containing the listener port on which the request was received.
- `loadbalancer.openstack.org/x-forwarded-proto` adds `X-Forwarded-Proto`, using `http` for an `HTTP` listener and `https` for a `TERMINATED_HTTPS` listener.

also, `X-Forwarded-Proto` requires Octavia API version 2.1 or later.

listener updates now reconcile only the three OCCM managed X-Forwarded headers. unrelated existing `insert_headers` entries are preserved, and no Octavia update is sent when the headers already match.


**Which issue this PR fixes(if applicable)**:
fixes #3034 

**Special notes for reviewers**:

- Existing `X-Forwarded-For` feature is preserved for supported TCP configurations.
- The three `X-Forwarded-*` annotations can be enabled and disabled independently.
- All Service ports must use TCP.
- X-Forwarded-* annotations cannot be combined with the proxy protocol annotation.
- The annotations are supported by the Amphora provider **but not by OVN**. Other provider-driver support depends on the driver.
- Unsupported existing `X-Forwarded-For` configurations, such as OVN or non-TCP Services, now fail validation before octavia resources are modified.

Enabling the first `X-Forwarded-*` annotation on a non-TLS Service changes the listener protocol from TCP to HTTP. Disabling the last annotation changes it back to TCP. thats because Octavia listener protocols are immutable, so OCCM replaces the Service owned listener and its childern resources while retaining the load balancer and vip. 
This replacement may cause a brief interruption.

The commits are organized for sequential review, 1. feature implementation and listener reconciliation, 2. unit and e2e tests, 3. documentation.

test coverage includes independent and combined header changes, annotation disablement, no-op reconciliation, unrelated-header preservation, provider/protocol validation, and TCP/HTTP listener replacement.

**Release note**:

```release-note
[openstack-cloud-controller-manager] Add `loadbalancer.openstack.org/x-forwarded-port` and `loadbalancer.openstack.org/x-forwarded-proto` Service annotations for Octavia load balancers.
```
