### PR TITLE
More updates to release docs

### DIFF
--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -94,25 +94,34 @@ dependency or sidecar container.
     $ git push origin release-X.Y
     ```
 
-    This will kick the [`cloud-provider-openstack-push-images` job](https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/cloud-provider-openstack-push-images)
-    and will result in new container images being pushed to [the staging area](https://console.cloud.google.com/artifacts/docker/k8s-staging-provider-os/us/gcr.io).
+    This will kick the [`cloud-provider-openstack-push-images`
+    job](https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/cloud-provider-openstack-push-images)
+    and will result in new container images being pushed to [the staging
+    area](https://console.cloud.google.com/artifacts/docker/k8s-staging-provider-os/us/gcr.io).
 
-6. Make PR modifying [images.yaml](https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/images/k8s-staging-provider-os/images.yaml) to promote staging images to registry.k8s.io. The point is to copy the proper image sha256 hashes from the staging repository to the `images.yaml`.
+6. Make PR modifying
+   [images.yaml](https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/images/k8s-staging-provider-os/images.yaml)
+   to promote staging images to registry.k8s.io. The point is to copy the proper image
+   sha256 hashes from the staging repository to the `images.yaml`.
 
-    Use `hack/release-image-digests.sh` script and `hack/verify-image-digests.sh` to verify the digests before submitting the PR.
+    Use `hack/release-image-digests.sh` script and `hack/verify-image-digests.sh` to
+    verify the digests before submitting the PR.
 
     ```bash
     $ ./hack/release-image-digests.sh ../k8s.io/registry.k8s.io/images/k8s-staging-provider-os/images.yaml vX.Y.Z
     ```
 
-    Generate a PR with the updated `images.yaml` file. Make sure to review the changes and ensure that the correct images are being promoted.
+    Generate a PR with the updated `images.yaml` file. Make sure to review the changes
+    and ensure that the correct images are being promoted.
 
-7. Once images are promoted (takes about 30 minutes) create release notes using the "Generate release notes" button in the GitHub "New release" UI and publish the release.
+7. Once images are promoted (takes about 30 minutes) create release notes using the
+   "Generate release notes" button in the GitHub "New release" UI and publish the
+   release.
 
 8. Update the helm chart version with the expected version.
 
-    Make changes in the `charts` directory using the
-    `hack/bump-release.sh` script by running the following command:
+    Make changes in the `charts` directory using the `hack/bump-release.sh` script by
+    running the following command:
 
     ```bash
     $ hack/bump-charts.sh 28 29 0
@@ -125,6 +134,10 @@ dependency or sidecar container.
     Make a PR to bump the chart version in the `charts` directory. Once the PR is
     merged, the chart will be automatically published to the repository registry.
 
-9. Update `kubernetes/test-infra` to add jobs for the new release branch in the [`config/jobs/kubernetes/cloud-provider-openstack`](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes/cloud-provider-openstack) directory.
+9. Update `kubernetes/test-infra` to add jobs for the new release branch in the
+   [`config/jobs/kubernetes/cloud-provider-openstack`](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes/cloud-provider-openstack)
+   directory.
 
-    This is generally as simple as copying the `release-master` file to `release-X.Y`, adding `--release-XY` suffixes to the job names and `testgrid-tab-name` annotations, and updating the branch specifiers.
+    This is generally as simple as copying the `release-master` file to `release-X.Y`,
+    adding `--release-XY` suffixes to the job names and `testgrid-tab-name` annotations,
+    and updating the branch specifiers.

--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -70,6 +70,11 @@ dependency or sidecar container.
 
 2. Update the minor version with the expected version.
 
+    > [!NOTE]
+    > You only need to do this if you are releasing a new version of
+    > cloud-provider-openstack itself. If you are just updating the Helm
+    > Charts, this step can be skipped.
+
     Make changes in the `docs`, `manifests`, `tests`, and `examples`
     directories using the `hack/bump-release.sh` script by running the
     following command:
@@ -82,9 +87,31 @@ dependency or sidecar container.
     directories. Ensure that you double-check the diff before committing the
     changes. Non-related changes must not be shipped.
 
-3. Create a new pull request (PR) and make sure all CI checks have passed.
+3. Update the Helm Chart version with the expected version.
 
