### PR TITLE
[cinder-csi-plugin]: add appendVolumeMetadata support to Cinder CSI

### DIFF
--- a/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
+++ b/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
@@ -283,10 +283,12 @@ helm install --namespace kube-system --name cinder-csi ./charts/cinder-csi-plugi
 |-------------------------   |-----------------------|-----------------|-----------------|
 | StorageClass `parameters`  | `availability`          | `nova`          | String. Volume Availability Zone |
 | StorageClass `parameters`  | `type`                  | Empty String    | String. Name/ID of Volume type. Corresponding volume type should exist in cinder     |
+| StorageClass `parameters`  | `appendVolumeMetadata`   | Empty String    | Append user-defined metadata to the provisioned volume. If not empty, this field must be a string of a valid JSON object. The object must consist of key-value pairs of type string. Example: "{..., \"key\": \"value\"}". |
 | VolumeSnapshotClass `parameters` | `force-create`    | `false`         | Enable to support creating snapshot for a volume in in-use status |
 | VolumeSnapshotClass `parameters` | `type`            | Empty String    | `snapshot` creates a VolumeSnapshot object linked to a Cinder volume snapshot. `backup` creates a VolumeSnapshot object linked to a cinder volume backup. Defaults to `snapshot` if not defined |
 | VolumeSnapshotClass `parameters` | `backup-max-duration-seconds-per-gb`  | `20`    | Defines the amount of time to wait for a backup to complete in seconds per GB of volume size |
 | VolumeSnapshotClass `parameters`  | `availability`          | Same as volume | String. Backup Availability Zone |
+| VolumeSnapshotClass `parameters`  | `appendVolumeMetadata`   | Empty String   | Append user-defined metadata to the created snapshot/backup. If not empty, this field must be a string of a valid JSON object. The object must consist of key-value pairs of type string. Example: "{..., \"key\": \"value\"}". |
 | Inline Volume `volumeAttributes`   | `capacity`              | `1Gi`       | volume size for creating inline volumes|
 | Inline Volume `VolumeAttributes`   | `type`              | Empty String  | Name/ID of Volume type. Corresponding volume type should exist in cinder |
 

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -18,6 +18,7 @@ package cinder
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -84,7 +85,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	volSizeGB := int(util.RoundUpSize(volSizeBytes, 1024*1024*1024))
 
 	// Volume Type
-	volType := volParams["type"]
+	volType := volParams[openstack.VolumeType]
 
 	// Volume AZ
 
@@ -94,8 +95,8 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	// First check if volAvailability is already specified, if not get preferred from Topology
 	// Required, in case vol AZ is different from node AZ
 	var volAvailability string
-	if volParams["availability"] != "" {
-		volAvailability = volParams["availability"]
+	if volParams[openstack.VolumeAvailabilityZone] != "" {
+		volAvailability = volParams[openstack.VolumeAvailabilityZone]
 	} else if cs.Driver.withTopology && accessibleTopologyReq != nil {
 		volAvailability = sharedcsi.GetAZFromTopology(topologyKey, accessibleTopologyReq)
 	}
@@ -135,6 +136,12 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 			properties[mKey] = v
 		}
 	}
+	// Append metadata specified in parameters.appendVolumeMetadata
+	properties, err = appendVolumeMetadata(properties, volParams[openstack.VolumeAppendVolumeMetadata], "StorageClass", volName)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "append properties for volume %q: %v", volName, err)
+	}
+
 	content := req.GetVolumeContentSource()
 	var snapshotID string
 	var sourceVolID string
@@ -714,6 +721,11 @@ func (cs *controllerServer) createSnapshot(ctx context.Context, cloud openstack.
 			properties[mKey] = v
 		}
 	}
+	// Append metadata specified in parameters.appendVolumeMetadata
+	properties, err = appendVolumeMetadata(properties, parameters[openstack.SnapshotAppendVolumeMetadata], "VolumeSnapshotClass", name)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "append properties for snapshot %q: %v", name, err)
+	}
 
 	// TODO: Delegate the check to openstack itself and ignore the conflict
 	snap, err = cloud.CreateSnapshot(ctx, name, volumeID, properties)
@@ -739,6 +751,11 @@ func (cs *controllerServer) createBackup(ctx context.Context, cloud openstack.IO
 		if v, ok := parameters[mKey]; ok {
 			properties[mKey] = v
 		}
+	}
+	// Append metadata specified in parameters.appendVolumeMetadata
+	properties, err := appendVolumeMetadata(properties, parameters[openstack.SnapshotAppendVolumeMetadata], "VolumeSnapshotClass", name)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "append properties for snapshot(backup) %q: %v", name, err)
 	}
 
 	backup, err := cloud.CreateBackup(ctx, name, volumeID, snap.ID, parameters[openstack.SnapshotAvailabilityZone], properties)
