### PR TITLE
feat(cinder-csi-plugin): add splitMode

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.36.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.36.2
+version: 2.36.3
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/ci/hostmount-values.yaml
+++ b/charts/cinder-csi-plugin/ci/hostmount-values.yaml
@@ -1,0 +1,3 @@
+secret:
+  enabled: false
+  hostMount: true

--- a/charts/cinder-csi-plugin/ci/secret-enabled-values.yaml
+++ b/charts/cinder-csi-plugin/ci/secret-enabled-values.yaml
@@ -1,0 +1,8 @@
+secret:
+  enabled: true
+  create: true
+  name: cinder-csi-cloud-config
+  data:
+    cloud.conf: |
+      [Global]
+      auth-url=http://openstack-control-plane

--- a/charts/cinder-csi-plugin/templates/cinder-csi-driver.yaml
+++ b/charts/cinder-csi-plugin/templates/cinder-csi-driver.yaml
@@ -1,3 +1,4 @@
+{{- if or (not .Values.splitMode.enabled) (eq .Values.splitMode.type "workload") }}
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
@@ -8,3 +9,4 @@ spec:
   volumeLifecycleModes:
   - Persistent
   - Ephemeral
+{{- end }}

--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if or (not .Values.splitMode.enabled) (eq .Values.splitMode.type "management") }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -10,7 +11,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  replicas: {{ .Values.csi.plugin.controllerPlugin.replicas }}
+  replicas: {{ and .Values.splitMode.enabled (eq .Values.splitMode.type "management") | ternary .Values.splitMode.replicas .Values.csi.plugin.controllerPlugin.replicas }}
   strategy:
     type: {{ .Values.csi.plugin.controllerPlugin.strategy.type }}
 {{- if eq .Values.csi.plugin.controllerPlugin.strategy.type "RollingUpdate" }}
@@ -28,7 +29,11 @@ spec:
       annotations:
         {{- include "cinder-csi.controllerplugin.podAnnotations" . | nindent 8 }}
     spec:
-      serviceAccount: csi-cinder-controller-sa
+      {{- if .Values.splitMode.enabled }}
+      automountServiceAccountToken: false
+      {{- else }}
+      serviceAccountName: csi-cinder-controller-sa
+      {{- end }}
       securityContext:
         {{- toYaml .Values.csi.plugin.controllerPlugin.podSecurityContext | nindent 8 }}
       containers:
@@ -43,6 +48,9 @@ spec:
             - "--timeout={{ .Values.timeout }}"
             - "--leader-election=true"
             - "--default-fstype=ext4"
+            {{- if and .Values.splitMode.enabled (eq .Values.splitMode.type "management") }}
+            - "--kubeconfig=/etc/kubernetes/kubeconfig"
+            {{- end }}
             {{- if .Values.csi.attacher.extraArgs }}
             {{- with .Values.csi.attacher.extraArgs }}
             {{- tpl . $ | trim | nindent 12 }}
@@ -57,6 +65,11 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+            {{- if and .Values.splitMode.enabled (eq .Values.splitMode.type "management") }}
+            - name: kubeconfig
+              mountPath: /etc/kubernetes
+              readOnly: true
+            {{- end }}
           resources: {{ toYaml .Values.csi.attacher.resources | nindent 12 }}
         - name: csi-provisioner
           securityContext:
@@ -71,6 +84,9 @@ spec:
             - "--default-fstype=ext4"
             - "--feature-gates=Topology={{ .Values.csi.provisioner.topology }}"
             - "--extra-create-metadata"
+            {{- if and .Values.splitMode.enabled (eq .Values.splitMode.type "management") }}
+            - "--kubeconfig=/etc/kubernetes/kubeconfig"
+            {{- end }}
             {{- if .Values.csi.provisioner.extraArgs }}
             {{- with .Values.csi.provisioner.extraArgs }}
             {{- tpl . $ | trim | nindent 12 }}
