### PR TITLE
ansible: remove workaround for deleting old manila endpoint

### DIFF
--- a/tests/playbooks/roles/install-devstack/tasks/main.yml
+++ b/tests/playbooks/roles/install-devstack/tasks/main.yml
@@ -115,19 +115,3 @@
         cmd: |
           set -ex
           sudo -u {{ user }} -H ./stack.sh
-
-    # FIXME(stephenfin): We should remove this as soon as [1] merges and we
-    # bump our dependencies to include it.
-    # [1] https://github.com/gophercloud/gophercloud/pull/3435
-    - name: Delete legacy manila endpoint
-      shell:
-        executable: /bin/bash
-        chdir: "{{ workdir }}"
-        cmd: |
-          set -ex
-          export OS_CLOUD=devstack-admin
-
-          # delete legacy manila API endpoints
-          if openstack service show manila > /dev/null 2>&1; then
-            openstack service delete manila
-          fi


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes an old FIXME which was deleting the old manila endpoint in devstack. Now we have discoverable endpoints in gophercloud ([the linked PR](https://github.com/gophercloud/gophercloud/pull/3435)), we do not need this workaround anymore.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
