### PR TITLE
[cinder-csi-plugin] Protect OsInstances global map with mutex

### DIFF
--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sync"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack"
@@ -147,8 +148,9 @@ func GetConfigFromFiles(configFilePaths []string) (Config, error) {
 const defaultMaxVolAttachLimit int64 = 256
 
 var (
-	OsInstances map[string]IOpenStack
-	configFiles = []string{"/etc/cloud.conf"}
+	OsInstances   map[string]IOpenStack
+	osInstancesMu sync.Mutex
+	configFiles   = []string{"/etc/cloud.conf"}
 )
 
 func InitOpenStackProvider(cfgFiles []string, httpEndpoint string) {
@@ -212,7 +214,7 @@ func CreateOpenStackProvider(cloudName string) (IOpenStack, error) {
 	}
 
 	// Init OpenStack
-	OsInstances[cloudName] = &OpenStack{
+	osInstance := &OpenStack{
 		compute:      computeclient,
 		blockstorage: blockstorageclient,
 		bsOpts:       cfg.BlockStorage,
@@ -220,21 +222,27 @@ func CreateOpenStackProvider(cloudName string) (IOpenStack, error) {
 		metadataOpts: cfg.Metadata,
 	}
 
-	return OsInstances[cloudName], nil
+	osInstancesMu.Lock()
+	OsInstances[cloudName] = osInstance
+	osInstancesMu.Unlock()
+
+	return osInstance, nil
 }
 
 // GetOpenStackProvider returns Openstack Instance
 func GetOpenStackProvider(cloudName string) (IOpenStack, error) {
-	OsInstance, OsInstanceDefined := OsInstances[cloudName]
-	if OsInstanceDefined {
-		return OsInstance, nil
+	osInstancesMu.Lock()
+	osInstance, ok := OsInstances[cloudName]
+	osInstancesMu.Unlock()
+	if ok {
+		return osInstance, nil
 	}
-	OsInstance, err := CreateOpenStackProvider(cloudName)
+	osInstance, err := CreateOpenStackProvider(cloudName)
 	if err != nil {
 		return nil, err
 	}
 
-	return OsInstance, nil
+	return osInstance, nil
 }
 
 // GetMetadataOpts returns metadataopts


### PR DESCRIPTION
**What this PR does / why we need it**:

The `OsInstances` map is accessed from both `CreateOpenStackProvider` (write) and `GetOpenStackProvider` (read) without synchronization. Although current usage is single-threaded at startup, this is a latent data race that would cause a runtime panic (`concurrent map read and map write`) if the driver is ever accessed concurrently.

This adds a `sync.Mutex` to guard read and write access to the `OsInstances` map.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
The mutex is intentionally a simple `sync.Mutex` rather than `sync.RWMutex` since write contention is negligible (only at startup). The lock is held for the minimum scope needed around map access, not around the full `CreateOpenStackProvider` call to avoid holding the lock during network I/O.

**Release note**:
```release-note
[cinder-csi-plugin] Add mutex protection to OsInstances global map to prevent potential concurrent access panics.
```