### PR TITLE
occm: Fix node with `providerID=""` deletion when underlying Server does not exist

### DIFF
--- a/pkg/openstack/instances.go
+++ b/pkg/openstack/instances.go
@@ -208,7 +208,7 @@ func getServerByName(ctx context.Context, client *gophercloud.ServiceClient, nam
 	}
 
 	if len(serverList) == 0 {
-		return nil, errors.ErrNotFound
+		return nil, fmt.Errorf("%w: %w", cloudprovider.InstanceNotFound, errors.ErrNotFound)
 	}
 
 	return &serverList[0], nil


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:
Currently `getServerByName()` returns `errors.ErrNotFound`, whereas the caller only handles `cloudprovider.InstanceNotFound`. This PR now returns a wrapped error containing `cloudprovider.InstanceNotFound` so that its caller `InstanceExists()` can suppress `cloudprovider.InstanceNotFound` error.
This is crucial as the `cloud-controller-manager` expects `InstancesV2.InstanceExists()` to suppress `cloudprovider.InstanceNotFound` errors and return `exist=false, err=nil`.
Further details are discussion in the linked issue.

There was a similar PR raised earlier which targeted loadbalancers error handling: #1935 

**Which issue this PR fixes(if applicable)**:
fixes #3114 

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->
I have decided to wrap the error with `cloudprovider.InstanceNotFound` and `errors.ErrNotFound` rather than just returning `cloudprovider.InstanceNotFound` so that downstream systems depending on `errors.ErrNotFound` do not fail.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[openstack-cloud-controller-manager] An issue preventing Node with providerID="" to be deleted when the corresponding OpenStack Server does no longer exists is now fixed.
```
