### PR TITLE
[cinder-csi-plugin] Configure topology with --with-topology

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.36.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.36.2
+version: 2.36.3
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/ci/topology-disabled-values.yaml
+++ b/charts/cinder-csi-plugin/ci/topology-disabled-values.yaml
@@ -1,0 +1,3 @@
+csi:
+  provisioner:
+    topology: "false"

--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -69,7 +69,6 @@ spec:
             - "--timeout={{ .Values.timeout }}"
             - "--leader-election=true"
             - "--default-fstype=ext4"
-            - "--feature-gates=Topology={{ .Values.csi.provisioner.topology }}"
             - "--extra-create-metadata"
             {{- if .Values.csi.provisioner.extraArgs }}
             {{- with .Values.csi.provisioner.extraArgs }}
@@ -174,6 +173,7 @@ spec:
             - "--cloud-config=$(CLOUD_CONFIG)"
             - "--cluster=$(CLUSTER_NAME)"
             - "--provide-node-service=false"
+            - "--with-topology={{ .Values.csi.provisioner.topology }}"
             {{- if .Values.csi.plugin.httpEndpoint.enabled }}
             - "--http-endpoint=:{{ .Values.csi.plugin.httpEndpoint.port }}"
             {{- end }}

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -93,6 +93,7 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--provide-controller-service=false"
             - "--cloud-config=$(CLOUD_CONFIG)"
+            - "--with-topology={{ .Values.csi.provisioner.topology }}"
             {{- if .Values.csi.plugin.extraArgs }}
             {{- with .Values.csi.plugin.extraArgs }}
             {{- tpl . $ | trim | nindent 12 }}

--- a/docs/cinder-csi-plugin/features.md
+++ b/docs/cinder-csi-plugin/features.md
@@ -34,8 +34,8 @@ This feature enables driver to consider the topology constraints while creating 
 * Supported topology keys:
   `topology.cinder.csi.openstack.org/zone` : Availability by Zone
 * `allowedTopologies` can be specified in storage class to restrict the topology of provisioned volumes to specific zones and should be used as replacement of `availability` parameter.
-* To disable: set `--feature-gates=Topology=false` in external-provisioner (container `csi-provisioner` of `csi-cinder-controllerplugin`).
-  * If using Helm, it can be disabled by setting `Values.csi.provisioner.topology: "false"` 
+* To disable, pass `--with-topology=false` to both the controller and node Cinder CSI driver services.
+  * With Helm, set `.Values.csi.provisioner.topology: "false"`.
 
 For usage, refer [sample app](./examples.md#use-topology)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The Cinder chart currently applies `csi.provisioner.topology` only to the external-provisioner feature gate, so the value does not control the Cinder driver topology capabilities.

This uses the existing value for `--with-topology` in both Cinder driver containers and removes the explicit external-provisioner feature-gate argument. The existing `"true"` default is unchanged. The pinned [external-provisioner v5.3.0](https://github.com/kubernetes-csi/external-provisioner/blob/v5.3.0/pkg/features/features.go#L60-L66) enables its GA Topology gate by default, while `"false"` now makes the driver stop advertising and returning topology information.

The affected documentation is updated and an explicit disabled-values render is added to chart CI. This follows #2998, which established the required driver behavior.

**Which issue this PR fixes(if applicable)**:

Fixes #2993

**Special notes for reviewers**:

Validated with Helm v3.10.0:

- `helm lint` passes with defaults and every `ci/*-values.yaml` file.
- The default render passes `--with-topology=true` to both driver containers.
- The disabled render passes `--with-topology=false` to both driver containers.
- Neither render sets the external-provisioner `Topology` feature gate.
- Existing driver `extraArgs` retain their override precedence.
- `git diff --check origin/master...HEAD` passes.

**Release note**:

```release-note
[cinder-csi-plugin] Fixed the Helm chart so `csi.provisioner.topology: "false"` disables topology awareness in both the controller and node plugins.
```
