### PR TITLE
[magnum-auto-healer] Add TLS cert verification

### DIFF
--- a/docs/magnum-auto-healer/using-magnum-auto-healer.md
+++ b/docs/magnum-auto-healer/using-magnum-auto-healer.md
@@ -183,6 +183,23 @@ spec:
 EOF
 ```
 
+#### Endpoint health check parameters
+
+The `Endpoint` type health check supports the following parameters:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `protocol` | string | `HTTPS` | URL scheme to use. `HTTP` or `HTTPS` (case-insensitive). |
+| `port` | int | `6443` | Port to connect to on the node. |
+| `endpoints` | []string | `["/healthz"]` | List of URL paths to check. |
+| `ok-codes` | []int | `[200]` | HTTP response codes considered healthy. |
+| `unhealthy-duration` | duration | `300s` | How long a node must be continuously unhealthy before repair is triggered. |
+| `unhealthy-annotation` | string | `autohealing.openstack.org/unhealthy-timestamp` | Node annotation used to record when the node first became unhealthy. |
+| `require-token` | bool | `false` | Whether to include a bearer token in the request. |
+| `token` | string | read from `/var/run/secrets/kubernetes.io/serviceaccount/token` | Bearer token value. Only used when `require-token` is `true`. |
+| `ca-file` | string | `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` | Path to a CA certificate file used to verify the server's TLS certificate. Only used when `protocol` is `HTTPS`. |
+| `insecure-skip-verify` | bool | `false` | Skip TLS certificate verification entirely. Not recommended for production use. |
+
 ### Testing magnum-auto-healer
 
 We could ssh into a worker node(`lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-minion-1` in this example) and stop the kubelet service to simulate the worker node failure. The node status check is covered in NodeCondition type of health check plugin(see configuration above).

--- a/pkg/autohealing/healthcheck/plugin_endpoint.go
+++ b/pkg/autohealing/healthcheck/plugin_endpoint.go
@@ -19,6 +19,7 @@ package healthcheck
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net/http"
 	"os"
@@ -33,6 +34,7 @@ import (
 const (
 	EndpointType = "Endpoint"
 	TokenPath    = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	CAPath       = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	TimeLayout   = "2006-01-02 15:04:05"
 )
 
@@ -60,6 +62,13 @@ type EndpointCheck struct {
 
 	// (Optional) Token to use in the request header. Default: read from TokenPath file
 	Token string `mapstructure:"token"`
+
+	// (Optional) Path to CA certificate file for TLS server verification. Only used when Protocol is HTTPS.
+	// Default: read from CAPath (the in-cluster Kubernetes CA).
+	CAFile string `mapstructure:"ca-file"`
+
+	// (Optional) Skip TLS certificate verification. Not recommended for production. Default: false.
+	InsecureSkipVerify bool `mapstructure:"insecure-skip-verify"`
 }
 
 // GetName returns name of the health check
@@ -140,9 +149,27 @@ func (check *EndpointCheck) Check(ctx context.Context, node NodeInfo, controller
 	protocol := strings.ToLower(check.Protocol)
 	switch protocol {
 	case "https":
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		tlsConfig := &tls.Config{}
+		if check.InsecureSkipVerify {
+			tlsConfig.InsecureSkipVerify = true
+		} else {
+			caFile := check.CAFile
+			if caFile == "" {
+				caFile = CAPath
+			}
+			caCert, err := os.ReadFile(caFile)
+			if err != nil {
+				log.Errorf("Node %s, failed to read CA certificate from %s: %v", nodeName, caFile, err)
+				return true
+			}
+			pool := x509.NewCertPool()
+			if !pool.AppendCertsFromPEM(caCert) {
+				log.Errorf("Node %s, failed to parse CA certificate from %s", nodeName, caFile)
+				return true
+			}
+			tlsConfig.RootCAs = pool
 		}
+		tr := &http.Transport{TLSClientConfig: tlsConfig}
 		client = &http.Client{Transport: tr, Timeout: time.Second * 5}
 	case "http":
 		client = &http.Client{Timeout: time.Second * 5}


### PR DESCRIPTION

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

When the protocol is HTTPS, we were creating a HTTP transport with `InsecureSkipVerify: true` which causes Go's TLS client to skip all certificate verification. This leaves the connection open to man-in-the-middle attacks.

I suspect things were done this way since the function connects directly to a node's raw IP address, but Kubernetes API server TLS certificates are typically issued for hostnames or DNS names (e.g., `api.cluster.example.com`) rather than raw IPs. Certificate hostname verification would fail unless the certificate includes the node IP as a Subject Alternative Name (SAN), which isn't guaranteed. Additionally, the Kubernetes cluster CA cert that signed the API server's certificate isn't typically included in theOS trust store and must be loaded explicitly. Neither of these issues are insurmountable though, and we should be secure-by-default. 

Fix things by adding a configurable CA file and an explicit opt-in `insecure-skip-verify` flag, defaulting to the in-cluster Kubernetes CA.

**Which issue this PR fixes(if applicable)**:

(none)

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

Please note the AI was used to assist in generation of this patch. This is noted in the relevant commit messages.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[magnum-auto-healer] Default to certificate verification with HTTPS

`magnum-auto-healer` now defaults to verifying certificates when using HTTPS
transport. When used, the API server cert will need to use node IPs as SANs.
A new `insecure-skip-verify` option is provided to allow users to opt into the
previous insecure behavior, which can be helpful during upgrades.
```
