### PR TITLE
Update release docs with new container registry

### DIFF
--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -94,9 +94,10 @@ dependency or sidecar container.
     $ git push origin release-X.Y
     ```
 
-    New [Docker images](https://console.cloud.google.com/gcr/images/k8s-staging-provider-os) will be built.
+    This will kick the [`cloud-provider-openstack-push-images` job](https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/cloud-provider-openstack-push-images)
+    and will result in new container images being pushed to [the staging area](https://console.cloud.google.com/artifacts/docker/k8s-staging-provider-os/us/gcr.io).
 
-6. Make PR modifying [images.yaml](https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/images/k8s-staging-provider-os/images.yaml) to promote gcr.io images to registry.k8s.io. The point is to copy the proper image sha256 hashes from the staging repository to the images.yaml.
+6. Make PR modifying [images.yaml](https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/images/k8s-staging-provider-os/images.yaml) to promote staging images to registry.k8s.io. The point is to copy the proper image sha256 hashes from the staging repository to the `images.yaml`.
 
     Use `hack/release-image-digests.sh` script and `hack/verify-image-digests.sh` to verify the digests before submitting the PR.
 


### PR DESCRIPTION

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Provide more information on staging images and update the link.

**Which issue this PR fixes(if applicable)**:

(n/a)

**Special notes for reviewers**:
(n/a)
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
