### PR TITLE
Fix config drive mount and add flag to control the search order in which the driver retrieves instance metadata

### DIFF
--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.36.0
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 2.36.1
+version: 2.36.2
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -95,7 +95,7 @@ spec:
               readOnly: true
             {{- end }}
             - name: configdrive-dev
-              mountPath: /dev
+              mountPath: /dev/disk
               mountPropagation: "HostToContainer"
             {{- with $.Values.nodeplugin.volumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -125,7 +125,7 @@ spec:
         {{- end }}
         - name: configdrive-dev
           hostPath:
-            path: /dev
+            path: /dev/disk
             type: Directory
         {{- with .Values.nodeplugin.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -95,7 +95,7 @@ spec:
               readOnly: true
             {{- end }}
             - name: configdrive-dev
-              mountPath: /dev/disk
+              mountPath: /dev
               mountPropagation: "HostToContainer"
             {{- with $.Values.nodeplugin.volumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -125,7 +125,7 @@ spec:
         {{- end }}
         - name: configdrive-dev
           hostPath:
-            path: /dev/disk
+            path: /dev
             type: Directory
         {{- with .Values.nodeplugin.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -62,7 +62,10 @@ spec:
             --drivername=$(DRIVER_NAME)
             --share-protocol-selector=$(MANILA_SHARE_PROTO)
             --fwdendpoint=$(FWD_CSI_ENDPOINT)
-            --cluster-id=$(CLUSTER_NAME)'
+            --cluster-id="{{ $.Values.csimanila.clusterID }}"
+            {{- if $.Values.csimanila.searchOrder }}
+            --search-order="{{ $.Values.csimanila.searchOrder }}"
+            {{- end }}'
           ]
           env:
             - name: DRIVER_NAME
@@ -91,6 +94,9 @@ spec:
               mountPath: /runtimeconfig
               readOnly: true
             {{- end }}
+            - name: configdrive-dev
+              mountPath: /dev
+              mountPropagation: "HostToContainer"
             {{- with $.Values.nodeplugin.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -117,6 +123,10 @@ spec:
             name: manila-csi-runtimeconf-cm
         {{- end }}
         {{- end }}
+        - name: configdrive-dev
+          hostPath:
+            path: /dev
+            type: Directory
         {{- with .Values.nodeplugin.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -142,4 +142,3 @@ controllerplugin:
 # See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md
 # for description of individual verbosity levels.
 logVerbosityLevel: 2
-

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -143,4 +143,3 @@ controllerplugin:
 # for description of individual verbosity levels.
 logVerbosityLevel: 2
 
-searchOrder:

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -48,6 +48,9 @@ csimanila:
     pullPolicy: IfNotPresent
     tag:  # defaults to .Chart.AppVersion
 
+  # Set the search order in which the driver retrieves metadata relating to the instance (s) in which it runs
+  searchOrder: ""
+
 # DeamonSet deployment
 nodeplugin:
   # Component name
@@ -139,3 +142,5 @@ controllerplugin:
 # See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md
 # for description of individual verbosity levels.
 logVerbosityLevel: 2
+
+searchOrder:

--- a/cmd/manila-csi-plugin/main.go
+++ b/cmd/manila-csi-plugin/main.go
@@ -52,6 +52,7 @@ var (
 	userAgentData            []string
 	provideControllerService bool
 	provideNodeService       bool
+	searchOrder              string
 )
 
 func validateShareProtocolSelector(v string) error {
@@ -104,8 +105,13 @@ func main() {
 			}
 
 			if provideNodeService {
+				err = metadata.CheckMetadataSearchOrder(searchOrder)
+				if err != nil {
+					klog.Fatalf("Invalid search-order: %v", err)
+				}
+
 				// Initialize metadata
-				metadata := metadata.GetMetadataProvider("")
+				metadata := metadata.GetMetadataProvider(searchOrder)
 
 				err = d.SetupNodeService(metadata)
 				if err != nil {
@@ -158,6 +164,7 @@ func main() {
 
 	cmd.PersistentFlags().BoolVar(&provideControllerService, "provide-controller-service", true, "If set to true then the CSI driver does provide the controller service (default: true)")
 	cmd.PersistentFlags().BoolVar(&provideNodeService, "provide-node-service", true, "If set to true then the CSI driver does provide the node service (default: true)")
+	cmd.PersistentFlags().StringVar(&searchOrder, "search-order", "configDrive,metadataService", "The search order in which the driver retrieves metadata relating to the instance (s) in which it runs")
 
 	code := cli.Run(cmd)
 	os.Exit(code)

--- a/docs/manila-csi-plugin/using-manila-csi-plugin.md
+++ b/docs/manila-csi-plugin/using-manila-csi-plugin.md
@@ -44,6 +44,7 @@ Option | Default value | Description
 `--provide-controller-service` | `true` | If set to true then the CSI driver does provide the controller service.
 `--provide-node-service` | `true` | If set to true then the CSI driver does provide the node service.
 `--pvc-annotations` | `false` | If set to true then the CSI driver will use PVC annotations as an additional information when creating shares. See [Supported PVC annotations](#supported-pvc-annotations) for more info.
+`--search-order` | `configDrive,metadataService` | The search order in which the driver retrieves metadata relating to the instance (s) in which it runs.
 
 ### Controller Service volume parameters
 

--- a/docs/manila-csi-plugin/using-manila-csi-plugin.md
+++ b/docs/manila-csi-plugin/using-manila-csi-plugin.md
@@ -44,7 +44,7 @@ Option | Default value | Description
 `--provide-controller-service` | `true` | If set to true then the CSI driver does provide the controller service.
 `--provide-node-service` | `true` | If set to true then the CSI driver does provide the node service.
 `--pvc-annotations` | `false` | If set to true then the CSI driver will use PVC annotations as an additional information when creating shares. See [Supported PVC annotations](#supported-pvc-annotations) for more info.
-`--search-order` | `configDrive,metadataService` | The search order in which the driver retrieves metadata relating to the instance (s) in which it runs.
+`--search-order` | `configDrive,metadataService` | The search order in which the driver retrieves metadata relating to the instance in which it runs. Only effective when `--provide-node-service=true`.
 
 ### Controller Service volume parameters
 

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -80,6 +80,9 @@ spec:
               mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
             - name: fwd-plugin-dir
               mountPath: /var/lib/kubelet/plugins/FWD-NODEPLUGIN
+            - name: configdrive-dev
+              mountPath: /dev
+              mountPropagation: "HostToContainer"
       volumes:
         - name: registration-dir
           hostPath:
@@ -93,4 +96,7 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/FWD-NODEPLUGIN
             type: DirectoryOrCreate
-
+        - name: configdrive-dev
+          hostPath:
+            path: /dev
+            type: Directory

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -81,7 +81,7 @@ spec:
             - name: fwd-plugin-dir
               mountPath: /var/lib/kubelet/plugins/FWD-NODEPLUGIN
             - name: configdrive-dev
-              mountPath: /dev
+              mountPath: /dev/disk
               mountPropagation: "HostToContainer"
       volumes:
         - name: registration-dir
@@ -98,5 +98,5 @@ spec:
             type: DirectoryOrCreate
         - name: configdrive-dev
           hostPath:
-            path: /dev
+            path: /dev/disk
             type: Directory

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -81,7 +81,7 @@ spec:
             - name: fwd-plugin-dir
               mountPath: /var/lib/kubelet/plugins/FWD-NODEPLUGIN
             - name: configdrive-dev
-              mountPath: /dev/disk
+              mountPath: /dev
               mountPropagation: "HostToContainer"
       volumes:
         - name: registration-dir
@@ -98,5 +98,5 @@ spec:
             type: DirectoryOrCreate
         - name: configdrive-dev
           hostPath:
-            path: /dev/disk
+            path: /dev
             type: Directory


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Currently the manila csi only uses metadata service to get instance metadata, which fails when using config drive.

* This PR adds a new flag `--search-order` (similar to cinder) to allow setting up the order in which the driver should try to retrieve the metadata. By default: configDrive,metadataService
* And this PR adds the missing bits to get the config drive to work.

**Which issue this PR fixes(if applicable)**:
fixes https://github.com/kubernetes/cloud-provider-openstack/issues/3118

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

1. Start the node plugin without `--search-order`. It will use the default value of configDrive,metadataService. On a machine using metadata service, this is the output:
```
}
I0701 14:15:22.146174       1 driver.go:327] [ID:2] GRPC call: /csi.v1.Node/NodeGetInfo
...
I0701 14:15:22.146893       1 metadata.go:170] Attempting to mount configdrive on /tmp
I0701 14:15:22.148041       1 mount_linux.go:326] 'umount /tmp/kubelet-detect-safe-umount3371542402' failed with: exit status 1, output: umount: can't unmount /tmp/kubelet-detect-safe-umount3371542402: Invalid argument
...
E0701 14:15:22.148613       1 mount_linux.go:271] Mount failed: exit status 1


I0701 14:15:22.149110       1 metadata.go:204] Attempting to fetch metadata from http://169.254.169.254/openstack/latest/meta_data.json, ignoring proxy settings
I0701 14:15:22.288691       1 driver.go:333] [ID:2] GRPC response: {"node_id":"<node id>"}
```
It tried to mount the config drive, fails, and then tries the metadata service, which works. 

2. Start the node plugin with --search-order=metadataService,configDrive. On an instance using config drive, this is the output:
```
I0701 14:47:56.211444       1 driver.go:327] [ID:2] GRPC call: /csi.v1.Node/NodeGetInfo
I0701 14:47:56.211462       1 driver.go:328] [ID:2] GRPC request: {}
I0701 14:47:56.211486       1 metadata.go:204] Attempting to fetch metadata from http://169.254.169.254/openstack/latest/meta_data.json, ignoring proxy settings

I0701 14:48:26.212841       1 metadata.go:170] Attempting to mount configdrive /dev/disk/by-label/config-2 on /tmp
...
I0701 14:48:26.216486       1 metadata.go:182] Configdrive mounted on /tmp
I0701 14:48:26.216921       1 mount_linux.go:401] Unmounting /tmp
I0701 14:48:26.218503       1 driver.go:333] [ID:2] GRPC response: {"node_id":"<node-id>"}

```
It tried to use the matadata sevice, and when it didn't work, tried the config drive, which worked.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
4. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[manila-csi-plugin] Add `--search-order` flag to control the order in which instance metadata is retrieved (configDrive, metadataService)
```