### PR TITLE
[occm] Include cloudConfigContents in DaemonSet checksum annotation

### DIFF
--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.36.0
+version: 2.36.1
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include "cloudConfig" . | sha256sum }}
+        checksum/config: {{ print (include "cloudConfig" .) (.Values.cloudConfigContents | default "") | sha256sum }}
         {{- include "occm.controllermanager.annotations" . | nindent 8 }}
       labels:
         {{- include "occm.controllermanager.labels" . | nindent 8 }}


### PR DESCRIPTION
The DaemonSet checksum annotation only hashes the output of the `cloudConfig` template helper. When cloud config is supplied via `cloudConfigContents`, changes to it do not trigger pod restarts. Credential rotations and endpoint changes go undetected.

Include `cloudConfigContents` in the checksum input.

Ref #3030

```release-note
occm: Fix DaemonSet checksum annotation to include cloudConfigContents so that config changes trigger pod restarts.
```