### PR TITLE
[manila-csi-plugin] Use GET method for listing share access rules

### DIFF
--- a/pkg/csi/manila/manilaclient/client.go
+++ b/pkg/csi/manila/manilaclient/client.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/v2/messages"
+	"github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/v2/shareaccessrules"
 	"github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/v2/shares"
 	"github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/v2/sharetypes"
 	"github.com/gophercloud/gophercloud/v2/openstack/sharedfilesystems/v2/snapshots"
@@ -75,7 +76,35 @@ func (c Client) SetShareMetadata(ctx context.Context, shareID string, opts share
 }
 
 func (c Client) GetAccessRights(ctx context.Context, shareID string) ([]shares.AccessRight, error) {
-	return shares.ListAccessRights(ctx, c.c, shareID).Extract()
+	// Set microversion to 2.45 to use the GET /share-access-rules endpoint
+	v := c.GetMicroversion()
+	c.SetMicroversion("2.45")
+	defer c.SetMicroversion(v)
+
+	rules, err := shareaccessrules.List(ctx, c.c, shareID).Extract()
+	if err != nil {
+		return nil, err
+	}
+
+	return toAccessRights(rules), nil
+}
+
+// toAccessRights adapts the shareaccessrules API type to the shares.AccessRight type
+func toAccessRights(rules []shareaccessrules.ShareAccess) []shares.AccessRight {
+	accessRights := make([]shares.AccessRight, len(rules))
+	for i, r := range rules {
+		accessRights[i] = shares.AccessRight{
+			ShareID:     r.ShareID,
+			AccessType:  r.AccessType,
+			AccessTo:    r.AccessTo,
+			AccessKey:   r.AccessKey,
+			AccessLevel: r.AccessLevel,
+			State:       r.State,
+			ID:          r.ID,
+		}
+	}
+
+	return accessRights
 }
 
 func (c Client) GrantAccess(ctx context.Context, shareID string, opts shares.GrantAccessOptsBuilder) (*shares.AccessRight, error) {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Replaces the deprecated POST-based `shares.ListAccessRights` with the GET-based `shareaccessrules.List` when listing share access rules.

**Which issue this PR fixes(if applicable)**:
[#2277](https://github.com/kubernetes/cloud-provider-openstack/issues/2277)

**Special notes for reviewers**:
The microversion is set to 2.45 only for this call and restored immediately after via defer, so no other API interactions are affected. A `toAccessRights` adapter converts the new response type to the existing `shares.AccessRight` type used throughout the plugin.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[manila-csi-plugin] Use shareaccessrules.List instead of deprecated POST-based shares.ListAccessRights to avoid rate-limiting on some OpenStack deployments.
```
