### PR TITLE
[occm] test: add loadbalancer servicemonitor regression

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,7 +3,9 @@ name: Lint Charts
 on:
   pull_request:
     paths:
+      - '.github/workflows/pr.yaml'
       - 'charts/**'
+      - 'tests/helm/**'
 
 jobs:
   lint:
@@ -30,3 +32,18 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: ct lint --target-branch ${GITHUB_BASE_REF}
+
+      # v1.0.3 is the latest release compatible with Helm v3.10.0.
+      - name: Install helm-unittest v1.0.3
+        run: >-
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git
+          --version 6f82a998e0b5461762ca959f87f5dd344af5e4eb
+
+      - name: Build OCCM chart dependencies
+        run: helm dependency build charts/openstack-cloud-controller-manager
+
+      - name: Run OCCM Helm unit tests
+        run: >-
+          helm unittest --strict --with-subchart=false
+          --file '../../tests/helm/openstack-cloud-controller-manager/*_test.yaml'
+          charts/openstack-cloud-controller-manager

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -59,8 +59,7 @@ metadata:
   namespace: monitoring
 spec:
   endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    interval: 30s
+  - interval: 30s
     port: http
     scheme: https
     tlsConfig:

--- a/tests/helm/openstack-cloud-controller-manager/servicemonitor_test.yaml
+++ b/tests/helm/openstack-cloud-controller-manager/servicemonitor_test.yaml
@@ -1,0 +1,105 @@
+suite: OCCM ServiceMonitor
+templates:
+  - templates/clusterrolebinding-sm.yaml
+  - templates/daemonset.yaml
+  - templates/service-sm.yaml
+  - templates/servicemonitor.yaml
+
+release:
+  name: test-release
+  namespace: test-namespace
+
+chart:
+  version: 1.2.3
+  appVersion: v4.5.6
+
+tests:
+  - it: keeps the metrics endpoint private by default
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/servicemonitor.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/service-sm.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/clusterrolebinding-sm.yaml
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --bind-address=127.0.0.1
+        template: templates/daemonset.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --authorization-always-allow-paths=/metrics
+        template: templates/daemonset.yaml
+
+  - it: wires the ServiceMonitor to the OCCM metrics endpoint
+    set:
+      serviceMonitor.enabled: true
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+        template: templates/servicemonitor.yaml
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/instance: test-release
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: openstack-cloud-controller-manager
+            app.kubernetes.io/version: v4.5.6
+            helm.sh/chart: openstack-cloud-controller-manager-1.2.3
+        template: templates/servicemonitor.yaml
+      - notExists:
+          path: spec.endpoints[0].bearerTokenFile
+        template: templates/servicemonitor.yaml
+      - equal:
+          path: spec.endpoints[0].port
+          value: http
+        template: templates/servicemonitor.yaml
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: test-release
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: openstack-cloud-controller-manager
+            app.kubernetes.io/version: v4.5.6
+            helm.sh/chart: openstack-cloud-controller-manager-1.2.3
+        template: templates/service-sm.yaml
+      - equal:
+          path: spec.ports[0].name
+          value: http
+        template: templates/service-sm.yaml
+      - equal:
+          path: spec.ports[0].port
+          value: 10258
+        template: templates/service-sm.yaml
+      - equal:
+          path: spec.selector
+          value:
+            app: openstack-cloud-controller-manager
+            component: controllermanager
+            release: test-release
+        template: templates/service-sm.yaml
+      - isSubset:
+          path: spec.template.metadata.labels
+          content:
+            app: openstack-cloud-controller-manager
+            component: controllermanager
+            release: test-release
+        template: templates/daemonset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --authorization-always-allow-paths=/metrics
+        template: templates/daemonset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --bind-address=0.0.0.0
+        template: templates/daemonset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 10258
+            name: http
+          any: true
+        template: templates/daemonset.yaml

--- a/tests/helm/openstack-cloud-controller-manager/servicemonitor_test.yaml
+++ b/tests/helm/openstack-cloud-controller-manager/servicemonitor_test.yaml
@@ -39,6 +39,9 @@ tests:
       serviceMonitor.enabled: true
     asserts:
       - isKind:
+          of: ClusterRoleBinding
+        template: templates/clusterrolebinding-sm.yaml
+      - isKind:
           of: ServiceMonitor
         template: templates/servicemonitor.yaml
       - equal:


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->
**What this PR does / why we need it**:

Hi maintainers, 
this PR adds renderering level regression coverage for the OCCM Helm chart ServiceMonitor behavior fixed by #3039

currently, the existing chart CI runs `ct lint` with the default values, where `serviceMonitor.enabled` is disabled. and it therefore does not exercise or semantically validate the ServiceMonitor, metrics Service, and DaemonSet wiring.

The new tests verify this things:
- add metric resources and public metrics access remain disabled by default
- enabling `serviceMonitor` creates matching Service and ServiceMonitor resources
- the Service selects the OCCM DaemonSet pods
- update document that deprecated `bearerTokenFile` authentication is not now used
- update OCCM exposes and authorizes `/metrics` only when monitoring is enabled

references:
- https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/tests/controller-servicemonitor_test.yaml
- https://github.com/kubernetes-sigs/descheduler/blob/master/.github/workflows/helm.yaml
- https://github.com/kubernetes-sigs/descheduler/blob/master/charts/descheduler/tests/servicemonitor_test.yaml

**Which issue this PR fixes(if applicable)**:
Follow-up to #3039, adds regression coverage for #3144

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

`helm-unittest` is pinned to the immutable `v1.0.3` commit, because this is the latest release compatible with the Helm `v3.10.0` currently used by the chart workflow.

The suite passes against current `master` branch. 
against the parent of #3039, it fails on the previous selector mismatch, deprecated bearer token configuration, and missing metrics authorization flag.

also, this is a renderering level test and does not require a Kubernetes, Prometheus, or OpenStack environment.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
