### PR TITLE
[release-1.34] Sync chart changes from master

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.34.1
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.34.1
+version: 2.34.2
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.34.1
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.34.2
+version: 2.34.3
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: v1.34.0
+appVersion: v1.34.1
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.34.0
+version: 2.34.1
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -23,6 +23,8 @@ spec:
       serviceAccount: csi-cinder-node-sa
       hostNetwork: true
       dnsPolicy: {{ .Values.csi.plugin.nodePlugin.dnsPolicy }}
+      securityContext:
+        {{- toYaml .Values.csi.plugin.nodePlugin.podSecurityContext | nindent 8 }}
       containers:
         - name: node-driver-registrar
           securityContext:

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -25,7 +25,7 @@ csi:
   snapshotter:
     image:
       repository: registry.k8s.io/sig-storage/csi-snapshotter
-      tag: v8.3.0
+      tag: v8.4.0
       pullPolicy: IfNotPresent
     resources: {}
     extraArgs: {}

--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: v1.34.0
+appVersion: v1.34.1
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 2.34.0
+version: 2.34.1
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.34.1
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 2.34.1
+version: 2.34.2
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -100,7 +100,7 @@ controllerplugin:
   snapshotter:
     image:
       repository: registry.k8s.io/sig-storage/csi-snapshotter
-      tag: v8.3.0
+      tag: v8.4.0
       pullPolicy: IfNotPresent
     resources: {}
     extraEnv: []

--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
-appVersion: v1.34.0
+appVersion: v1.34.1
 description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.34.0
+version: 2.34.1
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.34.1
+version: 2.34.2
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/templates/clusterrolebinding-sm.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/clusterrolebinding-sm.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- end }}
 subjects:
 - kind: User
-  name: system:serviceaccount:{{ .Release.Namespace }}:{{ include "occm.name" . }}
+  name: system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.serviceAccountName }}
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/daemonset.yaml
@@ -46,6 +46,10 @@ spec:
       containers:
         - name: openstack-cloud-controller-manager
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
             - /bin/openstack-cloud-controller-manager
             - --v={{ .Values.logVerbosityLevel }}

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -74,6 +74,16 @@ podSecurityContext:
   # seccompProfile:
   #   type: RuntimeDefault
 
+# Set security settings for the controller container
+# For all available options, see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
+securityContext: {}
+# securityContext:
+#   capabilities:
+#     drop:
+#     - ALL
+#   readOnlyRootFilesystem: true
+#   allowPrivilegeEscalation: false
+
 # List of controllers should be enabled.
 # Use '*' to enable all controllers.
 # Prefix a controller with '-' to disable it.

--- a/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
+++ b/manifests/cinder-csi-plugin/cinder-csi-controllerplugin.yaml
@@ -55,7 +55,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.3.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"

--- a/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
@@ -23,8 +23,13 @@ spec:
       labels:
         k8s-app: openstack-cloud-controller-manager
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/control-plane: "true"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
       securityContext:
         runAsUser: 1001
       tolerations:

--- a/manifests/manila-csi-plugin/csi-controllerplugin.yaml
+++ b/manifests/manila-csi-plugin/csi-controllerplugin.yaml
@@ -50,7 +50,7 @@ spec:
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins/manila.csi.openstack.org
         - name: snapshotter
-          image: "registry.k8s.io/sig-storage/csi-snapshotter:v8.3.0"
+          image: "registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0"
           args:
             - "--csi-address=$(ADDRESS)"
           env:


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

This PR cherry-picks all commits from *after* `v1.34.0` (commit da130f1c) to `v1.35.0~`. It is intended to allow us to start backporting Helm chart fixes going forward.

The commits on this branch were cherry-picked using the following commits:

```bash
git cherry-pick $(git for-each-ref --sort=creatordate --format='%(objectname)' --contains da130f1c --no-contains v1.35.0~ refs/tags)
```

We also include changes to manifests, which were identified with `git log`:

```bash
git log --oneline --no-decorate v1.34.0..v1.35.0~ -- manifests/
```

(Yes, this same command could have been used for identifying changes to `charts/`)

Note that this will not result in a new release. The `version` in each `Chart.yaml` is now in line with those on `master` and those have already been released.

*Commits*

- `update helm charts to 1.34.1 (#3019)`
- `Add node affinity to schedule cloud controller manager only on control plane nodes. (#2929)`
- `fix: Incorrect SA name in auth-delegate clusterRoleBiding (#2907)`
- `[cinder-csi-plugin] podSecurityContext is missing in nodePlugin DaemonSet (#2981)`
- `[occm] Add container-level securityContext to Helm chart (#3041)`
- `bump Cinder CSI sidecar versions to latest minor version (#3046)`
- `bump Manila CSI sidecar versions to latest minor version (#3047)`

**Which issue this PR fixes(if applicable)**:

Ref #3194

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
