### PR TITLE
fix(manila-csi-plugin): revert to setting cluster id from environment

### DIFF
--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.36.0
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 2.36.2
+version: 2.36.3
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -62,7 +62,7 @@ spec:
             --drivername=$(DRIVER_NAME)
             --share-protocol-selector=$(MANILA_SHARE_PROTO)
             --fwdendpoint=$(FWD_CSI_ENDPOINT)
-            --cluster-id="{{ $.Values.csimanila.clusterID }}"
+            --cluster-id=$(CLUSTER_NAME)
             {{- if $.Values.csimanila.searchOrder }}
             --search-order="{{ $.Values.csimanila.searchOrder }}"
             {{- end }}'

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -65,7 +65,7 @@ spec:
             --drivername=$(DRIVER_NAME)
             --share-protocol-selector=$(MANILA_SHARE_PROTO)
             --fwdendpoint=$(FWD_CSI_ENDPOINT)
-            --cluster-id="{{ $.Values.csimanila.clusterID }}"
+            --cluster-id=$(CLUSTER_NAME)
             {{- if $.Values.csimanila.searchOrder }}
             --search-order="{{ $.Values.csimanila.searchOrder }}"
             {{- end }}'


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/kubernetes/cloud-provider-openstack/pull/3141/changes#diff-b7f52a172b36d41c221a2e0760bf071c34a1ed12b7eb99e34d1aedb8e5d128f1R65 reverted my change in https://github.com/kubernetes/cloud-provider-openstack/pull/3152 because it was not rebased properly.

This reverts this change so that I can once again set the cluster ID argument by passing the information from a config map.

**Which issue this PR fixes(if applicable)**:
fixes #3070

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
