### PR TITLE
tests: make E2E tests optional and add local development workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,6 @@ zz_generated.openapi.go
 
 # local gopath
 .go
+
+# Openstack credential file
+clouds.yaml

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -6,8 +6,12 @@
   - [Prerequisites](#prerequisites)
     - [OpenStack Cloud](#openstack-cloud)
     - [Kubernetes cluster](#kubernetes-cluster)
+    - [DevStack-based testing environment](#devstack-based-testing-environment)
   - [Contribution](#contribution)
   - [Development](#development)
+    - [Testing](#testing)
+    - [Unit tests](#unit-tests)
+    - [E2E tests](#e2e-tests)
     - [Build openstack-cloud-controller-manager image](#build-openstack-cloud-controller-manager-image)
     - [Troubleshooting](#troubleshooting)
     - [Review process](#review-process)
@@ -48,6 +52,10 @@ You can also use our CI scripts to setup a simple development environment based 
 Once the VM is up make sure your SSH keys allow logging in as `ubuntu` user and from your PC and cloud-provider-openstack directory run:
 
 ```
+ssh ubuntu@<PUBLIC_IP_OF_YOUR_VM> \
+  sudo git clone https://github.com/kubernetes/cloud-provider-openstack.git \
+  /root/src/k8s.io/cloud-provider-openstack
+
 ansible-playbook -v \
   --user ubuntu \
   --inventory <PUBLIC_IP_OF_YOUR_VM>, \
@@ -102,6 +110,47 @@ $ curl 172.24.5.121
 test-846c6ffb69-w52vq: HELLO! I AM ALIVE!!!
 ```
 
+Alternately, if you prefer to develop locally, you can use below steps:
+
+* Forward traffic to the cluster with `sshuttle`.
+
+```sh
+sshuttle -r ubuntu@<PUBLIC_IP_OF_YOUR_VM> 172.24.0.0/16
+```
+
+* (Optional) Log in to the k3s master node.
+
+```sh
+ssh ubuntu@<PUBLIC_IP_OF_YOUR_VM> sudo cat /root/.ssh/id_rsa | cat > _tmp/id_rsa && chmod 0600 _tmp/id_rsa
+# Get the float IP of the k3s node with `openstack server show k3s-master -c "addresses"`
+ssh -i _tmp/id_rsa  ubuntu@<K3S_NODE_FLOAT_IP>
+```
+
+* Fetch k3s kubeconfig file.
+
+```sh
+ssh ubuntu@<PUBLIC_IP_OF_YOUR_VM> sudo cat /root/.kube/config > _tmp/kubeconfig
+
+export KUBECONFIG=_tmp/kubeconfig
+```
+
+* Get the image register CA cert from the node and add it into docker certs.
+
+```sh
+ssh ubuntu@<PUBLIC_IP_OF_YOUR_VM> sudo cat /root/certs/ca.pem
+sudo mkdir -p /etc/docker/certs.d/<PUBLIC_IP_OF_YOUR_VM>
+sudo vi /etc/docker/certs.d/<PUBLIC_IP_OF_YOUR_VM>/ca.crt
+```
+
+* Build image and push to the remote register.
+
+```sh
+make push-multiarch-image-cinder-csi-plugin \
+  ARCHS='amd64' \
+  VERSION=v0.0.100 \
+  REGISTRY=<PUBLIC_IP_OF_YOUR_VM>
+```
+
 ## Contribution
 Now you should have a kubernetes cluster running in openstack and openstack-cloud-controller-manager is deployed in the cluster. Over time, you may find a bug or have some feature requirements, it's time for contribution!
 
@@ -154,7 +203,8 @@ ansible-playbook \
   --user ubuntu \
   --inventory 10.0.110.127, \
   --ssh-common-args "-o StrictHostKeyChecking=no" \
-  tests/playbooks/test-csi-cinder-e2e.yaml
+  tests/playbooks/test-csi-cinder-e2e.yaml \
+  -e run_e2e=true
 ```
 
 As you can see, this whole area needs improvement to make this a little more approachable for non-CI use cases. This should be enough direction to get started though.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -52,9 +52,7 @@ You can also use our CI scripts to setup a simple development environment based 
 Once the VM is up make sure your SSH keys allow logging in as `ubuntu` user and from your PC and cloud-provider-openstack directory run:
 
 ```
-ssh ubuntu@<PUBLIC_IP_OF_YOUR_VM> \
-  sudo git clone https://github.com/kubernetes/cloud-provider-openstack.git \
-  /root/src/k8s.io/cloud-provider-openstack
+ssh ubuntu@<PUBLIC_IP_OF_YOUR_VM> sh -c 'echo; git clone https://github.com/kubernetes/cloud-provider-openstack.git ~/src/k8s.io/cloud-provider-openstack'
 
 ansible-playbook -v \
   --user ubuntu \
@@ -71,11 +69,8 @@ After it finishes you should be able to access both DevStack and Kubernetes:
 # SSH to the VM
 $ ssh ubuntu@<PUBLIC_IP_OF_YOUR_VM>
 
-# Apparently we install K8s in root
-$ sudo su
-
 # Load OpenStack credentials
-$ source /home/stack/devstack/openrc admin admin
+$ source openrc-demo
 
 # List all pods in K8s
 $ kubectl get pods -A
@@ -121,7 +116,9 @@ sshuttle -r ubuntu@<PUBLIC_IP_OF_YOUR_VM> 172.24.0.0/16
 * (Optional) Log in to the k3s master node.
 
 ```sh
-ssh ubuntu@<PUBLIC_IP_OF_YOUR_VM> sudo cat /root/.ssh/id_rsa | cat > _tmp/id_rsa && chmod 0600 _tmp/id_rsa
+mkdir _tmp
+
+scp ubuntu@<PUBLIC_IP_OF_YOUR_VM>:~/.ssh/id_rsa _tmp/id_rsa && chmod 0600 _tmp/id_rsa
 # Get the float IP of the k3s node with `openstack server show k3s-master -c "addresses"`
 ssh -i _tmp/id_rsa  ubuntu@<K3S_NODE_FLOAT_IP>
 ```
@@ -129,7 +126,7 @@ ssh -i _tmp/id_rsa  ubuntu@<K3S_NODE_FLOAT_IP>
 * Fetch k3s kubeconfig file.
 
 ```sh
-ssh ubuntu@<PUBLIC_IP_OF_YOUR_VM> sudo cat /root/.kube/config > _tmp/kubeconfig
+scp ubuntu@<PUBLIC_IP_OF_YOUR_VM>:~/.kube/config _tmp/kubeconfig
 
 export KUBECONFIG=_tmp/kubeconfig
 ```
@@ -137,9 +134,8 @@ export KUBECONFIG=_tmp/kubeconfig
 * Get the image register CA cert from the node and add it into docker certs.
 
 ```sh
-ssh ubuntu@<PUBLIC_IP_OF_YOUR_VM> sudo cat /root/certs/ca.pem
 sudo mkdir -p /etc/docker/certs.d/<PUBLIC_IP_OF_YOUR_VM>
-sudo vi /etc/docker/certs.d/<PUBLIC_IP_OF_YOUR_VM>/ca.crt
+sudo scp ubuntu@<PUBLIC_IP_OF_YOUR_VM>:~/certs/ca.pem /etc/docker/certs.d/<PUBLIC_IP_OF_YOUR_VM>/ca.crt
 ```
 
 * Build image and push to the remote register.

--- a/tests/ci-csi-cinder-e2e.sh
+++ b/tests/ci-csi-cinder-e2e.sh
@@ -125,7 +125,8 @@ ansible-playbook -v \
   --private-key ~/.ssh/google_compute_engine \
   --inventory ${PUBLIC_IP}, \
   --ssh-common-args "-o StrictHostKeyChecking=no" \
-  tests/playbooks/test-csi-cinder-e2e.yaml
+  tests/playbooks/test-csi-cinder-e2e.yaml \
+  -e run_e2e=true
 exit_code=$?
 
 # Fetch logs for debugging purpose

--- a/tests/ci-csi-cinder-e2e.sh
+++ b/tests/ci-csi-cinder-e2e.sh
@@ -116,7 +116,7 @@ fi
 # Upload CPO code
 scp -i ~/.ssh/google_compute_engine \
   -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-  -r ${GOPATH}/* ${USERNAME}@${PUBLIC_IP}:/root/
+  -r ${GOPATH}/* ${USERNAME}@${PUBLIC_IP}:~/
 
 # Run ansible playbook on the CI host, e.g. a VM in GCP
 # USERNAME and PUBLIC_IP are global env variables set after creating the CI host.
@@ -144,7 +144,7 @@ ansible-playbook -v \
 # Fetch cinder-csi tests logs for debugging purpose
 scp -i ~/.ssh/google_compute_engine \
   -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-  -r ${USERNAME}@${PUBLIC_IP}:/var/log/csi-pod/* $ARTIFACTS/logs/ || true
+  -r ${USERNAME}@${PUBLIC_IP}:~/csi-pod/* $ARTIFACTS/logs/ || true
 
 # If Boskos is being used then release the resource back to Boskos.
 [ -z "${BOSKOS_HOST:-}" ] || python3 tests/scripts/boskos.py --release >> "$ARTIFACTS/logs/boskos.log" 2>&1

--- a/tests/ci-csi-manila-e2e.sh
+++ b/tests/ci-csi-manila-e2e.sh
@@ -125,7 +125,8 @@ ansible-playbook -v \
   --private-key ~/.ssh/google_compute_engine \
   --inventory ${PUBLIC_IP}, \
   --ssh-common-args "-o StrictHostKeyChecking=no" \
-  tests/playbooks/test-csi-manila-e2e.yaml
+  tests/playbooks/test-csi-manila-e2e.yaml \
+  -e run_e2e=true
 exit_code=$?
 
 # Fetch logs for debugging purpose

--- a/tests/ci-csi-manila-e2e.sh
+++ b/tests/ci-csi-manila-e2e.sh
@@ -116,7 +116,7 @@ fi
 # Upload CPO code
 scp -i ~/.ssh/google_compute_engine \
   -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-  -r ${GOPATH}/* ${USERNAME}@${PUBLIC_IP}:/root/
+  -r ${GOPATH}/* ${USERNAME}@${PUBLIC_IP}:~/
 
 # Run ansible playbook on the CI host, e.g. a VM in GCP
 # USERNAME and PUBLIC_IP are global env variables set after creating the CI host.
@@ -144,7 +144,7 @@ ansible-playbook -v \
 # Fetch manila-csi tests results
 scp -i ~/.ssh/google_compute_engine \
   -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-  -r ${USERNAME}@${PUBLIC_IP}:/var/log/csi-pod/* $ARTIFACTS/logs/ || true
+  -r ${USERNAME}@${PUBLIC_IP}:~/csi-pod/* $ARTIFACTS/logs/ || true
 
 # If Boskos is being used then release the resource back to Boskos.
 [ -z "${BOSKOS_HOST:-}" ] || python3 tests/scripts/boskos.py --release >> "$ARTIFACTS/logs/boskos.log" 2>&1

--- a/tests/ci-occm-e2e.sh
+++ b/tests/ci-occm-e2e.sh
@@ -117,7 +117,7 @@ fi
 # Upload CPO code
 scp -i ~/.ssh/google_compute_engine \
   -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-  -r ${GOPATH}/* ${USERNAME}@${PUBLIC_IP}:/root/
+  -r ${GOPATH}/* ${USERNAME}@${PUBLIC_IP}:~/
 
 # Run ansible playbook on the CI host, e.g. a VM in GCP
 # USERNAME and PUBLIC_IP are global env variables set after creating the CI host.

--- a/tests/playbooks/fetch-logs.yaml
+++ b/tests/playbooks/fetch-logs.yaml
@@ -1,5 +1,4 @@
 - hosts: all
-  become: true
   become_method: sudo
   gather_facts: true
 

--- a/tests/playbooks/roles/fetch-logs/tasks/main.yaml
+++ b/tests/playbooks/roles/fetch-logs/tasks/main.yaml
@@ -2,7 +2,7 @@
   shell:
     executable: /bin/bash
     cmd: |
-      set +x; source {{ devstack_workdir }}/openrc demo demo > /dev/null
+      set +x; source {{ ansible_facts["user_dir"] }}/openrc-demo > /dev/null; set -x
       openstack floating ip list --port {{ master_port_name }} -c "Floating IP Address" -f value
   register: fip
 
@@ -12,16 +12,17 @@
 
 - name: Creates directory
   ansible.builtin.file:
-    path: "/root/logs"
+    path: "{{ ansible_facts['user_dir'] }}/logs"
     state: directory
 
 - name: Fetch k3s logs
   shell:
     executable: /bin/bash
     cmd: |
-      ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ ansible_user_dir }}/.ssh/id_rsa ubuntu@{{ k3s_fip }} sudo journalctl -u k3s.service --no-pager > /root/logs/k3s.log
+      ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ ansible_user_dir }}/.ssh/id_rsa ubuntu@{{ k3s_fip }} sudo journalctl -u k3s.service --no-pager > {{ ansible_facts["user_dir"] }}/logs/k3s.log
 
 - name: Fetch DevStack logs
+  become: true
   shell:
     executable: /bin/bash
     cmd: |
@@ -30,5 +31,6 @@
       for unit in $units; do
         filename=${unit#"devstack@"}
         filename=${filename%".service"}
-        sudo journalctl -u $unit --no-pager > /root/logs/${filename}.log
+        journalctl -u $unit --no-pager > {{ ansible_facts["user_dir"] }}/logs/${filename}.log
       done;
+      chown {{ ansible_facts["user_id"] }}:{{ ansible_facts["user_gid"] }} {{ ansible_facts["user_dir"] }}/logs/*

--- a/tests/playbooks/roles/install-cpo-occm/defaults/main.yaml
+++ b/tests/playbooks/roles/install-cpo-occm/defaults/main.yaml
@@ -3,7 +3,7 @@ devstack_workdir: "{{ ansible_user_dir }}/devstack"
 
 # Used for uploading image to local registry.
 image_registry_host: localhost
-run_e2e: false
+run_e2e_ccm: false
 # Used for access the private registry image from k8s
 remote_registry_host: "{{ ansible_default_ipv4.address }}"
 

--- a/tests/playbooks/roles/install-cpo-occm/tasks/main.yaml
+++ b/tests/playbooks/roles/install-cpo-occm/tasks/main.yaml
@@ -128,7 +128,7 @@
         msg: *failmsg
 
 - name: Run functional tests for openstack-cloud-controller-manager
-  when: run_e2e | bool
+  when: run_e2e_ccm | bool
   register: run_tests
   shell:
     executable: /bin/bash
@@ -145,7 +145,7 @@
 
 - name: Print logs for debugging
   when:
-    - run_e2e | bool
+    - run_e2e_ccm | bool
     - run_tests.failed
   block:
   - name: Show openstack-cloud-controller-manager pod logs

--- a/tests/playbooks/roles/install-cpo-occm/tasks/main.yaml
+++ b/tests/playbooks/roles/install-cpo-occm/tasks/main.yaml
@@ -31,12 +31,13 @@
 
       set -ex
 
-      set +x; source {{ devstack_workdir }}/openrc admin admin > /dev/null; set -x
+      set +x; source openrc-admin; set -x
       tenant_id=$(openstack project show demo -c id -f value)
       sudnet_id=$(openstack subnet show private-subnet -c id -f value)
       external_network_id=$(openstack network list --external -c ID -f value)
 
-      set +x; source {{ devstack_workdir }}/openrc demo demo > /dev/null; set -x
+      set +x; source openrc-demo; set -x
+
       cat <<EOF > {{ ansible_user_dir }}/cloud.conf
       [Global]
       auth-url=${OS_AUTH_URL}/v3
@@ -137,7 +138,7 @@
 
       # GATEWAY_IP is the default value in devstack
       GATEWAY_IP=172.24.5.1 \
-      DEVSTACK_OS_RC={{ devstack_workdir }}/openrc \
+      DEVSTACK_OS_RC={{ ansible_facts["user_dir"] }}/openrc-demo \
       OCTAVIA_PROVIDER={{ octavia_provider }} \
       bash tests/e2e/cloudprovider/test-lb-service.sh
   timeout: 3600

--- a/tests/playbooks/roles/install-csi-cinder/defaults/main.yaml
+++ b/tests/playbooks/roles/install-csi-cinder/defaults/main.yaml
@@ -5,3 +5,4 @@ devstack_workdir: "{{ ansible_user_dir }}/devstack"
 image_registry_host: localhost
 # Used for access the private registry image from k8s
 remote_registry_host: "{{ ansible_default_ipv4.address }}"
+run_e2e_cinder: false

--- a/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
@@ -173,60 +173,64 @@
       fail:
         msg: *failmsg
 
-- name: Fetch kubernetes-test-linux-amd64.tar.gz
-  unarchive:
-    src: "https://dl.k8s.io/{{ e2e_test_version }}/kubernetes-test-linux-amd64.tar.gz"
-    dest: /tmp/
-    remote_src: true
-    extra_opts:
-      - --add-file
-      - kubernetes/test/bin/e2e.test
+- name: Run Cinder tests
+  when:
+    - run_e2e_cinder | bool
+  block:
+    - name: Fetch kubernetes-test-linux-amd64.tar.gz
+      unarchive:
+        src: "https://dl.k8s.io/{{ e2e_test_version }}/kubernetes-test-linux-amd64.tar.gz"
+        dest: /tmp/
+        remote_src: true
+        extra_opts:
+          - --add-file
+          - kubernetes/test/bin/e2e.test
 
-- name: Run functional tests for csi-cinder-plugin
-  shell:
-    executable: /bin/bash
-    cmd: |
-      set -x
-      set -e
-      set -o pipefail
+    - name: Run functional tests for csi-cinder-plugin
+      shell:
+        executable: /bin/bash
+        cmd: |
+          set -x
+          set -e
+          set -o pipefail
 
-      cd {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack
-      mkdir -p /var/log/csi-pod
-      # TODO(chrigl): No idea why both tests fail in CI. On a real OpenStack both pass.
-      /tmp/kubernetes/test/bin/e2e.test \
-        -storage.testdriver=tests/e2e/csi/cinder/test-driver.yaml \
-        --ginkgo.focus='External.Storage' \
-        --ginkgo.skip='\[Disruptive\]|\[Testpattern:\s+Dynamic\s+PV\s+\(default\s+fs\)\]\s+provisioning\s+should\s+mount\s+multiple\s+PV\s+pointing\s+to\s+the\s+same\s+storage\s+on\s+the\s+same\s+node|\[Testpattern:\s+Dynamic\s+PV\s+\(default\s+fs\)\]\s+provisioning\s+should\s+provision\s+storage\s+with\s+any\s+volume\s+data\s+source\s+\[Serial\]|should\s+support\s+expansion\s+of\s+pvcs\s+created\s+for\s+ephemeral\s+pvcs' \
-        --ginkgo.v \
-        --ginkgo.no-color \
-        --ginkgo.show-node-events \
-        --ginkgo.timeout=1h45m \
-        -test.timeout=0 \
-        -report-dir="/var/log/csi-pod" | tee "/var/log/csi-pod/cinder-csi-e2e.log"
-  register: functional_test_result
-  ignore_errors: true
-  async: 6600 # wait 1h50m (i.e. 5 mins longer than the ginkgo timeout) then fail and fetch the logs
-  poll: 15
+          cd {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack
+          mkdir -p /var/log/csi-pod
+          # TODO(chrigl): No idea why both tests fail in CI. On a real OpenStack both pass.
+          /tmp/kubernetes/test/bin/e2e.test \
+            -storage.testdriver=tests/e2e/csi/cinder/test-driver.yaml \
+            --ginkgo.focus='External.Storage' \
+            --ginkgo.skip='\[Disruptive\]|\[Testpattern:\s+Dynamic\s+PV\s+\(default\s+fs\)\]\s+provisioning\s+should\s+mount\s+multiple\s+PV\s+pointing\s+to\s+the\s+same\s+storage\s+on\s+the\s+same\s+node|\[Testpattern:\s+Dynamic\s+PV\s+\(default\s+fs\)\]\s+provisioning\s+should\s+provision\s+storage\s+with\s+any\s+volume\s+data\s+source\s+\[Serial\]|should\s+support\s+expansion\s+of\s+pvcs\s+created\s+for\s+ephemeral\s+pvcs' \
+            --ginkgo.v \
+            --ginkgo.no-color \
+            --ginkgo.show-node-events \
+            --ginkgo.timeout=1h45m \
+            -test.timeout=0 \
+            -report-dir="/var/log/csi-pod" | tee "/var/log/csi-pod/cinder-csi-e2e.log"
+      register: functional_test_result
+      ignore_errors: true
+      async: 6600 # wait 1h50m (i.e. 5 mins longer than the ginkgo timeout) then fail and fetch the logs
+      poll: 15
 
-- name: Collect pod logs for debug purpose
-  shell:
-    executable: /bin/bash
-    cmd: |
-      set -x
-      set -e
+    - name: Collect pod logs for debug purpose
+      shell:
+        executable: /bin/bash
+        cmd: |
+          set -x
+          set -e
 
-      kubectl logs deployment/csi-cinder-controllerplugin -n kube-system -c cinder-csi-plugin > /var/log/csi-pod/csi-cinder-controllerplugin.log
-      kubectl logs daemonset/csi-cinder-nodeplugin -n kube-system -c cinder-csi-plugin > /var/log/csi-pod/csi-cinder-nodeplugin.log
-      kubectl -n kube-system exec $(kubectl -n kube-system get pod -l app=csi-cinder-nodeplugin -o name) -c cinder-csi-plugin -- dmesg -T > /var/log/csi-pod/dmesg.log
-  ignore_errors: true
+          kubectl logs deployment/csi-cinder-controllerplugin -n kube-system -c cinder-csi-plugin > /var/log/csi-pod/csi-cinder-controllerplugin.log
+          kubectl logs daemonset/csi-cinder-nodeplugin -n kube-system -c cinder-csi-plugin > /var/log/csi-pod/csi-cinder-nodeplugin.log
+          kubectl -n kube-system exec $(kubectl -n kube-system get pod -l app=csi-cinder-nodeplugin -o name) -c cinder-csi-plugin -- dmesg -T > /var/log/csi-pod/dmesg.log
+      ignore_errors: true
 
-- name: Show dmesg logs
-  become: true
-  shell:
-    executable: /bin/bash
-    cmd: |
-      sudo dmesg -T > /var/log/csi-pod/dmesg_local.log
-  ignore_errors: true
+    - name: Show dmesg logs
+      become: true
+      shell:
+        executable: /bin/bash
+        cmd: |
+          sudo dmesg -T > /var/log/csi-pod/dmesg_local.log
+      ignore_errors: true
 
-- fail: msg="The execution has failed because of errors."
-  when: functional_test_result.failed
+    - fail: msg="The execution has failed because of errors."
+      when: functional_test_result.failed

--- a/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
@@ -33,9 +33,9 @@
 
       set -ex
 
-      set +x; source {{ devstack_workdir }}/openrc admin admin > /dev/null; set -x
+      set +x; source {{ ansible_facts["user_dir"] }}/openrc-admin > /dev/null; set -x
       tenant_id=$(openstack project show demo -c id -f value)
-      set +x; source {{ devstack_workdir }}/openrc demo demo > /dev/null; set -x
+      set +x; source {{ ansible_facts["user_dir"] }}/openrc-demo > /dev/null; set -x
       cat <<EOF > {{ ansible_user_dir }}/cloud.conf
       [Global]
       auth-url=${OS_AUTH_URL}
@@ -144,12 +144,12 @@
           set -x
           set -e
 
-          mkdir -p /var/log/csi-pod
+          mkdir -p {{ ansible_facts["user_dir"] }}/csi-pod
           kubectl logs deployment/csi-cinder-controllerplugin -n kube-system -c cinder-csi-plugin
           kubectl logs daemonset/csi-cinder-nodeplugin -n kube-system -c cinder-csi-plugin
 
-          kubectl logs deployment/csi-cinder-controllerplugin -n kube-system -c cinder-csi-plugin > /var/log/csi-pod/csi-cinder-controllerplugin.log
-          kubectl logs daemonset/csi-cinder-nodeplugin -n kube-system -c cinder-csi-plugin > /var/log/csi-pod/csi-cinder-nodeplugin.log
+          kubectl logs deployment/csi-cinder-controllerplugin -n kube-system -c cinder-csi-plugin > {{ ansible_facts["user_dir"] }}/csi-pod/csi-cinder-controllerplugin.log
+          kubectl logs daemonset/csi-cinder-nodeplugin -n kube-system -c cinder-csi-plugin > {{ ansible_facts["user_dir"] }}/csi-pod/csi-cinder-nodeplugin.log
 
     - name: Show openstack-cloud-controller-manager pod logs
       shell:
@@ -157,16 +157,16 @@
         cmd: |
           kubectl -n kube-system logs ds/openstack-cloud-controller-manager
 
-          kubectl -n kube-system logs ds/openstack-cloud-controller-manager > /var/log/csi-pod/occm.log
+          kubectl -n kube-system logs ds/openstack-cloud-controller-manager > {{ ansible_facts["user_dir"] }}/csi-pod/occm.log
 
     - name: Collect pod logs for debug purpose (early collection on deployment failure)
       shell:
         executable: /bin/bash
         cmd: |
           set -x
-          mkdir -p /var/log/csi-pod
-          kubectl logs deployment/csi-cinder-controllerplugin -n kube-system -c cinder-csi-plugin > /var/log/csi-pod/deployment-csi-cinder-controllerplugin.log
-          kubectl logs daemonset/csi-cinder-nodeplugin -n kube-system -c cinder-csi-plugin > /var/log/csi-pod/deployment-csi-cinder-nodeplugin.log
+          mkdir -p {{ ansible_facts["user_dir"] }}/csi-pod
+          kubectl logs deployment/csi-cinder-controllerplugin -n kube-system -c cinder-csi-plugin > {{ ansible_facts["user_dir"] }}/csi-pod/deployment-csi-cinder-controllerplugin.log
+          kubectl logs daemonset/csi-cinder-nodeplugin -n kube-system -c cinder-csi-plugin > {{ ansible_facts["user_dir"] }}/csi-pod/deployment-csi-cinder-nodeplugin.log
       ignore_errors: true
 
     - name: &failmsg Stop due to prior failure of csi-cinder-plugin
@@ -195,7 +195,7 @@
           set -o pipefail
 
           cd {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack
-          mkdir -p /var/log/csi-pod
+          mkdir -p {{ ansible_facts["user_dir"] }}/csi-pod
           # TODO(chrigl): No idea why both tests fail in CI. On a real OpenStack both pass.
           /tmp/kubernetes/test/bin/e2e.test \
             -storage.testdriver=tests/e2e/csi/cinder/test-driver.yaml \
@@ -206,7 +206,7 @@
             --ginkgo.show-node-events \
             --ginkgo.timeout=1h45m \
             -test.timeout=0 \
-            -report-dir="/var/log/csi-pod" | tee "/var/log/csi-pod/cinder-csi-e2e.log"
+            -report-dir="{{ ansible_facts["user_dir"] }}/csi-pod" | tee "{{ ansible_facts["user_dir"] }}/csi-pod/cinder-csi-e2e.log"
       register: functional_test_result
       ignore_errors: true
       async: 6600 # wait 1h50m (i.e. 5 mins longer than the ginkgo timeout) then fail and fetch the logs
@@ -219,9 +219,9 @@
           set -x
           set -e
 
-          kubectl logs deployment/csi-cinder-controllerplugin -n kube-system -c cinder-csi-plugin > /var/log/csi-pod/csi-cinder-controllerplugin.log
-          kubectl logs daemonset/csi-cinder-nodeplugin -n kube-system -c cinder-csi-plugin > /var/log/csi-pod/csi-cinder-nodeplugin.log
-          kubectl -n kube-system exec $(kubectl -n kube-system get pod -l app=csi-cinder-nodeplugin -o name) -c cinder-csi-plugin -- dmesg -T > /var/log/csi-pod/dmesg.log
+          kubectl logs deployment/csi-cinder-controllerplugin -n kube-system -c cinder-csi-plugin > {{ ansible_facts["user_dir"] }}/csi-pod/csi-cinder-controllerplugin.log
+          kubectl logs daemonset/csi-cinder-nodeplugin -n kube-system -c cinder-csi-plugin > {{ ansible_facts["user_dir"] }}/csi-pod/csi-cinder-nodeplugin.log
+          kubectl -n kube-system exec $(kubectl -n kube-system get pod -l app=csi-cinder-nodeplugin -o name) -c cinder-csi-plugin -- dmesg -T > {{ ansible_facts["user_dir"] }}/csi-pod/dmesg.log
       ignore_errors: true
 
     - name: Show dmesg logs
@@ -229,7 +229,7 @@
       shell:
         executable: /bin/bash
         cmd: |
-          sudo dmesg -T > /var/log/csi-pod/dmesg_local.log
+          sudo dmesg -T > {{ ansible_facts["user_dir"] }}/csi-pod/dmesg_local.log
       ignore_errors: true
 
     - fail: msg="The execution has failed because of errors."

--- a/tests/playbooks/roles/install-csi-manila/defaults/main.yaml
+++ b/tests/playbooks/roles/install-csi-manila/defaults/main.yaml
@@ -7,3 +7,5 @@ image_registry_host: localhost
 remote_registry_host: "{{ ansible_default_ipv4.address }}"
 
 k8s_log_dir: "/var/log/"
+
+run_e2e_manila: false

--- a/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
@@ -33,9 +33,9 @@
 
       set -ex
 
-      set +x; source {{ devstack_workdir }}/openrc admin admin > /dev/null; set -x
+      set +x; source {{ ansible_facts["user_dir"] }}/openrc-admin > /dev/null; set -x
       tenant_id=$(openstack project show demo -c id -f value)
-      set +x; source {{ devstack_workdir }}/openrc demo demo > /dev/null; set -x
+      set +x; source {{ ansible_facts["user_dir"] }}/openrc-demo > /dev/null; set -x
       cat <<EOF > {{ ansible_user_dir }}/cloud.conf
       [Global]
       auth-url=${OS_AUTH_URL}
@@ -190,9 +190,9 @@
         executable: /bin/bash
         cmd: |
           set -x
-          mkdir -p /var/log/csi-pod
-          kubectl logs -l app=openstack-manila-csi,component=controllerplugin -n default -c nfs-nodeplugin --tail=-1 > /var/log/csi-pod/deployment-csi-manila-controllerplugin.log
-          kubectl logs -l app=openstack-manila-csi,component=nodeplugin -n default -c nfs-nodeplugin --tail=-1 > /var/log/csi-pod/deployment-csi-manila-nodeplugin.log
+          mkdir -p {{ ansible_facts["user_dir"] }}/csi-pod
+          kubectl logs -l app=openstack-manila-csi,component=controllerplugin -n default -c nfs-nodeplugin --tail=-1 > {{ ansible_facts["user_dir"] }}/csi-pod/deployment-csi-manila-controllerplugin.log
+          kubectl logs -l app=openstack-manila-csi,component=nodeplugin -n default -c nfs-nodeplugin --tail=-1 > {{ ansible_facts["user_dir"] }}/csi-pod/deployment-csi-manila-nodeplugin.log
       ignore_errors: true
 
     - name: &failmsg Stop due to prior failure of manila-csi-plugin
@@ -203,7 +203,7 @@
   shell:
     executable: /bin/bash
     cmd: |
-      set +x; source {{ devstack_workdir }}/openrc demo demo > /dev/null; set -x
+      set +x; source {{ ansible_facts["user_dir"] }}/openrc-demo > /dev/null; set -x
 
       cat <<EOF | kubectl create -f -
       apiVersion: v1
@@ -236,13 +236,13 @@
           set -e
           set -o pipefail
 
-          set +x; source {{ devstack_workdir }}/openrc demo demo > /dev/null; set -x
+          set +x; source {{ ansible_facts["user_dir"] }}/openrc-demo > /dev/null; set -x
 
           cd {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack
-          mkdir -p /var/log/csi-pod
+          mkdir -p {{ ansible_facts["user_dir"] }}/csi-pod
           # GATEWAY_IP is the default value in devstack
           GATEWAY_IP=172.24.5.1 \
-          OS_RC={{ devstack_workdir }}/openrc \
+          OS_RC={{ ansible_facts["user_dir"] }}/openrc-demo \
           go test -v ./cmd/tests/manila-csi-e2e-suite/manila_csi_e2e_suite_test.go \
             --ginkgo.focus="\[manila-csi-e2e\]" \
             --ginkgo.skip="\[Disruptive\]|\[sig-storage\]\s+\[manila-csi-e2e\]\s+CSI\s+Volumes\s+\[Driver:\s+nfs.manila.csi.openstack.org\]\s+\[Testpattern:\s+Dynamic\s+PV\s+\(default\s+fs\)\]\s+provisioning\s+should\s+provision\s+storage\s+with\s+any\s+volume\s+data\s+source\s+\[Serial\]|should\s+provision\s+storage\s+with\s+snapshot\s+data\s+source|restoring\s+snapshot\s+to\s+larger\s+size" \
@@ -251,7 +251,7 @@
             --ginkgo.show-node-events \
             --ginkgo.timeout=1h45m \
             -timeout=0 \
-            -report-dir /var/log/csi-pod | tee "/var/log/csi-pod/manila-csi-e2e.log"
+            -report-dir {{ ansible_facts["user_dir"] }}/csi-pod | tee "{{ ansible_facts["user_dir"] }}/csi-pod/manila-csi-e2e.log"
       register: functional_test_result
       ignore_errors: true
       async: 6600 # wait 1h50m (i.e. 5 mins longer than the ginkgo timeout) then fail and fetch the logs
@@ -264,8 +264,8 @@
           set -x
           set -e
 
-          kubectl logs -l app=openstack-manila-csi,component=controllerplugin -n default -c nfs-nodeplugin --tail=-1 > /var/log/csi-pod/csi-manila-controllerplugin.log
-          kubectl logs -l app=openstack-manila-csi,component=nodeplugin -n default -c nfs-nodeplugin --tail=-1 > /var/log/csi-pod/csi-manila-nodeplugin.log
+          kubectl logs -l app=openstack-manila-csi,component=controllerplugin -n default -c nfs-nodeplugin --tail=-1 > {{ ansible_facts["user_dir"] }}/csi-pod/csi-manila-controllerplugin.log
+          kubectl logs -l app=openstack-manila-csi,component=nodeplugin -n default -c nfs-nodeplugin --tail=-1 > {{ ansible_facts["user_dir"] }}/csi-pod/csi-manila-nodeplugin.log
       ignore_errors: true
 
     - fail: msg="The execution has failed because of errors."

--- a/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
@@ -224,45 +224,49 @@
         os-domainID: "$OS_USER_DOMAIN_ID"
       EOF
 
-- name: Run functional tests for manila-csi-plugin
-  shell:
-    executable: /bin/bash
-    cmd: |
-      set -x
-      set -e
-      set -o pipefail
+- name: Run manila tests
+  when:
+    - run_e2e_manila | bool
+  block:
+    - name: Run functional tests for manila-csi-plugin
+      shell:
+        executable: /bin/bash
+        cmd: |
+          set -x
+          set -e
+          set -o pipefail
 
-      set +x; source {{ devstack_workdir }}/openrc demo demo > /dev/null; set -x
+          set +x; source {{ devstack_workdir }}/openrc demo demo > /dev/null; set -x
 
-      cd {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack
-      mkdir -p /var/log/csi-pod
-      # GATEWAY_IP is the default value in devstack
-      GATEWAY_IP=172.24.5.1 \
-      OS_RC={{ devstack_workdir }}/openrc \
-      go test -v ./cmd/tests/manila-csi-e2e-suite/manila_csi_e2e_suite_test.go \
-        --ginkgo.focus="\[manila-csi-e2e\]" \
-        --ginkgo.skip="\[Disruptive\]|\[sig-storage\]\s+\[manila-csi-e2e\]\s+CSI\s+Volumes\s+\[Driver:\s+nfs.manila.csi.openstack.org\]\s+\[Testpattern:\s+Dynamic\s+PV\s+\(default\s+fs\)\]\s+provisioning\s+should\s+provision\s+storage\s+with\s+any\s+volume\s+data\s+source\s+\[Serial\]|should\s+provision\s+storage\s+with\s+snapshot\s+data\s+source|restoring\s+snapshot\s+to\s+larger\s+size" \
-        --ginkgo.v \
-        --ginkgo.no-color \
-        --ginkgo.show-node-events \
-        --ginkgo.timeout=1h45m \
-        -timeout=0 \
-        -report-dir /var/log/csi-pod | tee "/var/log/csi-pod/manila-csi-e2e.log"
-  register: functional_test_result
-  ignore_errors: true
-  async: 6600 # wait 1h50m (i.e. 5 mins longer than the ginkgo timeout) then fail and fetch the logs
-  poll: 15
+          cd {{ ansible_user_dir }}/src/k8s.io/cloud-provider-openstack
+          mkdir -p /var/log/csi-pod
+          # GATEWAY_IP is the default value in devstack
+          GATEWAY_IP=172.24.5.1 \
+          OS_RC={{ devstack_workdir }}/openrc \
+          go test -v ./cmd/tests/manila-csi-e2e-suite/manila_csi_e2e_suite_test.go \
+            --ginkgo.focus="\[manila-csi-e2e\]" \
+            --ginkgo.skip="\[Disruptive\]|\[sig-storage\]\s+\[manila-csi-e2e\]\s+CSI\s+Volumes\s+\[Driver:\s+nfs.manila.csi.openstack.org\]\s+\[Testpattern:\s+Dynamic\s+PV\s+\(default\s+fs\)\]\s+provisioning\s+should\s+provision\s+storage\s+with\s+any\s+volume\s+data\s+source\s+\[Serial\]|should\s+provision\s+storage\s+with\s+snapshot\s+data\s+source|restoring\s+snapshot\s+to\s+larger\s+size" \
+            --ginkgo.v \
+            --ginkgo.no-color \
+            --ginkgo.show-node-events \
+            --ginkgo.timeout=1h45m \
+            -timeout=0 \
+            -report-dir /var/log/csi-pod | tee "/var/log/csi-pod/manila-csi-e2e.log"
+      register: functional_test_result
+      ignore_errors: true
+      async: 6600 # wait 1h50m (i.e. 5 mins longer than the ginkgo timeout) then fail and fetch the logs
+      poll: 15
 
-- name: Collect pod logs for debug purpose
-  shell:
-    executable: /bin/bash
-    cmd: |
-      set -x
-      set -e
+    - name: Collect pod logs for debug purpose
+      shell:
+        executable: /bin/bash
+        cmd: |
+          set -x
+          set -e
 
-      kubectl logs -l app=openstack-manila-csi,component=controllerplugin -n default -c nfs-nodeplugin --tail=-1 > /var/log/csi-pod/csi-manila-controllerplugin.log
-      kubectl logs -l app=openstack-manila-csi,component=nodeplugin -n default -c nfs-nodeplugin --tail=-1 > /var/log/csi-pod/csi-manila-nodeplugin.log
-  ignore_errors: true
+          kubectl logs -l app=openstack-manila-csi,component=controllerplugin -n default -c nfs-nodeplugin --tail=-1 > /var/log/csi-pod/csi-manila-controllerplugin.log
+          kubectl logs -l app=openstack-manila-csi,component=nodeplugin -n default -c nfs-nodeplugin --tail=-1 > /var/log/csi-pod/csi-manila-nodeplugin.log
+      ignore_errors: true
 
-- fail: msg="The execution has failed because of errors."
-  when: functional_test_result.failed
+    - fail: msg="The execution has failed because of errors."
+      when: functional_test_result.failed

--- a/tests/playbooks/roles/install-devstack/defaults/main.yaml
+++ b/tests/playbooks/roles/install-devstack/defaults/main.yaml
@@ -13,3 +13,10 @@ enable_services:
 octavia_amphora_url: "https://tarballs.opendev.org/openstack/octavia/test-images/test-only-amphora-x64-haproxy-ubuntu-noble.qcow2"
 octavia_amphora_dir: /opt/octavia-amphora
 octavia_amphora_filename: amphora-x64-haproxy.qcow2
+
+# Note, only use alphanumeric characters as some services fail to work when using special characters.
+devstack_password: password
+swift_hash: 1234123412341234
+
+# Additional services can be enabled here, e.g. rabbit,mysql,key,horizon,swift
+default_enabled_services: rabbit,mysql,key

--- a/tests/playbooks/roles/install-devstack/defaults/main.yaml
+++ b/tests/playbooks/roles/install-devstack/defaults/main.yaml
@@ -2,6 +2,8 @@
 user: "stack"
 workdir: "/home/{{ user }}/devstack"
 branch: "stable/2025.2"
+# enable_services is used to enable services that have granular confguration in `local.conf.j2`.
+# See tests/playbooks/roles/install-devstack/templates/local.conf.j2 for which services have such configuration.
 enable_services:
   - nova
   - glance
@@ -19,4 +21,5 @@ devstack_password: password
 swift_hash: 1234123412341234
 
 # Additional services can be enabled here, e.g. rabbit,mysql,key,horizon,swift
+# default_enabled_services is used to enable services which do not have granular confguration in `local.conf.j2`
 default_enabled_services: rabbit,mysql,key

--- a/tests/playbooks/roles/install-devstack/tasks/main.yml
+++ b/tests/playbooks/roles/install-devstack/tasks/main.yml
@@ -78,7 +78,7 @@
         local_ip_address: "{{ local_ip_output.stdout }}"
 
     - name: Download octavia amphora image
-      when: octavia_amphora_url != ""
+      when: octavia_amphora_url != "" and "octavia" in enable_services
       block:
         - name: Ensure amphora image dest folder
           file:

--- a/tests/playbooks/roles/install-devstack/tasks/main.yml
+++ b/tests/playbooks/roles/install-devstack/tasks/main.yml
@@ -1,9 +1,11 @@
 - name: Manage stack group
+  become: true
   group:
     name: "{{ user }}"
     state: present
 
 - name: Manage stack user
+  become: true
   user:
     name: "{{ user }}"
     group: "{{ user }}"
@@ -12,16 +14,19 @@
     home: /home/{{ user }}
 
 - name: allow stack user to have passwordless sudo
+  become: true
   lineinfile:
     dest: /etc/sudoers
     line: "{{ user }} ALL=(ALL) NOPASSWD: ALL"
     validate: 'visudo -cf %s'
 
 - name: Update repositories cache
+  become: true
   ansible.builtin.apt:
     update_cache: yes
 
 - name: Check if devstack is already installed
+  become: true
   shell:
     executable: /bin/bash
     cmd: |
@@ -36,6 +41,7 @@
   register: devstack
 
 - name: Install devstack
+  become: true
   when: devstack.stdout != "installed"
   block:
     - name: Install packages
@@ -115,3 +121,16 @@
         cmd: |
           set -ex
           sudo -u {{ user }} -H ./stack.sh
+
+    - name: Prepare RC files for non-root user
+      become: true
+      shell:
+        executable: /bin/bash
+        chdir: "{{ workdir }}"
+        cmd: |
+          source openrc admin admin > /dev/null
+          env | grep OS_ | sed 's/\(.*\)/export \1/g' > {{ ansible_facts["user_dir"] }}/openrc-admin
+          source openrc demo demo > /dev/null
+          env | grep OS_ | sed 's/\(.*\)/export \1/g' > {{ ansible_facts["user_dir"] }}/openrc-demo
+          chown {{ ansible_facts["user_id"] }}:{{ ansible_facts["user_gid"] }} {{ ansible_facts["user_dir"] }}/openrc-*
+

--- a/tests/playbooks/roles/install-devstack/templates/local.conf.j2
+++ b/tests/playbooks/roles/install-devstack/templates/local.conf.j2
@@ -9,16 +9,19 @@ LOG_COLOR=False
 LOGDAYS=1
 SERVICE_TIMEOUT=300
 
-DATABASE_PASSWORD=password
-ADMIN_PASSWORD=password
-SERVICE_PASSWORD=password
-SERVICE_TOKEN=password
-RABBIT_PASSWORD=password
+DATABASE_PASSWORD={{ devstack_password }}
+ADMIN_PASSWORD={{ devstack_password }}
+SERVICE_PASSWORD={{ devstack_password }}
+SERVICE_TOKEN={{ devstack_password }}
+RABBIT_PASSWORD={{ devstack_password }}
+{% if "swift" in default_enabled_services %}
+SWIFT_HASH={{ swift_hash }}
+{% endif %}
 
 GIT_BASE=https://github.com
 TARGET_BRANCH={{ branch }}
 
-ENABLED_SERVICES=rabbit,mysql,key
+ENABLED_SERVICES={{ default_enabled_services }}
 
 # Host tuning
 # From: https://opendev.org/openstack/devstack/src/commit/05f7d302cfa2da73b2887afcde92ef65b1001194/.zuul.yaml#L645-L662
@@ -65,6 +68,10 @@ enable_service cinder
 enable_service c-api
 enable_service c-vol
 enable_service c-sch
+# Cinder backup uses swift by default
+{% if "swift" in default_enabled_services %}
+enable_service c-bak
+{% endif %}
 {% endif %}
 
 {% if "neutron" in enable_services %}

--- a/tests/playbooks/roles/install-docker-registry/tasks/main.yml
+++ b/tests/playbooks/roles/install-docker-registry/tasks/main.yml
@@ -5,6 +5,7 @@
     path: "{{ ansible_user_dir }}/certs"
 
 - name: Ensure cfssl is installed
+  become: true
   shell:
     executable: /bin/bash
     cmd: |

--- a/tests/playbooks/roles/install-docker/handlers/main.yml
+++ b/tests/playbooks/roles/install-docker/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: Restart Docker
+  become: true
   systemd:
     name: docker
     state: restarted

--- a/tests/playbooks/roles/install-docker/tasks/main.yml
+++ b/tests/playbooks/roles/install-docker/tasks/main.yml
@@ -46,3 +46,7 @@
     dest: /etc/docker/daemon.json
     mode: 0644
   notify: "Restart Docker"
+
+# Trigger docker restart immediately
+- name: Flush handlers
+  meta: flush_handlers

--- a/tests/playbooks/roles/install-docker/tasks/main.yml
+++ b/tests/playbooks/roles/install-docker/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 # apt-get install -y apt-transport-https ca-certificates curl software-properties-common
 - name: Install packages
+  become: true
   apt:
     name: "{{ packages }}"
     state: present
@@ -15,24 +16,38 @@
 
 # curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 - name: Add Docker's official GPG key
+  become: true
   apt_key:
     url: https://download.docker.com/linux/ubuntu/gpg
     state: present
 
 # add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 - name: Set up the stable repository
+  become: true
   apt_repository:
     repo: 'deb https://download.docker.com/linux/ubuntu {{ hostvars[inventory_hostname].ansible_distribution_release }} stable'
     state: present
 
 # apt-get update; apt install -y docker-ce=<version>
 - name: Install docker-ce
+  become: true
   apt:
     name: docker-ce #={{ docker_version }}
     state: present
     update_cache: yes
 
+- name: Add user into docker group
+  become: true
+  ansible.builtin.user:
+    name: ubuntu
+    groups: docker
+    append: yes
+
+- name: Reset ssh connection to allow group membership change to be effective
+  ansible.builtin.meta: reset_connection
+
 - name: Config docker
+  become: true
   copy:
     content: |
       {

--- a/tests/playbooks/roles/install-golang/tasks/main.yml
+++ b/tests/playbooks/roles/install-golang/tasks/main.yml
@@ -5,6 +5,7 @@
   register: curr_go_version
 
 - name: Download the Go tarball
+  become: true
   get_url:
     url: '{{ go_download_location }}'
     dest: '/usr/local/src/{{ go_tarball }}'
@@ -12,6 +13,7 @@
     - curr_go_version.stdout != go_version
 
 - name: Remove old installation of Go
+  become: true
   file:
     path: /usr/local/go
     state: absent
@@ -19,6 +21,7 @@
     - curr_go_version.stdout != go_version
 
 - name: Extract the Go tarball to place
+  become: true
   unarchive:
     src: '/usr/local/src/{{ go_tarball }}'
     dest: /usr/local

--- a/tests/playbooks/roles/install-k3s/defaults/main.yaml
+++ b/tests/playbooks/roles/install-k3s/defaults/main.yaml
@@ -9,3 +9,5 @@ keypair_name: "k3s_keypair"
 image_url: "https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img"
 image_name: "ubuntu-noble"
 master_port_name: "k3s_master"
+# DNS server for the k3s node
+dns_server: "8.8.8.8"

--- a/tests/playbooks/roles/install-k3s/tasks/main.yaml
+++ b/tests/playbooks/roles/install-k3s/tasks/main.yaml
@@ -1,4 +1,5 @@
 - name: Install packages
+  become: true
   apt:
     name: "{{ packages }}"
     state: present
@@ -11,10 +12,8 @@
   shell:
     executable: /bin/bash
     cmd: |
+      source openrc-admin
       set -x
-      cd {{ devstack_workdir }}
-
-      set +x; source openrc admin admin > /dev/null; set -x
       openstack image show {{ image_name }} > /dev/null 2>&1
 
       if [[ "$?" != "0" ]]; then
@@ -30,7 +29,7 @@
         openstack image create {{ image_name }} --container-format bare --disk-format qcow2 --public --file {{ image_name }}.img
       fi
 
-      set +x; source openrc demo demo > /dev/null; set -x
+      set +x; source openrc-demo; set -x
       openstack keypair show {{ keypair_name }} > /dev/null 2>&1
       if [[ "$?" != "0" ]]; then
         test -e {{ ansible_user_dir }}/.ssh/id_rsa || ssh-keygen -t rsa -b 4096 -N "" -f {{ ansible_user_dir }}/.ssh/id_rsa
@@ -45,13 +44,13 @@
         openstack security group rule create --protocol udp --dst-port 1:65535 {{ sg_name }}
       fi
 
-      openstack subnet set private-subnet --dns-nameserver 8.8.8.8 || true
+      openstack subnet set private-subnet --dns-nameserver {{ dns_server }} || true
 
 - name: Create port with floating IP
   shell:
     executable: /bin/bash
     cmd: |
-      set +x; source {{ devstack_workdir }}/openrc demo demo > /dev/null; set -x
+      source openrc-demo; set -x
 
       openstack port show {{ master_port_name }}
       if [ $? -ne 0 ]; then
@@ -64,7 +63,7 @@
   shell:
     executable: /bin/bash
     cmd: |
-      set +x; source {{ devstack_workdir }}/openrc demo demo > /dev/null
+      source openrc-demo; set -x
       openstack floating ip list --port {{ master_port_name }} -c "Floating IP Address" -f value
   register: fip
 
@@ -76,14 +75,12 @@
   shell:
     executable: /bin/bash
     cmd: |
-      set -x
-
-      set +x; source {{ devstack_workdir }}/openrc demo demo > /dev/null; set -x
+      source openrc-demo; set -x
 
       openstack server show k3s-master > /dev/null 2>&1
       if [ $? -ne 0 ]; then
         # Prepare user data file for k3s master
-        cat <<EOF > {{ devstack_workdir }}/init_k3s.yaml
+        cat <<EOF > {{ ansible_user_dir }}/init_k3s.yaml
         #cloud-config
         manage_etc_hosts: "localhost"
         package_update: true
@@ -98,12 +95,12 @@
         write_files:
           - path: /usr/local/share/ca-certificates/registry-ca.crt
             content: |
-      $(awk '{printf "        %s\n", $0}' < /root/certs/ca.pem)
+      $(awk '{printf "        %s\n", $0}' < {{ ansible_user_dir }}/certs/ca.pem)
       EOF
 
         # Create k3s master
         port_id=$(openstack port show {{ master_port_name }} -c id -f value)
-        openstack server create k3s-master --image {{ image_name }} --flavor {{ flavor_name }} --key-name {{ keypair_name }} --nic port-id=$port_id --user-data {{ devstack_workdir }}/init_k3s.yaml --wait
+        openstack server create k3s-master --image {{ image_name }} --flavor {{ flavor_name }} --key-name {{ keypair_name }} --nic port-id=$port_id --user-data {{ ansible_user_dir }}/init_k3s.yaml --wait
       fi
 
 - name: Run k3s workers
@@ -112,14 +109,12 @@
   shell:
     executable: /bin/bash
     cmd: |
-      set -x
-
-      set +x; source {{ devstack_workdir }}/openrc demo demo > /dev/null; set -x
+      source openrc-demo; set -x
 
       openstack server show k3s-worker{{ item }} > /dev/null 2>&1
       if [ $? -ne 0 ]; then
         # Prepare user data file for k3s worker
-        cat <<EOF > {{ devstack_workdir }}/init_k3s_worker{{ item }}.yaml
+        cat <<EOF > {{ ansible_user_dir }}/init_k3s_worker{{ item }}.yaml
         #cloud-config
         manage_etc_hosts: "localhost"
         package_update: true
@@ -134,11 +129,11 @@
         write_files:
           - path: /usr/local/share/ca-certificates/registry-ca.crt
             content: |
-      $(awk '{printf "        %s\n", $0}' < /root/certs/ca.pem)
+      $(awk '{printf "        %s\n", $0}' < {{ ansible_user_dir }}/certs/ca.pem)
       EOF
 
         # Create k3s worker
-        openstack server create k3s-worker{{ item }} --image {{ image_name }} --flavor {{ flavor_name }} --key-name {{ keypair_name }} --network private --security-group {{ sg_name }} --user-data {{ devstack_workdir }}/init_k3s_worker{{ item }}.yaml --wait
+        openstack server create k3s-worker{{ item }} --image {{ image_name }} --flavor {{ flavor_name }} --key-name {{ keypair_name }} --network private --security-group {{ sg_name }} --user-data {{ ansible_user_dir }}/init_k3s_worker{{ item }}.yaml --wait
       fi
 
 - name: Wait for ssh ready for k3s VM

--- a/tests/playbooks/test-csi-cinder-e2e.yaml
+++ b/tests/playbooks/test-csi-cinder-e2e.yaml
@@ -7,6 +7,7 @@
     e2e_test_version: v1.34.1
     user: stack
     devstack_workdir: /home/{{ user }}/devstack
+    run_e2e: false
 
   roles:
     - role: install-golang
@@ -22,9 +23,10 @@
     - role: install-k3s
       worker_node_count: 0
     - role: install-cpo-occm
-      run_e2e: false
+      run_e2e_ccm: false
     - role: install-csi-cinder
       environment:
         GOPATH: '{{ ansible_user_dir }}'
         PATH: '/usr/local/go/bin:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}'
         KUBECONFIG: '{{ ansible_user_dir }}/.kube/config'
+      run_e2e_cinder: "{{ run_e2e | bool }}"

--- a/tests/playbooks/test-csi-cinder-e2e.yaml
+++ b/tests/playbooks/test-csi-cinder-e2e.yaml
@@ -1,5 +1,4 @@
 - hosts: all
-  become: true
   become_method: sudo
   gather_facts: true
 

--- a/tests/playbooks/test-csi-manila-e2e.yaml
+++ b/tests/playbooks/test-csi-manila-e2e.yaml
@@ -6,6 +6,7 @@
   vars:
     user: stack
     devstack_workdir: /home/{{ user }}/devstack
+    run_e2e: false
 
   roles:
     - role: install-golang
@@ -21,10 +22,11 @@
     - role: install-k3s
       worker_node_count: 0
     - role: install-cpo-occm
-      run_e2e: false
+      run_e2e_ccm: false
     - role: install-helm
     - role: install-csi-manila
       environment:
         GOPATH: '{{ ansible_user_dir }}'
         PATH: '/usr/local/go/bin:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}'
         KUBECONFIG: '{{ ansible_user_dir }}/.kube/config'
+      run_e2e_manila: "{{ run_e2e | bool }}"

--- a/tests/playbooks/test-csi-manila-e2e.yaml
+++ b/tests/playbooks/test-csi-manila-e2e.yaml
@@ -1,5 +1,4 @@
 - hosts: all
-  become: true
   become_method: sudo
   gather_facts: true
 

--- a/tests/playbooks/test-occm-e2e.yaml
+++ b/tests/playbooks/test-occm-e2e.yaml
@@ -7,6 +7,7 @@
     user: stack
     devstack_workdir: /home/{{ user }}/devstack
     octavia_provider: ""
+    run_e2e: false
 
   roles:
     - role: install-golang
@@ -25,5 +26,5 @@
     - role: install-k3s
       worker_node_count: 0
     - role: install-cpo-occm
-      run_e2e: "{{ run_e2e | bool }}"
+      run_e2e_ccm: "{{ run_e2e | bool }}"
       octavia_provider: "{{ octavia_provider }}"

--- a/tests/playbooks/test-occm-e2e.yaml
+++ b/tests/playbooks/test-occm-e2e.yaml
@@ -1,5 +1,4 @@
 - hosts: all
-  become: true
   become_method: sudo
   gather_facts: true
 


### PR DESCRIPTION

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This PR:

* adds steps in `docs/developers-guide.md`  to set up env for local development after test devstack and k3s clusters are up.
* modifies playbooks/roles in `tests/playbooks` to allow skipping tests for cinder/manila.
* modifes `local.conf.j2` to allow specifying password for devstack and enabling additional services.
* removed `become` from test playbooks to reduce privileges.

**Which issue this PR fixes(if applicable)**:

None

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