@@ -85,6 +101,11 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+            {{- if and .Values.splitMode.enabled (eq .Values.splitMode.type "management") }}
+            - name: kubeconfig
+              mountPath: /etc/kubernetes
+              readOnly: true
+            {{- end }}
           resources: {{ toYaml .Values.csi.provisioner.resources | nindent 12 }}
         {{- if dig "enabled" true .Values.csi.snapshotter }}
         - name: csi-snapshotter
@@ -97,6 +118,9 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--timeout={{ .Values.timeout }}"
             - "--leader-election=true"
+            {{- if and .Values.splitMode.enabled (eq .Values.splitMode.type "management") }}
+            - "--kubeconfig=/etc/kubernetes/kubeconfig"
+            {{- end }}
             {{- if .Values.csi.snapshotter.extraArgs }}
             {{- with .Values.csi.snapshotter.extraArgs }}
             {{- tpl . $ | trim | nindent 12 }}
@@ -111,6 +135,11 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
+            {{- if and .Values.splitMode.enabled (eq .Values.splitMode.type "management") }}
+            - name: kubeconfig
+              mountPath: /etc/kubernetes
+              readOnly: true
+            {{- end }}
           resources: {{ toYaml .Values.csi.snapshotter.resources | nindent 12 }}
         {{- end }}
         - name: csi-resizer
@@ -124,6 +153,9 @@ spec:
             - "--timeout={{ .Values.timeout }}"
             - "--handle-volume-inuse-error=false"
             - "--leader-election=true"
+            {{- if and .Values.splitMode.enabled (eq .Values.splitMode.type "management") }}
+            - "--kubeconfig=/etc/kubernetes/kubeconfig"
+            {{- end }}
             {{- if .Values.csi.resizer.extraArgs }}
             {{- with .Values.csi.resizer.extraArgs }}
             {{- tpl . $ | trim | nindent 12 }}
@@ -138,6 +170,11 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+            {{- if and .Values.splitMode.enabled (eq .Values.splitMode.type "management") }}
+            - name: kubeconfig
+              mountPath: /etc/kubernetes
+              readOnly: true
+            {{- end }}
           resources: {{ toYaml .Values.csi.resizer.resources | nindent 12 }}
         - name: liveness-probe
           securityContext:
