### PR TITLE
[release-1.36] Sync chart changes from master

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.36.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.36.0
+version: 2.36.1
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.36.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.36.2
+version: 2.36.3
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.36.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.36.1
+version: 2.36.2
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.36.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.36.3
+version: 2.36.4
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.36.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.36.4
+version: 2.36.5
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/README.md
+++ b/charts/cinder-csi-plugin/README.md
@@ -6,6 +6,7 @@ Deploys a Cinder csi provisioner to your cluster, with the appropriate storageCl
 - Enable deployment of storageclasses using `storageClass.enabled`
 - Tag the retain or delete class as default class using `storageClass.delete.isDefault` in your value yaml
 - Set `storageClass.<reclaim-policy>.allowVolumeExpansion` to `true` or `false`
+- Set `storageClass.<reclaim-policy>.parameters` to add parameters (e.g. `availability` or `type`) to the storageclass
 
 First add the repo:
 

--- a/charts/cinder-csi-plugin/ci/snapshotter-disabled-values.yaml
+++ b/charts/cinder-csi-plugin/ci/snapshotter-disabled-values.yaml
@@ -1,0 +1,3 @@
+csi:
+  snapshotter:
+    enabled: false

--- a/charts/cinder-csi-plugin/ci/snapshotter-enabled-values.yaml
+++ b/charts/cinder-csi-plugin/ci/snapshotter-enabled-values.yaml
@@ -1,0 +1,3 @@
+csi:
+  snapshotter:
+    enabled: true

--- a/charts/cinder-csi-plugin/ci/topology-disabled-values.yaml
+++ b/charts/cinder-csi-plugin/ci/topology-disabled-values.yaml
@@ -1,0 +1,3 @@
+csi:
+  provisioner:
+    topology: "false"

--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -193,8 +193,10 @@ spec:
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
               value: /etc/config/{{ .Values.secret.filename }}
+            {{- if .Values.clusterID }}
             - name: CLUSTER_NAME
               value: "{{ .Values.clusterID }}"
+            {{- end }}
             {{- if .Values.csi.plugin.extraEnv }}
               {{- toYaml .Values.csi.plugin.extraEnv | nindent 12 }}
             {{- end }}

--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -86,6 +86,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
           resources: {{ toYaml .Values.csi.provisioner.resources | nindent 12 }}
+        {{- if dig "enabled" true .Values.csi.snapshotter }}
         - name: csi-snapshotter
           securityContext:
             {{- toYaml .Values.csi.plugin.controllerPlugin.securityContext | nindent 12 }}
@@ -111,6 +112,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
           resources: {{ toYaml .Values.csi.snapshotter.resources | nindent 12 }}
+        {{- end }}
         - name: csi-resizer
           securityContext:
             {{- toYaml .Values.csi.plugin.controllerPlugin.securityContext | nindent 12 }}

--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -69,7 +69,6 @@ spec:
             - "--timeout={{ .Values.timeout }}"
             - "--leader-election=true"
             - "--default-fstype=ext4"
-            - "--feature-gates=Topology={{ .Values.csi.provisioner.topology }}"
             - "--extra-create-metadata"
             {{- if .Values.csi.provisioner.extraArgs }}
             {{- with .Values.csi.provisioner.extraArgs }}
@@ -174,6 +173,7 @@ spec:
             - "--cloud-config=$(CLOUD_CONFIG)"
             - "--cluster=$(CLUSTER_NAME)"
             - "--provide-node-service=false"
+            - "--with-topology={{ .Values.csi.provisioner.topology }}"
             {{- if .Values.csi.plugin.httpEndpoint.enabled }}
             - "--http-endpoint=:{{ .Values.csi.plugin.httpEndpoint.port }}"
             {{- end }}

