### PR TITLE
[magnum-auto-healer] Add certificate validation

### DIFF
--- a/docs/magnum-auto-healer/using-magnum-auto-healer.md
+++ b/docs/magnum-auto-healer/using-magnum-auto-healer.md
@@ -183,6 +183,23 @@ spec:
 EOF
 ```
 
+#### Endpoint health check parameters
+
+The `Endpoint` type health check supports the following parameters:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `protocol` | string | `HTTPS` | URL scheme to use. `HTTP` or `HTTPS` (case-insensitive). |
+| `port` | int | `6443` | Port to connect to on the node. |
+| `endpoints` | []string | `["/healthz"]` | List of URL paths to check. |
+| `ok-codes` | []int | `[200]` | HTTP response codes considered healthy. |
+| `unhealthy-duration` | duration | `300s` | How long a node must be continuously unhealthy before repair is triggered. |
+| `unhealthy-annotation` | string | `autohealing.openstack.org/unhealthy-timestamp` | Node annotation used to record when the node first became unhealthy. |
+| `require-token` | bool | `false` | Whether to include a bearer token in the request. |
+| `token` | string | read from `/var/run/secrets/kubernetes.io/serviceaccount/token` | Bearer token value. Only used when `require-token` is `true`. |
+| `ca-file` | string | `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` | Path to a CA certificate file used to verify the server's TLS certificate. Only used when `protocol` is `HTTPS`. |
+| `tls-insecure` | bool | `false` | If true, skip TLS certificate verification. |
+
 ### Testing magnum-auto-healer
 
 We could ssh into a worker node(`lingxian-por-test-1-12-7-ha-bbgjts5g4xhb-minion-1` in this example) and stop the kubelet service to simulate the worker node failure. The node status check is covered in NodeCondition type of health check plugin(see configuration above).

--- a/pkg/autohealing/healthcheck/plugin_endpoint.go
+++ b/pkg/autohealing/healthcheck/plugin_endpoint.go
@@ -157,7 +157,7 @@ func (check *EndpointCheck) Check(ctx context.Context, node NodeInfo, controller
 			caPool, err = cert.NewPool(check.CAFile)
 			if err != nil {
 				log.Errorf("Node %s, failed to load CA file %s, error: %v", nodeName, check.CAFile, err)
-				return false
+				return check.checkDuration(ctx, node, controller, false)
 			}
 			tlsConfig.RootCAs = caPool
 		}

--- a/pkg/autohealing/healthcheck/plugin_endpoint.go
+++ b/pkg/autohealing/healthcheck/plugin_endpoint.go
@@ -19,6 +19,7 @@ package healthcheck
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net/http"
 	"os"
@@ -27,12 +28,14 @@ import (
 	"time"
 
 	"github.com/mitchellh/mapstructure"
+	"k8s.io/client-go/util/cert"
 	log "k8s.io/klog/v2"
 )
 
 const (
 	EndpointType = "Endpoint"
 	TokenPath    = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	CAPath       = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	TimeLayout   = "2006-01-02 15:04:05"
 )
 
@@ -60,6 +63,13 @@ type EndpointCheck struct {
 
 	// (Optional) Token to use in the request header. Default: read from TokenPath file
 	Token string `mapstructure:"token"`
+
+	// (Optional) Path to a CA certificate file used to verify the node's TLS certificate. Only used when Protocol is HTTPS.
+	// Default: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+	CAFile string `mapstructure:"ca-file"`
+
+	// (Optional) If true, skip TLS certificate verification. Default: false
+	TLSInsecure bool `mapstructure:"tls-insecure"`
 }
 
 // GetName returns name of the health check
@@ -140,9 +150,18 @@ func (check *EndpointCheck) Check(ctx context.Context, node NodeInfo, controller
 	protocol := strings.ToLower(check.Protocol)
 	switch protocol {
 	case "https":
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		tlsConfig := &tls.Config{InsecureSkipVerify: check.TLSInsecure}
+		if check.CAFile != "" && !check.TLSInsecure {
+			var caPool *x509.CertPool
+			var err error
+			caPool, err = cert.NewPool(check.CAFile)
+			if err != nil {
+				log.Errorf("Node %s, failed to load CA file %s, error: %v", nodeName, check.CAFile, err)
+				return false
+			}
+			tlsConfig.RootCAs = caPool
 		}
+		tr := &http.Transport{TLSClientConfig: tlsConfig}
 		client = &http.Client{Transport: tr, Timeout: time.Second * 5}
 	case "http":
 		client = &http.Client{Timeout: time.Second * 5}
@@ -194,6 +213,7 @@ func NewEndpointCheck(config interface{}) (HealthCheck, error) {
 		OKCodes:             []int{200},
 		RequireToken:        false,
 		UnhealthyAnnotation: "autohealing.openstack.org/unhealthy-timestamp",
+		CAFile:              CAPath,
 	}
 
 	decConfig := mapstructure.DecoderConfig{


### PR DESCRIPTION

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

The controller always sets InsecureSkipVerify. The two modern Magnum drivers in use today both use CAPI and thus kubeadm under the hood. kubeadm injects nodes internal IPs as SANs into the certs it generates, meaning certificate validation should pass when using the same root cert. Thus, we add two new configuration knobs: one to point to a CA file to use (defaulting to the well-known location k8s mounts certs to) and another to explicitly disable verification as an escape hatch.

**Which issue this PR fixes(if applicable)**:

(none)

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[magnum-auto-healer] Certificate validation is now enabled by default when using HTTPS
```
