### PR TITLE
Add -h / --help option to hack scripts

### DIFF
--- a/hack/release-image-digests.sh
+++ b/hack/release-image-digests.sh
@@ -14,11 +14,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# example:
-# ./release-image-digests.sh registry.k8s.io/images/k8s-staging-provider-os/images.yaml [v1.35.0] [v1.34.1]
+usage() {
+  cat <<EOF
+Usage: $0 <yaml_file> [<tag>...]
+
+Populate an image promoter manifest with content-digest-to-tag mappings for
+staged container images.
+
+The Kubernetes image promoter promotes images from staging to production using
+a manifest that maps content digests (sha256:...) to tags. This script
+automates the step of looking up those digests from the GCR staging registry
+(gcr.io/k8s-staging-provider-os) after images have been pushed, and writing
+the dmap entries into the manifest YAML.
+
+Run this after cutting a release to update the promoter manifest before opening
+the promotion PR.
+
+Arguments:
+  yaml_file   Path to the image promoter manifest, e.g.
+              registry.k8s.io/images/k8s-staging-provider-os/images.yaml
+  tag         One or more release tags to process, e.g. v1.35.0 v1.34.1.
+              If omitted, all tags already present in the manifest are used.
+
+Examples:
+  $0 registry.k8s.io/images/k8s-staging-provider-os/images.yaml v1.35.0
+  $0 registry.k8s.io/images/k8s-staging-provider-os/images.yaml v1.35.0 v1.34.1
+  $0 registry.k8s.io/images/k8s-staging-provider-os/images.yaml
+EOF
+}
+
+ARGS=$(getopt -o h --long help -n "$0" -- "$@") || { usage >&2; exit 1; }
+eval set -- "$ARGS"
+while true; do
+  case "$1" in
+    -h|--help) usage; exit 0;;
+    --) shift; break;;
+  esac
+done
 
 YAML_FILE=${1:?Usage: $0 <yaml_file> [<tag>...]}
-TAGS="${@:2}"
+shift
+TAGS="$*"
 
 # fail if file does not exist
 if [ ! -f "${YAML_FILE}" ]; then

--- a/hack/release-image-digests.sh
+++ b/hack/release-image-digests.sh
@@ -14,12 +14,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# example usage:
-# ./release-image-digests.sh registry.k8s.io/images/k8s-staging-provider-os/images.yaml v1.36.0 v1.35.0
-# will replace all instances of the v1.35.0 tag with v1.36.0
+usage() {
+  cat <<EOF
+Usage: $0 <yaml_file> [<tag>...]
+
+Populate an image promoter manifest with content-digest-to-tag mappings for
+staged container images.
+
+The Kubernetes image promoter promotes images from staging to production using
+a manifest that maps content digests (sha256:...) to tags. This script
+automates the step of looking up those digests from the GCR staging registry
+(gcr.io/k8s-staging-provider-os) after images have been pushed, and writing
+the dmap entries into the manifest YAML.
+
+Run this after cutting a release to update the promoter manifest before opening
+the promotion PR.
+
+Arguments:
+  yaml_file   Path to the image promoter manifest, e.g.
+              registry.k8s.io/images/k8s-staging-provider-os/images.yaml
+  tag         One or more release tags to process, e.g. v1.35.0 v1.34.1.
+              If omitted, all tags already present in the manifest are used.
+
+Examples:
+  $0 registry.k8s.io/images/k8s-staging-provider-os/images.yaml v1.35.0
+  $0 registry.k8s.io/images/k8s-staging-provider-os/images.yaml v1.35.0 v1.34.1
+  $0 registry.k8s.io/images/k8s-staging-provider-os/images.yaml
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0;;
+    --) shift; break;;
+    -*) echo "$0: unknown option: $1" >&2; usage >&2; exit 1;;
+    *) break;;
+  esac
+  shift
+done
 
 YAML_FILE=${1:?Usage: $0 <yaml_file> [<tag>...]}
-TAGS="${@:2}"
+shift
+TAGS="$*"
 
 # fail if file does not exist
 if [ ! -f "${YAML_FILE}" ]; then

