### PR TITLE
Remove dulek from approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,13 +3,12 @@ emeritus_approvers:
 - lingxiankong
 - ramineni
 - jichenjc
-approvers:
 - dulek
+approvers:
 - kayrus
 - stephenfin
 - zetaab
 reviewers:
-- dulek
 - kayrus
 - stephenfin
 - zetaab


### PR DESCRIPTION
**What this PR does / why we need it**:
I don't work with OpenStack or cloud providers anymore and you can clearly see that my involvement with the project is almost non-existent. This commit removes me from approvers and reviewers of the project.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:

**Release note**:
```release-note
NONE
```
