### PR TITLE
[cinder-csi-plugin] Support creating incremental backups

### DIFF
--- a/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
+++ b/docs/cinder-csi-plugin/using-cinder-csi-plugin.md
@@ -287,6 +287,7 @@ helm install --namespace kube-system --name cinder-csi ./charts/cinder-csi-plugi
 | VolumeSnapshotClass `parameters` | `force-create`    | `false`         | Enable to support creating snapshot for a volume in in-use status |
 | VolumeSnapshotClass `parameters` | `type`            | Empty String    | `snapshot` creates a VolumeSnapshot object linked to a Cinder volume snapshot. `backup` creates a VolumeSnapshot object linked to a cinder volume backup. Defaults to `snapshot` if not defined |
 | VolumeSnapshotClass `parameters` | `backup-max-duration-seconds-per-gb`  | `20`    | Defines the amount of time to wait for a backup to complete in seconds per GB of volume size |
+| VolumeSnapshotClass `parameters` | `incremental`     | `false`         | Enable to create an incremental backup instead of a full backup. Only applies when `type` is `backup` |
 | VolumeSnapshotClass `parameters`  | `availability`          | Same as volume | String. Backup Availability Zone |
 | VolumeSnapshotClass `parameters`  | `appendVolumeMetadata`   | Empty String   | Append user-defined metadata to the created snapshot/backup. If not empty, this field must be a string of a valid JSON object. The object must consist of key-value pairs of type string. Example: "{..., \"key\": \"value\"}". |
 | Inline Volume `volumeAttributes`   | `capacity`              | `1Gi`       | volume size for creating inline volumes|

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -747,7 +747,7 @@ func (cs *controllerServer) createBackup(ctx context.Context, cloud openstack.IO
 	// Also, we don't want to tag every param but we still want to send the
 	// 'force-create' flag to openstack layer so that we will honor the
 	// force create functions
-	for _, mKey := range append(sharedcsi.RecognizedCSISnapshotterParams, openstack.SnapshotForceCreate, openstack.SnapshotType) {
+	for _, mKey := range append(sharedcsi.RecognizedCSISnapshotterParams, openstack.SnapshotForceCreate, openstack.SnapshotType, openstack.SnapshotIncremental) {
 		if v, ok := parameters[mKey]; ok {
 			properties[mKey] = v
 		}

--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -1207,6 +1207,46 @@ func TestCreateSnapshotBackupWithAppendVolumeMetadata(t *testing.T) {
 	}
 }
 
+// Test CreateSnapshot with snapshot type 'backup' and the incremental parameter
+func TestCreateSnapshotBackupWithIncremental(t *testing.T) {
+	fakeCs, osmock := fakeControllerServer()
+
+	expectedSnapshotProperties := map[string]string{
+		cinderCSIClusterIDKey: FakeCluster,
+	}
+
+	expectedBackupProperties := map[string]string{
+		cinderCSIClusterIDKey:         FakeCluster,
+		"type":                        "backup",
+		openstack.SnapshotIncremental: "true",
+	}
+
+	osmock.On("CreateSnapshot", FakeSnapshotName, FakeVolID, expectedSnapshotProperties).Return(&FakeSnapshotRes, nil)
+	osmock.On("ListSnapshots", map[string]string{"Name": FakeSnapshotName}).Return(FakeSnapshotListEmpty, "", nil)
+	osmock.On("WaitSnapshotReady", FakeSnapshotID).Return(FakeSnapshotRes.Status, nil)
+	osmock.On("DeleteSnapshot", FakeSnapshotID).Return(nil)
+
+	osmock.On("CreateBackup", FakeSnapshotName, FakeVolID, FakeSnapshotID, "", expectedBackupProperties).Return(&FakeBackupRes, nil)
+	osmock.On("ListBackups", map[string]string{"Name": FakeSnapshotName}).Return(FakeBackupListEmpty, nil)
+	osmock.On("WaitBackupReady", FakeBackupID).Return(FakeBackupRes.Status, nil)
+
+	fakeReq := &csi.CreateSnapshotRequest{
+		Name:           FakeSnapshotName,
+		SourceVolumeId: FakeVolID,
+		Parameters: map[string]string{
+			openstack.SnapshotType:        "backup",
+			openstack.SnapshotIncremental: "true",
+		},
+	}
+
+	_, err := fakeCs.CreateSnapshot(FakeCtx, fakeReq)
+	if err != nil {
+		t.Errorf("failed to CreateSnapshot backup with incremental: %v", err)
+	}
+
+	osmock.AssertCalled(t, "CreateBackup", FakeSnapshotName, FakeVolID, FakeSnapshotID, "", expectedBackupProperties)
+}
+
 // Test DeleteSnapshot
 func TestDeleteSnapshot(t *testing.T) {
 	fakeCs, osmock := fakeControllerServer()

--- a/pkg/csi/cinder/openstack/openstack_backups.go
+++ b/pkg/csi/cinder/openstack/openstack_backups.go
@@ -62,11 +62,24 @@ func (os *OpenStack) CreateBackup(ctx context.Context, name, volID, snapshotID, 
 		delete(tags, SnapshotForceCreate)
 	}
 
+	incremental := false
+	// if no flag given, then incremental will be false by default
+	// if flag it given , check it
+	if item, ok := (tags)[SnapshotIncremental]; ok {
+		var err error
+		incremental, err = strconv.ParseBool(item)
+		if err != nil {
+			klog.V(5).Infof("Make incremental flag to false due to: %v", err)
+		}
+		delete(tags, SnapshotIncremental)
+	}
+
 	opts := &backups.CreateOpts{
 		VolumeID:         volID,
 		SnapshotID:       snapshotID,
 		Name:             name,
 		Force:            force,
+		Incremental:      incremental,
 		Description:      backupDescription,
 		AvailabilityZone: availabilityZone,
 	}

--- a/pkg/csi/cinder/openstack/openstack_snapshots.go
+++ b/pkg/csi/cinder/openstack/openstack_snapshots.go
@@ -43,6 +43,7 @@ const (
 	SnapshotType                 = "type"
 	SnapshotAvailabilityZone     = "availability"
 	SnapshotAppendVolumeMetadata = "appendVolumeMetadata"
+	SnapshotIncremental          = "incremental"
 )
 
 // CreateSnapshot issues a request to take a Snapshot of the specified Volume with the corresponding ID and


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a new `incremental` parameter to the VolumeSnapshotClass. When set to `"true"` together with `type: backup`, the Cinder backup is created with `incremental=true`, so Cinder only stores changes since the latest existing backup of the volume.

The parameter follows the same pattern as the existing `force-create` flag: it is parsed with `strconv.ParseBool`, stripped from the metadata tags and mapped to the gophercloud `backups.CreateOpts.Incremental` field. Defaults to `false`, so existing behavior is unchanged.

**Which issue this PR fixes**:

fixes #3077

**Special notes for reviewers**:

Unit test `TestCreateSnapshotBackupWithIncremental` covers the parameter being recognized and passed through to `CreateBackup`; the docs table for VolumeSnapshotClass parameters is updated accordingly. This PR was written in part with the assistance of generative AI.

**Release note**:

```release-note
[cinder-csi-plugin] Add `incremental` parameter to VolumeSnapshotClass to create incremental Cinder backups when `type` is `backup`.
```