--- a/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-deployment.yaml
@@ -249,8 +249,8 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName }}
+    {{- if .Values.csi.plugin.controllerPlugin.priorityClassName }}
+      priorityClassName: {{ .Values.csi.plugin.controllerPlugin.priorityClassName }}
     {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-rbac.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-rbac.yaml
@@ -88,6 +88,7 @@ roleRef:
   name: csi-provisioner-role
   apiGroup: rbac.authorization.k8s.io
 
+{{- if dig "enabled" true .Values.csi.snapshotter }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -125,6 +126,7 @@ roleRef:
   kind: ClusterRole
   name: csi-snapshotter-role
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -93,6 +93,7 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--provide-controller-service=false"
             - "--cloud-config=$(CLOUD_CONFIG)"
+            - "--with-topology={{ .Values.csi.provisioner.topology }}"
             {{- if .Values.csi.plugin.extraArgs }}
             {{- with .Values.csi.plugin.extraArgs }}
             {{- tpl . $ | trim | nindent 12 }}

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -21,6 +21,9 @@ spec:
         {{- include "cinder-csi.nodeplugin.podAnnotations" . | nindent 8 }}
     spec:
       serviceAccount: csi-cinder-node-sa
+      # Host network access is usually necessary if using metadata service,
+      # since not all CNIs support link-local addresses, or if the OpenStack
+      # control plane is on a management network that is not advertised to pods
       hostNetwork: true
       dnsPolicy: {{ .Values.csi.plugin.nodePlugin.dnsPolicy }}
       securityContext:
@@ -82,8 +85,6 @@ spec:
         - name: cinder-csi-plugin
           securityContext:
             privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: "{{ .Values.csi.plugin.image.repository }}:{{ .Values.csi.plugin.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.csi.plugin.image.pullPolicy }}
@@ -178,8 +179,8 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName }}
+    {{- if .Values.csi.plugin.nodePlugin.priorityClassName }}
+      priorityClassName: {{ .Values.csi.plugin.nodePlugin.priorityClassName }}
     {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/cinder-csi-plugin/templates/storageclass.yaml
+++ b/charts/cinder-csi-plugin/templates/storageclass.yaml
@@ -10,6 +10,10 @@ metadata:
 provisioner: cinder.csi.openstack.org
 reclaimPolicy: Delete
 allowVolumeExpansion: {{ .Values.storageClass.delete.allowVolumeExpansion }}
+{{- with .Values.storageClass.delete.parameters }}
+parameters:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -22,4 +26,8 @@ metadata:
 provisioner: cinder.csi.openstack.org
 reclaimPolicy: Retain
 allowVolumeExpansion: {{ .Values.storageClass.retain.allowVolumeExpansion }}
+{{- with .Values.storageClass.retain.parameters }}
+parameters:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -23,6 +23,7 @@ csi:
     extraArgs: {}
     extraEnv: []
   snapshotter:
+    enabled: true
     image:
       repository: registry.k8s.io/sig-storage/csi-snapshotter
       tag: v8.4.0

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -197,9 +197,13 @@ storageClass:
   delete:
     isDefault: false
     allowVolumeExpansion: true
+    # optional parameters for the StorageClass, e.g. availability or type
+    parameters: {}
   retain:
     isDefault: false
     allowVolumeExpansion: true
+    # optional parameters for the StorageClass, e.g. availability or type
+    parameters: {}
 # any kind of custom StorageClasses
 #   custom: |-
 #     ---

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -91,17 +91,19 @@ csi:
         readOnly: true
     nodePlugin:
       dnsPolicy: ClusterFirstWithHostNet
+      priorityClassName: "system-node-critical"
       # Optional additional annotations to add to the nodePlugin Pods.
       podAnnotations: {}
       # Optional additional labels to add to the nodePlugin Pods.
       podLabels: {}
       podSecurityContext: {}
-      securityContext: {}
-        # capabilities:
-        #   drop:
-        #   - ALL
-        # seccompProfile:
-        #   type: RuntimeDefault
+      securityContext:
+        # Images use distroless/static:latest which runs as root; runAsNonRoot
+        # and allowPrivilegeEscalation cannot be set until upstream switches to
+        # a nonroot base image.
+        readOnlyRootFilesystem: true
+        seccompProfile:
+          type: RuntimeDefault
       affinity: {}
       nodeSelector: {}
       tolerations:
@@ -126,6 +128,7 @@ csi:
           # maxSurge is the maximum number of pods that can be
           # created over the desired number of pods.
           maxSurge: 1
+      priorityClassName: "system-cluster-critical"
       # Optional additional annotations to add to the controllerPlugin Pods.
       podAnnotations: {}
       # Optional additional labels to add to the controllerPlugin Pods.
@@ -136,13 +139,10 @@ csi:
         # runAsGroup: 65532
         # fsGroup: 65532
         # fsGroupChangePolicy: OnRootMismatch
-      securityContext: {}
-        # capabilities:
-        #   drop:
-        #   - ALL
-        # seccompProfile:
-        #   type: RuntimeDefault
-        # readOnlyRootFilesystem: true
+      securityContext:
+        readOnlyRootFilesystem: true
+        seccompProfile:
+          type: RuntimeDefault
       affinity: {}
       nodeSelector: {}
       tolerations: []
@@ -226,8 +226,6 @@ clusterID: "kubernetes"
 
 # Enable PVC annotations support to create PVCs with extra parameters
 pvcAnnotations: false
-
-priorityClassName: ""
 
 imagePullSecrets: []
 # - name: my-imagepull-secret

--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.36.0
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 2.36.0
+version: 2.36.1
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.36.0
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 2.36.1
+version: 2.36.2
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.36.0
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 2.36.2
+version: 2.36.3
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -101,7 +101,7 @@ spec:
             {{- if .compatibilitySettings }}
             --compatibility-settings={{ .compatibilitySettings }}
             {{- end }}
-            --cluster-id="{{ $.Values.csimanila.clusterID }}"
+            --cluster-id=$(CLUSTER_NAME)
             {{- if $.Values.csimanila.pvcAnnotations }}
             --pvc-annotations
             {{- end }}'
@@ -115,9 +115,17 @@ spec:
               value: "unix://{{ .fwdNodePluginEndpoint.dir }}/{{ .fwdNodePluginEndpoint.sockFile }}"
             - name: MANILA_SHARE_PROTO
               value: "{{ .protocolSelector }}"
+            {{- if $.Values.csimanila.clusterID }}
+            - name: CLUSTER_NAME
+              value: {{ $.Values.csimanila.clusterID }}
+            {{- end }}
             {{- if $.Values.controllerplugin.nodeplugin.extraEnv }}
               {{- toYaml $.Values.controllerplugin.nodeplugin.extraEnv | nindent 12 }}
             {{- end }}
+          {{- with $.Values.controllerplugin.nodeplugin.envFrom }}
+          envFrom:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           imagePullPolicy: {{ $.Values.csimanila.image.pullPolicy }}
           volumeMounts:
             - name: {{ .protocolSelector | lower }}-plugin-dir

--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -21,6 +21,8 @@ spec:
       containers:
         {{- range .Values.shareProtocols }}
         - name: {{ .protocolSelector | lower }}-provisioner
+          securityContext:
+            {{- toYaml $.Values.controllerplugin.securityContext | nindent 12 }}
           image: "{{ $.Values.controllerplugin.provisioner.image.repository }}:{{ $.Values.controllerplugin.provisioner.image.tag }}"
           args:
             - "-v={{ $.Values.logVerbosityLevel }}"
@@ -44,6 +46,8 @@ spec:
           resources:
 {{ toYaml $.Values.controllerplugin.provisioner.resources | indent 12 }}
         - name: {{ .protocolSelector | lower }}-snapshotter
+          securityContext:
+            {{- toYaml $.Values.controllerplugin.securityContext | nindent 12 }}
           image: "{{ $.Values.controllerplugin.snapshotter.image.repository }}:{{ $.Values.controllerplugin.snapshotter.image.tag }}"
           args:
             - "-v={{ $.Values.logVerbosityLevel }}"
@@ -61,6 +65,8 @@ spec:
           resources:
 {{ toYaml $.Values.controllerplugin.snapshotter.resources | indent 12 }}
         - name: {{ .protocolSelector | lower }}-resizer
+          securityContext:
+            {{- toYaml $.Values.controllerplugin.securityContext | nindent 12 }}
           image: "{{ $.Values.controllerplugin.resizer.image.repository }}:{{ $.Values.controllerplugin.resizer.image.tag }}"
           args:
             - "-v={{ $.Values.logVerbosityLevel }}"
@@ -81,8 +87,6 @@ spec:
         - name: {{ .protocolSelector | lower }}-nodeplugin
           securityContext:
             privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: "{{ $.Values.csimanila.image.repository }}:{{ $.Values.csimanila.image.tag | default $.Chart.AppVersion }}"
           command: ["/bin/sh", "-c",
@@ -181,6 +185,9 @@ spec:
     {{- with .Values.controllerplugin.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- if .Values.controllerplugin.priorityClassName }}
+      priorityClassName: {{ .Values.controllerplugin.priorityClassName }}
     {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -62,7 +62,7 @@ spec:
             --drivername=$(DRIVER_NAME)
             --share-protocol-selector=$(MANILA_SHARE_PROTO)
             --fwdendpoint=$(FWD_CSI_ENDPOINT)
-            --cluster-id="{{ $.Values.csimanila.clusterID }}"'
+            --cluster-id=$(CLUSTER_NAME)'
           ]
           env:
             - name: DRIVER_NAME
@@ -73,6 +73,10 @@ spec:
               value: "unix://{{ .fwdNodePluginEndpoint.dir }}/{{ .fwdNodePluginEndpoint.sockFile }}"
             - name: MANILA_SHARE_PROTO
               value: "{{ .protocolSelector }}"
+            {{- if $.Values.csimanila.clusterID }}
+            - name: CLUSTER_NAME
+              value: "{{ $.Values.csimanila.clusterID }}"
+            {{- end }}
             {{- if $.Values.nodeplugin.nodeplugin.extraEnv }}
               {{- toYaml $.Values.nodeplugin.nodeplugin.extraEnv | nindent 12 }}
             {{- end }}

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -62,7 +62,10 @@ spec:
             --drivername=$(DRIVER_NAME)
             --share-protocol-selector=$(MANILA_SHARE_PROTO)
             --fwdendpoint=$(FWD_CSI_ENDPOINT)
-            --cluster-id=$(CLUSTER_NAME)'
+            --cluster-id="{{ $.Values.csimanila.clusterID }}"
+            {{- if $.Values.csimanila.searchOrder }}
+            --search-order="{{ $.Values.csimanila.searchOrder }}"
+            {{- end }}'
           ]
           env:
             - name: DRIVER_NAME
@@ -91,6 +94,9 @@ spec:
               mountPath: /runtimeconfig
               readOnly: true
             {{- end }}
+            - name: configdrive-dev
+              mountPath: /dev
+              mountPropagation: "HostToContainer"
             {{- with $.Values.nodeplugin.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -117,6 +123,10 @@ spec:
             name: manila-csi-runtimeconf-cm
         {{- end }}
         {{- end }}
+        - name: configdrive-dev
+          hostPath:
+            path: /dev
+            type: Directory
         {{- with .Values.nodeplugin.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -16,11 +16,16 @@ spec:
     spec:
       securityContext: {{ toYaml .Values.nodeplugin.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "openstack-manila-csi.serviceAccountName.nodeplugin" . }}
+      # Host network access is usually necessary if using metadata service,
+      # since not all CNIs support link-local addresses, or if the OpenStack
+      # control plane is on a management network that is not advertised to pods
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         {{- range .Values.shareProtocols }}
         - name: {{ .protocolSelector | lower }}-registrar
+          securityContext:
+            {{- toYaml $.Values.nodeplugin.securityContext | nindent 12 }}
           image: "{{ $.Values.nodeplugin.registrar.image.repository }}:{{ $.Values.nodeplugin.registrar.image.tag }}"
           args:
             - "-v={{ $.Values.logVerbosityLevel }}"
@@ -45,8 +50,6 @@ spec:
         - name: {{ .protocolSelector | lower }}-nodeplugin
           securityContext:
             privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: "{{ $.Values.csimanila.image.repository }}:{{ $.Values.csimanila.image.tag | default $.Chart.AppVersion }}"
           command: ["/bin/sh", "-c",

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -48,6 +48,9 @@ csimanila:
     pullPolicy: IfNotPresent
     tag:  # defaults to .Chart.AppVersion
 
+  # Set the search order in which the driver retrieves metadata relating to the instance (s) in which it runs
+  searchOrder: ""
+
 # DeamonSet deployment
 nodeplugin:
   # Component name

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -55,6 +55,14 @@ csimanila:
 nodeplugin:
   # Component name
   name: nodeplugin
+  # Security context for sidecar containers
+  securityContext:
+    # Images use distroless/static:latest which runs as root; runAsNonRoot
+    # and allowPrivilegeEscalation cannot be set until upstream switches to
+    # a nonroot base image.
+    readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
   # CSI Manila container compute resources constraints
   nodeplugin:
     resources: {}
@@ -75,7 +83,7 @@ nodeplugin:
   #   - ip: "10.0.0.1"
   #     hostnames:
   #     - "keystone.hostname.com"
-  priorityClassName: ""
+  priorityClassName: "system-node-critical"
   # Use fullnameOverride to fully override the name of this component
   # fullnameOverride: some-other-name
   podSecurityContext: {}
@@ -85,6 +93,10 @@ nodeplugin:
 # StatefulSet deployment
 controllerplugin:
   name: controllerplugin
+  securityContext:
+    readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
   # CSI Manila container compute resources constraints
   nodeplugin:
     resources: {}
@@ -123,6 +135,7 @@ controllerplugin:
   #   - ip: "10.0.0.1"
   #     hostnames:
   #     - "keystone.hostname.com"
+  priorityClassName: "system-cluster-critical"
   # Use fullnameOverride to fully override the name of this component
   # fullnameOverride: some-other-name
   podSecurityContext: {}

--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.36.0
+version: 2.36.1
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.36.1
+version: 2.36.2
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.36.2
+version: 2.36.3
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.36.3
+version: 2.36.4
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -1,15 +1,11 @@
+---
 apiVersion: v2
 appVersion: v1.36.0
 description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.36.4
+version: 2.36.5
 maintainers:
-  - name: eumel8
-    email: f.kloeker@telekom.de
-    url: https://www.telekom.com
-dependencies:
-  - name: common
-    version: 2.14.1
-    repository: https://charts.bitnami.com/bitnami
+  - name: stephenfin
+    email: stephenfin@redhat.com

--- a/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
+++ b/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
@@ -12,6 +12,24 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Standard Kubernetes recommended labels.
+*/}}
+{{- define "occm.labels.standard" -}}
+helm.sh/chart: {{ include "occm.chart" . }}
+app.kubernetes.io/name: {{ include "occm.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "occm.labels.matchLabels" -}}
+app.kubernetes.io/name: {{ include "occm.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
 {{- define "occm.common.matchLabels" -}}
 app: {{ template "occm.name" . }}
 release: {{ .Release.Name }}

--- a/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
@@ -29,7 +29,11 @@ rules:
   resources:
   - nodes
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:
@@ -67,12 +71,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - persistentvolumes
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
   - endpoints
   verbs:
   - create
@@ -87,12 +85,4 @@ rules:
   verbs:
   - get
   - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - list
-  - get
   - watch

--- a/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrole.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Values.clusterRoleName }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "occm.labels.standard" . | nindent 4 }}
   annotations:
     {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/openstack-cloud-controller-manager/templates/clusterrolebinding-sm.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrolebinding-sm.yaml
@@ -3,7 +3,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: system:{{ include "occm.name" . }}:auth-delegate
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "occm.labels.standard" . | nindent 4 }}
   annotations:
     {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/openstack-cloud-controller-manager/templates/clusterrolebinding.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Values.clusterRoleName }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "occm.labels.standard" . | nindent 4 }}
   annotations:
     {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include "cloudConfig" . | sha256sum }}
+        checksum/config: {{ print (include "cloudConfig" .) (.Values.cloudConfigContents | default "") | sha256sum }}
         {{- include "occm.controllermanager.annotations" . | nindent 8 }}
       labels:
         {{- include "occm.controllermanager.labels" . | nindent 8 }}

--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -59,6 +59,7 @@ spec:
             - --use-service-account-credentials=false
             - --controllers={{- trimAll "," (include "occm.enabledControllers" . ) -}}
             {{- if .Values.serviceMonitor.enabled }}
+            - --authorization-always-allow-paths=/metrics
             - --bind-address=0.0.0.0
             {{- else }}
             - --bind-address=127.0.0.1

--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "occm.name" . }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "occm.labels.standard" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- with .Values.commonAnnotations }}

