### PR TITLE
[manila-csi-plugin] Move inactive reviewers/approvers to emeritus

### DIFF
--- a/pkg/csi/manila/OWNERS
+++ b/pkg/csi/manila/OWNERS
@@ -1,10 +1,12 @@
+emeritus_approvers:
+- tombarron
+emeritus_reviewers:
+- Fedosin
+- tombarron
+- tsmetana
 approvers:
 - gman0
 - gouthampacha
-- tombarron
 reviewers:
 - gman0
 - gouthampacha
-- tombarron
-- Fedosin
-- tsmetana


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves tombarron, Fedosin, and tsmetana to emeritus in the Manila CSI
OWNERS file. None have contributed to this repository in several years
and Prow's blunderbuss plugin assigns them reviews they won't action.

**Which issue this PR fixes(if applicable)**:

**Special notes for reviewers**:

Last commits to this repo:
- tombarron: Oct 2019
- Fedosin: Jan 2023
- tsmetana: Nov 2018

**Release note**:
```release-note
NONE
```