### PR TITLE
[manila-csi-plugin] Remove rules from aggregated ClusterRoles to fix Helm v4 SSA conflict

### DIFF
--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.36.0
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 2.36.0
+version: 2.36.1
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/templates/controllerplugin-clusterrole.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-clusterrole.yaml
@@ -8,4 +8,3 @@ aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
         rbac.manila.csi.openstack.org/aggregate-to-controller-{{ include "openstack-manila-csi.name" . }}: "true"
-rules: []

--- a/charts/manila-csi-plugin/templates/nodeplugin-clusterrole.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-clusterrole.yaml
@@ -8,4 +8,3 @@ aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
         rbac.manila.csi.openstack.org/aggregate-to-nodeplugin-{{ include "openstack-manila-csi.name" . }}: "true"
-rules: []


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

When a ClusterRole uses aggregationRule, the clusterrole-aggregation-controller takes SSA ownership of the .rules field. The chart currently renders rules: [] on both the controllerplugin and nodeplugin aggregated ClusterRoles. With Helm v4 (which defaults to Server-Side Apply), this causes a field manager conflict on every helm upgrade after the initial install, because both Helm and the aggregation controller claim ownership of .rules. This PR removes the redundant rules: [] from both templates. The aggregation controller continues to populate the rules from the matching child ClusterRoles as before.

**Which issue this PR fixes(if applicable)**:
fixes #3119

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[manila-csi-plugin] Fixed Helm v4 upgrade failure caused by SSA conflict on aggregated ClusterRoles.
```
