### PR TITLE
[cinder-csi-plugin] Fix panic when backup lookup fails in CreateSnapshot

### DIFF
--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -565,9 +565,10 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		if len(backups) == 1 {
 			// since backup.VolumeID is not part of ListBackups response
 			// we need fetch single backup to get the full object.
-			backup, err = cloud.GetBackupByID(ctx, backups[0].ID)
+			backupID := backups[0].ID
+			backup, err = cloud.GetBackupByID(ctx, backupID)
 			if err != nil {
-				klog.Errorf("Failed to get backup by ID %s: %v", backup.ID, err)
+				klog.Errorf("Failed to get backup by ID %s: %v", backupID, err)
 				return nil, status.Error(codes.Internal, "Failed to get backup by ID")
 			}
 

--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package cinder
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/backups"
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -1048,6 +1050,40 @@ func TestCreateSnapshotWithExtraMetadata(t *testing.T) {
 	assert.Equal(FakeVolID, actualRes.Snapshot.SourceVolumeId)
 
 	assert.NotNil(FakeSnapshotID, actualRes.Snapshot.SnapshotId)
+}
+
+func TestCreateSnapshotBackupGetBackupByIDError(t *testing.T) {
+	fakeCs, osmock := fakeControllerServer()
+
+	backendErr := errors.New("backend lookup failed")
+	existingBackup := backups.Backup{
+		ID:   "existing-backup-id",
+		Name: FakeSnapshotName,
+	}
+
+	osmock.On("ListBackups", map[string]string{"Name": FakeSnapshotName}).Return([]backups.Backup{existingBackup}, nil)
+	osmock.On("GetBackupByID", existingBackup.ID).Return((*backups.Backup)(nil), backendErr)
+
+	fakeReq := &csi.CreateSnapshotRequest{
+		Name:           FakeSnapshotName,
+		SourceVolumeId: FakeVolID,
+		Parameters: map[string]string{
+			openstack.SnapshotType: "backup",
+		},
+	}
+
+	_, err := fakeCs.CreateSnapshot(FakeCtx, fakeReq)
+	if err == nil {
+		t.Fatal("expected CreateSnapshot to return an error")
+	}
+
+	statusErr, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected grpc status error, got %v", err)
+	}
+
+	assert.Equal(t, codes.Internal, statusErr.Code())
+	assert.Equal(t, "Failed to get backup by ID", statusErr.Message())
 }
 
 // Test DeleteSnapshot

--- a/pkg/csi/cinder/openstack/openstack_mock.go
+++ b/pkg/csi/cinder/openstack/openstack_mock.go
@@ -463,6 +463,29 @@ func (_m *OpenStackMock) WaitSnapshotReady(ctx context.Context, snapshotID strin
 }
 
 func (_m *OpenStackMock) GetBackupByID(ctx context.Context, backupID string) (*backups.Backup, error) {
+	for _, call := range _m.ExpectedCalls {
+		if call.Method != "GetBackupByID" {
+			continue
+		}
+
+		ret := _m.Called(backupID)
+
+		var r0 *backups.Backup
+		if rf, ok := ret.Get(0).(func(string) *backups.Backup); ok {
+			r0 = rf(backupID)
+		} else if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*backups.Backup)
+		}
+
+		var r1 error
+		if rf, ok := ret.Get(1).(func(string) error); ok {
+			r1 = rf(backupID)
+		} else {
+			r1 = ret.Error(1)
+		}
+
+		return r0, r1
+	}
 
 	return &fakeBackup, nil
 }


### PR DESCRIPTION
What this PR does / why we need it:

This fixes a nil pointer panic in the cinder CSI backup snapshot path.
If `CreateSnapshot` runs with `snapshotType=backup`, `ListBackups` finds one match, and `GetBackupByID` then errors, the code dereferences `backup.ID` and blows up. Kinda nasty.

The fix logs the already known backup ID from `ListBackups` and returns `codes.Internal` cleanly.

Which issue this PR fixes(if applicable):

fixes #

Special notes for reviewers:

Repro before this patch:
```bash
go test ./pkg/csi/cinder -run TestCreateSnapshotBackupGetBackupByIDError -count=1
```

Before the fix this panics in `CreateSnapshot`.
With this patch it returns a normal gRPC internal error, so no crash, nice and boring.

Release note:
```release-note
[cinder-csi-plugin] Fix panic when backup lookup fails in CreateSnapshot
```
