### PR TITLE
[occm] test: fix servicemonitor test after label reduction

### DIFF
--- a/tests/helm/openstack-cloud-controller-manager/servicemonitor_test.yaml
+++ b/tests/helm/openstack-cloud-controller-manager/servicemonitor_test.yaml
@@ -48,10 +48,7 @@ tests:
           path: spec.selector.matchLabels
           value:
             app.kubernetes.io/instance: test-release
-            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: openstack-cloud-controller-manager
-            app.kubernetes.io/version: v4.5.6
-            helm.sh/chart: openstack-cloud-controller-manager-1.2.3
         template: templates/servicemonitor.yaml
       - notExists:
           path: spec.endpoints[0].bearerTokenFile


### PR DESCRIPTION
PR #3191 reduced the labels on the OCCM chart manifests, which removed managed-by, version, and chart labels from the Service selector. Update the servicemonitor helm test to match the current selector labels.

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
This situation could have been avoided if we had enabled merge queue in github :-/

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
