### PR TITLE
[manila-csi-plugin, cinder-csi-plugin]: Allow cluster-id to be populated from configmap / secret

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.36.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.36.0
+version: 2.36.1
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -193,8 +193,10 @@ spec:
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
               value: /etc/config/{{ .Values.secret.filename }}
+            {{- if .Values.clusterID }}
             - name: CLUSTER_NAME
               value: "{{ .Values.clusterID }}"
+            {{- end }}
             {{- if .Values.csi.plugin.extraEnv }}
               {{- toYaml .Values.csi.plugin.extraEnv | nindent 12 }}
             {{- end }}

--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.36.0
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 2.36.0
+version: 2.36.1
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -101,7 +101,7 @@ spec:
             {{- if .compatibilitySettings }}
             --compatibility-settings={{ .compatibilitySettings }}
             {{- end }}
-            --cluster-id="{{ $.Values.csimanila.clusterID }}"
+            --cluster-id=$(CLUSTER_NAME)
             {{- if $.Values.csimanila.pvcAnnotations }}
             --pvc-annotations
             {{- end }}'
@@ -115,9 +115,17 @@ spec:
               value: "unix://{{ .fwdNodePluginEndpoint.dir }}/{{ .fwdNodePluginEndpoint.sockFile }}"
             - name: MANILA_SHARE_PROTO
               value: "{{ .protocolSelector }}"
+            {{- if $.Values.csimanila.clusterID }}
+            - name: CLUSTER_NAME
+              value: {{ $.Values.csimanila.clusterID }}
+            {{- end }}
             {{- if $.Values.controllerplugin.nodeplugin.extraEnv }}
               {{- toYaml $.Values.controllerplugin.nodeplugin.extraEnv | nindent 12 }}
             {{- end }}
+          {{- with $.Values.controllerplugin.nodeplugin.envFrom }}
+          envFrom:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           imagePullPolicy: {{ $.Values.csimanila.image.pullPolicy }}
           volumeMounts:
             - name: {{ .protocolSelector | lower }}-plugin-dir

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -62,7 +62,7 @@ spec:
             --drivername=$(DRIVER_NAME)
             --share-protocol-selector=$(MANILA_SHARE_PROTO)
             --fwdendpoint=$(FWD_CSI_ENDPOINT)
-            --cluster-id="{{ $.Values.csimanila.clusterID }}"'
+            --cluster-id=$(CLUSTER_NAME)'
           ]
           env:
             - name: DRIVER_NAME
@@ -73,6 +73,10 @@ spec:
               value: "unix://{{ .fwdNodePluginEndpoint.dir }}/{{ .fwdNodePluginEndpoint.sockFile }}"
             - name: MANILA_SHARE_PROTO
               value: "{{ .protocolSelector }}"
+            {{- if $.Values.csimanila.clusterID }}
+            - name: CLUSTER_NAME
+              value: "{{ $.Values.csimanila.clusterID }}"
+            {{- end }}
             {{- if $.Values.nodeplugin.nodeplugin.extraEnv }}
               {{- toYaml $.Values.nodeplugin.nodeplugin.extraEnv | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
Follow up from https://github.com/kubernetes/cloud-provider-openstack/pull/3069 which got closed when I rebased and I can not reopen now.

**What this PR does / why we need it**:

Adds supports for loading cluster_id from a secret / configmap in cluster. If clusterID is not set then CLUSTER_NAME can be overridden using extraEnv to pull configuration from an external object.

e.g.

```yaml
# values.yaml
openstack-cinder-csi:
  clusterID: ""
  secret:
    filename: "cloud-config"
  csi:
    plugin:
      extraEnv:
        - name: CLUSTER_NAME
          valueFrom:
            configMapKeyRef:
              name: cluster-info
              key: cluster_uuid
```

This allows us to maintain a single configuration for manila / cinder for all of our cluster's, whilst ensuring that they correctly have the cluster-id metadata attached to the created shares / volumes for each cluster. 


**Which issue this PR fixes(if applicable)**:
fixes #3070

**Special notes for reviewers**:
None

**Release note**:
```release-note
* [cinder-csi-plugin] Allow cluster-id to be populated from configmap / secret.
* [manila-csi-plugin] Allow cluster-id to be populated from configmap / secret.
```
