### PR TITLE
[occm] Fix cloud-node-controller ClusterRoleBinding subject

### DIFF
--- a/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
+++ b/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
@@ -10,7 +10,7 @@ items:
     name: system:cloud-node-controller
   subjects:
   - kind: ServiceAccount
-    name: cloud-node-controller
+    name: cloud-controller-manager
     namespace: kube-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding


### PR DESCRIPTION
## Summary

- The `system:cloud-node-controller` ClusterRoleBinding in raw manifests was bound to a non-existent `cloud-node-controller` ServiceAccount
- The DaemonSet uses `serviceAccountName: cloud-controller-manager`, and no `cloud-node-controller` SA is defined anywhere in the repo
- Fixed the binding subject to `cloud-controller-manager` to match the actual deployment model
- This aligns the raw manifests with the Helm chart, which already binds both roles to `cloud-controller-manager`

## Test plan

- [x] Deployed raw manifests to a live cluster and verified all 3 OCCM pods are Running/Ready.
- [x] Verified both ClusterRoleBindings point to `cloud-controller-manager` SA.
- [x] Confirmed SA has correct RBAC permissions via `kubectl auth can-i`.

```release-note
Fix cloud-node-controller ClusterRoleBinding to reference the correct cloud-controller-manager ServiceAccount.
```