--- a/hack/verify-image-digests.sh
+++ b/hack/verify-image-digests.sh
@@ -14,14 +14,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# example:
-# ./verify-image-digests.sh 'v1.33.*' registry.k8s.io/images/k8s-staging-provider-os/images.yaml
+usage() {
+  cat <<EOF
+Usage: $0 [<match>] <yaml_file>
 
-# default to match all images
-MATCH=${1:-'.*'}
+Verify that content digests in an image promoter manifest match what is
+currently in the GCR staging registry and the production registry.
 
-# fail if $2 is not set
-YAML_FILE=${2:?Usage: $0 '<match>' <yaml_file>}
+For each image/tag pair recorded in the manifest, this script fetches the
+digest from both gcr.io/k8s-staging-provider-os and registry.k8s.io/provider-os
+and compares them against the digest stored in the dmap. Any mismatch is
+reported as an error.
+
+Arguments:
+  match       A regex to filter tags (e.g. 'v1.33.*'). Defaults to '.*'
+              (all tags).
+  yaml_file   Path to the image promoter manifest, e.g.
+              registry.k8s.io/images/k8s-staging-provider-os/images.yaml
+
+Examples:
+  $0 'v1.33.*' registry.k8s.io/images/k8s-staging-provider-os/images.yaml
+  $0 registry.k8s.io/images/k8s-staging-provider-os/images.yaml
+EOF
+}
+
+ARGS=$(getopt -o h --long help -n "$0" -- "$@") || { usage >&2; exit 1; }
+eval set -- "$ARGS"
+while true; do
+  case "$1" in
+    -h|--help) usage; exit 0;;
+    --) shift; break;;
+  esac
+done
+
+# if only one arg remains it's the yaml file; two args means match + yaml file
+if [ $# -eq 1 ]; then
+  MATCH='.*'
+  YAML_FILE=$1
+else
+  MATCH=${1:-'.*'}
+  YAML_FILE=${2:?$(usage)}
+fi
 
 # fail if file does not exist
 if [ ! -f "${YAML_FILE}" ]; then
@@ -47,4 +80,4 @@ while read -r IMAGE DIGEST TAG; do
   if [ "$digest1" != "$DIGEST" ]; then
     echo "ERROR: registry.k8s.io/provider-os/$IMAGE:$TAG digest mismatch: expected $DIGEST, got $digest1" >&2
   fi
-done <<< `yq '.[] | .name as $name | .dmap | to_entries | sort_by(.value[0]) | reverse | .[] | select(.value[0] | test("'"${MATCH}"'")) | "\($name) \(.key) \(.value[0])"' "${YAML_FILE}"`
+done <<< $(yq '.[] | .name as $name | .dmap | to_entries | sort_by(.value[0]) | reverse | .[] | select(.value[0] | test("'"${MATCH}"'")) | "\($name) \(.key) \(.value[0])"' "${YAML_FILE}")

--- a/hack/verify-image-digests.sh
+++ b/hack/verify-image-digests.sh
@@ -14,14 +14,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# example usage:
-# ./verify-image-digests.sh 'v1.33.*' registry.k8s.io/images/k8s-staging-provider-os/images.yaml
+usage() {
+  cat <<EOF
+Usage: $0 [<match>] <yaml_file>
 
-# default to match all images
-MATCH=${1:-'.*'}
+Verify that content digests in an image promoter manifest match what is
+currently in the GCR staging registry and the production registry.
 
-# fail if $2 is not set
-YAML_FILE=${2:?Usage: $0 '<match>' <yaml_file>}
+For each image/tag pair recorded in the manifest, this script fetches the
+digest from both gcr.io/k8s-staging-provider-os and registry.k8s.io/provider-os
+and compares them against the digest stored in the dmap. Any mismatch is
+reported as an error.
+
+Arguments:
+  match       A regex to filter tags (e.g. 'v1.33.*'). Defaults to '.*'
+              (all tags).
+  yaml_file   Path to the image promoter manifest, e.g.
+              registry.k8s.io/images/k8s-staging-provider-os/images.yaml
+
+Examples:
+  $0 'v1.33.*' registry.k8s.io/images/k8s-staging-provider-os/images.yaml
+  $0 registry.k8s.io/images/k8s-staging-provider-os/images.yaml
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0;;
+    --) shift; break;;
+    -*) echo "$0: unknown option: $1" >&2; usage >&2; exit 1;;
+    *) break;;
+  esac
+  shift
+done
+
+# if only one arg remains it's the yaml file; two args means match + yaml file
+if [ $# -eq 1 ]; then
+  MATCH='.*'
+  YAML_FILE=$1
+else
+    MATCH=${1:-'.*'}
+    if [ -z "${2-}" ]; then
+        usage >&2
+        exit 1
+    fi
+    YAML_FILE=${2}
+fi
 
 # fail if file does not exist
 if [ ! -f "${YAML_FILE}" ]; then


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Add `-h` / `--help` options to two release-related scripts to help users understand what they are for.

**Which issue this PR fixes(if applicable)**:

(none)

**Special notes for reviewers**:

(none)

**Release note**:

```release-note
NONE
```
