### PR TITLE
[cinder-csi-plugin] Allow setting parameters on chart-managed StorageClasses

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.36.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.36.4
+version: 2.36.5
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/README.md
+++ b/charts/cinder-csi-plugin/README.md
@@ -6,6 +6,7 @@ Deploys a Cinder csi provisioner to your cluster, with the appropriate storageCl
 - Enable deployment of storageclasses using `storageClass.enabled`
 - Tag the retain or delete class as default class using `storageClass.delete.isDefault` in your value yaml
 - Set `storageClass.<reclaim-policy>.allowVolumeExpansion` to `true` or `false`
+- Set `storageClass.<reclaim-policy>.parameters` to add parameters (e.g. `availability` or `type`) to the storageclass
 
 First add the repo:
 

--- a/charts/cinder-csi-plugin/templates/storageclass.yaml
+++ b/charts/cinder-csi-plugin/templates/storageclass.yaml
@@ -10,6 +10,10 @@ metadata:
 provisioner: cinder.csi.openstack.org
 reclaimPolicy: Delete
 allowVolumeExpansion: {{ .Values.storageClass.delete.allowVolumeExpansion }}
+{{- with .Values.storageClass.delete.parameters }}
+parameters:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -22,4 +26,8 @@ metadata:
 provisioner: cinder.csi.openstack.org
 reclaimPolicy: Retain
 allowVolumeExpansion: {{ .Values.storageClass.retain.allowVolumeExpansion }}
+{{- with .Values.storageClass.retain.parameters }}
+parameters:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -197,9 +197,13 @@ storageClass:
   delete:
     isDefault: false
     allowVolumeExpansion: true
+    # optional parameters for the StorageClass, e.g. availability or type
+    parameters: {}
   retain:
     isDefault: false
     allowVolumeExpansion: true
+    # optional parameters for the StorageClass, e.g. availability or type
+    parameters: {}
 # any kind of custom StorageClasses
 #   custom: |-
 #     ---


### PR DESCRIPTION
**What this PR does / why we need it**:

The Helm chart's built-in `csi-cinder-sc-delete` / `csi-cinder-sc-retain` StorageClasses currently cannot carry any `parameters` (e.g. `availability` or `type`), forcing users to disable them and maintain custom classes just to set a parameter. This adds optional `storageClass.delete.parameters` and `storageClass.retain.parameters` values that are rendered into the respective StorageClass. They default to `{}`, and the rendered output is byte-identical to the previous chart when unset.

**Which issue this PR fixes**:

fixes #1980

**Special notes for reviewers**:

Picks up where the closed #2434 left off (thanks @sakshi-1505). Verified with `helm template`: output is unchanged with default values, and the `parameters:` block renders correctly when set; `helm lint` passes. Chart version bumped to 2.36.3, matching the patch-bump convention of recent chart changes (#3152, #3078). This PR was written in part with the assistance of generative AI.

**Release note**:

```release-note
[cinder-csi-plugin] The Helm chart now supports setting `parameters` on the chart-managed delete/retain StorageClasses via `storageClass.<reclaim-policy>.parameters`.
```
