### PR TITLE
[cinder-csi-plugin] Return backups from ListSnapshots by ID

### DIFF
--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -834,8 +834,7 @@ func (cs *controllerServer) ListSnapshots(ctx context.Context, req *csi.ListSnap
 		snap, err := cloud.GetSnapshotByID(ctx, snapshotID)
 		if err != nil {
 			if cpoerrors.IsNotFound(err) {
-				klog.V(3).Infof("Snapshot %s not found", snapshotID)
-				return &csi.ListSnapshotsResponse{}, nil
+				return listBackupByID(ctx, cloud, snapshotID)
 			}
 			return nil, status.Errorf(codes.Internal, "Failed to GetSnapshot %s: %v", snapshotID, err)
 		}
@@ -902,6 +901,30 @@ func (cs *controllerServer) ListSnapshots(ctx context.Context, req *csi.ListSnap
 		Entries:   sentries,
 		NextToken: nextPageToken,
 	}, nil
+}
+
+func listBackupByID(ctx context.Context, cloud openstack.IOpenStack, backupID string) (*csi.ListSnapshotsResponse, error) {
+	backup, err := cloud.GetBackupByID(ctx, backupID)
+	if err != nil {
+		if cpoerrors.IsNotFound(err) {
+			klog.V(3).Infof("Snapshot or backup %s not found", backupID)
+			return &csi.ListSnapshotsResponse{}, nil
+		}
+		return nil, status.Errorf(codes.Internal, "Failed to GetBackup %s: %v", backupID, err)
+	}
+
+	ctime := timestamppb.New(backup.CreatedAt)
+	return &csi.ListSnapshotsResponse{
+		Entries: []*csi.ListSnapshotsResponse_Entry{{
+			Snapshot: &csi.Snapshot{
+				SizeBytes:      int64(backup.Size * 1024 * 1024 * 1024),
+				SnapshotId:     backup.ID,
+				SourceVolumeId: backup.VolumeID,
+				CreationTime:   ctime,
+				ReadyToUse:     backup.Status == "available",
+			},
+		}},
+	}, ctime.CheckValid()
 }
 
 // ControllerGetCapabilities implements the default GRPC callout.

--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/backups"
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/snapshots"
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -1428,6 +1429,54 @@ func TestListSnapshots(t *testing.T) {
 	// Assert
 	assert.Equal(FakeVolID, actualRes.Entries[0].Snapshot.SourceVolumeId)
 	assert.NotNil(FakeSnapshotID, actualRes.Entries[0].Snapshot.SnapshotId)
+}
+
+func TestListSnapshotsBackupByID(t *testing.T) {
+	fakeCs, osmock := fakeControllerServer()
+	osmock.On("GetSnapshotByID", FakeBackupID).Return((*snapshots.Snapshot)(nil), cpoerrors.ErrNotFound)
+	osmock.On("GetBackupByID", FakeBackupID).Return(&FakeBackupRes, nil)
+
+	actualRes, err := fakeCs.ListSnapshots(FakeCtx, &csi.ListSnapshotsRequest{SnapshotId: FakeBackupID})
+	if err != nil {
+		t.Fatalf("ListSnapshots returned an error: %v", err)
+	}
+	if len(actualRes.Entries) != 1 {
+		t.Fatalf("ListSnapshots returned %d entries, want 1", len(actualRes.Entries))
+	}
+
+	actualSnapshot := actualRes.Entries[0].Snapshot
+	assert.Equal(t, FakeBackupID, actualSnapshot.SnapshotId)
+	assert.Equal(t, FakeVolID, actualSnapshot.SourceVolumeId)
+	assert.Equal(t, int64(FakeBackupRes.Size*1024*1024*1024), actualSnapshot.SizeBytes)
+	assert.True(t, FakeBackupRes.CreatedAt.Equal(actualSnapshot.CreationTime.AsTime()))
+	assert.True(t, actualSnapshot.ReadyToUse)
+	osmock.AssertExpectations(t)
+}
+
+func TestListSnapshotsByIDNotFound(t *testing.T) {
+	fakeCs, osmock := fakeControllerServer()
+
+	osmock.On("GetSnapshotByID", FakeSnapshotID).Return((*snapshots.Snapshot)(nil), cpoerrors.ErrNotFound)
+	osmock.On("GetBackupByID", FakeSnapshotID).Return((*backups.Backup)(nil), cpoerrors.ErrNotFound)
+
+	actualRes, err := fakeCs.ListSnapshots(FakeCtx, &csi.ListSnapshotsRequest{SnapshotId: FakeSnapshotID})
+	if err != nil {
+		t.Fatalf("ListSnapshots returned an error: %v", err)
+	}
+	assert.Empty(t, actualRes.Entries)
+	osmock.AssertExpectations(t)
+}
+
+func TestListSnapshotsBackupLookupError(t *testing.T) {
+	fakeCs, osmock := fakeControllerServer()
+	backendErr := errors.New("backup service unavailable")
+
+	osmock.On("GetSnapshotByID", FakeBackupID).Return((*snapshots.Snapshot)(nil), cpoerrors.ErrNotFound)
+	osmock.On("GetBackupByID", FakeBackupID).Return((*backups.Backup)(nil), backendErr)
+
+	_, err := fakeCs.ListSnapshots(FakeCtx, &csi.ListSnapshotsRequest{SnapshotId: FakeBackupID})
+	assert.Equal(t, codes.Internal, status.Code(err))
+	osmock.AssertExpectations(t)
 }
 
 func TestControllerExpandVolume(t *testing.T) {

--- a/pkg/csi/cinder/openstack/openstack_mock.go
+++ b/pkg/csi/cinder/openstack/openstack_mock.go
@@ -438,6 +438,19 @@ func (_m *OpenStackMock) GetInstanceID() (string, error) {
 }
 
 func (_m *OpenStackMock) GetSnapshotByID(ctx context.Context, snapshotID string) (*snapshots.Snapshot, error) {
+	for _, call := range _m.ExpectedCalls {
+		if call.Method != "GetSnapshotByID" {
+			continue
+		}
+
+		ret := _m.Called(snapshotID)
+
+		var r0 *snapshots.Snapshot
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*snapshots.Snapshot)
+		}
+		return r0, ret.Error(1)
+	}
 
 	return &fakeSnapshot, nil
 }


### PR DESCRIPTION
What this PR does / why we need it:

`ListSnapshots` only checks Cinder snapshots, so pre-provisioned snapshots backed by a Cinder backup never become ready. 
Fall back to `GetBackupByID` after a snapshot 404

Which issue this PR fixes(if applicable):

Related to #2473.

Special notes for reviewers:

Repro: create a pre-provisioned `VolumeSnapshotContent` using an available Cinder backup UUID. 
The snapshotter reports `can not find snapshot for snapshotID`

Tests: `make check`, `make unit`, `go test ./tests/sanity/cinder`

Release note:
```release-note
[cinder-csi-plugin] Make ListSnapshots recognize Cinder backup IDs used by pre-provisioned VolumeSnapshots.
```