### PR TITLE
[manila-csi-plugin] Restore --nodeid and --nodeaz as optional overrides

### DIFF
--- a/cmd/manila-csi-plugin/main.go
+++ b/cmd/manila-csi-plugin/main.go
@@ -89,6 +89,8 @@ func main() {
 				ManilaClientBuilder: manilaClientBuilder,
 				CSIClientBuilder:    csiClientBuilder,
 				ClusterID:           clusterID,
+				NodeID:              nodeID,
+				NodeAZ:              nodeAZ,
 				PVCLister:           csi.GetPVCLister(),
 			}
 
@@ -105,15 +107,16 @@ func main() {
 			}
 
 			if provideNodeService {
-				err = metadata.CheckMetadataSearchOrder(searchOrder)
-				if err != nil {
-					klog.Fatalf("Invalid search-order: %v", err)
+				var md metadata.IMetadata
+				if nodeID == "" || (withTopology && nodeAZ == "") {
+					err = metadata.CheckMetadataSearchOrder(searchOrder)
+					if err != nil {
+						klog.Fatalf("Invalid search-order: %v", err)
+					}
+					md = metadata.GetMetadataProvider(searchOrder)
 				}
 
-				// Initialize metadata
-				metadata := metadata.GetMetadataProvider(searchOrder)
-
-				err = d.SetupNodeService(metadata)
+				err = d.SetupNodeService(nodeID, nodeAZ, md)
 				if err != nil {
 					klog.Fatalf("Driver node service initialization failed: %v", err)
 				}
@@ -132,15 +135,8 @@ func main() {
 
 	cmd.PersistentFlags().StringVar(&driverName, "drivername", "manila.csi.openstack.org", "name of the driver")
 
-	cmd.PersistentFlags().StringVar(&nodeID, "nodeid", "", "this node's ID")
-	if err := cmd.PersistentFlags().MarkDeprecated("nodeid", "This option is now ignored by the driver. It will be removed in a future release."); err != nil {
-		klog.Fatalf("Unable to mark flag nodeid to be deprecated: %v", err)
-	}
-
-	cmd.PersistentFlags().StringVar(&nodeAZ, "nodeaz", "", "this node's availability zone")
-	if err := cmd.PersistentFlags().MarkDeprecated("nodeaz", "This option is now ignored by the driver. It will be removed in a future release."); err != nil {
-		klog.Fatalf("Unable to mark flag nodeaz to be deprecated: %v", err)
-	}
+	cmd.PersistentFlags().StringVar(&nodeID, "nodeid", "", "this node's ID. When set, the metadata service is not used to retrieve the node ID.")
+	cmd.PersistentFlags().StringVar(&nodeAZ, "nodeaz", "", "this node's availability zone. When set, the metadata service is not used to retrieve the availability zone.")
 
 	cmd.PersistentFlags().StringVar(&runtimeConfigFile, "runtime-config-file", "", "path to the runtime configuration file")
 

--- a/pkg/csi/manila/driver.go
+++ b/pkg/csi/manila/driver.go
@@ -74,10 +74,41 @@ type DriverOpts struct {
 	ServerCSIEndpoint string
 	FwdCSIEndpoint    string
 
+	NodeID string
+	NodeAZ string
+
 	ManilaClientBuilder manilaclient.Builder
 	CSIClientBuilder    csiclient.Builder
 
 	PVCLister v1.PersistentVolumeClaimLister
+}
+
+type staticMetadata struct {
+	nodeID string
+	nodeAZ string
+}
+
+func (m *staticMetadata) GetInstanceID() (string, error)       { return m.nodeID, nil }
+func (m *staticMetadata) GetAvailabilityZone() (string, error) { return m.nodeAZ, nil }
+
+type overrideMetadata struct {
+	nodeID   string
+	nodeAZ   string
+	fallback metadata.IMetadata
+}
+
+func (m *overrideMetadata) GetInstanceID() (string, error) {
+	if m.nodeID != "" {
+		return m.nodeID, nil
+	}
+	return m.fallback.GetInstanceID()
+}
+
+func (m *overrideMetadata) GetAvailabilityZone() (string, error) {
+	if m.nodeAZ != "" {
+		return m.nodeAZ, nil
+	}
+	return m.fallback.GetAvailabilityZone()
 }
 
 type nonBlockingGRPCServer struct {
@@ -176,8 +207,18 @@ func (d *Driver) SetupControllerService() error {
 	return nil
 }
 
-func (d *Driver) SetupNodeService(metadata metadata.IMetadata) error {
+func (d *Driver) SetupNodeService(nodeID, nodeAZ string, md metadata.IMetadata) error {
 	klog.Info("Providing node service")
+
+	var effectiveMD metadata.IMetadata
+	switch {
+	case nodeID != "" && nodeAZ != "":
+		effectiveMD = &staticMetadata{nodeID: nodeID, nodeAZ: nodeAZ}
+	case nodeID != "" || nodeAZ != "":
+		effectiveMD = &overrideMetadata{nodeID: nodeID, nodeAZ: nodeAZ, fallback: md}
+	default:
+		effectiveMD = md
+	}
 
 	var supportsNodeStage bool
 
@@ -198,7 +239,7 @@ func (d *Driver) SetupNodeService(metadata metadata.IMetadata) error {
 
 	d.ns = &nodeServer{
 		d:                 d,
-		metadata:          metadata,
+		metadata:          effectiveMD,
 		supportsNodeStage: supportsNodeStage,
 		nodeStageCache:    make(map[volumeID]stageCacheEntry),
 	}

--- a/pkg/csi/manila/metadata_test.go
+++ b/pkg/csi/manila/metadata_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manila
+
+import (
+	"errors"
+	"testing"
+)
+
+type fakeMetadataProvider struct {
+	instanceID       string
+	availabilityZone string
+	err              error
+}
+
+func (f *fakeMetadataProvider) GetInstanceID() (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.instanceID, nil
+}
+
+func (f *fakeMetadataProvider) GetAvailabilityZone() (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.availabilityZone, nil
+}
+
+func TestStaticMetadata(t *testing.T) {
+	tests := []struct {
+		name   string
+		nodeID string
+		nodeAZ string
+		wantID string
+		wantAZ string
+	}{
+		{"both set", "my-node", "az1", "my-node", "az1"},
+		{"empty values", "", "", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &staticMetadata{nodeID: tc.nodeID, nodeAZ: tc.nodeAZ}
+
+			id, err := m.GetInstanceID()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if id != tc.wantID {
+				t.Errorf("expected node ID %q, got %q", tc.wantID, id)
+			}
+
+			az, err := m.GetAvailabilityZone()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if az != tc.wantAZ {
+				t.Errorf("expected AZ %q, got %q", tc.wantAZ, az)
+			}
+		})
+	}
+}
+
+func TestOverrideMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		nodeID   string
+		nodeAZ   string
+		fallback *fakeMetadataProvider
+		wantID   string
+		wantAZ   string
+	}{
+		{
+			"nodeID set, AZ from fallback",
+			"flag-id", "",
+			&fakeMetadataProvider{instanceID: "meta-id", availabilityZone: "meta-az"},
+			"flag-id", "meta-az",
+		},
+		{
+			"nodeAZ set, ID from fallback",
+			"", "flag-az",
+			&fakeMetadataProvider{instanceID: "meta-id", availabilityZone: "meta-az"},
+			"meta-id", "flag-az",
+		},
+		{
+			"both set, fallback not called",
+			"flag-id", "flag-az",
+			&fakeMetadataProvider{err: errors.New("should not be called")},
+			"flag-id", "flag-az",
+		},
+		{
+			"neither set, both from fallback",
+			"", "",
+			&fakeMetadataProvider{instanceID: "meta-id", availabilityZone: "meta-az"},
+			"meta-id", "meta-az",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &overrideMetadata{nodeID: tc.nodeID, nodeAZ: tc.nodeAZ, fallback: tc.fallback}
+
+			id, err := m.GetInstanceID()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if id != tc.wantID {
+				t.Errorf("expected node ID %q, got %q", tc.wantID, id)
+			}
+
+			az, err := m.GetAvailabilityZone()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if az != tc.wantAZ {
+				t.Errorf("expected AZ %q, got %q", tc.wantAZ, az)
+			}
+		})
+	}
+}

--- a/tests/sanity/manila/sanity_test.go
+++ b/tests/sanity/manila/sanity_test.go
@@ -54,7 +54,7 @@ func TestDriver(t *testing.T) {
 
 	fakemeta := &fakemetadata{}
 
-	err = d.SetupNodeService(fakemeta)
+	err = d.SetupNodeService("", "", fakemeta)
 	if err != nil {
 		t.Fatalf("Failed to initialize CSI Manila node service: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Un-deprecates the `--nodeid` and `--nodeaz` flags so they can be used as
alternatives to the metadata service for node identity.

#2734 aligned Manila CSI with how Cinder CSI handles node identity by making
the metadata service mandatory. For Cinder this makes sense: the node must be
a Nova VM for volume attach/detach. Manila doesn't have that constraint. Shares
mount via NFS or CEPHFS on the host, and the node doesn't need to be a Nova
instance.

When `--nodeid` is set, the flag value is used directly. When unset, the driver
falls back to the metadata service (current behavior). Same for `--nodeaz`.
OpenStack deployments are unaffected.

**Which issue this PR fixes(if applicable)**:

Fixes #3139

**Special notes for reviewers**:

Tested end-to-end on a DevStack environment with Manila LVM:
- With `--nodeid=test-node-from-flag`: CSINode registers with the flag value,
  PVC binds, share mounts, pod reads/writes data
- Without `--nodeid` (default): CSINode registers with the metadata-provided
  UUID, PVC binds, share mounts, pod reads/writes data

**Release note**:
```release-note
[manila-csi-plugin] The `--nodeid` and `--nodeaz` flags are no longer
deprecated. When set, they override the metadata service for node identity,
allowing Manila CSI to run on nodes that are not OpenStack VMs.
```