--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -110,8 +110,8 @@ spec:
       {{- if .Values.extraInitContainers }}
       initContainers: {{ toYaml .Values.extraInitContainers | nindent 6 }}
       {{- end }}
+      hostNetwork: {{ .Values.hostNetwork }}
       dnsPolicy: {{ .Values.dnsPolicy }}
-      hostNetwork: true
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}

--- a/charts/openstack-cloud-controller-manager/templates/role.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/role.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.secret.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.clusterRoleName }}:secret-reader
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - {{ .Values.secret.name | default "cloud-config" }}
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}

--- a/charts/openstack-cloud-controller-manager/templates/role.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/role.yaml
@@ -4,7 +4,7 @@ kind: Role
 metadata:
   name: {{ .Values.clusterRoleName }}:secret-reader
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "occm.labels.standard" . | nindent 4 }}
   annotations:
     {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/openstack-cloud-controller-manager/templates/rolebinding.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/rolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.secret.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.clusterRoleName }}:secret-reader
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Values.clusterRoleName }}:secret-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/openstack-cloud-controller-manager/templates/rolebinding.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/rolebinding.yaml
@@ -4,7 +4,7 @@ kind: RoleBinding
 metadata:
   name: {{ .Values.clusterRoleName }}:secret-reader
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "occm.labels.standard" . | nindent 4 }}
   annotations:
     {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/openstack-cloud-controller-manager/templates/secret.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.secret.name | default "cloud-config" }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "occm.labels.standard" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- with .Values.commonAnnotations }}

