### PR TITLE
feat: add support for load balancer, listener, and pool tags annotations

### DIFF
--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -239,6 +239,18 @@ Request Body:
 
   If this annotation is specified, the other annotations which define the load balancer features will be ignored.
 
+- `loadbalancer.openstack.org/load-balancer-tags`
+
+  A comma-separated list of tags to add to the load balancer resource in addition to the tags managed by OCCM. Example: `env=prod,team=network`.
+
+- `loadbalancer.openstack.org/listener-tags`
+
+  A comma-separated list of tags to add to the load balancer listener resources in addition to the tags managed by OCCM. Example: `env=prod,team=network`.
+
+- `loadbalancer.openstack.org/pool-tags`
+
+  A comma-separated list of tags to add to the load balancer pool resources. Example: `env=prod,team=network`.
+
 - `loadbalancer.openstack.org/hostname`
 
   This annotations explicitly sets a hostname in the status of the load balancer service.

--- a/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
+++ b/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md
@@ -243,13 +243,15 @@ Request Body:
 
   A comma-separated list of tags to add to the load balancer resource in addition to the tags managed by OCCM. Example: `env=prod,team=network`.
 
+  > NOTE: Tags starting with `kube_service_` are reserved for OCCM's own ownership and shared-load-balancer tracking. Any such tag supplied through this annotation is ignored (a warning is logged) to avoid conflicting with the tags OCCM manages. This applies to all three tag annotations.
+
 - `loadbalancer.openstack.org/listener-tags`
 
-  A comma-separated list of tags to add to the load balancer listener resources in addition to the tags managed by OCCM. Example: `env=prod,team=network`.
+  A comma-separated list of tags to add to the load balancer listener resources in addition to the tags managed by OCCM. Example: `env=prod,team=network`. Tags starting with the reserved `kube_service_` prefix are ignored (see the note above).
 
 - `loadbalancer.openstack.org/pool-tags`
 