@@ -1121,4 +1138,45 @@ func getCreateVolumeResponse(vol *volumes.Volume, volCtx map[string]string, acce
 	}
 
 	return resp
+}
+
+func appendVolumeMetadata(properties map[string]string, metadataStr, classType, name string) (_ map[string]string, retErr error) {
+	defer func() {
+		if retErr == nil {
+			klog.V(4).Infof("volume/snapshot/backup (%s) properties: %q", name, properties)
+		}
+	}()
+
+	if metadataStr == "" {
+		return properties, nil
+	}
+
+	metadata := map[string]string{}
+	if err := json.Unmarshal([]byte(metadataStr), &metadata); err != nil {
+		return nil, fmt.Errorf("invalid appendVolumeMetadata %q in %s parameters, must be a string of a valid JSON object consisting of key-value pairs of type string: %w", metadataStr, classType, err)
+	}
+
+	for k, v := range metadata {
+		// This aligns with the implementation of manila, which ignores reserved keys
+		// that are duplicated in appendVolumeMetadata except the cluster id.
+		// It allows admin to specify a custom cluster id for the volume/snapshot/backup
+		// but honors other recognized CSI params.
+		// Manila PRs:
+		//   https://github.com/kubernetes/cloud-provider-openstack/pull/1459
+		//   https://github.com/kubernetes/cloud-provider-openstack/pull/2023
+		if existingValue, ok := properties[k]; ok {
+			if k != cinderCSIClusterIDKey {
+				klog.Warningf("ignore metadata key %q from appendVolumeMetadata because it already exists with value %q", k, existingValue)
+				continue
+			}
+
+			if existingValue != v {
+				klog.Warningf("override cluster ID %q with %q from appendVolumeMetadata", existingValue, v)
+			}
+		}
+
+		properties[k] = v
+	}
+
+	return properties, nil
 }

--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -372,6 +372,50 @@ func TestCreateVolumeWithExtraMetadata(t *testing.T) {
 	}
 }
 
