### PR TITLE
[occm] Tag security groups with service identifier

### DIFF
--- a/pkg/openstack/loadbalancer_sg.go
+++ b/pkg/openstack/loadbalancer_sg.go
@@ -203,6 +203,30 @@ func getRulesToCreateAndDelete(wantedRules []rules.CreateOpts, existingRules []r
 	return toCreate, toDelete
 }
 
+// ensureSecurityGroupTags ensures the security group has the proper tags for identification
+func (lbaas *LbaasV2) ensureSecurityGroupTags(ctx context.Context, sgID string, svcConf *serviceConfig) error {
+	// Tag with the same lbName as load balancers and listeners for consistency
+	// This allows querying all resources (LB, listeners, SG) for a given service
+	tag := svcConf.lbName
+
+	mc := metrics.NewMetricContext("security_group", "get")
+	sg, err := groups.Get(ctx, lbaas.network, sgID).Extract()
+	if mc.ObserveRequest(err) != nil {
+		return fmt.Errorf("failed to get security group %s: %v", sgID, err)
+	}
+
+	if !slices.Contains(sg.Tags, tag) {
+		mc := metrics.NewMetricContext("security_group_tag", "add")
+		err := neutrontags.Add(ctx, lbaas.network, "security-groups", sgID, tag).ExtractErr()
+		if mc.ObserveRequest(err) != nil {
+			return fmt.Errorf("failed to add tag %s to security group %s: %v", tag, sgID, err)
+		}
+		klog.V(4).InfoS("Tagged security group", "sgID", sgID, "tag", tag)
+	}
+
+	return nil
+}
+
 // ensureAndUpdateOctaviaSecurityGroup handles the creation and update of the security group and the securiry rules for the octavia load balancer
 func (lbaas *LbaasV2) ensureAndUpdateOctaviaSecurityGroup(ctx context.Context, clusterName string, apiService *corev1.Service, nodes []*corev1.Node, svcConf *serviceConfig) error {
 	// get service ports
@@ -235,6 +259,16 @@ func (lbaas *LbaasV2) ensureAndUpdateOctaviaSecurityGroup(ctx context.Context, c
 			return fmt.Errorf("failed to create Security Group for loadbalancer service %s/%s: %v", apiService.Namespace, apiService.Name, err)
 		}
 		lbSecGroupID = lbSecGroup.ID
+
+		// Tag the newly created security group
+		if err := lbaas.ensureSecurityGroupTags(ctx, lbSecGroupID, svcConf); err != nil {
+			klog.Warningf("Failed to tag security group %s for service %s/%s: %v", lbSecGroupID, apiService.Namespace, apiService.Name, err)
+		}
+	} else {
+		// Ensure existing security groups have tags for backward compatibility
+		if err := lbaas.ensureSecurityGroupTags(ctx, lbSecGroupID, svcConf); err != nil {
+			klog.Warningf("Failed to tag security group %s for service %s/%s: %v", lbSecGroupID, apiService.Namespace, apiService.Name, err)
+		}
 	}
 
 	mc := metrics.NewMetricContext("subnet", "get")


### PR DESCRIPTION


**What this PR does / why we need it**:

Tags security groups created by OCCM with the same identifier format as load balancers and listeners (`kube_service_{cluster}_{namespace}_{name}`).

Currently, security groups created when `manage-security-groups: true` are not tagged, making it difficult to identify which cluster owns them in multi-cluster OpenStack environments. This change adds automatic tagging to align with how load balancers and listeners are already tagged.
**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] Security groups created with manage-security-groups enabled are now tagged with the service identifier for easier identification and management```
