### PR TITLE
[manila-csi-plugin] Add staticVolume parameter to CephFS volume context

### DIFF
--- a/pkg/csi/manila/shareadapters/cephfs.go
+++ b/pkg/csi/manila/shareadapters/cephfs.go
@@ -119,6 +119,7 @@ func (Cephfs) BuildVolumeContext(args *VolumeContextArgs) (volumeContext map[str
 		"monitors":        monitors,
 		"rootPath":        rootPath,
 		"mounter":         args.Options.CephfsMounter,
+		"staticVolume":    "true",
 		"provisionVolume": "false",
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

ceph-csi [introduced volume ID format validation](https://github.com/ceph/ceph-csi/commit/e2a1f6e8ca47c87d517949c15ee41a48014ebe6a) that rejects IDs not matching its internal format (`^[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[a-zA-Z0-9\-\_]+$`). The format check is skipped when [`IsStaticVol()`](https://github.com/ceph/ceph-csi/blob/devel/internal/util/validate.go) returns true, which requires `staticVolume: "true"` in the volume attributes. Manila CSI only sets `provisionVolume: "false"`, which ceph-csi does not check for this purpose. This causes `NodeStageVolume` to fail with `volumeID has an unexpected format` on ceph-csi v3.14.0+.

This PR adds `staticVolume: "true"` to the CephFS volume context alongside the existing `provisionVolume: "false"`. The parameter is ignored by older ceph-csi versions that do not recognize it, making this change backwards compatible.

**Which issue this PR fixes(if applicable)**:
fixes #3137

**Special notes for reviewers**:

One-line change. Tested on DevStack with native CephFS backend using ceph-csi v3.12 (confirms backwards compatibility — parameter is ignored) and verified the fix against ceph-csi v3.17 source code.

**Release note**:
```release-note
[manila-csi-plugin] Add staticVolume parameter to CephFS volume context for compatibility with ceph-csi v3.14.0+.
```