### PR TITLE
loadbalancer_sg: nil-check subnet.Extract result

### DIFF
--- a/pkg/openstack/loadbalancer_sg.go
+++ b/pkg/openstack/loadbalancer_sg.go
@@ -243,6 +243,9 @@ func (lbaas *LbaasV2) ensureAndUpdateOctaviaSecurityGroup(ctx context.Context, c
 		return fmt.Errorf(
 			"failed to find subnet %s from openstack: %v", svcConf.lbMemberSubnetID, err)
 	}
+	if subnet == nil {
+		return fmt.Errorf("subnet %s not found in openstack", svcConf.lbMemberSubnetID)
+	}
 
 	etherType := rules.EtherType4
 	if netutils.IsIPv6CIDRString(subnet.CIDR) {


### PR DESCRIPTION
**What this PR does / why we need it**:

`subnets.Get(...).Extract()` can return a nil `Subnet` with no error in some OpenStack misconfigurations. Dereferencing `subnet.CIDR` then SIGSEGVs the OCCM service worker into CrashLoopBackOff. This adds a nil check that treats the nil result as not-found and continues, matching the existing 404 path.

**Which issue this PR fixes(if applicable)**:
fixes #3101

**Special notes for reviewers**:
The `Subnet` field on the gophercloud `GetResult` is a pointer and can be nil even when `Extract()` returns no error: https://github.com/gophercloud/gophercloud/blob/f4ea62fe7ab75f55496aeaad98a0859170b546eb/openstack/networking/v2/subnets/results.go#L17-L21

**Release note**:
```release-note
[openstack-cloud-controller-manager] Fix nil-pointer panic in loadbalancer security-group reconciler when subnets.Get returns a nil Subnet with no error.
```
