### PR TITLE
[occm] Add node-address-type annotation to control LB member IP selection

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -118,6 +118,14 @@ Request Body:
 
   Member subnet ID of the load balancer created.
 
+- `loadbalancer.openstack.org/node-address-type`
+
+  The node address type to use when selecting the IP address for load balancer pool members. By default, InternalIP is preferred over ExternalIP. Set to `ExternalIP` to reverse this priority, which is useful when nodes have multiple interfaces and the member subnet corresponds to the ExternalIP network.
+
+  Default: InternalIP is tried first, then ExternalIP.
+
+  Possible values: `ExternalIP`
+
 - `loadbalancer.openstack.org/network-id`
 
   The network ID which will allocate virtual IP for loadbalancer.

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -73,6 +73,7 @@ const (
 	ServiceAnnotationLoadBalancerSubnetID             = "loadbalancer.openstack.org/subnet-id"
 	ServiceAnnotationLoadBalancerNetworkID            = "loadbalancer.openstack.org/network-id"
 	ServiceAnnotationLoadBalancerMemberSubnetID       = "loadbalancer.openstack.org/member-subnet-id"
+	ServiceAnnotationLoadBalancerNodeAddressType      = "loadbalancer.openstack.org/node-address-type"
 	ServiceAnnotationLoadBalancerTimeoutClientData    = "loadbalancer.openstack.org/timeout-client-data"
 	ServiceAnnotationLoadBalancerTimeoutMemberConnect = "loadbalancer.openstack.org/timeout-member-connect"
 	ServiceAnnotationLoadBalancerTimeoutMemberData    = "loadbalancer.openstack.org/timeout-member-data"
@@ -145,7 +146,8 @@ type serviceConfig struct {
 	healthMonitorTimeout        int
 	healthMonitorMaxRetries     int
 	healthMonitorMaxRetriesDown int
-	preferredIPFamily           corev1.IPFamily // preferred (the first) IP family indicated in service's `spec.ipFamilies`
+	preferredIPFamily           corev1.IPFamily        // preferred (the first) IP family indicated in service's `spec.ipFamilies`
+	nodeAddressType             corev1.NodeAddressType // preferred node address type for pool members
 }
 
 type listenerKey struct {
@@ -382,13 +384,17 @@ func (lbaas *LbaasV2) getLoadBalancerLegacyName(service *corev1.Service) string 
 // If neither InternalIP nor ExternalIP can be found an error is
 // returned.
 // If preferredIPFamily is specified, only address of the specified IP family can be returned.
-func nodeAddressForLB(node *corev1.Node, preferredIPFamily corev1.IPFamily) (string, error) {
+// If preferredAddrType is ExternalIP, ExternalIP is tried first.
+func nodeAddressForLB(node *corev1.Node, preferredIPFamily corev1.IPFamily, preferredAddrType corev1.NodeAddressType) (string, error) {
 	addrs := node.Status.Addresses
 	if len(addrs) == 0 {
 		return "", cpoerrors.ErrNoAddressFound
 	}
 
 	allowedAddrTypes := []corev1.NodeAddressType{corev1.NodeInternalIP, corev1.NodeExternalIP}
+	if preferredAddrType == corev1.NodeExternalIP {
+		allowedAddrTypes = []corev1.NodeAddressType{corev1.NodeExternalIP, corev1.NodeInternalIP}
+	}
 	for _, allowedAddrType := range allowedAddrTypes {
 		for _, addr := range addrs {
 			if addr.Type == allowedAddrType {
@@ -493,7 +499,7 @@ func getProxyProtocolFromServiceAnnotation(service *corev1.Service) *v2pools.Pro
 
 // getSubnetIDForLB returns subnet-id for a specific node
 func getSubnetIDForLB(ctx context.Context, network *gophercloud.ServiceClient, node corev1.Node, preferredIPFamily corev1.IPFamily) (string, error) {
-	ipAddress, err := nodeAddressForLB(&node, preferredIPFamily)
+	ipAddress, err := nodeAddressForLB(&node, preferredIPFamily, "")
 	if err != nil {
 		return "", err
 	}
@@ -1017,7 +1023,7 @@ func (lbaas *LbaasV2) buildBatchUpdateMemberOpts(ctx context.Context, port corev
 	newMembers := sets.New[string]()
 
 	for _, node := range nodes {
-		addr, err := nodeAddressForLB(node, svcConf.preferredIPFamily)
+		addr, err := nodeAddressForLB(node, svcConf.preferredIPFamily, svcConf.nodeAddressType)
 		if err != nil {
 			if err == cpoerrors.ErrNoAddressFound {
 				// Node failure, do not create member
@@ -1308,6 +1314,8 @@ func (lbaas *LbaasV2) checkServiceUpdate(ctx context.Context, service *corev1.Se
 		svcConf.preferredIPFamily = service.Spec.IPFamilies[0]
 	}
 
+	svcConf.nodeAddressType = corev1.NodeAddressType(getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerNodeAddressType, ""))
+
 	// Find subnet ID for creating members
 	memberSubnetID, err := lbaas.getMemberSubnetID(service)
 	if err != nil {
@@ -1370,6 +1378,8 @@ func (lbaas *LbaasV2) checkService(ctx context.Context, service *corev1.Service,
 		// the first IP family will determine the IP family of the load-balancer
 		svcConf.preferredIPFamily = service.Spec.IPFamilies[0]
 	}
+
+	svcConf.nodeAddressType = corev1.NodeAddressType(getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerNodeAddressType, ""))
 
 	// If in the config file internal-lb=true, user is not allowed to create external service.
 	if lbaas.opts.InternalLB {

--- a/pkg/openstack/loadbalancer_sg.go
+++ b/pkg/openstack/loadbalancer_sg.go
@@ -57,7 +57,7 @@ func applyNodeSecurityGroupIDForLB(ctx context.Context, network *gophercloud.Ser
 			return fmt.Errorf("error getting server ID from the node: %w", err)
 		}
 
-		addr, _ := nodeAddressForLB(node, svcConf.preferredIPFamily)
+		addr, _ := nodeAddressForLB(node, svcConf.preferredIPFamily, svcConf.nodeAddressType)
 		if addr == "" {
 			// If node has no viable address let's ignore it.
 			continue

--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -1470,6 +1470,7 @@ func Test_nodeAddressForLB(t *testing.T) {
 	type testArgs struct {
 		node              *corev1.Node
 		preferredIPFamily corev1.IPFamily
+		preferredAddrType corev1.NodeAddressType
 	}
 
 	tests := []struct {
@@ -1775,11 +1776,76 @@ func Test_nodeAddressForLB(t *testing.T) {
 			expect:      "",
 			expectedErr: cpoerrors.ErrNoAddressFound,
 		},
+		{
+			name: "ExternalIP preferred over InternalIP with IPv4",
+			testArgs: testArgs{
+				node: &corev1.Node{
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.1.1",
+							},
+							{
+								Type:    corev1.NodeExternalIP,
+								Address: "10.0.0.1",
+							},
+						},
+					},
+				},
+				preferredIPFamily: corev1.IPv4Protocol,
+				preferredAddrType: corev1.NodeExternalIP,
+			},
+			expect:      "10.0.0.1",
+			expectedErr: nil,
+		},
+		{
+			name: "ExternalIP preferred falls back to InternalIP when no ExternalIP",
+			testArgs: testArgs{
+				node: &corev1.Node{
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.1.1",
+							},
+						},
+					},
+				},
+				preferredIPFamily: corev1.IPv4Protocol,
+				preferredAddrType: corev1.NodeExternalIP,
+			},
+			expect:      "192.168.1.1",
+			expectedErr: nil,
+		},
+		{
+			name: "ExternalIP preferred with IPv6",
+			testArgs: testArgs{
+				node: &corev1.Node{
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "2001:db8::1",
+							},
+							{
+								Type:    corev1.NodeExternalIP,
+								Address: "2001:db8::2",
+							},
+						},
+					},
+				},
+				preferredIPFamily: corev1.IPv6Protocol,
+				preferredAddrType: corev1.NodeExternalIP,
+			},
+			expect:      "2001:db8::2",
+			expectedErr: nil,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := nodeAddressForLB(test.testArgs.node, test.testArgs.preferredIPFamily)
+			got, err := nodeAddressForLB(test.testArgs.node, test.testArgs.preferredIPFamily, test.testArgs.preferredAddrType)
 			if test.expectedErr != nil {
 				assert.EqualError(t, err, test.expectedErr.Error())
 			} else {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

When nodes have multiple network interfaces, `nodeAddressForLB` always prefers InternalIP for load balancer pool members. If the user configures `loadbalancer.openstack.org/member-subnet-id` pointing to a subnet that corresponds to the node's ExternalIP, the pool members end up with an IP outside that subnet because the Octavia API lets the address field take precedence over subnet_id.

This PR adds a new service annotation `loadbalancer.openstack.org/node-address-type` that allows users to set `ExternalIP` to reverse the address selection priority. When set, ExternalIP is tried first with a fallback to InternalIP. Default behavior (InternalIP first) is unchanged.

**Which issue this PR fixes(if applicable)**:
fixes #3090

**Special notes for reviewers**:

1. The annotation accepts the string `ExternalIP` (matching `corev1.NodeExternalIP`). Any other value (including empty/absent) preserves existing behavior.
2. `getSubnetIDForLB` intentionally passes `""` for the new parameter since it auto-detects the subnet and should always use InternalIP for that purpose.
3. The `applyNodeSecurityGroupIDForLB` caller is also updated so the security group is applied to the port matching the address actually used for the pool member.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] Add `loadbalancer.openstack.org/node-address-type` annotation to control which node address type (InternalIP or ExternalIP) is used for load balancer pool members.
```