### PR TITLE
[occm][manila-csi-plugin][cinder-csi-plugin] Use Kubernetes recommended labels

### DIFF
--- a/charts/cinder-csi-plugin/templates/_helpers.tpl
+++ b/charts/cinder-csi-plugin/templates/_helpers.tpl
@@ -7,24 +7,6 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "cinder-csi.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "cinder-csi.chart" -}}
@@ -45,16 +27,6 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "cinder-csi.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "cinder-csi.fullname" .) .Values.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
 
 {{/*
 Create unified labels for cinder-csi components
@@ -107,16 +79,6 @@ app.kubernetes.io/component: nodeplugin
 {{ if .Values.csi.plugin.nodePlugin.podLabels }}
 {{- toYaml .Values.csi.plugin.nodePlugin.podLabels }}
 {{- end }}
-{{- end -}}
-
-{{- define "cinder-csi.snapshot-controller.matchLabels" -}}
-app.kubernetes.io/component: snapshot-controller
-{{ include "cinder-csi.common.matchLabels" . }}
-{{- end -}}
-
-{{- define "cinder-csi.snapshot-controller.labels" -}}
-{{ include "cinder-csi.snapshot-controller.matchLabels" . }}
-{{ include "cinder-csi.common.metaLabels" . }}
 {{- end -}}
 
 {{/*

--- a/charts/cinder-csi-plugin/templates/_helpers.tpl
+++ b/charts/cinder-csi-plugin/templates/_helpers.tpl
@@ -60,20 +60,23 @@ Create the name of the service account to use
 Create unified labels for cinder-csi components
 */}}
 {{- define "cinder-csi.common.matchLabels" -}}