-  A comma-separated list of tags to add to the load balancer pool resources. Example: `env=prod,team=network`.
+  A comma-separated list of tags to add to the load balancer pool resources. Example: `env=prod,team=network`. Tags starting with the reserved `kube_service_` prefix are ignored (see the note above).
 
 - `loadbalancer.openstack.org/hostname`
 

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -96,6 +96,13 @@ const (
 	defaultProxyHostnameSuffix      = "nip.io"
 	ServiceAnnotationLoadBalancerID = "loadbalancer.openstack.org/load-balancer-id"
 
+	// ServiceAnnotationLoadBalancerTags The lb tags annotation is used to set tags on the loadbalancer resource itself(support json list).
+	ServiceAnnotationLoadBalancerTags = "loadbalancer.openstack.org/load-balancer-tags"
+	// ServiceAnnotationListenerTags The listener tags annotation is used to set tags on the loadbalancer listener resources(support json list).
+	ServiceAnnotationListenerTags = "loadbalancer.openstack.org/listener-tags"
+	// ServiceAnnotationPoolTags The pool tags annotation is used to set tags on the loadbalancer pool resources(support json list).
+	ServiceAnnotationPoolTags = "loadbalancer.openstack.org/pool-tags"
+
 	// Octavia resources name formats
 	servicePrefix  = "kube_service_"
 	lbFormat       = "%s%s_%s_%s"
@@ -146,6 +153,9 @@ type serviceConfig struct {
 	healthMonitorMaxRetries     int
 	healthMonitorMaxRetriesDown int
 	preferredIPFamily           corev1.IPFamily // preferred (the first) IP family indicated in service's `spec.ipFamilies`
+	lbTags                      string
+	listenerTags                string
+	poolTags                    string
 }
 
 type listenerKey struct {
@@ -197,6 +207,20 @@ func getLoadbalancerByName(ctx context.Context, client *gophercloud.ServiceClien
 	return &validLBs[0], nil
 }
 
+// mergeTags merges existedTags and desiredTags, returns true if all desiredTags are in existedTags.
+func mergeTags(existedTags []string, desiredTags []string) (bool, []string) {
+	if len(existedTags) == 0 || existedTags == nil {
+		return false, desiredTags
+	}
+	desiredTagsSet := sets.NewString(desiredTags...)
+	tagSet := sets.NewString(existedTags...)
+	if tagSet.HasAll(desiredTags...) {
+		return true, nil
+	} else {
+		return false, tagSet.Union(desiredTagsSet).List()
+	}
+}
+
 func popListener(existingListeners []listeners.Listener, id string) []listeners.Listener {
 	newListeners := []listeners.Listener{}
 	for _, existingListener := range existingListeners {
@@ -235,7 +259,13 @@ func (lbaas *LbaasV2) createOctaviaLoadBalancer(ctx context.Context, name, clust
 	}
 
 	if svcConf.supportLBTags {
-		createOpts.Tags = []string{svcConf.lbName}
+		var desiredTags []string
+		if len(svcConf.lbTags) == 0 {
+			klog.V(4).Infof("No load balancer tags found from service annotation key: %s", ServiceAnnotationLoadBalancerTags)
+		} else if err := json.Unmarshal([]byte(svcConf.lbTags), &desiredTags); err != nil {
+			klog.Warningf("unmarshal service annotation load balancer tags from key: %s, error: %s", ServiceAnnotationLoadBalancerTags, err)
+		}
+		createOpts.Tags = append([]string{svcConf.lbName}, desiredTags...)
 	}
 
 	if svcConf.flavorID != "" {
@@ -923,16 +953,43 @@ func (lbaas *LbaasV2) ensureOctaviaPool(ctx context.Context, lbID string, name s
 		}
 	}
 
+	var desiredTags []string
+	if len(svcConf.poolTags) == 0 {
+		klog.V(4).Infof("No pools tags found from service annotation key: %s", ServiceAnnotationPoolTags)
+	} else if err := json.Unmarshal([]byte(svcConf.poolTags), &desiredTags); err != nil {
+		klog.Warningf("unmarshal service annotation pools tags from key: %s, error: %s", ServiceAnnotationPoolTags, err)
+	}
+
 	if pool == nil {
 		createOpt := lbaas.buildPoolCreateOpt(listener.Protocol, service, svcConf, name)
 		createOpt.ListenerID = listener.ID
-
+		if svcConf.supportLBTags {
+			createOpt.Tags = desiredTags
+		}
 		klog.InfoS("Creating pool", "listenerID", listener.ID, "protocol", createOpt.Protocol)
+		klog.V(4).Infof("Pool create options: %+v", createOpt)
 		pool, err = openstackutil.CreatePool(ctx, lbaas.lb, createOpt, lbID)
 		if err != nil {
 			return nil, err
 		}
 		klog.V(2).Infof("Pool %s created for listener %s", pool.ID, listener.ID)
+	} else {
+		if svcConf.supportLBTags {
+			// Update tags if needed
+			if len(desiredTags) > 0 {
+				klog.V(4).Infof("Desired pools tags: %+v from service annotation key: %s", desiredTags, ServiceAnnotationPoolTags)
+				if ok, tags := mergeTags(pool.Tags, desiredTags); !ok {
+					klog.V(4).Infof("Will update pools' tags, current pools tags: %+v, desired tags: %+v", pool.Tags, tags)
+					updateOpts := v2pools.UpdateOpts{
+						Tags: &tags,
+					}
+					klog.InfoS("Updating pool tags", "poolID", pool.ID, "listenerID", listener.ID, "lbID", lbID, "tags", desiredTags)
+					if err := openstackutil.UpdatePool(ctx, lbaas.lb, lbID, pool.ID, updateOpts); err != nil {
+						klog.Warningf("Error updating LB pool tags: %v", err)
+					}
+				}
+			}
+		}
 	}
 
 	if lbaas.opts.ProviderRequiresSerialAPICalls {
@@ -1105,6 +1162,23 @@ func (lbaas *LbaasV2) ensureOctaviaListener(ctx context.Context, lbID string, na
 				newTags = append(newTags, svcConf.lbName)
 				updateOpts.Tags = &newTags
 				listenerChanged = true
+			} else {
+				// Get desired tags from Service annotations
+				var desiredTags []string
+				if len(svcConf.listenerTags) == 0 {
+					klog.V(4).Infof("No listeners tags found from service annotation key: %s", ServiceAnnotationListenerTags)
+				} else if err := json.Unmarshal([]byte(svcConf.listenerTags), &desiredTags); err != nil {
+					klog.Warningf("unmarshal service annotation listeners tags from key: %s, error: %s", ServiceAnnotationListenerTags, err)
+				}
+				// Ensure listeners tags match the desired tags from Service annotations
+				if len(desiredTags) > 0 {
+					klog.Infof("Desired listener tags: %+v from service annotation key: %s", desiredTags, ServiceAnnotationListenerTags)
+					if ok, tags := mergeTags(listener.Tags, desiredTags); !ok {
+						klog.V(4).Infof("Will update listeners' tags, current listeners tags: %+v, desired tags: %+v", listener.Tags, tags)
+						updateOpts.Tags = &tags
+						listenerChanged = true
+					}
+				}
 			}
 		}
 
@@ -1177,7 +1251,20 @@ func (lbaas *LbaasV2) buildListenerCreateOpt(ctx context.Context, port corev1.Se
 	}
 
 	if svcConf.supportLBTags {
-		listenerCreateOpt.Tags = []string{svcConf.lbName}
+		// Get desired tags from Service annotations
+		var desiredTags []string
+		if len(svcConf.listenerTags) == 0 {
+			klog.V(4).Infof("No listeners tags found from service annotation key: %s", ServiceAnnotationListenerTags)
+		} else if err := json.Unmarshal([]byte(svcConf.listenerTags), &desiredTags); err != nil {
+			klog.Warningf("unmarshal service annotation listeners tags from key: %s, error: %s", ServiceAnnotationListenerTags, err)
+		}
+		if len(desiredTags) > 0 {
+			klog.V(4).Infof("Desired listener tags: %+v from service annotation key: %s", desiredTags, ServiceAnnotationListenerTags)
+			if ok, tags := mergeTags([]string{svcConf.lbName}, desiredTags); !ok {
+				klog.V(4).Infof("Will update listeners' tags, current listeners tags: %s, desired tags: %+v", svcConf.lbName, tags)
+				listenerCreateOpt.Tags = tags
+			}
+		}
 	}
 
 	if openstackutil.IsOctaviaFeatureSupported(ctx, lbaas.lb, openstackutil.OctaviaFeatureTimeout, lbaas.opts.LBProvider) {
@@ -1364,6 +1451,11 @@ func (lbaas *LbaasV2) checkService(ctx context.Context, service *corev1.Service,
 	if len(ports) == 0 {
 		return fmt.Errorf("no service ports provided")
 	}
+
+	annotations := service.GetAnnotations()
+	svcConf.lbTags = annotations[ServiceAnnotationLoadBalancerTags]
+	svcConf.listenerTags = annotations[ServiceAnnotationListenerTags]
+	svcConf.poolTags = annotations[ServiceAnnotationPoolTags]
 
 	if len(service.Spec.IPFamilies) > 0 {
 		// Since OCCM does not support multiple load-balancers per service yet,
@@ -1755,6 +1847,25 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 
 	// Make sure LB ID will be saved at this point.
 	lbaas.updateServiceAnnotation(service, ServiceAnnotationLoadBalancerID, loadbalancer.ID)
+
+	if svcConf.supportLBTags {
+		var desiredTags []string
+		if len(svcConf.lbTags) == 0 {
+			klog.V(4).Infof("No load balancer tags found from service annotation key: %s", ServiceAnnotationLoadBalancerTags)
+		} else if err := json.Unmarshal([]byte(svcConf.lbTags), &desiredTags); err != nil {
+			klog.Warningf("unmarshal service annotation load balancer tags from key: %s, error: %s", ServiceAnnotationLoadBalancerTags, err)
+		}
+		// add the service annotation tags to load balancer tags if the tags don't match
+		if len(desiredTags) > 0 {
+			klog.V(4).Infof("Desired load balancer tags: %v from service annotation: %v", desiredTags, ServiceAnnotationLoadBalancerTags)
+			if ok, tags := mergeTags(loadbalancer.Tags, desiredTags); !ok {
+				klog.Infof("Will update load balancer's tags, current load balancer tags: %+v, desired tags: %+v", loadbalancer.Tags, tags)
+				if err := openstackutil.UpdateLoadBalancerTags(ctx, lbaas.lb, loadbalancer.ID, tags); err != nil {
+					klog.Warningf("failed to update load balancer %s tags: %v", loadbalancer.ID, err)
+				}
+			}
+		}
+	}
 
 	if loadbalancer.ProvisioningStatus != activeStatus {
 		return nil, fmt.Errorf("load balancer %s is not ACTIVE, current provisioning status: %s", loadbalancer.ID, loadbalancer.ProvisioningStatus)

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -96,11 +96,11 @@ const (
 	defaultProxyHostnameSuffix      = "nip.io"
 	ServiceAnnotationLoadBalancerID = "loadbalancer.openstack.org/load-balancer-id"
 
-	// ServiceAnnotationLoadBalancerTags The lb tags annotation is used to set tags on the loadbalancer resource itself(support json list).
+	// ServiceAnnotationLoadBalancerTags is used to set additional tags on the loadbalancer resource itself (comma-separated list).
 	ServiceAnnotationLoadBalancerTags = "loadbalancer.openstack.org/load-balancer-tags"
-	// ServiceAnnotationListenerTags The listener tags annotation is used to set tags on the loadbalancer listener resources(support json list).
+	// ServiceAnnotationListenerTags is used to set additional tags on the loadbalancer listener resources (comma-separated list).
 	ServiceAnnotationListenerTags = "loadbalancer.openstack.org/listener-tags"
-	// ServiceAnnotationPoolTags The pool tags annotation is used to set tags on the loadbalancer pool resources(support json list).
+	// ServiceAnnotationPoolTags is used to set additional tags on the loadbalancer pool resources (comma-separated list).
 	ServiceAnnotationPoolTags = "loadbalancer.openstack.org/pool-tags"
 
 	// Octavia resources name formats
@@ -207,18 +207,18 @@ func getLoadbalancerByName(ctx context.Context, client *gophercloud.ServiceClien
 	return &validLBs[0], nil
 }
 
-// mergeTags merges existedTags and desiredTags, returns true if all desiredTags are in existedTags.
+// mergeTags merges existedTags and desiredTags, returns true if all desiredTags are already in existedTags.
 func mergeTags(existedTags []string, desiredTags []string) (bool, []string) {
-	if len(existedTags) == 0 || existedTags == nil {
+	if len(existedTags) == 0 {
 		return false, desiredTags
 	}
-	desiredTagsSet := sets.NewString(desiredTags...)
+
 	tagSet := sets.NewString(existedTags...)
 	if tagSet.HasAll(desiredTags...) {
 		return true, nil
-	} else {
-		return false, tagSet.Union(desiredTagsSet).List()
 	}
+
+	return false, tagSet.Union(sets.NewString(desiredTags...)).List()
 }
 
 func popListener(existingListeners []listeners.Listener, id string) []listeners.Listener {
@@ -259,12 +259,7 @@ func (lbaas *LbaasV2) createOctaviaLoadBalancer(ctx context.Context, name, clust
 	}
 
 	if svcConf.supportLBTags {
-		var desiredTags []string
-		if len(svcConf.lbTags) == 0 {
-			klog.V(4).Infof("No load balancer tags found from service annotation key: %s", ServiceAnnotationLoadBalancerTags)
-		} else {
-			desiredTags = cpoutil.SplitTrim(svcConf.lbTags, ',')
-		}
+		desiredTags := cpoutil.SplitTrim(svcConf.lbTags, ',')
 		createOpts.Tags = append([]string{svcConf.lbName}, desiredTags...)
 	}
 
@@ -953,12 +948,7 @@ func (lbaas *LbaasV2) ensureOctaviaPool(ctx context.Context, lbID string, name s
 		}
 	}
 
-	var desiredTags []string
-	if len(svcConf.poolTags) == 0 {
-		klog.V(4).Infof("No pools tags found from service annotation key: %s", ServiceAnnotationPoolTags)
-	} else {
-		desiredTags = cpoutil.SplitTrim(svcConf.poolTags, ',')
-	}
+	desiredTags := cpoutil.SplitTrim(svcConf.poolTags, ',')
 
 	if pool == nil {
 		createOpt := lbaas.buildPoolCreateOpt(listener.Protocol, service, svcConf, name)
@@ -973,19 +963,17 @@ func (lbaas *LbaasV2) ensureOctaviaPool(ctx context.Context, lbID string, name s
 			return nil, err
 		}
 		klog.V(2).Infof("Pool %s created for listener %s", pool.ID, listener.ID)
-	} else if svcConf.supportLBTags {
+	} else if svcConf.supportLBTags && len(desiredTags) > 0 {
 		// Update tags if needed
-		if len(desiredTags) > 0 {
-			klog.V(4).Infof("Desired pools tags: %+v from service annotation key: %s", desiredTags, ServiceAnnotationPoolTags)
-			if ok, tags := mergeTags(pool.Tags, desiredTags); !ok {
-				klog.V(4).Infof("Will update pools' tags, current pools tags: %+v, desired tags: %+v", pool.Tags, tags)
-				updateOpts := v2pools.UpdateOpts{
-					Tags: &tags,
-				}
-				klog.InfoS("Updating pool tags", "poolID", pool.ID, "listenerID", listener.ID, "lbID", lbID, "tags", desiredTags)
-				if err := openstackutil.UpdatePool(ctx, lbaas.lb, lbID, pool.ID, updateOpts); err != nil {
-					klog.Warningf("Error updating LB pool tags: %v", err)
-				}
+		klog.V(4).Infof("Desired pool tags: %+v from service annotation key: %s", desiredTags, ServiceAnnotationPoolTags)
+		if ok, tags := mergeTags(pool.Tags, desiredTags); !ok {
+			klog.V(4).Infof("Will update pool tags, current pool tags: %+v, desired tags: %+v", pool.Tags, tags)
+			updateOpts := v2pools.UpdateOpts{
+				Tags: &tags,
+			}
+			klog.InfoS("Updating pool tags", "poolID", pool.ID, "listenerID", listener.ID, "lbID", lbID, "tags", tags)
+			if err := openstackutil.UpdatePool(ctx, lbaas.lb, lbID, pool.ID, updateOpts); err != nil {
+				klog.Warningf("Error updating LB pool tags: %v", err)
 			}
 		}
 	}
@@ -1154,17 +1142,11 @@ func (lbaas *LbaasV2) ensureOctaviaListener(ctx context.Context, lbID string, na
 		updateOpts := listeners.UpdateOpts{}
 
 		if svcConf.supportLBTags {
-			// Get desired tags from Service annotations
-			var desiredTags []string
-			if len(svcConf.listenerTags) == 0 {
-				klog.V(4).Infof("No listeners tags found from service annotation key: %s", ServiceAnnotationListenerTags)
-			} else {
-				desiredTags = cpoutil.SplitTrim(svcConf.listenerTags, ',')
-			}
-
+			// Ensure the LB name tag plus any desired tags from the Service annotation.
+			desiredTags := cpoutil.SplitTrim(svcConf.listenerTags, ',')
 			tagsToEnsure := append([]string{svcConf.lbName}, desiredTags...)
 			if ok, tags := mergeTags(listener.Tags, tagsToEnsure); !ok {
-				klog.V(4).Infof("Will update listeners' tags, current listeners tags: %+v, desired tags: %+v", listener.Tags, tags)
+				klog.V(4).Infof("Will update listener tags, current listener tags: %+v, desired tags: %+v", listener.Tags, tags)
 				updateOpts.Tags = &tags
 				listenerChanged = true
 			}
@@ -1239,20 +1221,11 @@ func (lbaas *LbaasV2) buildListenerCreateOpt(ctx context.Context, port corev1.Se
 	}
 
 	if svcConf.supportLBTags {
-		// Get desired tags from Service annotations
-		var desiredTags []string
-		if len(svcConf.listenerTags) == 0 {
-			klog.V(4).Infof("No listeners tags found from service annotation key: %s", ServiceAnnotationListenerTags)
-		} else {
-			desiredTags = cpoutil.SplitTrim(svcConf.listenerTags, ',')
-		}
-
+		// The LB name is always tagged, plus any desired tags from the Service annotation.
+		desiredTags := cpoutil.SplitTrim(svcConf.listenerTags, ',')
 		tags := []string{svcConf.lbName}
-		if len(desiredTags) > 0 {
-			klog.V(4).Infof("Desired listener tags: %+v from service annotation key: %s", desiredTags, ServiceAnnotationListenerTags)
-			if ok, merged := mergeTags(tags, desiredTags); !ok {
-				tags = merged
-			}
+		if _, merged := mergeTags(tags, desiredTags); merged != nil {
+			tags = merged
 		}
 		listenerCreateOpt.Tags = tags
 	}
@@ -1839,17 +1812,12 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 	lbaas.updateServiceAnnotation(service, ServiceAnnotationLoadBalancerID, loadbalancer.ID)
 
 	if svcConf.supportLBTags {
-		var desiredTags []string
-		if len(svcConf.lbTags) == 0 {
-			klog.V(4).Infof("No load balancer tags found from service annotation key: %s", ServiceAnnotationLoadBalancerTags)
-		} else {
-			desiredTags = cpoutil.SplitTrim(svcConf.lbTags, ',')
-		}
-		// add the service annotation tags to load balancer tags if the tags don't match
+		desiredTags := cpoutil.SplitTrim(svcConf.lbTags, ',')
+		// Add the Service annotation tags to the load balancer tags if they don't match.
 		if len(desiredTags) > 0 {
 			klog.V(4).Infof("Desired load balancer tags: %v from service annotation: %v", desiredTags, ServiceAnnotationLoadBalancerTags)
 			if ok, tags := mergeTags(loadbalancer.Tags, desiredTags); !ok {
-				klog.Infof("Will update load balancer's tags, current load balancer tags: %+v, desired tags: %+v", loadbalancer.Tags, tags)
+				klog.Infof("Will update load balancer tags, current load balancer tags: %+v, desired tags: %+v", loadbalancer.Tags, tags)
 				if err := openstackutil.UpdateLoadBalancerTags(ctx, lbaas.lb, loadbalancer.ID, tags); err != nil {
 					klog.Warningf("failed to update load balancer %s tags: %v", loadbalancer.ID, err)
 				}

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -932,7 +932,7 @@ func (lbaas *LbaasV2) ensureOctaviaPool(ctx context.Context, lbID string, name s
 		pool = nil
 	}
 
-	// Resolve the desired LB method, falling back to OCCM's default.
+	// If LBMethod changes, update the Pool with the new value
 	var poolLbMethod string
 	if svcConf.poolLbMethod != "" {
 		poolLbMethod = svcConf.poolLbMethod
@@ -942,7 +942,6 @@ func (lbaas *LbaasV2) ensureOctaviaPool(ctx context.Context, lbID string, name s
 	}
 	poolTags := cpoutil.SplitTrim(svcConf.poolTags, ',')
 
-	// If the LBMethod or tags change, update the existing pool in a single call.
 	if pool != nil {
 		updateOpts := v2pools.UpdateOpts{}
 		if pool.LBMethod != poolLbMethod {

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -207,6 +207,12 @@ func getLoadbalancerByName(ctx context.Context, client *gophercloud.ServiceClien
 	return &validLBs[0], nil
 }
 
+// withLBNameTag returns the LB name (OCCM's ownership tag) followed by the
+// comma-separated tags from the given Service annotation value.
+func withLBNameTag(lbName, annotation string) []string {
+	return append([]string{lbName}, cpoutil.SplitTrim(annotation, ',')...)
+}
+
 // mergeTags merges existedTags and desiredTags, returns true if all desiredTags are already in existedTags.
 func mergeTags(existedTags []string, desiredTags []string) (bool, []string) {
 	if len(existedTags) == 0 {
@@ -259,8 +265,7 @@ func (lbaas *LbaasV2) createOctaviaLoadBalancer(ctx context.Context, name, clust
 	}
 
 	if svcConf.supportLBTags {
-		lbTags := cpoutil.SplitTrim(svcConf.lbTags, ',')
-		createOpts.Tags = append([]string{svcConf.lbName}, lbTags...)
+		createOpts.Tags = withLBNameTag(svcConf.lbName, svcConf.lbTags)
 	}
 
 	if svcConf.flavorID != "" {
@@ -956,13 +961,11 @@ func (lbaas *LbaasV2) ensureOctaviaPool(ctx context.Context, lbID string, name s
 		var newLBMethod string
 		var newTags []string
 
-		// If LBMethod changes, update the Pool with the new value.
 		if pool.LBMethod != poolLbMethod {
 			newLBMethod = poolLbMethod
 			updateOpts.LBMethod = v2pools.LBMethod(poolLbMethod)
 		}
 
-		// If tags differ, update them too.
 		if svcConf.supportLBTags && len(poolTags) > 0 {
 			klog.V(4).Infof("Desired pool tags: %+v from service annotation key: %s", poolTags, ServiceAnnotationPoolTags)
 			if ok, tags := mergeTags(pool.Tags, poolTags); !ok {
@@ -1154,8 +1157,7 @@ func (lbaas *LbaasV2) ensureOctaviaListener(ctx context.Context, lbID string, na
 
 		if svcConf.supportLBTags {
 			// Ensure the LB name tag plus any desired tags from the Service annotation.
-			listenerTags := cpoutil.SplitTrim(svcConf.listenerTags, ',')
-			tagsToEnsure := append([]string{svcConf.lbName}, listenerTags...)
+			tagsToEnsure := withLBNameTag(svcConf.lbName, svcConf.listenerTags)
 			if ok, tags := mergeTags(listener.Tags, tagsToEnsure); !ok {
 				klog.V(4).Infof("Will update listener tags, current listener tags: %+v, desired tags: %+v", listener.Tags, tags)
 				updateOpts.Tags = &tags
@@ -1233,12 +1235,7 @@ func (lbaas *LbaasV2) buildListenerCreateOpt(ctx context.Context, port corev1.Se
 
 	if svcConf.supportLBTags {
 		// The LB name is always tagged, plus any desired tags from the Service annotation.
-		listenerTags := cpoutil.SplitTrim(svcConf.listenerTags, ',')
-		tags := []string{svcConf.lbName}
-		if ok, merged := mergeTags(tags, listenerTags); !ok && len(merged) > 0 {
-			tags = merged
-		}
-		listenerCreateOpt.Tags = tags
+		listenerCreateOpt.Tags = withLBNameTag(svcConf.lbName, svcConf.listenerTags)
 	}
 
 	if openstackutil.IsOctaviaFeatureSupported(ctx, lbaas.lb, openstackutil.OctaviaFeatureTimeout, lbaas.opts.LBProvider) {
@@ -1824,8 +1821,7 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 
 	if svcConf.supportLBTags {
 		// Ensure the LB name tag plus any tags from the Service annotation in a single update.
-		lbTags := cpoutil.SplitTrim(svcConf.lbTags, ',')
-		desiredLBTags := append([]string{lbName}, lbTags...)
+		desiredLBTags := withLBNameTag(lbName, svcConf.lbTags)
 		klog.V(4).Infof("Desired load balancer tags: %v (LB name plus annotation %s)", desiredLBTags, ServiceAnnotationLoadBalancerTags)
 		if ok, tags := mergeTags(loadbalancer.Tags, desiredLBTags); !ok {
 			klog.InfoS("Updating load balancer tags", "lbID", loadbalancer.ID, "tags", tags)

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -213,18 +213,18 @@ func withLBNameTag(lbName, annotation string) []string {
 	return append([]string{lbName}, cpoutil.SplitTrim(annotation, ',')...)
 }
 
-// mergeTags merges existedTags and desiredTags, returns true if all desiredTags are already in existedTags.
-func mergeTags(existedTags []string, desiredTags []string) (bool, []string) {
+// mergeTags merges existedTags and newTags, returns true if all newTags are already in existedTags.
+func mergeTags(existedTags []string, newTags []string) (bool, []string) {
 	if len(existedTags) == 0 {
-		return false, desiredTags
+		return false, newTags
 	}
 
 	tagSet := sets.NewString(existedTags...)
-	if tagSet.HasAll(desiredTags...) {
+	if tagSet.HasAll(newTags...) {
 		return true, nil
 	}
 
-	return false, tagSet.Union(sets.NewString(desiredTags...)).List()
+	return false, tagSet.Union(sets.NewString(newTags...)).List()
 }
 
 func popListener(existingListeners []listeners.Listener, id string) []listeners.Listener {
@@ -958,36 +958,25 @@ func (lbaas *LbaasV2) ensureOctaviaPool(ctx context.Context, lbID string, name s
 	} else {
 		// Gather all desired changes to the existing pool into a single update.
 		updateOpts := v2pools.UpdateOpts{}
-		var newLBMethod string
-		var newTags []string
 
 		if pool.LBMethod != poolLbMethod {
-			newLBMethod = poolLbMethod
 			updateOpts.LBMethod = v2pools.LBMethod(poolLbMethod)
 		}
 
 		if svcConf.supportLBTags && len(poolTags) > 0 {
 			klog.V(4).Infof("Desired pool tags: %+v from service annotation key: %s", poolTags, ServiceAnnotationPoolTags)
 			if ok, tags := mergeTags(pool.Tags, poolTags); !ok {
-				newTags = tags
-				updateOpts.Tags = &newTags
+				updateOpts.Tags = &tags
 			}
 		}
 
-		if newLBMethod != "" || newTags != nil {
-			klog.InfoS("Updating pool", "poolID", pool.ID, "listenerID", listener.ID, "lbID", lbID, "lbMethod", newLBMethod, "tags", newTags)
+		if updateOpts != (v2pools.UpdateOpts{}) {
+			klog.InfoS("Updating pool", "poolID", pool.ID, "listenerID", listener.ID, "lbID", lbID, "lbMethod", updateOpts.LBMethod, "tags", updateOpts.Tags)
 			if err := openstackutil.UpdatePool(ctx, lbaas.lb, lbID, pool.ID, updateOpts); err != nil {
 				err = PreserveGopherError(err)
 				msg := fmt.Sprintf("Error updating pool for LoadBalancer: %v", err)
 				klog.Errorf(msg, "poolID", pool.ID, "listenerID", listener.ID, "lbID", lbID)
 				lbaas.eventRecorder.Event(service, corev1.EventTypeWarning, eventLBLbMethodUnknown, msg)
-			} else {
-				if newLBMethod != "" {
-					pool.LBMethod = newLBMethod
-				}
-				if newTags != nil {
-					pool.Tags = newTags
-				}
 			}
 		}
 	}
@@ -1157,8 +1146,8 @@ func (lbaas *LbaasV2) ensureOctaviaListener(ctx context.Context, lbID string, na
 
 		if svcConf.supportLBTags {
 			// Ensure the LB name tag plus any desired tags from the Service annotation.
-			tagsToEnsure := withLBNameTag(svcConf.lbName, svcConf.listenerTags)
-			if ok, tags := mergeTags(listener.Tags, tagsToEnsure); !ok {
+			listenerTags := withLBNameTag(svcConf.lbName, svcConf.listenerTags)
+			if ok, tags := mergeTags(listener.Tags, listenerTags); !ok {
 				klog.V(4).Infof("Will update listener tags, current listener tags: %+v, desired tags: %+v", listener.Tags, tags)
 				updateOpts.Tags = &tags
 				listenerChanged = true
@@ -1821,9 +1810,9 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 
 	if svcConf.supportLBTags {
 		// Ensure the LB name tag plus any tags from the Service annotation in a single update.
-		desiredLBTags := withLBNameTag(lbName, svcConf.lbTags)
-		klog.V(4).Infof("Desired load balancer tags: %v (LB name plus annotation %s)", desiredLBTags, ServiceAnnotationLoadBalancerTags)
-		if ok, tags := mergeTags(loadbalancer.Tags, desiredLBTags); !ok {
+		lbTags := withLBNameTag(lbName, svcConf.lbTags)
+		klog.V(4).Infof("Desired load balancer tags: %v (LB name plus annotation %s)", lbTags, ServiceAnnotationLoadBalancerTags)
+		if ok, tags := mergeTags(loadbalancer.Tags, lbTags); !ok {
 			klog.InfoS("Updating load balancer tags", "lbID", loadbalancer.ID, "tags", tags)
 			if err := openstackutil.UpdateLoadBalancerTags(ctx, lbaas.lb, loadbalancer.ID, tags); err != nil {
 				return nil, fmt.Errorf("failed to update load balancer %s tags: %w", loadbalancer.ID, err)

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -259,8 +259,8 @@ func (lbaas *LbaasV2) createOctaviaLoadBalancer(ctx context.Context, name, clust
 	}
 
 	if svcConf.supportLBTags {
-		desiredTags := cpoutil.SplitTrim(svcConf.lbTags, ',')
-		createOpts.Tags = append([]string{svcConf.lbName}, desiredTags...)
+		lbTags := cpoutil.SplitTrim(svcConf.lbTags, ',')
+		createOpts.Tags = append([]string{svcConf.lbName}, lbTags...)
 	}
 
 	if svcConf.flavorID != "" {
@@ -927,7 +927,7 @@ func (lbaas *LbaasV2) ensureOctaviaPool(ctx context.Context, lbID string, name s
 		pool = nil
 	}
 
-	// If LBMethod changes, update the Pool with the new value
+	// Resolve the desired LB method, falling back to OCCM's default.
 	var poolLbMethod string
 	if svcConf.poolLbMethod != "" {
 		poolLbMethod = svcConf.poolLbMethod
@@ -935,26 +935,13 @@ func (lbaas *LbaasV2) ensureOctaviaPool(ctx context.Context, lbID string, name s
 		// if LBMethod is not defined, fallback on default OCCM's default method
 		poolLbMethod = lbaas.opts.LBMethod
 	}
-	if pool != nil && pool.LBMethod != poolLbMethod {
-		klog.InfoS("Updating LoadBalancer LBMethod", "poolID", pool.ID, "listenerID", listener.ID, "lbID", lbID)
-		err = openstackutil.UpdatePool(ctx, lbaas.lb, lbID, pool.ID, v2pools.UpdateOpts{LBMethod: v2pools.LBMethod(poolLbMethod)})
-		if err != nil {
-			err = PreserveGopherError(err)
-			msg := fmt.Sprintf("Error updating LB method for LoadBalancer: %v", err)
-			klog.Errorf(msg, "poolID", pool.ID, "listenerID", listener.ID, "lbID", lbID)
-			lbaas.eventRecorder.Event(service, corev1.EventTypeWarning, eventLBLbMethodUnknown, msg)
-		} else {
-			pool.LBMethod = poolLbMethod
-		}
-	}
-
-	desiredTags := cpoutil.SplitTrim(svcConf.poolTags, ',')
+	poolTags := cpoutil.SplitTrim(svcConf.poolTags, ',')
 
 	if pool == nil {
 		createOpt := lbaas.buildPoolCreateOpt(listener.Protocol, service, svcConf, name)
 		createOpt.ListenerID = listener.ID
 		if svcConf.supportLBTags {
-			createOpt.Tags = desiredTags
+			createOpt.Tags = poolTags
 		}
 		klog.InfoS("Creating pool", "listenerID", listener.ID, "protocol", createOpt.Protocol)
 		klog.V(4).Infof("Pool create options: %+v", createOpt)
@@ -963,17 +950,41 @@ func (lbaas *LbaasV2) ensureOctaviaPool(ctx context.Context, lbID string, name s
 			return nil, err
 		}
 		klog.V(2).Infof("Pool %s created for listener %s", pool.ID, listener.ID)
-	} else if svcConf.supportLBTags && len(desiredTags) > 0 {
-		// Update tags if needed
-		klog.V(4).Infof("Desired pool tags: %+v from service annotation key: %s", desiredTags, ServiceAnnotationPoolTags)
-		if ok, tags := mergeTags(pool.Tags, desiredTags); !ok {
-			klog.V(4).Infof("Will update pool tags, current pool tags: %+v, desired tags: %+v", pool.Tags, tags)
-			updateOpts := v2pools.UpdateOpts{
-				Tags: &tags,
+	} else {
+		// Gather all desired changes to the existing pool into a single update.
+		updateOpts := v2pools.UpdateOpts{}
+		var newLBMethod string
+		var newTags []string
+
+		// If LBMethod changes, update the Pool with the new value.
+		if pool.LBMethod != poolLbMethod {
+			newLBMethod = poolLbMethod
+			updateOpts.LBMethod = v2pools.LBMethod(poolLbMethod)
+		}
+
+		// If tags differ, update them too.
+		if svcConf.supportLBTags && len(poolTags) > 0 {
+			klog.V(4).Infof("Desired pool tags: %+v from service annotation key: %s", poolTags, ServiceAnnotationPoolTags)
+			if ok, tags := mergeTags(pool.Tags, poolTags); !ok {
+				newTags = tags
+				updateOpts.Tags = &newTags
 			}
-			klog.InfoS("Updating pool tags", "poolID", pool.ID, "listenerID", listener.ID, "lbID", lbID, "tags", tags)
+		}
+
+		if newLBMethod != "" || newTags != nil {
+			klog.InfoS("Updating pool", "poolID", pool.ID, "listenerID", listener.ID, "lbID", lbID, "lbMethod", newLBMethod, "tags", newTags)
 			if err := openstackutil.UpdatePool(ctx, lbaas.lb, lbID, pool.ID, updateOpts); err != nil {
-				klog.Warningf("Error updating LB pool tags: %v", err)
+				err = PreserveGopherError(err)
+				msg := fmt.Sprintf("Error updating pool for LoadBalancer: %v", err)
+				klog.Errorf(msg, "poolID", pool.ID, "listenerID", listener.ID, "lbID", lbID)
+				lbaas.eventRecorder.Event(service, corev1.EventTypeWarning, eventLBLbMethodUnknown, msg)
+			} else {
+				if newLBMethod != "" {
+					pool.LBMethod = newLBMethod
+				}
+				if newTags != nil {
+					pool.Tags = newTags
+				}
 			}
 		}
 	}
@@ -1143,8 +1154,8 @@ func (lbaas *LbaasV2) ensureOctaviaListener(ctx context.Context, lbID string, na
 
 		if svcConf.supportLBTags {
 			// Ensure the LB name tag plus any desired tags from the Service annotation.
-			desiredTags := cpoutil.SplitTrim(svcConf.listenerTags, ',')
-			tagsToEnsure := append([]string{svcConf.lbName}, desiredTags...)
+			listenerTags := cpoutil.SplitTrim(svcConf.listenerTags, ',')
+			tagsToEnsure := append([]string{svcConf.lbName}, listenerTags...)
 			if ok, tags := mergeTags(listener.Tags, tagsToEnsure); !ok {
 				klog.V(4).Infof("Will update listener tags, current listener tags: %+v, desired tags: %+v", listener.Tags, tags)
 				updateOpts.Tags = &tags
@@ -1222,9 +1233,9 @@ func (lbaas *LbaasV2) buildListenerCreateOpt(ctx context.Context, port corev1.Se
 
 	if svcConf.supportLBTags {
 		// The LB name is always tagged, plus any desired tags from the Service annotation.
-		desiredTags := cpoutil.SplitTrim(svcConf.listenerTags, ',')
+		listenerTags := cpoutil.SplitTrim(svcConf.listenerTags, ',')
 		tags := []string{svcConf.lbName}
-		if _, merged := mergeTags(tags, desiredTags); merged != nil {
+		if ok, merged := mergeTags(tags, listenerTags); !ok && len(merged) > 0 {
 			tags = merged
 		}
 		listenerCreateOpt.Tags = tags
@@ -1812,16 +1823,16 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 	lbaas.updateServiceAnnotation(service, ServiceAnnotationLoadBalancerID, loadbalancer.ID)
 
 	if svcConf.supportLBTags {
-		desiredTags := cpoutil.SplitTrim(svcConf.lbTags, ',')
-		// Add the Service annotation tags to the load balancer tags if they don't match.
-		if len(desiredTags) > 0 {
-			klog.V(4).Infof("Desired load balancer tags: %v from service annotation: %v", desiredTags, ServiceAnnotationLoadBalancerTags)
-			if ok, tags := mergeTags(loadbalancer.Tags, desiredTags); !ok {
-				klog.Infof("Will update load balancer tags, current load balancer tags: %+v, desired tags: %+v", loadbalancer.Tags, tags)
-				if err := openstackutil.UpdateLoadBalancerTags(ctx, lbaas.lb, loadbalancer.ID, tags); err != nil {
-					klog.Warningf("failed to update load balancer %s tags: %v", loadbalancer.ID, err)
-				}
+		// Ensure the LB name tag plus any tags from the Service annotation in a single update.
+		lbTags := cpoutil.SplitTrim(svcConf.lbTags, ',')
+		desiredLBTags := append([]string{lbName}, lbTags...)
+		klog.V(4).Infof("Desired load balancer tags: %v (LB name plus annotation %s)", desiredLBTags, ServiceAnnotationLoadBalancerTags)
+		if ok, tags := mergeTags(loadbalancer.Tags, desiredLBTags); !ok {
+			klog.InfoS("Updating load balancer tags", "lbID", loadbalancer.ID, "tags", tags)
+			if err := openstackutil.UpdateLoadBalancerTags(ctx, lbaas.lb, loadbalancer.ID, tags); err != nil {
+				return nil, fmt.Errorf("failed to update load balancer %s tags: %w", loadbalancer.ID, err)
 			}
+			loadbalancer.Tags = tags
 		}
 	}
 
@@ -1894,18 +1905,6 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 
 	// save address into the annotation
 	lbaas.updateServiceAnnotation(service, ServiceAnnotationLoadBalancerAddress, addr)
-
-	// add LB name to load balancer tags.
-	if svcConf.supportLBTags {
-		lbTags := loadbalancer.Tags
-		if !slices.Contains(lbTags, lbName) {
-			lbTags = append(lbTags, lbName)
-			klog.InfoS("Updating load balancer tags", "lbID", loadbalancer.ID, "tags", lbTags)
-			if err := openstackutil.UpdateLoadBalancerTags(ctx, lbaas.lb, loadbalancer.ID, lbTags); err != nil {
-				return nil, err
-			}
-		}
-	}
 
 	// Create status the load balancer
 	status := lbaas.createLoadBalancerStatus(service, svcConf, addr)

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -942,6 +942,30 @@ func (lbaas *LbaasV2) ensureOctaviaPool(ctx context.Context, lbID string, name s
 	}
 	poolTags := cpoutil.SplitTrim(svcConf.poolTags, ',')
 
+	// If the LBMethod or tags change, update the existing pool in a single call.
+	if pool != nil {
+		updateOpts := v2pools.UpdateOpts{}
+		if pool.LBMethod != poolLbMethod {
+			updateOpts.LBMethod = v2pools.LBMethod(poolLbMethod)
+		}
+		if svcConf.supportLBTags && len(poolTags) > 0 {
+			klog.V(4).Infof("Desired pool tags: %+v from service annotation key: %s", poolTags, ServiceAnnotationPoolTags)
+			if ok, tags := mergeTags(pool.Tags, poolTags); !ok {
+				updateOpts.Tags = &tags
+			}
+		}
+		if updateOpts != (v2pools.UpdateOpts{}) {
+			klog.InfoS("Updating pool", "poolID", pool.ID, "listenerID", listener.ID, "lbID", lbID, "lbMethod", updateOpts.LBMethod, "tags", updateOpts.Tags)
+			err = openstackutil.UpdatePool(ctx, lbaas.lb, lbID, pool.ID, updateOpts)
+			if err != nil {
+				err = PreserveGopherError(err)
+				msg := fmt.Sprintf("Error updating pool for LoadBalancer: %v", err)
+				klog.Errorf(msg, "poolID", pool.ID, "listenerID", listener.ID, "lbID", lbID)
+				lbaas.eventRecorder.Event(service, corev1.EventTypeWarning, eventLBLbMethodUnknown, msg)
+			}
+		}
+	}
+
 	if pool == nil {
 		createOpt := lbaas.buildPoolCreateOpt(listener.Protocol, service, svcConf, name)
 		createOpt.ListenerID = listener.ID
@@ -955,30 +979,6 @@ func (lbaas *LbaasV2) ensureOctaviaPool(ctx context.Context, lbID string, name s
 			return nil, err
 		}
 		klog.V(2).Infof("Pool %s created for listener %s", pool.ID, listener.ID)
-	} else {
-		// Gather all desired changes to the existing pool into a single update.
-		updateOpts := v2pools.UpdateOpts{}
-
-		if pool.LBMethod != poolLbMethod {
-			updateOpts.LBMethod = v2pools.LBMethod(poolLbMethod)
-		}
-
-		if svcConf.supportLBTags && len(poolTags) > 0 {
-			klog.V(4).Infof("Desired pool tags: %+v from service annotation key: %s", poolTags, ServiceAnnotationPoolTags)
-			if ok, tags := mergeTags(pool.Tags, poolTags); !ok {
-				updateOpts.Tags = &tags
-			}
-		}
-
-		if updateOpts != (v2pools.UpdateOpts{}) {
-			klog.InfoS("Updating pool", "poolID", pool.ID, "listenerID", listener.ID, "lbID", lbID, "lbMethod", updateOpts.LBMethod, "tags", updateOpts.Tags)
-			if err := openstackutil.UpdatePool(ctx, lbaas.lb, lbID, pool.ID, updateOpts); err != nil {
-				err = PreserveGopherError(err)
-				msg := fmt.Sprintf("Error updating pool for LoadBalancer: %v", err)
-				klog.Errorf(msg, "poolID", pool.ID, "listenerID", listener.ID, "lbID", lbID)
-				lbaas.eventRecorder.Event(service, corev1.EventTypeWarning, eventLBLbMethodUnknown, msg)
-			}
-		}
 	}
 
 	if lbaas.opts.ProviderRequiresSerialAPICalls {
@@ -1808,19 +1808,6 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 	// Make sure LB ID will be saved at this point.
 	lbaas.updateServiceAnnotation(service, ServiceAnnotationLoadBalancerID, loadbalancer.ID)
 
-	if svcConf.supportLBTags {
-		// Ensure the LB name tag plus any tags from the Service annotation in a single update.
-		lbTags := withLBNameTag(lbName, svcConf.lbTags)
-		klog.V(4).Infof("Desired load balancer tags: %v (LB name plus annotation %s)", lbTags, ServiceAnnotationLoadBalancerTags)
-		if ok, tags := mergeTags(loadbalancer.Tags, lbTags); !ok {
-			klog.InfoS("Updating load balancer tags", "lbID", loadbalancer.ID, "tags", tags)
-			if err := openstackutil.UpdateLoadBalancerTags(ctx, lbaas.lb, loadbalancer.ID, tags); err != nil {
-				return nil, fmt.Errorf("failed to update load balancer %s tags: %w", loadbalancer.ID, err)
-			}
-			loadbalancer.Tags = tags
-		}
-	}
-
 	if loadbalancer.ProvisioningStatus != activeStatus {
 		return nil, fmt.Errorf("load balancer %s is not ACTIVE, current provisioning status: %s", loadbalancer.ID, loadbalancer.ProvisioningStatus)
 	}
@@ -1890,6 +1877,19 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 
 	// save address into the annotation
 	lbaas.updateServiceAnnotation(service, ServiceAnnotationLoadBalancerAddress, addr)
+
+	// Ensure the LB name tag plus any tags from the Service annotation in a single update.
+	if svcConf.supportLBTags {
+		lbTags := withLBNameTag(lbName, svcConf.lbTags)
+		klog.V(4).Infof("Desired load balancer tags: %v (LB name plus annotation %s)", lbTags, ServiceAnnotationLoadBalancerTags)
+		if ok, tags := mergeTags(loadbalancer.Tags, lbTags); !ok {
+			klog.InfoS("Updating load balancer tags", "lbID", loadbalancer.ID, "tags", tags)
+			if err := openstackutil.UpdateLoadBalancerTags(ctx, lbaas.lb, loadbalancer.ID, tags); err != nil {
+				return nil, fmt.Errorf("failed to update load balancer %s tags: %w", loadbalancer.ID, err)
+			}
+			loadbalancer.Tags = tags
+		}
+	}
 
 	// Create status the load balancer
 	status := lbaas.createLoadBalancerStatus(service, svcConf, addr)

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -1422,11 +1422,6 @@ func (lbaas *LbaasV2) checkService(ctx context.Context, service *corev1.Service,
 		return fmt.Errorf("no service ports provided")
 	}
 
-	annotations := service.GetAnnotations()
-	svcConf.lbTags = annotations[ServiceAnnotationLoadBalancerTags]
-	svcConf.listenerTags = annotations[ServiceAnnotationListenerTags]
-	svcConf.poolTags = annotations[ServiceAnnotationPoolTags]
-
 	if len(service.Spec.IPFamilies) > 0 {
 		// Since OCCM does not support multiple load-balancers per service yet,
 		// the first IP family will determine the IP family of the load-balancer
@@ -1604,6 +1599,11 @@ func (lbaas *LbaasV2) makeSvcConf(ctx context.Context, serviceName string, servi
 	svcConf.lbID = getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerID, "")
 	svcConf.poolLbMethod = getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerLbMethod, "")
 	svcConf.supportLBTags = openstackutil.IsOctaviaFeatureSupported(ctx, lbaas.lb, openstackutil.OctaviaFeatureTags, lbaas.opts.LBProvider)
+
+	annotations := service.GetAnnotations()
+	svcConf.lbTags = annotations[ServiceAnnotationLoadBalancerTags]
+	svcConf.listenerTags = annotations[ServiceAnnotationListenerTags]
+	svcConf.poolTags = annotations[ServiceAnnotationPoolTags]
 
 	// Get service node-selector annotations
 	svcConf.nodeSelectors = getKeyValueFromServiceAnnotation(service, ServiceAnnotationLoadBalancerNodeSelector, lbaas.opts.NodeSelector)

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -207,17 +207,25 @@ func getLoadbalancerByName(ctx context.Context, client *gophercloud.ServiceClien
 	return &validLBs[0], nil
 }
 
-// withLBNameTag returns the LB name (OCCM's ownership tag) followed by the
-// comma-separated tags from the given Service annotation value, skipping any
-// annotation tag that duplicates the LB name so it cannot appear twice.
-func withLBNameTag(lbName, annotation string) []string {
-	tags := []string{lbName}
-	for _, t := range cpoutil.SplitTrim(annotation, ',') {
-		if t != lbName {
-			tags = append(tags, t)
+// dedupTags returns tags with duplicates removed, preserving first-seen order.
+func dedupTags(tags []string) []string {
+	seen := sets.NewString()
+	result := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if !seen.Has(t) {
+			seen.Insert(t)
+			result = append(result, t)
 		}
 	}
-	return tags
+	return result
+}
+
+// withLBNameTag returns the LB name (OCCM's ownership tag) followed by the
+// comma-separated tags from the given Service annotation value, with duplicate
+// tags removed (including ones that duplicate the LB name) so no tag can appear
+// twice.
+func withLBNameTag(lbName, annotation string) []string {
+	return dedupTags(append([]string{lbName}, cpoutil.SplitTrim(annotation, ',')...))
 }
 
 // mergeTags merges existedTags and newTags, returns true if all newTags are already in existedTags.
@@ -943,7 +951,7 @@ func (lbaas *LbaasV2) ensureOctaviaPool(ctx context.Context, lbID string, name s
 		// if LBMethod is not defined, fallback on default OCCM's default method
 		poolLbMethod = lbaas.opts.LBMethod
 	}
-	poolTags := cpoutil.SplitTrim(svcConf.poolTags, ',')
+	poolTags := dedupTags(cpoutil.SplitTrim(svcConf.poolTags, ','))
 
 	if pool != nil {
 		updateOpts := v2pools.UpdateOpts{}

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -220,15 +220,27 @@ func dedupTags(tags []string) []string {
 	return result
 }
 
-// sanitizeUserTags drops any user-supplied tag that equals lbName, the special
-// ownership tag OCCM derives from GetLoadBalancerName. Allowing a user to set it
-// via annotation could clash with OCCM's ownership detection (e.g. a tag that
-// matches another load balancer's name), so it is reserved for OCCM's own use.
-func sanitizeUserTags(lbName string, tags []string) []string {
+// stripReservedTags drops any user-supplied tag that begins with servicePrefix.
+//
+// Tags with this prefix are how OCCM marks resource ownership: the ownership tag
+// written to a resource is always a GetLoadBalancerName value, which always
+// starts with servicePrefix. Every ownership check in this file matches tags
+// exclusively on that form -- either an exact match against the prefixed lbName
+// (e.g. slices.Contains(tags, lbName)) or a strings.HasPrefix(tag, servicePrefix)
+// scan (used for shared-LB counting and deletion decisions).
+//
+// Because of that, keeping user tags out of the servicePrefix subspace fully
+// partitions the tag namespace: ownership tags live in the kube_service_* space,
+// user tags live in its complement, and no user tag can ever satisfy an ownership
+// check. This prevents a Service from injecting a tag matching another (possibly
+// cross-tenant) load balancer's name to hijack ownership, shared-LB limits, or
+// deletion. INVARIANT: any new tag-based ownership check must also key on
+// servicePrefix, or this guarantee no longer holds.
+func stripReservedTags(tags []string) []string {
 	result := make([]string, 0, len(tags))
 	for _, t := range tags {
-		if t == lbName {
-			klog.Warningf("Ignoring reserved tag %q: it matches the load balancer name and is reserved for OCCM ownership tracking", t)
+		if strings.HasPrefix(t, servicePrefix) {
+			klog.Warningf("Ignoring reserved tag %q: tags starting with %q are reserved for OCCM ownership tracking", t, servicePrefix)
 			continue
 		}
 		result = append(result, t)
@@ -237,11 +249,11 @@ func sanitizeUserTags(lbName string, tags []string) []string {
 }
 
 // withLBNameTag returns the LB name (OCCM's ownership tag) followed by the
-// comma-separated tags from the given Service annotation value, with duplicate
-// tags removed (including ones that duplicate the LB name) so no tag can appear
-// twice.
+// comma-separated tags from the given Service annotation value. Any user tag
+// using the reserved servicePrefix is stripped, and duplicate tags are removed
+// (including ones that duplicate the LB name) so no tag can appear twice.
 func withLBNameTag(lbName, annotation string) []string {
-	userTags := sanitizeUserTags(lbName, cpoutil.SplitTrim(annotation, ','))
+	userTags := stripReservedTags(cpoutil.SplitTrim(annotation, ','))
 	return dedupTags(append([]string{lbName}, userTags...))
 }
 
@@ -968,7 +980,7 @@ func (lbaas *LbaasV2) ensureOctaviaPool(ctx context.Context, lbID string, name s
 		// if LBMethod is not defined, fallback on default OCCM's default method
 		poolLbMethod = lbaas.opts.LBMethod
 	}
-	poolTags := dedupTags(sanitizeUserTags(svcConf.lbName, cpoutil.SplitTrim(svcConf.poolTags, ',')))
+	poolTags := dedupTags(stripReservedTags(cpoutil.SplitTrim(svcConf.poolTags, ',')))
 
 	if pool != nil {
 		updateOpts := v2pools.UpdateOpts{}

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -215,10 +215,6 @@ func withLBNameTag(lbName, annotation string) []string {
 
 // mergeTags merges existedTags and newTags, returns true if all newTags are already in existedTags.
 func mergeTags(existedTags []string, newTags []string) (bool, []string) {
-	if len(existedTags) == 0 {
-		return false, newTags
-	}
-
 	tagSet := sets.NewString(existedTags...)
 	if tagSet.HasAll(newTags...) {
 		return true, nil

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -208,9 +208,16 @@ func getLoadbalancerByName(ctx context.Context, client *gophercloud.ServiceClien
 }
 
 // withLBNameTag returns the LB name (OCCM's ownership tag) followed by the
-// comma-separated tags from the given Service annotation value.
+// comma-separated tags from the given Service annotation value, skipping any
+// annotation tag that duplicates the LB name so it cannot appear twice.
 func withLBNameTag(lbName, annotation string) []string {
-	return append([]string{lbName}, cpoutil.SplitTrim(annotation, ',')...)
+	tags := []string{lbName}
+	for _, t := range cpoutil.SplitTrim(annotation, ',') {
+		if t != lbName {
+			tags = append(tags, t)
+		}
+	}
+	return tags
 }
 
 // mergeTags merges existedTags and newTags, returns true if all newTags are already in existedTags.

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -220,12 +220,29 @@ func dedupTags(tags []string) []string {
 	return result
 }
 
+// sanitizeUserTags drops any user-supplied tag that equals lbName, the special
+// ownership tag OCCM derives from GetLoadBalancerName. Allowing a user to set it
+// via annotation could clash with OCCM's ownership detection (e.g. a tag that
+// matches another load balancer's name), so it is reserved for OCCM's own use.
+func sanitizeUserTags(lbName string, tags []string) []string {
+	result := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if t == lbName {
+			klog.Warningf("Ignoring reserved tag %q: it matches the load balancer name and is reserved for OCCM ownership tracking", t)
+			continue
+		}
+		result = append(result, t)
+	}
+	return result
+}
+
 // withLBNameTag returns the LB name (OCCM's ownership tag) followed by the
 // comma-separated tags from the given Service annotation value, with duplicate
 // tags removed (including ones that duplicate the LB name) so no tag can appear
 // twice.
 func withLBNameTag(lbName, annotation string) []string {
-	return dedupTags(append([]string{lbName}, cpoutil.SplitTrim(annotation, ',')...))
+	userTags := sanitizeUserTags(lbName, cpoutil.SplitTrim(annotation, ','))
+	return dedupTags(append([]string{lbName}, userTags...))
 }
 
 // mergeTags merges existedTags and newTags, returns true if all newTags are already in existedTags.
@@ -951,7 +968,7 @@ func (lbaas *LbaasV2) ensureOctaviaPool(ctx context.Context, lbID string, name s
 		// if LBMethod is not defined, fallback on default OCCM's default method
 		poolLbMethod = lbaas.opts.LBMethod
 	}
-	poolTags := dedupTags(cpoutil.SplitTrim(svcConf.poolTags, ','))
+	poolTags := dedupTags(sanitizeUserTags(svcConf.lbName, cpoutil.SplitTrim(svcConf.poolTags, ',')))
 
 	if pool != nil {
 		updateOpts := v2pools.UpdateOpts{}

--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -207,19 +207,6 @@ func getLoadbalancerByName(ctx context.Context, client *gophercloud.ServiceClien
 	return &validLBs[0], nil
 }
 
-// dedupTags returns tags with duplicates removed, preserving first-seen order.
-func dedupTags(tags []string) []string {
-	seen := sets.NewString()
-	result := make([]string, 0, len(tags))
-	for _, t := range tags {
-		if !seen.Has(t) {
-			seen.Insert(t)
-			result = append(result, t)
-		}
-	}
-	return result
-}
-
 // stripReservedTags drops any user-supplied tag that begins with servicePrefix.
 //
 // Tags with this prefix are how OCCM marks resource ownership: the ownership tag
@@ -254,17 +241,7 @@ func stripReservedTags(tags []string) []string {
 // (including ones that duplicate the LB name) so no tag can appear twice.
 func withLBNameTag(lbName, annotation string) []string {
 	userTags := stripReservedTags(cpoutil.SplitTrim(annotation, ','))
-	return dedupTags(append([]string{lbName}, userTags...))
-}
-
-// mergeTags merges existedTags and newTags, returns true if all newTags are already in existedTags.
-func mergeTags(existedTags []string, newTags []string) (bool, []string) {
-	tagSet := sets.NewString(existedTags...)
-	if tagSet.HasAll(newTags...) {
-		return true, nil
-	}
-
-	return false, tagSet.Union(sets.NewString(newTags...)).List()
+	return cpoutil.Unique(append([]string{lbName}, userTags...))
 }
 
 func popListener(existingListeners []listeners.Listener, id string) []listeners.Listener {
@@ -980,7 +957,7 @@ func (lbaas *LbaasV2) ensureOctaviaPool(ctx context.Context, lbID string, name s
 		// if LBMethod is not defined, fallback on default OCCM's default method
 		poolLbMethod = lbaas.opts.LBMethod
 	}
-	poolTags := dedupTags(stripReservedTags(cpoutil.SplitTrim(svcConf.poolTags, ',')))
+	poolTags := cpoutil.Unique(stripReservedTags(cpoutil.SplitTrim(svcConf.poolTags, ',')))
 
 	if pool != nil {
 		updateOpts := v2pools.UpdateOpts{}
@@ -989,7 +966,7 @@ func (lbaas *LbaasV2) ensureOctaviaPool(ctx context.Context, lbID string, name s
 		}
 		if svcConf.supportLBTags && len(poolTags) > 0 {
 			klog.V(4).Infof("Desired pool tags: %+v from service annotation key: %s", poolTags, ServiceAnnotationPoolTags)
-			if ok, tags := mergeTags(pool.Tags, poolTags); !ok {
+			if tags, changed := cpoutil.Merge(pool.Tags, poolTags); changed {
 				updateOpts.Tags = &tags
 			}
 		}
@@ -1186,7 +1163,7 @@ func (lbaas *LbaasV2) ensureOctaviaListener(ctx context.Context, lbID string, na
 		if svcConf.supportLBTags {
 			// Ensure the LB name tag plus any desired tags from the Service annotation.
 			listenerTags := withLBNameTag(svcConf.lbName, svcConf.listenerTags)
-			if ok, tags := mergeTags(listener.Tags, listenerTags); !ok {
+			if tags, changed := cpoutil.Merge(listener.Tags, listenerTags); changed {
 				klog.V(4).Infof("Will update listener tags, current listener tags: %+v, desired tags: %+v", listener.Tags, tags)
 				updateOpts.Tags = &tags
 				listenerChanged = true
@@ -1921,7 +1898,7 @@ func (lbaas *LbaasV2) ensureOctaviaLoadBalancer(ctx context.Context, clusterName
 	if svcConf.supportLBTags {
 		lbTags := withLBNameTag(lbName, svcConf.lbTags)
 		klog.V(4).Infof("Desired load balancer tags: %v (LB name plus annotation %s)", lbTags, ServiceAnnotationLoadBalancerTags)
-		if ok, tags := mergeTags(loadbalancer.Tags, lbTags); !ok {
+		if tags, changed := cpoutil.Merge(loadbalancer.Tags, lbTags); changed {
 			klog.InfoS("Updating load balancer tags", "lbID", loadbalancer.ID, "tags", tags)
 			if err := openstackutil.UpdateLoadBalancerTags(ctx, lbaas.lb, loadbalancer.ID, tags); err != nil {
 				return nil, fmt.Errorf("failed to update load balancer %s tags: %w", loadbalancer.ID, err)

--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -2575,7 +2575,7 @@ func TestBuildListenerCreateOpt(t *testing.T) {
 				Protocol:     listeners.ProtocolTCP,
 				ProtocolPort: 80,
 				ConnLimit:    &svcConf.connLimit,
-				Tags:         []string{"bar", "foo", "my-lb"},
+				Tags:         []string{"my-lb", "foo", "bar"},
 			},
 		},
 	}

--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -152,6 +152,60 @@ type testGetRulesToCreateAndDelete struct {
 	toDelete      []rules.SecGroupRule
 }
 
+func TestMergeTags(t *testing.T) {
+	testCases := []struct {
+		name         string
+		existedTags  []string
+		desiredTags  []string
+		expectedOK   bool
+		expectedTags []string
+	}{
+		{
+			name:         "nil existing tags returns desired tags",
+			existedTags:  nil,
+			desiredTags:  []string{"a", "b"},
+			expectedOK:   false,
+			expectedTags: []string{"a", "b"},
+		},
+		{
+			name:         "empty existing tags returns desired tags",
+			existedTags:  []string{},
+			desiredTags:  []string{"a"},
+			expectedOK:   false,
+			expectedTags: []string{"a"},
+		},
+		{
+			name:         "all desired tags already present",
+			existedTags:  []string{"a", "b", "c"},
+			desiredTags:  []string{"a", "b"},
+			expectedOK:   true,
+			expectedTags: nil,
+		},
+		{
+			name:         "some desired tags missing are merged and sorted",
+			existedTags:  []string{"b", "d"},
+			desiredTags:  []string{"a", "c"},
+			expectedOK:   false,
+			expectedTags: []string{"a", "b", "c", "d"},
+		},
+		{
+			name:         "empty desired tags with existing tags is a no-op",
+			existedTags:  []string{"a"},
+			desiredTags:  []string{},
+			expectedOK:   true,
+			expectedTags: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, tags := mergeTags(tc.existedTags, tc.desiredTags)
+			assert.Equal(t, tc.expectedOK, ok)
+			assert.Equal(t, tc.expectedTags, tags)
+		})
+	}
+}
+
 func TestGetRulesToCreateAndDelete(t *testing.T) {
 	tests := []testGetRulesToCreateAndDelete{
 		{
@@ -2483,6 +2537,45 @@ func TestBuildListenerCreateOpt(t *testing.T) {
 				ConnLimit:     &svcConf.connLimit,
 				InsertHeaders: map[string]string{"X-Forwarded-For": "true"},
 				Tags:          nil,
+			},
+		},
+		{
+			name: "Test with LB tags support and no listener-tags annotation",
+			port: corev1.ServicePort{
+				Protocol: "TCP",
+				Port:     80,
+			},
+			svcConf: &serviceConfig{
+				connLimit:     100,
+				lbName:        "my-lb",
+				supportLBTags: true,
+			},
+			expectedCreateOpt: listeners.CreateOpts{
+				Name:         "Test with LB tags support and no listener-tags annotation",
+				Protocol:     listeners.ProtocolTCP,
+				ProtocolPort: 80,
+				ConnLimit:    &svcConf.connLimit,
+				Tags:         []string{"my-lb"},
+			},
+		},
+		{
+			name: "Test with LB tags support and listener-tags annotation",
+			port: corev1.ServicePort{
+				Protocol: "TCP",
+				Port:     80,
+			},
+			svcConf: &serviceConfig{
+				connLimit:     100,
+				lbName:        "my-lb",
+				supportLBTags: true,
+				listenerTags:  "foo, bar",
+			},
+			expectedCreateOpt: listeners.CreateOpts{
+				Name:         "Test with LB tags support and listener-tags annotation",
+				Protocol:     listeners.ProtocolTCP,
+				ProtocolPort: 80,
+				ConnLimit:    &svcConf.connLimit,
+				Tags:         []string{"bar", "foo", "my-lb"},
 			},
 		},
 	}

--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -156,42 +156,42 @@ func TestMergeTags(t *testing.T) {
 	testCases := []struct {
 		name         string
 		existedTags  []string
-		desiredTags  []string
+		newTags      []string
 		expectedOK   bool
 		expectedTags []string
 	}{
 		{
 			name:         "nil existing tags returns desired tags",
 			existedTags:  nil,
-			desiredTags:  []string{"a", "b"},
+			newTags:      []string{"a", "b"},
 			expectedOK:   false,
 			expectedTags: []string{"a", "b"},
 		},
 		{
 			name:         "empty existing tags returns desired tags",
 			existedTags:  []string{},
-			desiredTags:  []string{"a"},
+			newTags:      []string{"a"},
 			expectedOK:   false,
 			expectedTags: []string{"a"},
 		},
 		{
 			name:         "all desired tags already present",
 			existedTags:  []string{"a", "b", "c"},
-			desiredTags:  []string{"a", "b"},
+			newTags:      []string{"a", "b"},
 			expectedOK:   true,
 			expectedTags: nil,
 		},
 		{
 			name:         "some desired tags missing are merged and sorted",
 			existedTags:  []string{"b", "d"},
-			desiredTags:  []string{"a", "c"},
+			newTags:      []string{"a", "c"},
 			expectedOK:   false,
 			expectedTags: []string{"a", "b", "c", "d"},
 		},
 		{
 			name:         "empty desired tags with existing tags is a no-op",
 			existedTags:  []string{"a"},
-			desiredTags:  []string{},
+			newTags:      []string{},
 			expectedOK:   true,
 			expectedTags: nil,
 		},
@@ -199,7 +199,7 @@ func TestMergeTags(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ok, tags := mergeTags(tc.existedTags, tc.desiredTags)
+			ok, tags := mergeTags(tc.existedTags, tc.newTags)
 			assert.Equal(t, tc.expectedOK, ok)
 			assert.Equal(t, tc.expectedTags, tags)
 		})

--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -214,47 +214,67 @@ func TestMergeTags(t *testing.T) {
 }
 
 func TestWithLBNameTag(t *testing.T) {
+	lbName := servicePrefix + "cluster_ns_svc"
 	testCases := []struct {
 		name       string
-		lbName     string
 		annotation string
 		expected   []string
 	}{
 		{
 			name:       "empty annotation returns only the LB name",
-			lbName:     "kube_service_cluster_ns_svc",
 			annotation: "",
-			expected:   []string{"kube_service_cluster_ns_svc"},
+			expected:   []string{lbName},
 		},
 		{
 			name:       "user tags are appended after the LB name",
-			lbName:     "kube_service_cluster_ns_svc",
 			annotation: "team=foo,env=prod",
-			expected:   []string{"kube_service_cluster_ns_svc", "team=foo", "env=prod"},
+			expected:   []string{lbName, "team=foo", "env=prod"},
 		},
 		{
-			name:       "user tag matching the LB name is dropped, not duplicated",
-			lbName:     "kube_service_cluster_ns_svc",
-			annotation: "kube_service_cluster_ns_svc,team=foo",
-			expected:   []string{"kube_service_cluster_ns_svc", "team=foo"},
+			name:       "user tag using the reserved prefix is stripped",
+			annotation: servicePrefix + "cluster_ns_other,team=foo",
+			expected:   []string{lbName, "team=foo"},
 		},
 		{
-			name:       "user tag not matching this LB name is preserved",
-			lbName:     "kube_service_cluster_ns_svc",
-			annotation: "kube_service_cluster_ns_other,team=foo",
-			expected:   []string{"kube_service_cluster_ns_svc", "kube_service_cluster_ns_other", "team=foo"},
+			name:       "user tag equal to this LB name is stripped, not duplicated",
+			annotation: lbName + ",team=foo",
+			expected:   []string{lbName, "team=foo"},
 		},
 		{
 			name:       "duplicate user tags are removed",
-			lbName:     "kube_service_cluster_ns_svc",
 			annotation: "team=foo,team=foo",
-			expected:   []string{"kube_service_cluster_ns_svc", "team=foo"},
+			expected:   []string{lbName, "team=foo"},
+		},
+		{
+			name:       "whitespace-padded reserved tag is trimmed then stripped",
+			annotation: "  " + servicePrefix + "cluster_ns_other  ,team=foo",
+			expected:   []string{lbName, "team=foo"},
+		},
+		{
+			name:       "bare reserved prefix is stripped",
+			annotation: servicePrefix + ",team=foo",
+			expected:   []string{lbName, "team=foo"},
+		},
+		{
+			name:       "multiple reserved tags are all stripped",
+			annotation: servicePrefix + "a," + servicePrefix + "b,team=foo",
+			expected:   []string{lbName, "team=foo"},
+		},
+		{
+			name:       "prefix appearing mid-string is not stripped",
+			annotation: "owner=" + servicePrefix + "x,team=foo",
+			expected:   []string{lbName, "owner=" + servicePrefix + "x", "team=foo"},
+		},
+		{
+			name:       "only reserved tags leaves just the LB name",
+			annotation: servicePrefix + "a," + servicePrefix + "b",
+			expected:   []string{lbName},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, withLBNameTag(tc.lbName, tc.annotation))
+			assert.Equal(t, tc.expected, withLBNameTag(lbName, tc.annotation))
 		})
 	}
 }

--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -213,6 +213,52 @@ func TestMergeTags(t *testing.T) {
 	}
 }
 
+func TestWithLBNameTag(t *testing.T) {
+	testCases := []struct {
+		name       string
+		lbName     string
+		annotation string
+		expected   []string
+	}{
+		{
+			name:       "empty annotation returns only the LB name",
+			lbName:     "kube_service_cluster_ns_svc",
+			annotation: "",
+			expected:   []string{"kube_service_cluster_ns_svc"},
+		},
+		{
+			name:       "user tags are appended after the LB name",
+			lbName:     "kube_service_cluster_ns_svc",
+			annotation: "team=foo,env=prod",
+			expected:   []string{"kube_service_cluster_ns_svc", "team=foo", "env=prod"},
+		},
+		{
+			name:       "user tag matching the LB name is dropped, not duplicated",
+			lbName:     "kube_service_cluster_ns_svc",
+			annotation: "kube_service_cluster_ns_svc,team=foo",
+			expected:   []string{"kube_service_cluster_ns_svc", "team=foo"},
+		},
+		{
+			name:       "user tag not matching this LB name is preserved",
+			lbName:     "kube_service_cluster_ns_svc",
+			annotation: "kube_service_cluster_ns_other,team=foo",
+			expected:   []string{"kube_service_cluster_ns_svc", "kube_service_cluster_ns_other", "team=foo"},
+		},
+		{
+			name:       "duplicate user tags are removed",
+			lbName:     "kube_service_cluster_ns_svc",
+			annotation: "team=foo,team=foo",
+			expected:   []string{"kube_service_cluster_ns_svc", "team=foo"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, withLBNameTag(tc.lbName, tc.annotation))
+		})
+	}
+}
+
 func TestGetRulesToCreateAndDelete(t *testing.T) {
 	tests := []testGetRulesToCreateAndDelete{
 		{

--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -195,6 +195,13 @@ func TestMergeTags(t *testing.T) {
 			expectedOK:   true,
 			expectedTags: nil,
 		},
+		{
+			name:         "empty existing and empty desired tags is a no-op",
+			existedTags:  []string{},
+			newTags:      []string{},
+			expectedOK:   true,
+			expectedTags: nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -152,67 +152,6 @@ type testGetRulesToCreateAndDelete struct {
 	toDelete      []rules.SecGroupRule
 }
 
-func TestMergeTags(t *testing.T) {
-	testCases := []struct {
-		name         string
-		existedTags  []string
-		newTags      []string
-		expectedOK   bool
-		expectedTags []string
-	}{
-		{
-			name:         "nil existing tags returns desired tags",
-			existedTags:  nil,
-			newTags:      []string{"a", "b"},
-			expectedOK:   false,
-			expectedTags: []string{"a", "b"},
-		},
-		{
-			name:         "empty existing tags returns desired tags",
-			existedTags:  []string{},
-			newTags:      []string{"a"},
-			expectedOK:   false,
-			expectedTags: []string{"a"},
-		},
-		{
-			name:         "all desired tags already present",
-			existedTags:  []string{"a", "b", "c"},
-			newTags:      []string{"a", "b"},
-			expectedOK:   true,
-			expectedTags: nil,
-		},
-		{
-			name:         "some desired tags missing are merged and sorted",
-			existedTags:  []string{"b", "d"},
-			newTags:      []string{"a", "c"},
-			expectedOK:   false,
-			expectedTags: []string{"a", "b", "c", "d"},
-		},
-		{
-			name:         "empty desired tags with existing tags is a no-op",
-			existedTags:  []string{"a"},
-			newTags:      []string{},
-			expectedOK:   true,
-			expectedTags: nil,
-		},
-		{
-			name:         "empty existing and empty desired tags is a no-op",
-			existedTags:  []string{},
-			newTags:      []string{},
-			expectedOK:   true,
-			expectedTags: nil,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			ok, tags := mergeTags(tc.existedTags, tc.newTags)
-			assert.Equal(t, tc.expectedOK, ok)
-			assert.Equal(t, tc.expectedTags, tags)
-		})
-	}
-}
-
 func TestWithLBNameTag(t *testing.T) {
 	lbName := servicePrefix + "cluster_ns_svc"
 	testCases := []struct {

--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -2585,6 +2585,26 @@ func TestBuildListenerCreateOpt(t *testing.T) {
 				Tags:         []string{"my-lb", "foo", "bar"},
 			},
 		},
+		{
+			name: "Test with listener-tags annotation duplicating the LB name",
+			port: corev1.ServicePort{
+				Protocol: "TCP",
+				Port:     80,
+			},
+			svcConf: &serviceConfig{
+				connLimit:     100,
+				lbName:        "my-lb",
+				supportLBTags: true,
+				listenerTags:  "foo, my-lb, bar",
+			},
+			expectedCreateOpt: listeners.CreateOpts{
+				Name:         "Test with listener-tags annotation duplicating the LB name",
+				Protocol:     listeners.ProtocolTCP,
+				ProtocolPort: 80,
+				ConnLimit:    &svcConf.connLimit,
+				Tags:         []string{"my-lb", "foo", "bar"},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/openstack/loadbalancer_test.go
+++ b/pkg/openstack/loadbalancer_test.go
@@ -2605,6 +2605,26 @@ func TestBuildListenerCreateOpt(t *testing.T) {
 				Tags:         []string{"my-lb", "foo", "bar"},
 			},
 		},
+		{
+			name: "Test with duplicate tags within the listener-tags annotation",
+			port: corev1.ServicePort{
+				Protocol: "TCP",
+				Port:     80,
+			},
+			svcConf: &serviceConfig{
+				connLimit:     100,
+				lbName:        "my-lb",
+				supportLBTags: true,
+				listenerTags:  "foo, foo, bar, foo",
+			},
+			expectedCreateOpt: listeners.CreateOpts{
+				Name:         "Test with duplicate tags within the listener-tags annotation",
+				Protocol:     listeners.ProtocolTCP,
+				ProtocolPort: 80,
+				ConnLimit:    &svcConf.connLimit,
+				Tags:         []string{"my-lb", "foo", "bar"},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -181,6 +181,41 @@ func SplitTrim(s string, sep rune) []string {
 	return strings.FieldsFunc(s, f)
 }
 
+// Unique returns slice with duplicates removed, preserving first-seen order.
+func Unique[T comparable](slice []T) []T {
+	seen := make(map[T]struct{}, len(slice))
+	result := make([]T, 0, len(slice))
+	for _, item := range slice {
+		if _, ok := seen[item]; !ok {
+			seen[item] = struct{}{}
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+// Merge appends the items of src that are not already in dest, preserving
+// order. It returns the merged slice and true if any item was added.
+func Merge[T comparable](dest, src []T) ([]T, bool) {
+	existing := make(map[T]struct{}, len(dest))
+	for _, item := range dest {
+		existing[item] = struct{}{}
+	}
+
+	merged := false
+	result := make([]T, len(dest), len(dest)+len(src))
+	copy(result, dest)
+
+	for _, item := range src {
+		if _, ok := existing[item]; !ok {
+			existing[item] = struct{}{}
+			result = append(result, item)
+			merged = true
+		}
+	}
+	return result, merged
+}
+
 // UUID converts a string to a valid UUID string.
 func UUID(s string) (string, error) {
 	u, err := uuid.Parse(s)

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -47,3 +47,83 @@ func TestStringToMap(t *testing.T) {
 		})
 	}
 }
+
+func TestUnique(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		out  []string
+	}{
+		{name: "nil", in: nil, out: []string{}},
+		{name: "empty", in: []string{}, out: []string{}},
+		{name: "no duplicates preserves order", in: []string{"b", "a", "c"}, out: []string{"b", "a", "c"}},
+		{name: "duplicates removed keeping first-seen order", in: []string{"a", "b", "a", "c", "b"}, out: []string{"a", "b", "c"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.out, Unique(test.in))
+		})
+	}
+}
+
+func TestMerge(t *testing.T) {
+	tests := []struct {
+		name        string
+		dest        []string
+		src         []string
+		out         []string
+		wantChanged bool
+	}{
+		{
+			name:        "nil dest returns src",
+			dest:        nil,
+			src:         []string{"a", "b"},
+			out:         []string{"a", "b"},
+			wantChanged: true,
+		},
+		{
+			name:        "empty dest returns src",
+			dest:        []string{},
+			src:         []string{"a"},
+			out:         []string{"a"},
+			wantChanged: true,
+		},
+		{
+			name:        "all src already present is a no-op",
+			dest:        []string{"a", "b", "c"},
+			src:         []string{"a", "b"},
+			out:         []string{"a", "b", "c"},
+			wantChanged: false,
+		},
+		{
+			name:        "missing src appended preserving order",
+			dest:        []string{"b", "d"},
+			src:         []string{"a", "c"},
+			out:         []string{"b", "d", "a", "c"},
+			wantChanged: true,
+		},
+		{
+			name:        "empty src with existing dest is a no-op",
+			dest:        []string{"a"},
+			src:         []string{},
+			out:         []string{"a"},
+			wantChanged: false,
+		},
+		{
+			name:        "empty dest and empty src is a no-op",
+			dest:        []string{},
+			src:         []string{},
+			out:         []string{},
+			wantChanged: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out, changed := Merge(test.dest, test.src)
+			assert.Equal(t, test.wantChanged, changed)
+			assert.Equal(t, test.out, out)
+		})
+	}
+}


### PR DESCRIPTION
Superceds https://github.com/kubernetes/cloud-provider-openstack/pull/3058.

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[OCCM] Support addiing tags to load balancer, listener, and pool via service annotations.
-->

**What this PR does / why we need it**:
This PR adds support for the add tags to load balancer, listener, and pool via the service annotations in cloud-provider-openstack (OCCM).

**Which issue this PR fixes(if applicable)**:
fixes #3032 #2327 

**Special notes for reviewers**:
You can add annotations to the service like:
```
loadbalancer.openstack.org/listener-tags: "tags-test"
loadbalancer.openstack.org/load-balancer-tags: "tags-test"
loadbalancer.openstack.org/pool-tags: "tags-test"
```
Then check if the tags have been added to the service's load blancer(the service's type should be load balancer)

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] Support adding tags to load balancers, listeners, and pools via Service annotations.
```
