### PR TITLE
[k8s-keystone-auth] Don't log tokens

### DIFF
--- a/pkg/identity/keystone/keystone.go
+++ b/pkg/identity/keystone/keystone.go
@@ -286,7 +286,7 @@ func (k *Auth) Handler(w http.ResponseWriter, r *http.Request) {
 
 func (k *Auth) authenticateToken(ctx context.Context, w http.ResponseWriter, r *http.Request, token string, data map[string]interface{}) *userInfo {
 	user, authenticated, err := k.authn.AuthenticateToken(ctx, token)
-	klog.V(4).Infof("authenticateToken : %v, %v, %v\n", token, user, err)
+	klog.V(4).Infof("authenticateToken : %v, %v\n", user, err)
 
 	if !authenticated {
 		var response status


### PR DESCRIPTION

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

The Keystone authentication webhook handler writes the raw bearer token submitted in every TokenReview to the log stream when verbosity is 4 or higher. It is pretty common to set this level (-v=4) while e.g. debugging. Additionally, it is common for logs to be sent to a central store, with different access controls than the main cluster. A user with access to this store can use the captured token for replay attacks for any user that authenticates against the cluster until the token's TTL.

Stop logging the token and avoid all of this. The combo of user, any error and the usual timestamp etc. should be more than sufficient.

**Which issue this PR fixes(if applicable)**:

(none)

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