-4. Once the PR is merged, make a tag and push it to the upstream repository.
+    Make changes in the `charts` directory using the `hack/bump-release.sh` script by
+    running the following command:
+
+    ```bash
+    $ hack/bump-charts.sh 28 29 0
+    ```
+
+    This will replace `1.28.x`/`2.28.x` with `1.29.0`/`2.29.0` strings in the `charts`
+    directory. Ensure that you double-check the diff before committing the changes.
+    Non-related changes must not be shipped.
+
+    > [!NOTE]
+    > If you are just updating the Helm Charts, it may not be necessary to bump
+    > the version for all charts. If so, just commit the versions of tags that are
+    > needed.
+
+4. Create a new pull request (PR) and make sure all CI checks have passed.
+
+5. Once the PR is merged, tags will automatically be created for any Helm Charts that
+   have changed their version (i.e. `openstack-cloud-controller-manager-X.Y.Z`,
+   `openstack-cinder-csi-X.Y.Z`, and `openstack-manila-csi-X.Y.Z`). Make a `vX.Y.Z`
+   release tag and `release-X.Y` release branch and push both to the upstream
+   repository.
 
     ```bash
     $ git checkout master
@@ -100,7 +127,7 @@ dependency or sidecar container.
     and will result in new container images being pushed to [the staging
     area](https://console.cloud.google.com/artifacts/docker/k8s-staging-provider-os/us/gcr.io).
 
-6. Make PR modifying
+7. Make PR modifying
    [images.yaml](https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/images/k8s-staging-provider-os/images.yaml)
    to promote staging images to registry.k8s.io. The point is to copy the proper image
    sha256 hashes from the staging repository to the `images.yaml`.
@@ -118,22 +145,6 @@ dependency or sidecar container.
 7. Once images are promoted (takes about 30 minutes) create release notes using the
    "Generate release notes" button in the GitHub "New release" UI and publish the
    release.
-
-8. Update the helm chart version with the expected version.
-
-    Make changes in the `charts` directory using the `hack/bump-release.sh` script by
-    running the following command:
-
-    ```bash
-    $ hack/bump-charts.sh 28 29 0
-    ```
-
-    This will replace `1.28.x`/`2.28.x` with `1.29.0`/`2.29.0` strings in the
-    `docs/manifests/tests/examples` directories. Ensure that you double-check the
-    diff before committing the changes. Non-related changes must not be shipped.
-
-    Make a PR to bump the chart version in the `charts` directory. Once the PR is
-    merged, the chart will be automatically published to the repository registry.
 
 9. Update `kubernetes/test-infra` to add jobs for the new release branch in the
    [`config/jobs/kubernetes/cloud-provider-openstack`](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes/cloud-provider-openstack)

--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -70,16 +70,17 @@ dependency or sidecar container.
 
 2. Update the minor version with the expected version.
 
-    Make changes in the `docs/manifests/tests/examples` directories using the
-    `hack/bump-release.sh` script by running the following command:
+    Make changes in the `docs`, `manifests`, `tests`, and `examples`
+    directories using the `hack/bump-release.sh` script by running the
+    following command:
 
     ```bash
     $ hack/bump-release.sh 28 29 0
     ```
 
-    This will replace `1.28.x` with `1.29.0` strings in the
-    `docs/manifests/tests/examples` directories. Ensure that you double-check the
-    diff before committing the changes. Non-related changes must not be shipped.
+    This will replace `1.28.x` with `1.29.0` strings in the relevant
+    directories. Ensure that you double-check the diff before committing the
+    changes. Non-related changes must not be shipped.
 
 3. Create a new pull request (PR) and make sure all CI checks have passed.
 

--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -89,7 +89,7 @@ dependency or sidecar container.
 
 3. Update the Helm Chart version with the expected version.
 
-    Make changes in the `charts` directory using the `hack/bump-release.sh` script by
+    Make changes in the `charts` directory using the `hack/bump-charts.sh` script by
     running the following command:
 
     ```bash
