### PR TITLE
feat(openstack-cloud-controller-manager): add option to change deployment type

### DIFF
--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: DaemonSet
+kind: {{ .Values.controllerKind }}
 metadata:
   name: {{ include "occm.name" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
@@ -12,8 +12,14 @@ spec:
   selector:
     matchLabels:
       {{- include "occm.controllermanager.matchLabels" . | nindent 6 }}
+  {{- if eq .Values.controllerKind "Deployment" }}
+  replicas: {{ .Values.controllerReplicas }}
+  strategy:
+    type: RollingUpdate
+  {{- else }}
   updateStrategy:
     type: RollingUpdate
+  {{- end }}
   template:
     metadata:
       annotations:
@@ -26,9 +32,16 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if eq .Values.controllerKind "Deployment" }}
+      {{- with .Values.deploymentNodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- else }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.podSecurityContext }}
       securityContext:

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -2,6 +2,14 @@
 #
 # Define deployment mode for the controller and provide cloud credentials in cloudConfig at the end of the file
 #
+# Controller kind: DaemonSet or Deployment
+# Use DaemonSet to run on all control-plane nodes (default)
+# Use Deployment to run a specific number of replicas
+controllerKind: DaemonSet
+
+# Number of replicas (only used when controllerKind is Deployment)
+controllerReplicas: 2
+
 ## Annotations to apply to all resources
 commonAnnotations: {}
 # commonAnnotations:
@@ -48,9 +56,13 @@ readinessProbe: {}
 
 dnsPolicy: ClusterFirst
 
-# Set nodeSelector where the controller should run, i.e. controlplane nodes
+# Set nodeSelector where the controller should run, i.e. controlplane nodes (used for DaemonSet)
 nodeSelector:
   node-role.kubernetes.io/control-plane: ""
+
+# Set nodeSelector for Deployment (used when controllerKind is Deployment)
+# Defaults to empty (no node restriction)
+deploymentNodeSelector: {}
 
 # Set tolerations for nodes where the controller should run, i.e. node
 # should be uninitialized, controlplane...


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows the user to choose between DaemonSet and Deployment.

**Release note**:

<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
feat(openstack-cloud-controller-manager): allow user to choose between DaemonSet and Deployment
```
