### PR TITLE
[cinder-csi-plugin] Make csi-snapshotter sidecar optional

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.36.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.36.1
+version: 2.36.2
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/ci/snapshotter-disabled-values.yaml
+++ b/charts/cinder-csi-plugin/ci/snapshotter-disabled-values.yaml
@@ -1,0 +1,3 @@
+csi:
+  snapshotter:
+    enabled: false

--- a/charts/cinder-csi-plugin/ci/snapshotter-enabled-values.yaml
+++ b/charts/cinder-csi-plugin/ci/snapshotter-enabled-values.yaml
@@ -1,0 +1,3 @@
+csi:
+  snapshotter:
+    enabled: true

--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -86,6 +86,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
           resources: {{ toYaml .Values.csi.provisioner.resources | nindent 12 }}
+        {{- if dig "enabled" true .Values.csi.snapshotter }}
         - name: csi-snapshotter
           securityContext:
             {{- toYaml .Values.csi.plugin.controllerPlugin.securityContext | nindent 12 }}
@@ -111,6 +112,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
           resources: {{ toYaml .Values.csi.snapshotter.resources | nindent 12 }}
+        {{- end }}
         - name: csi-resizer
           securityContext:
             {{- toYaml .Values.csi.plugin.controllerPlugin.securityContext | nindent 12 }}

--- a/charts/cinder-csi-plugin/templates/controllerplugin-rbac.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-rbac.yaml
@@ -88,6 +88,7 @@ roleRef:
   name: csi-provisioner-role
   apiGroup: rbac.authorization.k8s.io
 
+{{- if dig "enabled" true .Values.csi.snapshotter }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -125,6 +126,7 @@ roleRef:
   kind: ClusterRole
   name: csi-snapshotter-role
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -23,6 +23,7 @@ csi:
     extraArgs: {}
     extraEnv: []
   snapshotter:
+    enabled: true
     image:
       repository: registry.k8s.io/sig-storage/csi-snapshotter
       tag: v8.4.0


### PR DESCRIPTION
The csi-snapshotter sidecar is always deployed regardless of whether VolumeSnapshot CRDs are installed. On clusters without external-snapshotter, this produces continuous error logs.

Add `csi.snapshotter.enabled` (default `true` for backward compatibility) to gate the snapshotter container and its RBAC resources. Users without CRDs can set it to `false`.

Ref #2767

```release-note
cinder-csi: Add csi.snapshotter.enabled toggle to allow disabling the csi-snapshotter sidecar when VolumeSnapshot CRDs are not installed.
```