@@ -127,7 +127,7 @@ dependency or sidecar container.
     and will result in new container images being pushed to [the staging
     area](https://console.cloud.google.com/artifacts/docker/k8s-staging-provider-os/us/gcr.io).
 
-7. Make PR modifying
+6. Make PR modifying
    [images.yaml](https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/images/k8s-staging-provider-os/images.yaml)
    to promote staging images to registry.k8s.io. The point is to copy the proper image
    sha256 hashes from the staging repository to the `images.yaml`.
@@ -146,7 +146,7 @@ dependency or sidecar container.
    "Generate release notes" button in the GitHub "New release" UI and publish the
    release.
 
-9. Update `kubernetes/test-infra` to add jobs for the new release branch in the
+8. Update `kubernetes/test-infra` to add jobs for the new release branch in the
    [`config/jobs/kubernetes/cloud-provider-openstack`](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes/cloud-provider-openstack)
    directory.
 

--- a/hack/bump-charts.sh
+++ b/hack/bump-charts.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright 2025 The Kubernetes Authors.
 #
@@ -32,4 +32,4 @@ else
   SED_EXTENDED=(-E)
 fi
 
-find charts -type f -exec sed "${SED_INPLACE[@]}" "${SED_EXTENDED[@]}" -e 's/((ersion)?: ?v?)?([1-2]\.)'${FROM_MAJOR}'\.([0-9][0-9a-zA-Z.-]*)/\1\3'${TO_MAJOR}'.'${TO_MINOR}'/g' "{}" \;
+find charts -type f -exec sed "${SED_INPLACE[@]}" "${SED_EXTENDED[@]}" -e 's/((ersion)?: ?v?)?([1-2]\.)'"${FROM_MAJOR}"'\.([0-9][0-9a-zA-Z.-]*)/\1\3'"${TO_MAJOR}"'.'"${TO_MINOR}"'/g' "{}" \;

--- a/hack/bump-release.sh
+++ b/hack/bump-release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright 2023 The Kubernetes Authors.
 #
@@ -32,4 +32,4 @@ else
   SED_EXTENDED=(-E)
 fi
 
-find docs manifests tests examples -type f -exec sed "${SED_INPLACE[@]}" "${SED_EXTENDED[@]}" -e 's/((ersion)?: ?v?)?([1-2]\.)'${FROM_MAJOR}'\.([0-9][0-9a-zA-Z.-]*)/\1\3'${TO_MAJOR}'.'${TO_MINOR}'/g' "{}" \;
+find docs manifests tests examples -type f -exec sed "${SED_INPLACE[@]}" "${SED_EXTENDED[@]}" -e 's/((ersion)?: ?v?)?([1-2]\.)'"${FROM_MAJOR}"'\.([0-9][0-9a-zA-Z.-]*)/\1\3'"${TO_MAJOR}"'.'"${TO_MINOR}"'/g' "{}" \;

--- a/hack/release-image-digests.sh
+++ b/hack/release-image-digests.sh
@@ -14,8 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# example:
-# ./release-image-digests.sh registry.k8s.io/images/k8s-staging-provider-os/images.yaml [v1.36.0] [v1.35.0]
+# example usage:
+# ./release-image-digests.sh registry.k8s.io/images/k8s-staging-provider-os/images.yaml v1.36.0 v1.35.0
+# will replace all instances of the v1.35.0 tag with v1.36.0
 
 YAML_FILE=${1:?Usage: $0 <yaml_file> [<tag>...]}
 TAGS="${@:2}"

--- a/hack/verify-image-digests.sh
+++ b/hack/verify-image-digests.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# example:
+# example usage:
 # ./verify-image-digests.sh 'v1.33.*' registry.k8s.io/images/k8s-staging-provider-os/images.yaml
 
 # default to match all images
@@ -47,4 +47,4 @@ while read -r IMAGE DIGEST TAG; do
   if [ "$digest1" != "$DIGEST" ]; then
     echo "ERROR: registry.k8s.io/provider-os/$IMAGE:$TAG digest mismatch: expected $DIGEST, got $digest1" >&2
   fi
-done <<< `yq '.[] | .name as $name | .dmap | to_entries | sort_by(.value[0]) | reverse | .[] | select(.value[0] | test("'"${MATCH}"'")) | "\($name) \(.key) \(.value[0])"' "${YAML_FILE}"`
+done <<< $(yq '.[] | .name as $name | .dmap | to_entries | sort_by(.value[0]) | reverse | .[] | select(.value[0] | test("'"${MATCH}"'")) | "\($name) \(.key) \(.value[0])"' "${YAML_FILE}")


### PR DESCRIPTION
**What this PR does / why we need it**:

Make it clearer that Helm Chart versions can (and should) be bumped at the same time as the release itself. Also clarify some wording and indicate that it is possible to release just a new version of one or more Helm Charts.

**Which issue this PR fixes(if applicable)**:

(none)

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->
(none)

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
