### PR TITLE
[cinder-csi-plugin] Fix incorrect RPC name in ListSnapshots error message

### DIFF
--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -794,7 +794,7 @@ func (cs *controllerServer) ListSnapshots(ctx context.Context, req *csi.ListSnap
 	volCloud := req.GetSecrets()["cloud"]
 	cloud, cloudExist := cs.Clouds[volCloud]
 	if !cloudExist {
-		return nil, status.Error(codes.InvalidArgument, "[DeleteSnapshot] specified cloud undefined")
+		return nil, status.Error(codes.InvalidArgument, "[ListSnapshots] specified cloud undefined")
 	}
 
 	snapshotID := req.GetSnapshotId()


### PR DESCRIPTION
**What this PR does / why we need it**:

The error message when the cloud is undefined in `ListSnapshots` incorrectly references `[DeleteSnapshot]` due to a copy-paste error. This fixes it to say `[ListSnapshots]`, making log messages accurate for operators debugging failures.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
One-line fix, copy-paste error in an error string.

**Release note**:
```release-note
NONE
```