### PR TITLE
make: Add lint-charts target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,8 @@ BUILD_CMDS	?= openstack-cloud-controller-manager \
 				barbican-kms-plugin \
 				magnum-auto-healer \
 				client-keystone-auth
+export GOLANGCI_LINT_VERSION ?= v2.13.2
+export HELM_UNITTEST_VERSION ?= v1.1.2
 
 # CTI targets
 
@@ -81,7 +83,11 @@ $(BUILD_CMDS): $(SOURCES)
 test: unit functional
 
 check: work
-	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.2 run --timeout=20m ./...
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run --timeout=20m ./...
+
+.PHONY: lint-charts
+lint-charts:
+	hack/verify-helm-charts.sh
 
 unit: work
 	go test -tags=unit $(shell go list ./... | sed -e '/sanity/ { N; d; }' | sed -e '/tests/ {N; d;}') $(TESTARGS)

--- a/hack/verify-helm-charts.sh
+++ b/hack/verify-helm-charts.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "${REPO_ROOT}"
+
+if ! command -v helm &>/dev/null; then
+  echo "ERROR: helm not found. Please install helm: https://helm.sh/docs/intro/install/" >&2
+  exit 1
+fi
+
+echo "=== Linting charts ==="
+helm lint charts/*
+for values_file in charts/*/ci/*.yaml; do
+  chart_dir="$(dirname "$(dirname "${values_file}")")"
+  helm lint "${chart_dir}" --values "${values_file}"
+done
+
+echo "=== Installing helm-unittest plugin ==="
+if ! helm plugin list | grep -q unittest; then
+  helm plugin install --verify=false \
+    "https://github.com/helm-unittest/helm-unittest/releases/download/${HELM_UNITTEST_VERSION}/unittest-${HELM_UNITTEST_VERSION#v}.tgz"
+fi
+
+echo "=== Running helm unit tests ==="
+helm unittest --strict --with-subchart=false \
+  --file '../../tests/helm/openstack-cloud-controller-manager/*_test.yaml' \
+  charts/openstack-cloud-controller-manager


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

We will add a prow job to run this separately, allowing us to remove the GitHub Action workflow.

Note that we lose `yamllint` by doing this. That seems acceptable. If we want, we could hack something together with pipx or uvx but it seems...unrobust for CI purposes.

**Which issue this PR fixes(if applicable)**:

Ref #3194

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

This is a step towards addressing the issue @mandre reported in https://kubernetes.slack.com/archives/C0LSA3T7C/p1788939409251989.

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
