### PR TITLE
[cinder-csi-plugin] Reduce caps of manifests, charts

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.36.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.36.3
+version: 2.36.4
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -249,8 +249,8 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName }}
+    {{- if .Values.csi.plugin.controllerPlugin.priorityClassName }}
+      priorityClassName: {{ .Values.csi.plugin.controllerPlugin.priorityClassName }}
     {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -85,8 +85,6 @@ spec:
         - name: cinder-csi-plugin
           securityContext:
             privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: "{{ .Values.csi.plugin.image.repository }}:{{ .Values.csi.plugin.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.csi.plugin.image.pullPolicy }}

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -21,6 +21,9 @@ spec:
         {{- include "cinder-csi.nodeplugin.podAnnotations" . | nindent 8 }}
     spec:
       serviceAccount: csi-cinder-node-sa
+      # Host network access is usually necessary if using metadata service,
+      # since not all CNIs support link-local addresses, or if the OpenStack
+      # control plane is on a management network that is not advertised to pods
       hostNetwork: true
       dnsPolicy: {{ .Values.csi.plugin.nodePlugin.dnsPolicy }}
       securityContext:

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -179,8 +179,8 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName }}
+    {{- if .Values.csi.plugin.nodePlugin.priorityClassName }}
+      priorityClassName: {{ .Values.csi.plugin.nodePlugin.priorityClassName }}
     {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -96,12 +96,13 @@ csi:
       # Optional additional labels to add to the nodePlugin Pods.
       podLabels: {}
       podSecurityContext: {}
-      securityContext: {}
-        # capabilities:
-        #   drop:
-        #   - ALL
-        # seccompProfile:
-        #   type: RuntimeDefault
+      securityContext:
+        # Images use distroless/static:latest which runs as root; runAsNonRoot
+        # and allowPrivilegeEscalation cannot be set until upstream switches to
+        # a nonroot base image.
+        readOnlyRootFilesystem: true
+        seccompProfile:
+          type: RuntimeDefault
       affinity: {}
       nodeSelector: {}
       tolerations:

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -137,13 +137,10 @@ csi:
         # runAsGroup: 65532
         # fsGroup: 65532
         # fsGroupChangePolicy: OnRootMismatch
-      securityContext: {}
-        # capabilities:
-        #   drop:
-        #   - ALL
-        # seccompProfile:
-        #   type: RuntimeDefault
-        # readOnlyRootFilesystem: true
+      securityContext:
+        readOnlyRootFilesystem: true
+        seccompProfile:
+          type: RuntimeDefault
       affinity: {}
       nodeSelector: {}
       tolerations: []

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -91,6 +91,7 @@ csi:
         readOnly: true
     nodePlugin:
       dnsPolicy: ClusterFirstWithHostNet
+      priorityClassName: "system-node-critical"
       # Optional additional annotations to add to the nodePlugin Pods.
       podAnnotations: {}
       # Optional additional labels to add to the nodePlugin Pods.
@@ -127,6 +128,7 @@ csi:
           # maxSurge is the maximum number of pods that can be
           # created over the desired number of pods.
           maxSurge: 1
+      priorityClassName: "system-cluster-critical"
       # Optional additional annotations to add to the controllerPlugin Pods.
       podAnnotations: {}
       # Optional additional labels to add to the controllerPlugin Pods.
@@ -224,8 +226,6 @@ clusterID: "kubernetes"
 
 # Enable PVC annotations support to create PVCs with extra parameters
 pvcAnnotations: false
-
-priorityClassName: ""
 
 imagePullSecrets: []
 # - name: my-imagepull-secret

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -25,6 +25,13 @@ spec:
       serviceAccount: csi-cinder-controller-sa
       containers:
         - name: csi-attacher
+          securityContext:
+            # Images use distroless/static:latest which runs as root; runAsNonRoot
+            # and allowPrivilegeEscalation cannot be set until upstream switches to
+            # a nonroot base image.
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: registry.k8s.io/sig-storage/csi-attacher:v4.10.0
           args:
             - "--csi-address=$(ADDRESS)"
@@ -39,6 +46,10 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
+          securityContext:
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
           args:
             - "--csi-address=$(ADDRESS)"
@@ -55,6 +66,10 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
+          securityContext:
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0
           args:
             - "--csi-address=$(ADDRESS)"
@@ -69,6 +84,10 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: csi-resizer
+          securityContext:
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
           args:
             - "--csi-address=$(ADDRESS)"
@@ -83,6 +102,10 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
+          securityContext:
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
           args:
             - "--csi-address=$(ADDRESS)"
@@ -93,6 +116,10 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: cinder-csi-plugin
+          securityContext:
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: registry.k8s.io/provider-os/cinder-csi-plugin:v1.36.0
           args:
             - /bin/cinder-csi-plugin

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -158,6 +158,7 @@ spec:
             # - name: cacert
             #   mountPath: /etc/cacert
             #   readOnly: true
+      priorityClassName: system-cluster-critical
       volumes:
         - name: socket-dir
           emptyDir:

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -24,6 +24,13 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
+          securityContext:
+            # Images use distroless/static:latest which runs as root; runAsNonRoot
+            # and allowPrivilegeEscalation cannot be set until upstream switches to
+            # a nonroot base image.
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0
           args:
             - "--csi-address=$(ADDRESS)"
@@ -44,6 +51,10 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
+          securityContext:
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
           args:
             - --csi-address=/csi/csi.sock

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -22,6 +22,7 @@ spec:
       # since not all CNIs support link-local addresses, or if the OpenStack
       # control plane is on a management network that is not advertised to pods
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: node-driver-registrar
           securityContext:

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -23,6 +23,7 @@ spec:
       # control plane is on a management network that is not advertised to pods
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      priorityClassName: system-node-critical
       containers:
         - name: node-driver-registrar
           securityContext:

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -53,8 +53,6 @@ spec:
         - name: cinder-csi-plugin
           securityContext:
             privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: registry.k8s.io/provider-os/cinder-csi-plugin:v1.36.0
           args:

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -18,6 +18,9 @@ spec:
       tolerations:
         - operator: Exists
       serviceAccount: csi-cinder-node-sa
+      # Host network access is usually necessary if using metadata service,
+      # since not all CNIs support link-local addresses, or if the OpenStack
+      # control plane is on a management network that is not advertised to pods
       hostNetwork: true
       containers:
         - name: node-driver-registrar

--- a/tests/playbooks/roles/install-k3s/tasks/main.yaml
+++ b/tests/playbooks/roles/install-k3s/tasks/main.yaml
@@ -154,6 +154,18 @@
   retries: 100
   delay: 5
 
+- name: Check k3s kernel config
+  shell:
+    executable: /bin/bash
+    cmd: |
+      ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ ansible_user_dir }}/.ssh/id_rsa ubuntu@{{ k3s_fip }} sudo NO_COLOR=1 k3s check-config
+  register: k3s_check_config
+  ignore_errors: yes
+
+- name: Report k3s kernel config
+  debug:
+    msg: "{{ k3s_check_config.stdout_lines }}"
+
 - name: Prepare kubeconfig file
   shell:
     executable: /bin/bash