--- a/charts/openstack-cloud-controller-manager/templates/service-sm.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/service-sm.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "occm.name" . }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "occm.labels.standard" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- with .Values.commonAnnotations }}

--- a/charts/openstack-cloud-controller-manager/templates/serviceaccount.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccountName }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "occm.labels.standard" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- with .Values.commonAnnotations }}

--- a/charts/openstack-cloud-controller-manager/templates/servicemonitor.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/servicemonitor.yaml
@@ -15,8 +15,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    interval: 30s
+  - interval: 30s
     port: http
     scheme: https
     tlsConfig:
@@ -24,5 +23,5 @@ spec:
   jobLabel: component
   selector:
     matchLabels:
-      {{- include "occm.controllermanager.matchLabels" . | nindent 6 }}
+      {{- include "common.labels.standard" . | nindent 6 }}
 {{- end }}

--- a/charts/openstack-cloud-controller-manager/templates/servicemonitor.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/servicemonitor.yaml
@@ -3,8 +3,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "occm.name" . }}
-  labels: 
-    {{- include "common.labels.standard" . | nindent 4 }}
+  labels:
+    {{- include "occm.labels.standard" . | nindent 4 }}
   {{- if .Values.serviceMonitor.additionalLabels }}
     {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
   {{- end }}
@@ -23,5 +23,5 @@ spec:
   jobLabel: component
   selector:
     matchLabels:
-      {{- include "common.labels.standard" . | nindent 6 }}
+      {{- include "occm.labels.matchLabels" . | nindent 6 }}
 {{- end }}

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -46,7 +46,11 @@ livenessProbe: {}
 # Set readinessProbe in the same way like livenessProbe
 readinessProbe: {}
 
-dnsPolicy: ClusterFirst
+# Use host network. Can be disabled if only the service (Octavia LB) controller is needed
+hostNetwork: true
+
+# Set to ClusterFirst if hostNetwork is disabled
+dnsPolicy: ClusterFirstWithHostNet
 
 # Set nodeSelector where the controller should run, i.e. controlplane nodes
 nodeSelector:

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -46,7 +46,10 @@ livenessProbe: {}
 # Set readinessProbe in the same way like livenessProbe
 readinessProbe: {}
 
-# Use host network. Can be disabled if only the service (Octavia LB) controller is needed
+# Host network access is usually necessary if using metadata service, since not
+# all CNIs support link-local addresses, or if the OpenStack control plane is
+# on a management network that is not advertised to pods. Can be disabled if
+# only the service (Octavia LB) controller is needed.
 hostNetwork: true
 
 # Set to ClusterFirst if hostNetwork is disabled
@@ -75,18 +78,20 @@ podLabels: {}
 # For all available options, see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
 podSecurityContext:
   runAsUser: 1001
-  # seccompProfile:
-  #   type: RuntimeDefault
+  seccompProfile:
+    type: RuntimeDefault
 
 # Set security settings for the controller container
 # For all available options, see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
-securityContext: {}
-# securityContext:
-#   capabilities:
-#     drop:
-#     - ALL
-#   readOnlyRootFilesystem: true
-#   allowPrivilegeEscalation: false
+securityContext:
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  seccompProfile:
+    type: RuntimeDefault
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
 
 # List of controllers should be enabled.
 # Use '*' to enable all controllers.
@@ -141,7 +146,7 @@ cloudConfig:
 
 ## Pod priority settings
 ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-priorityClassName:
+priorityClassName: "system-node-critical"
 
 # The following three volumes are required to use all OCCM controllers,
 # but might not be needed if you just use a specific controller

--- a/cmd/manila-csi-plugin/main.go
+++ b/cmd/manila-csi-plugin/main.go
@@ -52,6 +52,7 @@ var (
 	userAgentData            []string
 	provideControllerService bool
 	provideNodeService       bool
+	searchOrder              string
 )
 
 func validateShareProtocolSelector(v string) error {
@@ -104,8 +105,13 @@ func main() {
 			}
 
 			if provideNodeService {
+				err = metadata.CheckMetadataSearchOrder(searchOrder)
+				if err != nil {
+					klog.Fatalf("Invalid search-order: %v", err)
+				}
+
 				// Initialize metadata
-				metadata := metadata.GetMetadataProvider("")
+				metadata := metadata.GetMetadataProvider(searchOrder)
 
 				err = d.SetupNodeService(metadata)
 				if err != nil {
@@ -158,6 +164,7 @@ func main() {
 
 	cmd.PersistentFlags().BoolVar(&provideControllerService, "provide-controller-service", true, "If set to true then the CSI driver does provide the controller service (default: true)")
 	cmd.PersistentFlags().BoolVar(&provideNodeService, "provide-node-service", true, "If set to true then the CSI driver does provide the node service (default: true)")
+	cmd.PersistentFlags().StringVar(&searchOrder, "search-order", "configDrive,metadataService", "The search order in which the driver retrieves metadata relating to the instance (s) in which it runs")
 
 	code := cli.Run(cmd)
 	os.Exit(code)

--- a/docs/cinder-csi-plugin/features.md
+++ b/docs/cinder-csi-plugin/features.md
@@ -34,8 +34,8 @@ This feature enables driver to consider the topology constraints while creating 
 * Supported topology keys:
   `topology.cinder.csi.openstack.org/zone` : Availability by Zone
 * `allowedTopologies` can be specified in storage class to restrict the topology of provisioned volumes to specific zones and should be used as replacement of `availability` parameter.
-* To disable: set `--feature-gates=Topology=false` in external-provisioner (container `csi-provisioner` of `csi-cinder-controllerplugin`).
-  * If using Helm, it can be disabled by setting `Values.csi.provisioner.topology: "false"` 
+* To disable, pass `--with-topology=false` to both the controller and node Cinder CSI driver services.
+  * With Helm, set `.Values.csi.provisioner.topology: "false"`.
 
 For usage, refer [sample app](./examples.md#use-topology)
 

--- a/docs/manila-csi-plugin/using-manila-csi-plugin.md
+++ b/docs/manila-csi-plugin/using-manila-csi-plugin.md
@@ -44,6 +44,7 @@ Option | Default value | Description
 `--provide-controller-service` | `true` | If set to true then the CSI driver does provide the controller service.
 `--provide-node-service` | `true` | If set to true then the CSI driver does provide the node service.
 `--pvc-annotations` | `false` | If set to true then the CSI driver will use PVC annotations as an additional information when creating shares. See [Supported PVC annotations](#supported-pvc-annotations) for more info.
+`--search-order` | `configDrive,metadataService` | The search order in which the driver retrieves metadata relating to the instance in which it runs. Only effective when `--provide-node-service=true`.
 
 ### Controller Service volume parameters
 

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -25,6 +25,13 @@ spec:
       serviceAccount: csi-cinder-controller-sa
       containers:
         - name: csi-attacher
+          securityContext:
+            # Images use distroless/static:latest which runs as root; runAsNonRoot
+            # and allowPrivilegeEscalation cannot be set until upstream switches to
+            # a nonroot base image.
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: registry.k8s.io/sig-storage/csi-attacher:v4.10.0
           args:
             - "--csi-address=$(ADDRESS)"
@@ -39,6 +46,10 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
+          securityContext:
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
           args:
             - "--csi-address=$(ADDRESS)"
@@ -55,6 +66,10 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
+          securityContext:
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0
           args:
             - "--csi-address=$(ADDRESS)"
@@ -69,6 +84,10 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: csi-resizer
+          securityContext:
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
           args:
             - "--csi-address=$(ADDRESS)"
@@ -83,6 +102,10 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
+          securityContext:
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
           args:
             - "--csi-address=$(ADDRESS)"
@@ -93,6 +116,10 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: cinder-csi-plugin
+          securityContext:
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: registry.k8s.io/provider-os/cinder-csi-plugin:v1.36.0
           args:
             - /bin/cinder-csi-plugin
@@ -131,6 +158,7 @@ spec:
             # - name: cacert
             #   mountPath: /etc/cacert
             #   readOnly: true
+      priorityClassName: system-cluster-critical
       volumes:
         - name: socket-dir
           emptyDir:

--- a/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-nodeplugin.yaml
@@ -18,9 +18,21 @@ spec:
       tolerations:
         - operator: Exists
       serviceAccount: csi-cinder-node-sa
+      # Host network access is usually necessary if using metadata service,
+      # since not all CNIs support link-local addresses, or if the OpenStack
+      # control plane is on a management network that is not advertised to pods
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      priorityClassName: system-node-critical
       containers:
         - name: node-driver-registrar
+          securityContext:
+            # Images use distroless/static:latest which runs as root; runAsNonRoot
+            # and allowPrivilegeEscalation cannot be set until upstream switches to
+            # a nonroot base image.
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0
           args:
             - "--csi-address=$(ADDRESS)"
@@ -41,6 +53,10 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
+          securityContext:
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
           args:
             - --csi-address=/csi/csi.sock
@@ -50,8 +66,6 @@ spec:
         - name: cinder-csi-plugin
           securityContext:
             privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: registry.k8s.io/provider-os/cinder-csi-plugin:v1.36.0
           args:

--- a/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
+++ b/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
@@ -24,5 +24,18 @@ items:
   - kind: ServiceAccount
     name: cloud-controller-manager
     namespace: kube-system
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: system:cloud-controller-manager:secret-reader
+    namespace: kube-system
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: system:cloud-controller-manager:secret-reader
+  subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: kube-system
 kind: List
 metadata: {}

--- a/manifests/controller-manager/cloud-controller-manager-roles.yaml
+++ b/manifests/controller-manager/cloud-controller-manager-roles.yaml
@@ -26,7 +26,11 @@ items:
     resources:
     - nodes
     verbs:
-    - '*'
+    - get
+    - list
+    - watch
+    - patch
+    - update
   - apiGroups:
     - ""
     resources:
@@ -64,12 +68,6 @@ items:
   - apiGroups:
     - ""
     resources:
-    - persistentvolumes
-    verbs:
-    - '*'
-  - apiGroups:
-    - ""
-    resources:
     - endpoints
     verbs:
     - create
@@ -85,13 +83,21 @@ items:
     - get
     - list
     - watch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: system:cloud-controller-manager:secret-reader
+    namespace: kube-system
+  rules:
   - apiGroups:
     - ""
     resources:
     - secrets
+    resourceNames:
+    - cloud-config
     verbs:
-    - list
     - get
+    - list
     - watch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole

--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -32,6 +32,8 @@ spec:
                 operator: Exists
       securityContext:
         runAsUser: 1001
+        seccompProfile:
+          type: RuntimeDefault
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Equal"
@@ -47,6 +49,15 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: openstack-cloud-controller-manager
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
           image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.36.0
           args:
             - /bin/openstack-cloud-controller-manager
@@ -74,8 +85,12 @@ spec:
               value: /etc/config/cloud.conf
             - name: CLUSTER_NAME
               value: kubernetes
-      dnsPolicy: ClusterFirst
+      dnsPolicy: ClusterFirstWithHostNet
+      # Host network access is usually necessary if using metadata service,
+      # since not all CNIs support link-local addresses, or if the OpenStack
+      # control plane is on a management network that is not advertised to pods
       hostNetwork: true
+      priorityClassName: system-node-critical
       volumes:
       - hostPath:
           path: /etc/kubernetes/pki

--- a/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-pod.yaml
@@ -11,6 +11,15 @@ metadata:
 spec:
   containers:
     - name: openstack-cloud-controller-manager
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        seccompProfile:
+          type: RuntimeDefault
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
       image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.36.0
       args:
         - /bin/openstack-cloud-controller-manager
@@ -38,10 +47,16 @@ spec:
           value: /etc/config/cloud.conf
         - name: CLUSTER_NAME
           value: kubernetes
-  dnsPolicy: ClusterFirst
+  dnsPolicy: ClusterFirstWithHostNet
+  # Host network access is usually necessary if using metadata service,
+  # since not all CNIs support link-local addresses, or if the OpenStack
+  # control plane is on a management network that is not advertised to pods
   hostNetwork: true
+  priorityClassName: system-cluster-critical
   securityContext:
     runAsUser: 1001
+    seccompProfile:
+      type: RuntimeDefault
   volumes:
   - hostPath:
       path: /etc/kubernetes/pki

--- a/manifests/manila-csi-plugin/csi-controllerplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-controllerplugin.yaml
@@ -36,6 +36,13 @@ spec:
       serviceAccountName: openstack-manila-csi-controllerplugin
       containers:
         - name: provisioner
+          securityContext:
+            # Images use distroless/static:latest which runs as root; runAsNonRoot
+            # and allowPrivilegeEscalation cannot be set until upstream switches to
+            # a nonroot base image.
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: "registry.k8s.io/sig-storage/csi-provisioner:v5.3.0"
           args:
             - "--csi-address=$(ADDRESS)"
@@ -50,6 +57,10 @@ spec:
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
         - name: snapshotter
+          securityContext:
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: "registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0"
           args:
             - "--csi-address=$(ADDRESS)"
@@ -61,6 +72,10 @@ spec:
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
         - name: resizer
+          securityContext:
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: "registry.k8s.io/sig-storage/csi-resizer:v1.14.0"
           args:
             - "--csi-address=$(ADDRESS)"
@@ -75,8 +90,6 @@ spec:
         - name: nodeplugin
           securityContext:
             privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: registry.k8s.io/provider-os/manila-csi-plugin:v1.36.0
           command: ["/bin/sh", "-c",
@@ -112,6 +125,7 @@ spec:
             - name: pod-mounts
               mountPath: /var/lib/kubelet/pods
               mountPropagation: Bidirectional
+      priorityClassName: system-cluster-critical
       volumes:
         - name: plugin-dir
           hostPath:

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -80,6 +80,9 @@ spec:
               mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
             - name: fwd-plugin-dir
               mountPath: /var/lib/kubelet/plugins/FWD-NODEPLUGIN
+            - name: configdrive-dev
+              mountPath: /dev
+              mountPropagation: "HostToContainer"
       volumes:
         - name: registration-dir
           hostPath:
@@ -93,4 +96,7 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/FWD-NODEPLUGIN
             type: DirectoryOrCreate
-
+        - name: configdrive-dev
+          hostPath:
+            path: /dev
+            type: Directory

--- a/manifests/manila-csi-plugin/csi-nodeplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-nodeplugin.yaml
@@ -17,10 +17,21 @@ spec:
         component: nodeplugin
     spec:
       serviceAccountName: openstack-manila-csi-nodeplugin
+      # Host network access is usually necessary if using metadata service,
+      # since not all CNIs support link-local addresses, or if the OpenStack
+      # control plane is on a management network that is not advertised to pods
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      priorityClassName: system-node-critical
       containers:
         - name: registrar
+          securityContext:
+            # Images use distroless/static:latest which runs as root; runAsNonRoot
+            # and allowPrivilegeEscalation cannot be set until upstream switches to
+            # a nonroot base image.
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           image: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0"
           args:
             - "--csi-address=/csi/csi.sock"
@@ -47,8 +58,6 @@ spec:
         - name: nodeplugin
           securityContext:
             privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: registry.k8s.io/provider-os/manila-csi-plugin:v1.36.0
           command: ["/bin/sh", "-c",

--- a/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-manila/tasks/main.yaml
@@ -89,8 +89,6 @@
               - name: nfs
                 securityContext:
                   privileged: true
-                  capabilities:
-                    add: ["SYS_ADMIN"]
                   allowPrivilegeEscalation: true
                 image: registry.k8s.io/sig-storage/nfsplugin:v4.12.1
                 args:

--- a/tests/playbooks/roles/install-k3s/tasks/main.yaml
+++ b/tests/playbooks/roles/install-k3s/tasks/main.yaml
@@ -154,6 +154,18 @@
   retries: 100
   delay: 5
 
+- name: Check k3s kernel config
+  shell:
+    executable: /bin/bash
+    cmd: |
+      ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ ansible_user_dir }}/.ssh/id_rsa ubuntu@{{ k3s_fip }} sudo NO_COLOR=1 k3s check-config
+  register: k3s_check_config
+  ignore_errors: yes
+
+- name: Report k3s kernel config
+  debug:
+    msg: "{{ k3s_check_config.stdout_lines }}"
+
 - name: Prepare kubeconfig file
   shell:
     executable: /bin/bash


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This PR cherry-picks all commits from *after* `v1.36.0` (commit 46c2161c) to the current `HEAD` of `master`. It is intended to allow us to start backporting Helm chart fixes going forward.

The commits on this branch were cherry-picked using the following commits:

```bash
git cherry-pick $(git for-each-ref --sort=creatordate --format='%(objectname)' --contains 46c2161c refs/tags)
```

Note that this will not result in a new release. The `version` in each `Chart.yaml` is now in line with those on `master` and those have already been released.

Also note that this does include one code change corresponding to https://github.com/kubernetes/cloud-provider-openstack/pull/3141. This is a bugfix though and I believe it's reasonable to backport this. If reviewers prefer, I could split this PR into 3 (all manifest/chart changes before the bugfix, the bugfix, then all manifest/chart changes after the bugfix).

*Commits*

- `[occm] Include cloudConfigContents in DaemonSet checksum annotation (#3080)`
- `[manila-csi-plugin, cinder-csi-plugin]: Allow cluster-id to be populated from configmap / secret (#3152)`
- `Fix config drive mount and add flag to control the search order in which the driver retrieves instance metadata (#3141)`
- `cinder-csi: make csi-snapshotter sidecar optional (#3078)`
- `[occm] Reduce ClusterRole scope (#3165)`
- `[occm] Fix serviceMonitor labelSelector and remove deprecated bearerTokenFile auth (#3039)`
- `cinder-csi: configure topology with --with-topology (#3155)`
- `[occm] Make hostNetwork configurable in the Helm chart (#3097)`
- `[cinder-csi-plugin] Reduce caps of manifests, charts (#3181)`
- `[manila-csi-plugin] Reduce caps of manifests, charts (#3182)`
- `[cinder-csi-plugin] Allow setting parameters on chart-managed StorageClasses (#3173)`
- `[occm] Reduce caps of manifests, charts (#3191)`

**Which issue this PR fixes(if applicable)**:

Ref #3194

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[manila-csi-plugin] Add `--search-order` flag to control the order in which instance metadata is retrieved (configDrive, metadataService)
```
