### PR TITLE
[manila-csi-plugin] Reduce caps of manifests, charts

### DIFF
--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.36.0
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 2.36.2
+version: 2.36.3
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -81,8 +81,6 @@ spec:
         - name: {{ .protocolSelector | lower }}-nodeplugin
           securityContext:
             privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: "{{ $.Values.csimanila.image.repository }}:{{ $.Values.csimanila.image.tag | default $.Chart.AppVersion }}"
           command: ["/bin/sh", "-c",

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -21,6 +21,8 @@ spec:
       containers:
         {{- range .Values.shareProtocols }}
         - name: {{ .protocolSelector | lower }}-provisioner
+          securityContext:
+            {{- toYaml $.Values.controllerplugin.securityContext | nindent 12 }}
           image: "{{ $.Values.controllerplugin.provisioner.image.repository }}:{{ $.Values.controllerplugin.provisioner.image.tag }}"
           args:
             - "-v={{ $.Values.logVerbosityLevel }}"
@@ -44,6 +46,8 @@ spec:
           resources:
 {{ toYaml $.Values.controllerplugin.provisioner.resources | indent 12 }}
         - name: {{ .protocolSelector | lower }}-snapshotter
+          securityContext:
+            {{- toYaml $.Values.controllerplugin.securityContext | nindent 12 }}
           image: "{{ $.Values.controllerplugin.snapshotter.image.repository }}:{{ $.Values.controllerplugin.snapshotter.image.tag }}"
           args:
             - "-v={{ $.Values.logVerbosityLevel }}"
@@ -61,6 +65,8 @@ spec:
           resources:
 {{ toYaml $.Values.controllerplugin.snapshotter.resources | indent 12 }}
         - name: {{ .protocolSelector | lower }}-resizer
+          securityContext:
+            {{- toYaml $.Values.controllerplugin.securityContext | nindent 12 }}
           image: "{{ $.Values.controllerplugin.resizer.image.repository }}:{{ $.Values.controllerplugin.resizer.image.tag }}"
           args:
             - "-v={{ $.Values.logVerbosityLevel }}"

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -186,6 +186,9 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .Values.controllerplugin.priorityClassName }}
+      priorityClassName: {{ .Values.controllerplugin.priorityClassName }}
+    {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -24,6 +24,8 @@ spec:
       containers:
         {{- range .Values.shareProtocols }}
         - name: {{ .protocolSelector | lower }}-registrar
+          securityContext:
+            {{- toYaml $.Values.nodeplugin.securityContext | nindent 12 }}
           image: "{{ $.Values.nodeplugin.registrar.image.repository }}:{{ $.Values.nodeplugin.registrar.image.tag }}"
           args:
             - "-v={{ $.Values.logVerbosityLevel }}"

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -48,8 +48,6 @@ spec:
         - name: {{ .protocolSelector | lower }}-nodeplugin
           securityContext:
             privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: "{{ $.Values.csimanila.image.repository }}:{{ $.Values.csimanila.image.tag | default $.Chart.AppVersion }}"
           command: ["/bin/sh", "-c",

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -16,6 +16,9 @@ spec:
     spec:
       securityContext: {{ toYaml .Values.nodeplugin.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "openstack-manila-csi.serviceAccountName.nodeplugin" . }}
+      # Host network access is usually necessary if using metadata service,
+      # since not all CNIs support link-local addresses, or if the OpenStack
+      # control plane is on a management network that is not advertised to pods
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -55,6 +55,14 @@ csimanila:
 nodeplugin:
   # Component name
   name: nodeplugin
+  # Security context for sidecar containers
+  securityContext:
+    # Images use distroless/static:latest which runs as root; runAsNonRoot
+    # and allowPrivilegeEscalation cannot be set until upstream switches to
+    # a nonroot base image.
+    readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
   # CSI Manila container compute resources constraints
   nodeplugin:
     resources: {}

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -83,7 +83,7 @@ nodeplugin:
   #   - ip: "10.0.0.1"
   #     hostnames:
   #     - "keystone.hostname.com"
-  priorityClassName: ""
+  priorityClassName: "system-node-critical"
   # Use fullnameOverride to fully override the name of this component
   # fullnameOverride: some-other-name
   podSecurityContext: {}
@@ -135,6 +135,7 @@ controllerplugin:
   #   - ip: "10.0.0.1"
   #     hostnames:
   #     - "keystone.hostname.com"
+  priorityClassName: "system-cluster-critical"
   # Use fullnameOverride to fully override the name of this component
   # fullnameOverride: some-other-name
   podSecurityContext: {}

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -93,6 +93,10 @@ nodeplugin:
 # StatefulSet deployment
 controllerplugin:
   name: controllerplugin
+  securityContext:
+    readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
   # CSI Manila container compute resources constraints
   nodeplugin:
     resources: {}

--- a/manifests/manila-csi-plugin/csi-controllerplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-controllerplugin.yaml
@@ -125,6 +125,7 @@ spec:
             - name: pod-mounts
               mountPath: /var/lib/kubelet/pods
               mountPropagation: Bidirectional
+      priorityClassName: system-cluster-critical
       volumes:
         - name: plugin-dir
           hostPath:

--- a/manifests/manila-csi-plugin/csi-controllerplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-controllerplugin.yaml
@@ -75,8 +75,6 @@ spec:
         - name: nodeplugin
           securityContext:
             privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: registry.k8s.io/provider-os/manila-csi-plugin:v1.36.0
           command: ["/bin/sh", "-c",

--- a/manifests/manila-csi-plugin/csi-controllerplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-controllerplugin.yaml
@@ -36,6 +36,13 @@ spec:
       serviceAccountName: openstack-manila-csi-controllerplugin
       containers:
         - name: provisioner
+          securityContext:
+            # Images use distroless/static:latest which runs as root; runAsNonRoot
+            # and allowPrivilegeEscalation cannot be set until upstream switches to
+            # a nonroot base image.
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: "registry.k8s.io/sig-storage/csi-provisioner:v5.3.0"
           args:
             - "--csi-address=$(ADDRESS)"
@@ -50,6 +57,10 @@ spec:
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
         - name: snapshotter
+          securityContext:
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: "registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0"
           args:
             - "--csi-address=$(ADDRESS)"
@@ -61,6 +72,10 @@ spec:
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
         - name: resizer
+          securityContext:
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: "registry.k8s.io/sig-storage/csi-resizer:v1.14.0"
           args:
             - "--csi-address=$(ADDRESS)"

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -22,6 +22,7 @@ spec:
       # control plane is on a management network that is not advertised to pods
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      priorityClassName: system-node-critical
       containers:
         - name: registrar
           securityContext:

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -24,6 +24,13 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: registrar
+          securityContext:
+            # Images use distroless/static:latest which runs as root; runAsNonRoot
+            # and allowPrivilegeEscalation cannot be set until upstream switches to
+            # a nonroot base image.
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0"
           args:
             - "--csi-address=/csi/csi.sock"

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -17,6 +17,9 @@ spec:
         component: nodeplugin
     spec:
       serviceAccountName: openstack-manila-csi-nodeplugin
+      # Host network access is usually necessary if using metadata service,
+      # since not all CNIs support link-local addresses, or if the OpenStack
+      # control plane is on a management network that is not advertised to pods
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -50,8 +50,6 @@ spec:
         - name: nodeplugin
           securityContext:
             privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: registry.k8s.io/provider-os/manila-csi-plugin:v1.36.0
           command: ["/bin/sh", "-c",

--- a/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
@@ -89,8 +89,6 @@
               - name: nfs
                 securityContext:
                   privileged: true
-                  capabilities:
-                    add: ["SYS_ADMIN"]
                   allowPrivilegeEscalation: true
                 image: registry.k8s.io/sig-storage/nfsplugin:v4.12.1
                 args:


### PR DESCRIPTION
**What this PR does / why we need it**:

Restrict capabilities on the node and controller pods, along with their respective sidecar containers. Also set `priorityClassName` for both nodeplugin and controllerplugin to ensure pods don't get evicted under memory pressure, respectively.

- `manila-csi-plugin: Add note on why hostNetwork is required`
- `manila-csi-plugin: Drop redundant capabilities add`
- `manila-csi-plugin: Add securityContext for node plugin sidecars`
- `manila-csi-plugin: Add securityContext for all controller plugin containers`
- `manila-csi-plugin: Set priorityClassName`
- `manila-csi-plugin: Bump manila-csi-plugin chart to 2.36.3`

This is the Manila equivalent of #3181.

**Which issue this PR fixes(if applicable)**:

(none)

**Special notes for reviewers**:

(none)

**Release note**:

```release-note
[manila-csi-plugin] Changes to default manifests, charts

The following changes have been made to provided manfiests and charts:

- `securityContext` is now set by default for all pods.
- `priorityClassName` is now set to `system-node-critical` for nodeplugin
  and to `system-cluster-critical` for controllerplugin to ensure node
  drain works as expected.
```
