### PR TITLE
feat: add support for exclude network for openstack cloud controller

### DIFF
--- a/pkg/openstack/instances_addresses.go
+++ b/pkg/openstack/instances_addresses.go
@@ -249,6 +249,15 @@ func nodeAddresses(ctx context.Context, srv *servers.Server, ports []PortWithTru
 			var addressType v1.NodeAddressType
 			if props.IPType == "floating" {
 				addressType = v1.NodeExternalIP
+			} else if slices.Contains(networkingOpts.ExcludeNetworkName,network) {
+				// Skip networks that are in the exclude list
+				klog.V(5).Infof("Node '%s' network '%s' excluded due to 'exclude-network-name' option", srv.Name, network)
+				removeFromNodeAddresses(&addrs,
+					v1.NodeAddress{
+						Address: props.Addr,
+					},
+				)
+				continue
 			} else if slices.Contains(networkingOpts.PublicNetworkName, network) {
 				addressType = v1.NodeExternalIP
 				// removing already added address to avoid listing it as both ExternalIP and InternalIP

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -141,6 +141,7 @@ type NetworkingOpts struct {
 	IPv6SupportDisabled bool     `gcfg:"ipv6-support-disabled"`
 	PublicNetworkName   []string `gcfg:"public-network-name"`
 	InternalNetworkName []string `gcfg:"internal-network-name"`
+	ExcludeNetworkName  []string `gcfg:"exclude-network-name"`
 	AddressSortOrder    string   `gcfg:"address-sort-order"`
 }
 

--- a/pkg/openstack/openstack_test.go
+++ b/pkg/openstack/openstack_test.go
@@ -897,6 +897,97 @@ func TestNodeAddressesWithAddressSortOrderOptions(t *testing.T) {
 	}
 }
 
+func TestNodeAddressesWithExcludeNetworkName(t *testing.T) {
+	srv := servers.Server{
+		Status:     "ACTIVE",
+		HostID:     "29d3c8c896a45aa4c34e52247875d7fefc3d94bbcc9f622b5d204362",
+		AccessIPv4: "50.56.176.99",
+		AccessIPv6: "2001:4800:790e:510:be76:4eff:fe04:82a8",
+		Addresses: map[string]interface{}{
+			"private": []interface{}{
+				map[string]interface{}{
+					"OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:7c:1b:2b",
+					"version":                 float64(4),
+					"addr":                    "10.0.0.32",
+					"OS-EXT-IPS:type":         "fixed",
+				},
+				map[string]interface{}{
+					"version":         float64(4),
+					"addr":            "50.56.176.36",
+					"OS-EXT-IPS:type": "floating",
+				},
+				map[string]interface{}{
+					"version": float64(4),
+					"addr":    "10.0.0.31",
+					// No OS-EXT-IPS:type
+				},
+			},
+			"public": []interface{}{
+				map[string]interface{}{
+					"version": float64(4),
+					"addr":    "50.56.176.35",
+				},
+				map[string]interface{}{
+					"version": float64(6),
+					"addr":    "2001:4800:780e:510:be76:4eff:fe04:84a8",
+				},
+			},
+			"excluded-network": []interface{}{
+				map[string]interface{}{
+					"version": float64(4),
+					"addr":    "192.168.1.100",
+				},
+			},
+		},
+		Metadata: map[string]string{
+			"name":       "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy",
+			TypeHostName: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal",
+		},
+	}
+
+	networkingOpts := NetworkingOpts{
+		PublicNetworkName:  []string{"public"},
+		ExcludeNetworkName: []string{"excluded-network"},
+	}
+
+	ports := []PortWithTrunkDetails{{
+		Port: neutronports.Port{
+			Status: "ACTIVE",
+			FixedIPs: []neutronports.IP{
+				{
+					IPAddress: "10.0.0.32",
+				},
+				{
+					IPAddress: "10.0.0.31",
+				},
+			},
+		},
+	},
+	}
+
+	addrs, err := nodeAddresses(context.TODO(), &srv, ports, nil, networkingOpts)
+	if err != nil {
+		t.Fatalf("nodeAddresses returned error: %v", err)
+	}
+
+	t.Logf("addresses are %v", addrs)
+
+	want := []v1.NodeAddress{
+		{Type: v1.NodeInternalIP, Address: "10.0.0.32"},
+		{Type: v1.NodeInternalIP, Address: "10.0.0.31"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:790e:510:be76:4eff:fe04:82a8"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
+		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
+		{Type: v1.NodeExternalIP, Address: "2001:4800:780e:510:be76:4eff:fe04:84a8"},
+	}
+
+	if !reflect.DeepEqual(want, addrs) {
+		t.Errorf("nodeAddresses returned incorrect value, want %v", want)
+	}
+}
+
 func TestNewOpenStack(t *testing.T) {
 	cfg := ConfigFromEnv()
 	testConfigFromEnv(t, &cfg)


### PR DESCRIPTION
…manager

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[occm] feat: add support for exclude network for openstack cloud controller
-->

**What this PR does / why we need it**:
This PR added exclude-network-name feature which can be used to exlclude network names which can be excluded from nodeaddress list.

**Which issue this PR fixes(if applicable)**:
fixes #2995 

**Release note**:
Add option for exclude-network-list for cloud controller manager