-app: {{ template "cinder-csi.name" . }}
-release: {{ .Release.Name }}
+app.kubernetes.io/name: {{ template "cinder-csi.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "cinder-csi.common.metaLabels" -}}
-chart: {{ template "cinder-csi.chart" . }}
-heritage: {{ .Release.Service }}
+helm.sh/chart: {{ template "cinder-csi.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels -}}
 {{- end }}
 {{- end -}}
 
 {{- define "cinder-csi.controllerplugin.matchLabels" -}}
-component: controllerplugin
+app.kubernetes.io/component: controllerplugin
 {{ include "cinder-csi.common.matchLabels" . }}
 {{- end -}}
 
@@ -90,7 +93,7 @@ component: controllerplugin
 {{- end -}}
 
 {{- define "cinder-csi.nodeplugin.matchLabels" -}}
-component: nodeplugin
+app.kubernetes.io/component: nodeplugin
 {{ include "cinder-csi.common.matchLabels" . }}
 {{- end -}}
 
@@ -107,7 +110,7 @@ component: nodeplugin
 {{- end -}}
 
 {{- define "cinder-csi.snapshot-controller.matchLabels" -}}
-component: snapshot-controller
+app.kubernetes.io/component: snapshot-controller
 {{ include "cinder-csi.common.matchLabels" . }}
 {{- end -}}
 

--- a/charts/cinder-csi-plugin/templates/cinder-csi-driver.yaml
+++ b/charts/cinder-csi-plugin/templates/cinder-csi-driver.yaml
@@ -2,6 +2,8 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: cinder.csi.openstack.org
+  labels:
+    {{- include "cinder-csi.labels" . | nindent 4 }}
 spec:
   attachRequired: true
   podInfoOnMount: true

--- a/charts/manila-csi-plugin/templates/_helpers.tpl
+++ b/charts/manila-csi-plugin/templates/_helpers.tpl
@@ -7,24 +7,6 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "openstack-manila-csi.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Create fully qualified app name for the node plugin.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/charts/manila-csi-plugin/templates/_helpers.tpl
+++ b/charts/manila-csi-plugin/templates/_helpers.tpl
@@ -87,13 +87,16 @@ Create unified labels for manila-csi components
 */}}
 
 {{- define "openstack-manila-csi.common.matchLabels" -}}
-app: {{ template "openstack-manila-csi.name" . }}
-release: {{ .Release.Name }}
+app.kubernetes.io/name: {{ template "openstack-manila-csi.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "openstack-manila-csi.common.metaLabels" -}}
-chart: {{ template "openstack-manila-csi.chart" . }}
-heritage: {{ .Release.Service }}
+helm.sh/chart: {{ template "openstack-manila-csi.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels }}
 {{- end }}
@@ -105,7 +108,7 @@ heritage: {{ .Release.Service }}
 {{- end -}}
 
 {{- define "openstack-manila-csi.controllerplugin.matchLabels" -}}
-component: controllerplugin
+app.kubernetes.io/component: controllerplugin
 {{ include "openstack-manila-csi.common.matchLabels" . }}
 {{- end -}}
 
@@ -115,7 +118,7 @@ component: controllerplugin
 {{- end -}}
 
 {{- define "openstack-manila-csi.nodeplugin.matchLabels" -}}
-component: nodeplugin
+app.kubernetes.io/component: nodeplugin
 {{ include "openstack-manila-csi.common.matchLabels" . }}
 {{- end -}}
 

--- a/charts/manila-csi-plugin/templates/csidriver.yaml
+++ b/charts/manila-csi-plugin/templates/csidriver.yaml
@@ -3,6 +3,8 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: {{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}
+  labels:
+    {{- include "openstack-manila-csi.common.labels" $ | nindent 4 }}
 spec:
   attachRequired: false
   podInfoOnMount: false

--- a/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
+++ b/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
@@ -30,24 +30,14 @@ app.kubernetes.io/name: {{ include "occm.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
-{{- define "occm.common.matchLabels" -}}
-app: {{ template "occm.name" . }}
-release: {{ .Release.Name }}
-{{- end -}}
-
-{{- define "occm.common.metaLabels" -}}
-chart: {{ template "occm.chart" . }}
-heritage: {{ .Release.Service }}
-{{- end -}}
-
 {{- define "occm.controllermanager.matchLabels" -}}
-component: controllermanager
-{{ include "occm.common.matchLabels" . }}
+app.kubernetes.io/component: controllermanager
+{{ include "occm.labels.matchLabels" . }}
 {{- end -}}
 
 {{- define "occm.controllermanager.labels" -}}
-{{ include "occm.controllermanager.matchLabels" . }}
-{{ include "occm.common.metaLabels" . }}
+{{ include "occm.labels.standard" . }}
+app.kubernetes.io/component: controllermanager
 {{ if .Values.podLabels }}
 {{- toYaml .Values.podLabels }}
 {{- end }}

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -16,11 +16,13 @@ spec:
       maxSurge: 1
   selector:
     matchLabels:
-      app: csi-cinder-controllerplugin
+      app.kubernetes.io/name: openstack-cinder-csi
+      app.kubernetes.io/component: controllerplugin
   template:
     metadata:
       labels:
-        app: csi-cinder-controllerplugin
+        app.kubernetes.io/name: openstack-cinder-csi
+        app.kubernetes.io/component: controllerplugin
     spec:
       serviceAccount: csi-cinder-controller-sa
       containers:

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -9,11 +9,13 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: csi-cinder-nodeplugin
+      app.kubernetes.io/name: openstack-cinder-csi
+      app.kubernetes.io/component: nodeplugin
   template:
     metadata:
       labels:
-        app: csi-cinder-nodeplugin
+        app.kubernetes.io/name: openstack-cinder-csi
+        app.kubernetes.io/component: nodeplugin
     spec:
       tolerations:
         - operator: Exists

--- a/manifests/cinder-csi-plugin/csi-cinder-driver.yaml
+++ b/manifests/cinder-csi-plugin/csi-cinder-driver.yaml
@@ -2,6 +2,8 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: cinder.csi.openstack.org
+  labels:
+    app.kubernetes.io/name: openstack-cinder-csi
 spec:
   attachRequired: true
   podInfoOnMount: true

--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -11,17 +11,17 @@ metadata:
   name: openstack-cloud-controller-manager
   namespace: kube-system
   labels:
-    k8s-app: openstack-cloud-controller-manager
+    app.kubernetes.io/name: openstack-cloud-controller-manager
 spec:
   selector:
     matchLabels:
-      k8s-app: openstack-cloud-controller-manager
+      app.kubernetes.io/name: openstack-cloud-controller-manager
   updateStrategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        k8s-app: openstack-cloud-controller-manager
+        app.kubernetes.io/name: openstack-cloud-controller-manager
     spec:
       affinity:
         nodeAffinity:

--- a/manifests/manila-csi-plugin/csi-controllerplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-controllerplugin.yaml
@@ -3,12 +3,12 @@ apiVersion: v1
 metadata:
   name: openstack-manila-csi-controllerplugin
   labels:
-    app: openstack-manila-csi
-    component: controllerplugin
+    app.kubernetes.io/name: openstack-manila-csi
+    app.kubernetes.io/component: controllerplugin
 spec:
   selector:
-    app: openstack-manila-csi
-    component: controllerplugin
+    app.kubernetes.io/name: openstack-manila-csi
+    app.kubernetes.io/component: controllerplugin
   ports:
     - name: dummy
       port: 12345
@@ -18,8 +18,8 @@ apiVersion: apps/v1
 metadata:
   name: openstack-manila-csi-controllerplugin
   labels:
-    app: openstack-manila-csi
-    component: controllerplugin
+    app.kubernetes.io/name: openstack-manila-csi
+    app.kubernetes.io/component: controllerplugin
 spec:
   serviceName: openstack-manila-csi-controllerplugin
   replicas: 1

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -3,8 +3,8 @@ apiVersion: apps/v1
 metadata:
   name: openstack-manila-csi-nodeplugin
   labels:
-    app: openstack-manila-csi
-    component: nodeplugin
+    app.kubernetes.io/name: openstack-manila-csi
+    app.kubernetes.io/component: nodeplugin
 spec:
   selector:
     matchLabels:

--- a/manifests/manila-csi-plugin/csidriver.yaml
+++ b/manifests/manila-csi-plugin/csidriver.yaml
@@ -2,6 +2,8 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: manila.csi.openstack.org
+  labels:
+    app.kubernetes.io/name: openstack-manila-csi
 spec:
   attachRequired: false
   podInfoOnMount: false

--- a/tests/helm/openstack-cloud-controller-manager/servicemonitor_test.yaml
+++ b/tests/helm/openstack-cloud-controller-manager/servicemonitor_test.yaml
@@ -77,16 +77,16 @@ tests:
       - equal:
           path: spec.selector
           value:
-            app: openstack-cloud-controller-manager
-            component: controllermanager
-            release: test-release
+            app.kubernetes.io/component: controllermanager
+            app.kubernetes.io/instance: test-release
+            app.kubernetes.io/name: openstack-cloud-controller-manager
         template: templates/service-sm.yaml
       - isSubset:
           path: spec.template.metadata.labels
           content:
-            app: openstack-cloud-controller-manager
-            component: controllermanager
-            release: test-release
+            app.kubernetes.io/component: controllermanager
+            app.kubernetes.io/instance: test-release
+            app.kubernetes.io/name: openstack-cloud-controller-manager
         template: templates/daemonset.yaml
       - contains:
           path: spec.template.spec.containers[0].args


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

Replace the old-style Helm labels (`app`, `release`, `heritage`, `chart`, `component`) with the Kubernetes-recommended `app.kubernetes.io/` equivalents used by the cinder-csi and OCCM charts.

Note: the selector labels on the StatefulSet and DaemonSet are immutable, so existing deployments will need to be deleted and recreated on upgrade. This should only be included in a new major version.

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
[manila-csi-plugin] Use prefixed labels

The old-style Helm labels (`app`, `release`, `heritage`, `chart`, `component`)
have been replaced with the Kubernetes-recommended `app.kubernetes.io/`
equivalents used by the cinder-csi and OCCM charts.
```
