### PR TITLE
[occm] Reduce caps of manifests, charts

### DIFF
--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -9,7 +9,3 @@ maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de
     url: https://www.telekom.com
-dependencies:
-  - name: common
-    version: 2.14.1
-    repository: https://charts.bitnami.com/bitnami

--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -1,11 +1,11 @@
+---
 apiVersion: v2
 appVersion: v1.36.0
 description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.36.4
+version: 2.36.5
 maintainers:
-  - name: eumel8
-    email: f.kloeker@telekom.de
-    url: https://www.telekom.com
+  - name: stephenfin
+    email: stephenfin@redhat.com

--- a/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
+++ b/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
@@ -25,6 +25,11 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
+{{- define "occm.labels.matchLabels" -}}
+app.kubernetes.io/name: {{ include "occm.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
 {{- define "occm.common.matchLabels" -}}
 app: {{ template "occm.name" . }}
 release: {{ .Release.Name }}

--- a/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
+++ b/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
@@ -12,6 +12,19 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Standard Kubernetes recommended labels.
+*/}}
+{{- define "occm.labels.standard" -}}
+helm.sh/chart: {{ include "occm.chart" . }}
+app.kubernetes.io/name: {{ include "occm.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
 {{- define "occm.common.matchLabels" -}}
 app: {{ template "occm.name" . }}
 release: {{ .Release.Name }}

--- a/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Values.clusterRoleName }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "occm.labels.standard" . | nindent 4 }}
   annotations:
     {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/openstack-cloud-controller-manager/templates/clusterrolebinding-sm.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrolebinding-sm.yaml
@@ -3,7 +3,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: system:{{ include "occm.name" . }}:auth-delegate
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "occm.labels.standard" . | nindent 4 }}
   annotations:
     {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/openstack-cloud-controller-manager/templates/clusterrolebinding.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Values.clusterRoleName }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "occm.labels.standard" . | nindent 4 }}
   annotations:
     {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "occm.name" . }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "occm.labels.standard" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- with .Values.commonAnnotations }}

--- a/charts/openstack-cloud-controller-manager/templates/role.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/role.yaml
@@ -4,7 +4,7 @@ kind: Role
 metadata:
   name: {{ .Values.clusterRoleName }}:secret-reader
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "occm.labels.standard" . | nindent 4 }}
   annotations:
     {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/openstack-cloud-controller-manager/templates/rolebinding.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/rolebinding.yaml
@@ -4,7 +4,7 @@ kind: RoleBinding
 metadata:
   name: {{ .Values.clusterRoleName }}:secret-reader
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "occm.labels.standard" . | nindent 4 }}
   annotations:
     {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/openstack-cloud-controller-manager/templates/secret.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.secret.name | default "cloud-config" }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "occm.labels.standard" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- with .Values.commonAnnotations }}

--- a/charts/openstack-cloud-controller-manager/templates/service-sm.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/service-sm.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "occm.name" . }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "occm.labels.standard" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- with .Values.commonAnnotations }}

--- a/charts/openstack-cloud-controller-manager/templates/serviceaccount.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccountName }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "occm.labels.standard" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- with .Values.commonAnnotations }}

--- a/charts/openstack-cloud-controller-manager/templates/servicemonitor.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "occm.name" . }}
-  labels: 
+  labels:
     {{- include "occm.labels.standard" . | nindent 4 }}
   {{- if .Values.serviceMonitor.additionalLabels }}
     {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
@@ -23,5 +23,5 @@ spec:
   jobLabel: component
   selector:
     matchLabels:
-      {{- include "occm.labels.standard" . | nindent 6 }}
+      {{- include "occm.labels.matchLabels" . | nindent 6 }}
 {{- end }}

--- a/charts/openstack-cloud-controller-manager/templates/servicemonitor.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/servicemonitor.yaml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "occm.name" . }}
   labels: 
