### PR TITLE
fix: return backup lookup errors when deleting snapshots

### DIFF
--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -769,12 +769,17 @@ func (cs *controllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteS
 
 	// If volumeSnapshot object was linked to a cinder backup, delete the backup.
 	back, err := cloud.GetBackupByID(ctx, id)
-	if err == nil && back != nil {
+	if err != nil && !cpoerrors.IsNotFound(err) {
+		klog.Errorf("Failed to get backup %s: %v", id, err)
+		return nil, status.Errorf(codes.Internal, "GetBackupByID failed with error %v", err)
+	}
+	if back != nil {
 		err = cloud.DeleteBackup(ctx, id)
-		if err != nil {
+		if err != nil && !cpoerrors.IsNotFound(err) {
 			klog.Errorf("Failed to Delete backup: %v", err)
 			return nil, status.Error(codes.Internal, fmt.Sprintf("DeleteBackup failed with error %v", err))
 		}
+		return &csi.DeleteSnapshotResponse{}, nil
 	}
 
 	// Delegate the check to openstack itself

--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -1090,8 +1090,8 @@ func TestCreateSnapshotBackupGetBackupByIDError(t *testing.T) {
 func TestDeleteSnapshot(t *testing.T) {
 	fakeCs, osmock := fakeControllerServer()
 
+	osmock.On("GetBackupByID", FakeSnapshotID).Return((*backups.Backup)(nil), cpoerrors.ErrNotFound)
 	osmock.On("DeleteSnapshot", FakeSnapshotID).Return(nil)
-	osmock.On("DeleteBackup", FakeSnapshotID).Return(nil)
 
 	assert := assert.New(t)
 
@@ -1111,6 +1111,56 @@ func TestDeleteSnapshot(t *testing.T) {
 
 	// Assert
 	assert.Equal(expectedRes, actualRes)
+}
+
+func TestDeleteSnapshotDeletesBackupWithoutDeletingSnapshot(t *testing.T) {
+	fakeCs, osmock := fakeControllerServer()
+
+	osmock.On("GetBackupByID", FakeSnapshotID).Return(&backups.Backup{ID: FakeSnapshotID}, nil)
+	osmock.On("DeleteBackup", FakeSnapshotID).Return(nil)
+
+	actualRes, err := fakeCs.DeleteSnapshot(FakeCtx, &csi.DeleteSnapshotRequest{SnapshotId: FakeSnapshotID})
+	if err != nil {
+		t.Fatalf("DeleteSnapshot returned an error: %v", err)
+	}
+
+	assert.Equal(t, &csi.DeleteSnapshotResponse{}, actualRes)
+	osmock.AssertNotCalled(t, "DeleteSnapshot", FakeSnapshotID)
+}
+
+func TestDeleteSnapshotIgnoresBackupNotFoundDuringDelete(t *testing.T) {
+	fakeCs, osmock := fakeControllerServer()
+
+	osmock.On("GetBackupByID", FakeSnapshotID).Return(&backups.Backup{ID: FakeSnapshotID}, nil)
+	osmock.On("DeleteBackup", FakeSnapshotID).Return(cpoerrors.ErrNotFound)
+
+	actualRes, err := fakeCs.DeleteSnapshot(FakeCtx, &csi.DeleteSnapshotRequest{SnapshotId: FakeSnapshotID})
+	if err != nil {
+		t.Fatalf("DeleteSnapshot returned an error: %v", err)
+	}
+
+	assert.Equal(t, &csi.DeleteSnapshotResponse{}, actualRes)
+	osmock.AssertNotCalled(t, "DeleteSnapshot", FakeSnapshotID)
+}
+
+func TestDeleteSnapshotReturnsErrorWhenBackupLookupFails(t *testing.T) {
+	fakeCs, osmock := fakeControllerServer()
+	lookupErr := errors.New("cinder backup service unavailable")
+
+	osmock.On("GetBackupByID", FakeSnapshotID).Return((*backups.Backup)(nil), lookupErr)
+	osmock.On("DeleteSnapshot", FakeSnapshotID).Maybe().Return(cpoerrors.ErrNotFound)
+
+	_, err := fakeCs.DeleteSnapshot(FakeCtx, &csi.DeleteSnapshotRequest{SnapshotId: FakeSnapshotID})
+	if err == nil {
+		t.Fatal("expected DeleteSnapshot to return an error")
+	}
+
+	statusErr, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected grpc status error, got %v", err)
+	}
+	assert.Equal(t, codes.Internal, statusErr.Code())
+	osmock.AssertNotCalled(t, "DeleteSnapshot", FakeSnapshotID)
 }
 
 func TestListSnapshots(t *testing.T) {


### PR DESCRIPTION
Fixes a path where a Cinder backup lookup failure is ignored during `DeleteSnapshot`.

A non-404 error now reaches the snapshotter, so it retries instead of treating a later snapshot 404 as success.

Repro:
1. Use a VolumeSnapshotClass with `type: backup`
2. Make Cinder return 500 or 503 to `GET /backups/<id>`
3. Delete the VolumeSnapshot. Before this, it can report success and leave the backup behind.

Tests: `make unit`, `go test ./tests/sanity/cinder`

**Release note**:
```release-note
[cinder-csi-plugin] Return Cinder backup lookup failures when deleting a backup-backed VolumeSnapshot so the snapshotter retries deletion.
```