### PR TITLE
[cinder-csi-plugin] Fix ControllerGetVolume multi-cloud iteration bug

### DIFF
--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -952,6 +952,7 @@ func (cs *controllerServer) ControllerGetVolume(ctx context.Context, req *csi.Co
 			}
 			return nil, status.Errorf(codes.Internal, "ControllerGetVolume failed with error %v", err)
 		}
+		break
 	}
 	if err != nil {
 		return nil, status.Errorf(codes.NotFound, "Volume %s not found", volumeID)


### PR DESCRIPTION
**What this PR does / why we need it**:

In `ControllerGetVolume`, when multiple clouds are configured, the loop iterates over all clouds without breaking on success. If the volume is found in an earlier cloud but a subsequent cloud returns `NotFound`, the `err` variable is overwritten and the function erroneously returns `NotFound` despite having already located the volume.

This adds a `break` statement after a successful `GetVolume` call to stop iterating once the volume is found.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
Only affects multi-cloud configurations. Single-cloud setups are unaffected since the loop has only one iteration.

**Release note**:
```release-note
[cinder-csi-plugin] Fix ControllerGetVolume returning NotFound for volumes that exist in multi-cloud configurations.
```