+func TestCreateVolumeWithAppendVolumeMetadata(t *testing.T) {
+	fakeCs, osmock := fakeControllerServer()
+
+	expectedProperties := map[string]string{
+		cinderCSIClusterIDKey:     "override",
+		sharedcsi.PvNameKey:       FakePVName,
+		sharedcsi.PvcNameKey:      FakePVCName,
+		sharedcsi.PvcNamespaceKey: FakePVCNamespace,
+		"key1":                    "value1",
+		"key2":                    "value2",
+	}
+	osmock.On("CreateVolume", FakeVolName, mock.AnythingOfType("int"), "", "", "", "", "", expectedProperties).Return(&FakeVol, nil)
+	osmock.On("GetVolumesByName", FakeVolName).Return(FakeVolListEmpty, nil)
+	osmock.On("GetBlockStorageOpts").Return(openstack.BlockStorageOpts{})
+
+	fakeReq := &csi.CreateVolumeRequest{
+		Name: FakeVolName,
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				},
+			},
+		},
+
+		Parameters: map[string]string{
+			sharedcsi.PvNameKey:       FakePVName,
+			sharedcsi.PvcNameKey:      FakePVCName,
+			sharedcsi.PvcNamespaceKey: FakePVCNamespace,
+			openstack.VolumeAppendVolumeMetadata: `{
+  "key1": "value1",
+  "key2": "value2",
+  "csi.storage.k8s.io/pvc/namespace": "ignored",
+  "cinder.csi.openstack.org/cluster": "override"
+}`,
+		},
+	}
+
+	_, err := fakeCs.CreateVolume(FakeCtx, fakeReq)
+	if err != nil {
+		t.Errorf("failed to CreateVolume: %v", err)
+	}
+}
+
 func TestCreateVolumeFromSnapshot(t *testing.T) {
 	fakeCs, osmock := fakeControllerServer()
 
@@ -1052,6 +1096,40 @@ func TestCreateSnapshotWithExtraMetadata(t *testing.T) {
 	assert.NotNil(FakeSnapshotID, actualRes.Snapshot.SnapshotId)
 }
 
+func TestCreateSnapshotWithAppendVolumeMetadata(t *testing.T) {
+	fakeCs, osmock := fakeControllerServer()
+
+	expectedProperties := map[string]string{
+		cinderCSIClusterIDKey:             "override",
+		sharedcsi.VolSnapshotNamespaceKey: FakeSnapshotNamespace,
+		"key1":                            "value1",
+		"key2":                            "value2",
+	}
+
+	osmock.On("CreateSnapshot", FakeSnapshotName, FakeVolID, expectedProperties).Return(&FakeSnapshotRes, nil)
+	osmock.On("ListSnapshots", map[string]string{"Name": FakeSnapshotName}).Return(FakeSnapshotListEmpty, "", nil)
+	osmock.On("WaitSnapshotReady", FakeSnapshotID).Return(FakeSnapshotRes.Status, nil)
+
+	fakeReq := &csi.CreateSnapshotRequest{
+		Name:           FakeSnapshotName,
+		SourceVolumeId: FakeVolID,
+		Parameters: map[string]string{
+			sharedcsi.VolSnapshotNamespaceKey: FakeSnapshotNamespace,
+			openstack.SnapshotAppendVolumeMetadata: `{
+  "key1": "value1",
+  "key2": "value2",
+  "csi.storage.k8s.io/volumesnapshot/namespace": "ignored",
+  "cinder.csi.openstack.org/cluster": "override"
+}`,
+		},
+	}
+
+	_, err := fakeCs.CreateSnapshot(FakeCtx, fakeReq)
+	if err != nil {
+		t.Errorf("failed to CreateSnapshot with appendVolumeMetadata: %v", err)
+	}
+}
+
 func TestCreateSnapshotBackupGetBackupByIDError(t *testing.T) {
 	fakeCs, osmock := fakeControllerServer()
 
@@ -1084,6 +1162,49 @@ func TestCreateSnapshotBackupGetBackupByIDError(t *testing.T) {
 
 	assert.Equal(t, codes.Internal, statusErr.Code())
 	assert.Equal(t, "Failed to get backup by ID", statusErr.Message())
+}
+
+func TestCreateSnapshotBackupWithAppendVolumeMetadata(t *testing.T) {
+	fakeCs, osmock := fakeControllerServer()
+
+	expectedSnapshotProperties := map[string]string{
+		cinderCSIClusterIDKey: FakeCluster,
+		"key1":                "value1",
+		"key2":                "value2",
+	}
+
+	expectedBackupProperties := map[string]string{
+		cinderCSIClusterIDKey: FakeCluster,
+		"key1":                "value1",
+		"key2":                "value2",
+		"type":                "backup",
+	}
+
+	osmock.On("CreateSnapshot", FakeSnapshotName, FakeVolID, expectedSnapshotProperties).Return(&FakeSnapshotRes, nil)
+	osmock.On("ListSnapshots", map[string]string{"Name": FakeSnapshotName}).Return(FakeSnapshotListEmpty, "", nil)
+	osmock.On("WaitSnapshotReady", FakeSnapshotID).Return(FakeSnapshotRes.Status, nil)
+	osmock.On("DeleteSnapshot", FakeSnapshotID).Return(nil)
+
+	osmock.On("CreateBackup", FakeSnapshotName, FakeVolID, FakeSnapshotID, "", expectedBackupProperties).Return(&FakeBackupRes, nil)
+	osmock.On("ListBackups", map[string]string{"Name": FakeSnapshotName}).Return(FakeBackupListEmpty, nil)
+	osmock.On("WaitBackupReady", FakeBackupID).Return(FakeBackupRes.Status, nil)
+
+	fakeReq := &csi.CreateSnapshotRequest{
+		Name:           FakeSnapshotName,
+		SourceVolumeId: FakeVolID,
+		Parameters: map[string]string{
+			openstack.SnapshotType: "backup",
+			openstack.SnapshotAppendVolumeMetadata: `{
+  "key1": "value1",
+  "key2": "value2"
+}`,
+		},
+	}
+
+	_, err := fakeCs.CreateSnapshot(FakeCtx, fakeReq)
+	if err != nil {
+		t.Errorf("failed to CreateSnapshot backup with appendVolumeMetadata: %v", err)
+	}
 }
 
 // Test DeleteSnapshot
@@ -1274,4 +1395,87 @@ func TestValidateVolumeCapabilities(t *testing.T) {
 	// assert
 	assert.Equal(expectedRes, actualRes)
 	assert.Equal(expectedRes2, actualRes2)
+}
+
+func TestAppendVolumeMetadata(t *testing.T) {
+	assert := assert.New(t)
+
+	cases := []struct {
+		properties  map[string]string
+		metadataStr string
+		classType   string
+		name        string
+
+		expectedProperties    map[string]string
+		expectedErrStrPattern string
+	}{
+		{
+			properties:  map[string]string{},
+			metadataStr: `{"key1": "value1"}`,
+			classType:   "StorageClass",
+			name:        "vol1",
+
+			expectedProperties: map[string]string{
+				"key1": "value1",
+			},
+			expectedErrStrPattern: "",
+		},
+		{
+			properties:  map[string]string{},
+			metadataStr: "",
+			classType:   "StorageClass",
+			name:        "vol1",
+
+			expectedProperties:    map[string]string{},
+			expectedErrStrPattern: "",
+		},
+		{
+			properties: map[string]string{
+				"existingKey": "existingValue",
+			},
+			metadataStr: "",
+			classType:   "StorageClass",
+			name:        "vol1",
+
+			expectedProperties: map[string]string{
+				"existingKey": "existingValue",
+			},
+			expectedErrStrPattern: "",
+		},
+		{
+			properties:  map[string]string{},
+			metadataStr: "invalid metadata",
+			classType:   "StorageClass",
+			name:        "vol1",
+
+			expectedProperties:    nil,
+			expectedErrStrPattern: `invalid appendVolumeMetadata "invalid metadata" in StorageClass parameters, must be a string of a valid JSON object consisting of key-value pairs of type string`,
+		},
+		{
+			properties: map[string]string{
+				"existingKey":         "existingValue",
+				cinderCSIClusterIDKey: "origin",
+			},
+			metadataStr: `{"key1": "value1", "existingKey": "newValue", "cinder.csi.openstack.org/cluster": "override"}`,
+			classType:   "StorageClass",
+			name:        "vol1",
+
+			expectedProperties: map[string]string{
+				"existingKey":         "existingValue",
+				"key1":                "value1",
+				cinderCSIClusterIDKey: "override",
+			},
+			expectedErrStrPattern: "",
+		},
+	}
+
+	for _, c := range cases {
+		properties, err := appendVolumeMetadata(c.properties, c.metadataStr, c.classType, c.name)
+		assert.Equal(c.expectedProperties, properties)
+		if c.expectedErrStrPattern == "" {
+			assert.NoError(err)
+		} else {
+			assert.ErrorContains(err, c.expectedErrStrPattern)
+		}
+	}
 }

--- a/pkg/csi/cinder/fake.go
+++ b/pkg/csi/cinder/fake.go
@@ -18,6 +18,7 @@ package cinder
 
 import (
 	"context"
+	"time"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/backups"
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/snapshots"
@@ -34,6 +35,7 @@ var FakeVolName = "CSIVolumeName"
 var FakeVolID = "CSIVolumeID"
 var FakeSnapshotName = "CSISnapshotName"
 var FakeSnapshotID = "261a8b81-3660-43e5-bab8-6470b65ee4e8"
+var FakeBackupID = "67589b87-91e3-4c2f-8fa8-d53eed89ca56"
 var FakeCapacityGiB = 1
 var FakeVolType = ""
 var FakeAvailability = "nova"
@@ -97,6 +99,17 @@ var FakeSnapshotRes = snapshots.Snapshot{
 	VolumeID: FakeVolID,
 	Size:     1,
 	Status:   "available",
+}
+
+var FakeBackupRes = backups.Backup{
+	ID:         FakeBackupID,
+	Name:       "fake-backup",
+	VolumeID:   FakeVolID,
+	SnapshotID: FakeSnapshotID,
+	CreatedAt:  time.Now(),
+
+	Size:   1,
+	Status: "available",
 }
 
 var FakeSnapshotsRes = []snapshots.Snapshot{FakeSnapshotRes}

--- a/pkg/csi/cinder/openstack/openstack_snapshots.go
+++ b/pkg/csi/cinder/openstack/openstack_snapshots.go
@@ -38,10 +38,11 @@ const (
 	snapReadyFactor     = 1.2
 	snapReadySteps      = 10
 
-	snapshotDescription      = "Created by OpenStack Cinder CSI driver"
-	SnapshotForceCreate      = "force-create"
-	SnapshotType             = "type"
-	SnapshotAvailabilityZone = "availability"
+	snapshotDescription          = "Created by OpenStack Cinder CSI driver"
+	SnapshotForceCreate          = "force-create"
+	SnapshotType                 = "type"
+	SnapshotAvailabilityZone     = "availability"
+	SnapshotAppendVolumeMetadata = "appendVolumeMetadata"
 )
 
 // CreateSnapshot issues a request to take a Snapshot of the specified Volume with the corresponding ID and

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -54,6 +54,10 @@ const (
 	diskDetachFactor         = 1.2
 	diskDetachSteps          = 13
 	volumeDescription        = "Created by OpenStack Cinder CSI driver"
+
+	VolumeType                 = "type"
+	VolumeAvailabilityZone     = "availability"
+	VolumeAppendVolumeMetadata = "appendVolumeMetadata"
 )
 
 var volumeErrorStates = [...]string{"error", "error_extending", "error_deleting"}


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This adds support for `appendVolumeMetadata` in the `parameters` section of `StorageClass`/`VolumeSnapshotClass` for Cinder CSI, which matches the existing function of Manila CSI(`appendShareMetadata`) and enables user to supply custom metadata to the created volume/snapshot/backup.

**Which issue this PR fixes(if applicable)**:

**Special notes for reviewers**:

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[cinder-csi-plugin]: Support `appendVolumeMetadata` in `StorageClass`/`VolumeSnapshotClass` for Cinder CSI, allowing user to specify custom meta for the created volume/snapshot/backup.
```