-    {{- include "common.labels.standard" . | nindent 4 }}
+    {{- include "occm.labels.standard" . | nindent 4 }}
   {{- if .Values.serviceMonitor.additionalLabels }}
     {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
   {{- end }}
@@ -23,5 +23,5 @@ spec:
   jobLabel: component
   selector:
     matchLabels:
-      {{- include "common.labels.standard" . | nindent 6 }}
+      {{- include "occm.labels.standard" . | nindent 6 }}
 {{- end }}

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -78,18 +78,17 @@ podLabels: {}
 # For all available options, see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
 podSecurityContext:
   runAsUser: 1001
-  # seccompProfile:
-  #   type: RuntimeDefault
+  seccompProfile:
+    type: RuntimeDefault
 
 # Set security settings for the controller container
 # For all available options, see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
-securityContext: {}
-# securityContext:
-#   capabilities:
-#     drop:
-#     - ALL
-#   readOnlyRootFilesystem: true
-#   allowPrivilegeEscalation: false
+securityContext:
+  readOnlyRootFilesystem: true
+  seccompProfile:
+    type: RuntimeDefault
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
 
 # List of controllers should be enabled.
 # Use '*' to enable all controllers.

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -46,7 +46,10 @@ livenessProbe: {}
 # Set readinessProbe in the same way like livenessProbe
 readinessProbe: {}
 
-# Use host network. Can be disabled if only the service (Octavia LB) controller is needed
+# Host network access is usually necessary if using metadata service, since not
+# all CNIs support link-local addresses, or if the OpenStack control plane is
+# on a management network that is not advertised to pods. Can be disabled if
+# only the service (Octavia LB) controller is needed.
 hostNetwork: true
 
 # Set to ClusterFirst if hostNetwork is disabled

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -84,6 +84,9 @@ podSecurityContext:
 # Set security settings for the controller container
 # For all available options, see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
 securityContext:
+  capabilities:
+    drop:
+      - ALL
   readOnlyRootFilesystem: true
   seccompProfile:
     type: RuntimeDefault

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -143,7 +143,7 @@ cloudConfig:
 
 ## Pod priority settings
 ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-priorityClassName:
+priorityClassName: "system-node-critical"
 
 # The following three volumes are required to use all OCCM controllers,
 # but might not be needed if you just use a specific controller

--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -75,6 +75,9 @@ spec:
             - name: CLUSTER_NAME
               value: kubernetes
       dnsPolicy: ClusterFirst
+      # Host network access is usually necessary if using metadata service,
+      # since not all CNIs support link-local addresses, or if the OpenStack
+      # control plane is on a management network that is not advertised to pods
       hostNetwork: true
       volumes:
       - hostPath:

--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -82,7 +82,7 @@ spec:
               value: /etc/config/cloud.conf
             - name: CLUSTER_NAME
               value: kubernetes
-      dnsPolicy: ClusterFirst
+      dnsPolicy: ClusterFirstWithHostNet
       # Host network access is usually necessary if using metadata service,
       # since not all CNIs support link-local addresses, or if the OpenStack
       # control plane is on a management network that is not advertised to pods

--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -87,6 +87,7 @@ spec:
       # since not all CNIs support link-local addresses, or if the OpenStack
       # control plane is on a management network that is not advertised to pods
       hostNetwork: true
+      priorityClassName: system-node-critical
       volumes:
       - hostPath:
           path: /etc/kubernetes/pki

--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -32,6 +32,8 @@ spec:
                 operator: Exists
       securityContext:
         runAsUser: 1001
+        seccompProfile:
+          type: RuntimeDefault
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Equal"
@@ -47,6 +49,12 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: openstack-cloud-controller-manager
+          securityContext:
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
           image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.36.0
           args:
             - /bin/openstack-cloud-controller-manager

--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -50,6 +50,9 @@ spec:
       containers:
         - name: openstack-cloud-controller-manager
           securityContext:
+            capabilities:
+              drop:
+                - ALL
             readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault

--- a/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
@@ -39,6 +39,9 @@ spec:
         - name: CLUSTER_NAME
           value: kubernetes
   dnsPolicy: ClusterFirst
+  # Host network access is usually necessary if using metadata service,
+  # since not all CNIs support link-local addresses, or if the OpenStack
+  # control plane is on a management network that is not advertised to pods
   hostNetwork: true
   securityContext:
     runAsUser: 1001

--- a/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
@@ -49,6 +49,7 @@ spec:
   # since not all CNIs support link-local addresses, or if the OpenStack
   # control plane is on a management network that is not advertised to pods
   hostNetwork: true
+  priorityClassName: system-cluster-critical
   securityContext:
     runAsUser: 1001
     seccompProfile:

--- a/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
@@ -12,6 +12,9 @@ spec:
   containers:
     - name: openstack-cloud-controller-manager
       securityContext:
+        capabilities:
+          drop:
+            - ALL
         readOnlyRootFilesystem: true
         seccompProfile:
           type: RuntimeDefault

--- a/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
@@ -44,7 +44,7 @@ spec:
           value: /etc/config/cloud.conf
         - name: CLUSTER_NAME
           value: kubernetes
-  dnsPolicy: ClusterFirst
+  dnsPolicy: ClusterFirstWithHostNet
   # Host network access is usually necessary if using metadata service,
   # since not all CNIs support link-local addresses, or if the OpenStack
   # control plane is on a management network that is not advertised to pods

--- a/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
@@ -11,6 +11,12 @@ metadata:
 spec:
   containers:
     - name: openstack-cloud-controller-manager
+      securityContext:
+        readOnlyRootFilesystem: true
+        seccompProfile:
+          type: RuntimeDefault
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
       image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.36.0
       args:
         - /bin/openstack-cloud-controller-manager
@@ -45,6 +51,8 @@ spec:
   hostNetwork: true
   securityContext:
     runAsUser: 1001
+    seccompProfile:
+      type: RuntimeDefault
   volumes:
   - hostPath:
       path: /etc/kubernetes/pki


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Restrict capabilities on the OCCM controller pod.
Also set `dnsPolicy: ClusterFirstWithHostNet` since we use `hostNetwork: true` by default and set `priorityClassName` to ensure pods don't get evicted under memory pressure.
Finally, update the maintainers and remove use of a bitnami dependency to remove an unnecessary external dependency.

Commits:

- `openstack-cloud-controller-manager: Add note on why hostNetwork is required`
- `openstack-cloud-controller-manager: Add securityContext for controller containers`
- `openstack-cloud-controller-manager: Set dnsPolicy`
- `openstack-cloud-controller-manager: Set priorityClassName`
- `openstack-cloud-controller-manager: Drop Bitnami common chart dependency`
- `openstack-cloud-controller-manager: Bump openstack-cloud-controller-manager chart to 2.36.5`

**Which issue this PR fixes(if applicable)**:

(none)

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[occm] Changes to default manifests, charts


The following changes have been made to provided manfiests and charts:

- `securityContext` is now set by default.
- `dnsPolicy` is now set to `ClusterFirstWithHostNet`
- `priorityClassName` is now set to `system-node-critical` to ensure node drain
  works as expected.
```
