### PR TITLE
[cinder-csi-plugin] Fix volume from snapshot AZ selection

### DIFF
--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -94,10 +94,12 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	// First check if volAvailability is already specified, if not get preferred from Topology
 	// Required, in case vol AZ is different from node AZ
 	var volAvailability string
+	volAvailabilityFromTopology := false
 	if volParams["availability"] != "" {
 		volAvailability = volParams["availability"]
 	} else if cs.Driver.withTopology && accessibleTopologyReq != nil {
 		volAvailability = sharedcsi.GetAZFromTopology(topologyKey, accessibleTopologyReq)
+		volAvailabilityFromTopology = true
 	}
 
 	// get the PVC annotation
@@ -156,6 +158,10 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		// If the snapshot exists but is not yet available, fail.
 		if err == nil && snap.Status != "available" {
 			return nil, status.Errorf(codes.Unavailable, "VolumeContentSource Snapshot %s is not yet available. status: %s", snapshotID, snap.Status)
+		}
+		if err == nil && volAvailabilityFromTopology {
+			klog.V(4).Infof("CreateVolume: clearing topology-derived availability zone %q for snapshot %s to let Cinder select the correct zone", volAvailability, snapshotID)
+			volAvailability = ""
 		}
 
 		// In case a snapshot is not found

--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -417,6 +417,103 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 	assert.Equal(FakeSnapshotID, actualRes.Volume.ContentSource.GetSnapshot().SnapshotId)
 }
 
+func TestCreateVolumeFromSnapshotWithTopology(t *testing.T) {
+	fakeCs, osmock := fakeControllerServer()
+
+	properties := map[string]string{cinderCSIClusterIDKey: FakeCluster}
+	// Expect empty AZ: the driver should clear the topology-derived AZ
+	// and let Cinder place the volume in the snapshot's AZ.
+	osmock.On("CreateVolume", FakeVolName, mock.AnythingOfType("int"), FakeVolType, "", FakeSnapshotID, "", "", properties).Return(&FakeVolFromSnapshot, nil)
+	osmock.On("GetVolumesByName", FakeVolName).Return(FakeVolListEmpty, nil)
+	osmock.On("GetBlockStorageOpts").Return(openstack.BlockStorageOpts{})
+
+	assert := assert.New(t)
+
+	src := &csi.VolumeContentSource{
+		Type: &csi.VolumeContentSource_Snapshot{
+			Snapshot: &csi.VolumeContentSource_SnapshotSource{
+				SnapshotId: FakeSnapshotID,
+			},
+		},
+	}
+
+	fakeReq := &csi.CreateVolumeRequest{
+		Name: FakeVolName,
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				},
+			},
+		},
+		VolumeContentSource: src,
+		AccessibilityRequirements: &csi.TopologyRequirement{
+			Preferred: []*csi.Topology{
+				{
+					Segments: map[string]string{topologyKey: "az-2"},
+				},
+			},
+		},
+	}
+
+	actualRes, err := fakeCs.CreateVolume(FakeCtx, fakeReq)
+	if err != nil {
+		t.Errorf("failed to CreateVolume: %v", err)
+	}
+
+	assert.NotNil(actualRes.Volume)
+	assert.Equal(FakeSnapshotID, actualRes.Volume.ContentSource.GetSnapshot().SnapshotId)
+}
+
+func TestCreateVolumeFromSnapshotWithExplicitAvailability(t *testing.T) {
+	fakeCs, osmock := fakeControllerServer()
+
+	properties := map[string]string{cinderCSIClusterIDKey: FakeCluster}
+	osmock.On("CreateVolume", FakeVolName, mock.AnythingOfType("int"), FakeVolType, "explicit-az", FakeSnapshotID, "", "", properties).Return(&FakeVolFromSnapshot, nil)
+	osmock.On("GetVolumesByName", FakeVolName).Return(FakeVolListEmpty, nil)
+	osmock.On("GetBlockStorageOpts").Return(openstack.BlockStorageOpts{})
+
+	assert := assert.New(t)
+
+	src := &csi.VolumeContentSource{
+		Type: &csi.VolumeContentSource_Snapshot{
+			Snapshot: &csi.VolumeContentSource_SnapshotSource{
+				SnapshotId: FakeSnapshotID,
+			},
+		},
+	}
+
+	fakeReq := &csi.CreateVolumeRequest{
+		Name: FakeVolName,
+		Parameters: map[string]string{
+			"availability": "explicit-az",
+		},
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				},
+			},
+		},
+		VolumeContentSource: src,
+		AccessibilityRequirements: &csi.TopologyRequirement{
+			Preferred: []*csi.Topology{
+				{
+					Segments: map[string]string{topologyKey: "az-2"},
+				},
+			},
+		},
+	}
+
+	actualRes, err := fakeCs.CreateVolume(FakeCtx, fakeReq)
+	if err != nil {
+		t.Errorf("failed to CreateVolume: %v", err)
+	}
+
+	assert.NotNil(actualRes.Volume)
+	assert.Equal(FakeSnapshotID, actualRes.Volume.ContentSource.GetSnapshot().SnapshotId)
+}
+
 func TestCreateVolumeFromSourceVolume(t *testing.T) {
 	fakeCs, osmock := fakeControllerServer()
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

When restoring a volume from a snapshot in a multi-AZ cluster with volumeBindingMode: WaitForFirstConsumer, the topology-derived availability zone can conflict with the snapshot's AZ. Cinder requires the new volume to be in the same AZ as the snapshot, so it rejects the request with HTTP 400: "Volume must be in the same availability zone as the snapshot". This happens because the scheduler picks a node (and therefore an AZ) before the CSI driver gets called, and that AZ gets passed straight to Cinder's volume create without considering what AZ the snapshot lives in. The fix clears the topology derived AZ when creating a volume from a snapshot, letting Cinder auto-select the snapshot's AZ. Explicit availability set via StorageClass parameters is not affected.

**Which issue this PR fixes(if applicable)**:
fixes #3088

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

Only the topology-derived AZ path is changed. If the user explicitly sets availability in StorageClass params, that value is passed through unchanged.

Two tests added:
1. TestCreateVolumeFromSnapshotWithTopology - verifies the AZ is cleared when restoring from snapshot with topology
2. TestCreateVolumeFromSnapshotWithExplicitAvailability - verifies explicit availability param is preserved even with snapshot + topology

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and ashould begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[cinder-csi-plugin] Fix snapshot restore in multi-AZ clusters with topology-aware provisioning by clearing the topology-derived availability zone and letting Cinder select the snapshot's zone.
```