@@ -223,7 +260,12 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
-          {{- with .Values.csi.plugin.volumeMounts }}
+          {{- if or .Values.secret.enabled .Values.secret.hostMount }}
+            - name: cloud-config
+              mountPath: {{ .Values.secret.path }}
+              readOnly: true
+          {{- end }}
+          {{- with .Values.splitMode.enabled | ternary .Values.splitMode.volumeMounts .Values.csi.plugin.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           resources: {{ toYaml .Values.csi.plugin.resources | nindent 12 }}
@@ -239,11 +281,19 @@ spec:
           hostPath:
             path: /etc/config
         {{- end }}
-        {{- with .Values.csi.plugin.volumes }}
+        {{- with .Values.splitMode.enabled | ternary .Values.splitMode.volumes .Values.csi.plugin.volumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if and .Values.splitMode.enabled (eq .Values.splitMode.type "management") }}
+        - name: kubeconfig
+          secret:
+            secretName: {{ .Values.splitMode.kubeconfig.secretName }}
+            items:
+              - key: {{ .Values.splitMode.kubeconfig.secretKey }}
+                path: kubeconfig
+        {{- end }}
       affinity: {{ toYaml .Values.csi.plugin.controllerPlugin.affinity | nindent 8 }}
-      nodeSelector: {{ toYaml .Values.csi.plugin.controllerPlugin.nodeSelector | nindent 8 }}
+      nodeSelector: {{ toYaml (and .Values.splitMode.enabled (eq .Values.splitMode.type "management") | ternary .Values.splitMode.nodeSelector .Values.csi.plugin.controllerPlugin.nodeSelector) | nindent 8 }}
       tolerations: {{ toYaml .Values.csi.plugin.controllerPlugin.tolerations | nindent 8 }}
       {{- with .Values.csi.plugin.controllerPlugin.hostAliases }}
       hostAliases:
@@ -256,3 +306,4 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+{{- end }}

--- a/charts/cinder-csi-plugin/templates/controllerplugin-podmonitor.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-podmonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.csi.plugin.podMonitor.enabled }}
+{{- if and (or (not .Values.splitMode.enabled) (eq .Values.splitMode.type "management")) .Values.csi.plugin.podMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-rbac.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-rbac.yaml
@@ -1,12 +1,15 @@
+{{- if or (not .Values.splitMode.enabled) (eq .Values.splitMode.type "workload") }}
 # This YAML file contains RBAC API objects,
 # which are necessary to run csi controller plugin
 
+{{- if not .Values.splitMode.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: csi-cinder-controller-sa
   namespace: {{ .Release.Namespace }}
 ---
+{{- end }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -33,9 +36,15 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-attacher-binding
 subjects:
+  {{- if and .Values.splitMode.enabled (eq .Values.splitMode.type "workload") }}
+  - kind: User
+    name: {{ .Values.splitMode.subject.name }}
+    apiGroup: rbac.authorization.k8s.io
+  {{- else }}
   - kind: ServiceAccount
     name: csi-cinder-controller-sa
     namespace: {{ .Release.Namespace }}
+  {{- end }}
 roleRef:
   kind: ClusterRole
   name: csi-attacher-role
@@ -80,9 +89,15 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-provisioner-binding
 subjects:
+  {{- if and .Values.splitMode.enabled (eq .Values.splitMode.type "workload") }}
+  - kind: User
+    name: {{ .Values.splitMode.subject.name }}
+    apiGroup: rbac.authorization.k8s.io
+  {{- else }}
   - kind: ServiceAccount
     name: csi-cinder-controller-sa
     namespace: {{ .Release.Namespace }}
+  {{- end }}
 roleRef:
   kind: ClusterRole
   name: csi-provisioner-role
@@ -119,9 +134,15 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-snapshotter-binding
 subjects:
+  {{- if and .Values.splitMode.enabled (eq .Values.splitMode.type "workload") }}
+  - kind: User
+    name: {{ .Values.splitMode.subject.name }}
+    apiGroup: rbac.authorization.k8s.io
+  {{- else }}
   - kind: ServiceAccount
     name: csi-cinder-controller-sa
     namespace: {{ .Release.Namespace }}
+  {{- end }}
 roleRef:
   kind: ClusterRole
   name: csi-snapshotter-role
@@ -160,11 +181,17 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-resizer-binding
 subjects:
+  {{- if and .Values.splitMode.enabled (eq .Values.splitMode.type "workload") }}
+  - kind: User
+    name: {{ .Values.splitMode.subject.name }}
+    apiGroup: rbac.authorization.k8s.io
+  {{- else }}
   - kind: ServiceAccount
     name: csi-cinder-controller-sa
     namespace: {{ .Release.Namespace }}
+  {{- end }}
 roleRef:
   kind: ClusterRole
   name: csi-resizer-role
   apiGroup: rbac.authorization.k8s.io
----
+{{- end }}

--- a/charts/cinder-csi-plugin/templates/custom_storageclass.yaml
+++ b/charts/cinder-csi-plugin/templates/custom_storageclass.yaml
@@ -1,3 +1,3 @@
-{{- if .Values.storageClass.custom -}}
+{{- if and .Values.storageClass.custom (or (not .Values.splitMode.enabled) (eq .Values.splitMode.type "workload")) -}}
 {{ .Values.storageClass.custom }}
 {{- end }}

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if or (not .Values.splitMode.enabled) (eq .Values.splitMode.type "workload") }}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -20,7 +21,7 @@ spec:
       annotations:
         {{- include "cinder-csi.nodeplugin.podAnnotations" . | nindent 8 }}
     spec:
-      serviceAccount: csi-cinder-node-sa
+      serviceAccountName: csi-cinder-node-sa
       hostNetwork: true
       dnsPolicy: {{ .Values.csi.plugin.nodePlugin.dnsPolicy }}
       securityContext:
@@ -133,7 +134,12 @@ spec:
             - name: pods-probe-dir
               mountPath: /dev
               mountPropagation: "HostToContainer"
-          {{- with .Values.csi.plugin.volumeMounts }}
+          {{- if or .Values.secret.enabled .Values.secret.hostMount }}
+            - name: cloud-config
+              mountPath: {{ .Values.secret.path }}
+              readOnly: true
+          {{- end }}
+          {{- with .Values.splitMode.enabled | ternary .Values.splitMode.volumeMounts .Values.csi.plugin.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           resources: {{ toYaml .Values.csi.plugin.resources | nindent 12 }}
@@ -167,7 +173,7 @@ spec:
           hostPath:
             path: /etc/config
         {{- end }}
-        {{- with .Values.csi.plugin.volumes }}
+        {{- with .Values.splitMode.enabled | ternary .Values.splitMode.volumes .Values.csi.plugin.volumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
       affinity: {{ toYaml .Values.csi.plugin.nodePlugin.affinity | nindent 8 }}
@@ -184,3 +190,4 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+{{- end }}

--- a/charts/cinder-csi-plugin/templates/nodeplugin-rbac.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if or (not .Values.splitMode.enabled) (eq .Values.splitMode.type "workload") }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -26,3 +27,4 @@ roleRef:
   kind: ClusterRole
   name: csi-nodeplugin-role
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/cinder-csi-plugin/templates/storageclass.yaml
+++ b/charts/cinder-csi-plugin/templates/storageclass.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.storageClass.enabled }}
+{{- if and .Values.storageClass.enabled (or (not .Values.splitMode.enabled) (eq .Values.splitMode.type "workload")) }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -86,9 +86,6 @@ csi:
       - name: cacert
         mountPath: /etc/cacert
         readOnly: true
-      - name: cloud-config
-        mountPath: /etc/config
-        readOnly: true
     nodePlugin:
       dnsPolicy: ClusterFirstWithHostNet
       # Optional additional annotations to add to the nodePlugin Pods.
@@ -181,6 +178,7 @@ secret:
   hostMount: true
   create: false
   filename: cloud.conf
+  path: /etc/config
 #  name: cinder-csi-cloud-config
 #  data:
 #    cloud.conf: |-
@@ -234,3 +232,24 @@ imagePullSecrets: []
 
 # add annotations to all pods, deployment, daemonset and podmonitor
 commonAnnotations: {}
+
+# External mode for split-cluster deployments (e.g., Cluster API)
+# When disabled, deploys both controller and node plugin with standard RBAC
+splitMode:
+  enabled: false
+  # type: "management" - Deploy controller with external kubeconfig (management cluster)
+  # type: "workload" - Deploy node plugin with RBAC for external controller (workload cluster)
+  type: ""
+  # Management cluster settings (type: management)
+  kubeconfig:
+    secretName: ""
+    secretKey: value
+  replicas: 1
+  nodeSelector: {}
+  # Workload cluster settings (type: workload)
+  # The User subject name for controller RBAC (identity of external controller)
+  subject:
+    name: cinder-csi-controller
+  # Volumes and volumeMounts for splitMode (overrides csi.plugin.volumes/volumeMounts)
+  volumes: []
+  volumeMounts: []


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows the user to deploy the controller-manager split between the
management cluster and the workload cluster.

That way one can keep all openstack credentials out of the workload cluster.

**Release note**:

<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
[cinder-csi-controller-manager] Allow deploying the controller-manager split between management and workload clusters.
```