### PR DESCRIPTION
**What this PR does / why we need it**:

Restrict capabilities on the node and controller pods, along with their respective sidecar containers. Also set `dnsPolicy: ClusterFirstWithHostNet` for the nodeplugin, since that uses `hostNetwork: true` and set `priorityClassName` for both nodeplugin and controllerplugin to ensure pods don't get evicted under memory pressure, respectively.

Commits:

- `cinder-csi-plugin: Add note on why hostNetwork is required`
- `cinder-csi-plugin: Drop redundant capabilities add`
- `cinder-csi-plugin: Add securityContext for node plugin sidecars`
- `cinder-csi-plugin: Add securityContext for all controller plugin containers`
- `cinder-csi-plugin: Set dnsPolicy`
- `cinder-csi-plugin: Set priorityClassName`
- `cinder-csi-plugin: Bump cinder-csi-plugin chart to 2.36.3`

**Which issue this PR fixes(if applicable)**:

(none)

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:

```release-note
[cinder-csi-plugin] Changes to default manifests, charts

The following changes have been made to provided manfiests and charts:

- `securityContext` is now set by default for all pods.
- `dnsPolicy` is now set to `ClusterFirstWithHostNet` for the nodeplugin
- `priorityClassName` is now set to `system-node-critical` for nodeplugin
  and to `system-cluster-critical` for controllerplugin to ensure node
  drain works as expected.
- The `priorityClassName` chart variable is now ignored and has been replaced
  by `csi.plugin.controllerPlugin.priorityClassName` and
  `csi.plugin.nodePlugin.priorityClassName` variables.
```
