### PR TITLE
[manila-csi-plugin] feat: add configurable kubelet dir on manila csi driver

### DIFF
--- a/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-statefulset.yaml
@@ -35,14 +35,14 @@ spec:
             {{- end }}
           env:
             - name: ADDRESS
-              value: "unix:///var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}/csi-controllerplugin.sock"
+              value: "unix://{{ $.Values.kubeletDir }}/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}/csi-controllerplugin.sock"
             {{- if $.Values.controllerplugin.provisioner.extraEnv }}
               {{- toYaml $.Values.controllerplugin.provisioner.extraEnv | nindent 12 }}
             {{- end }}
           imagePullPolicy: {{ $.Values.controllerplugin.provisioner.image.pullPolicy }}
           volumeMounts:
             - name: {{ .protocolSelector | lower }}-plugin-dir
-              mountPath: /var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}
+              mountPath: {{ $.Values.kubeletDir }}/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}
           resources:
 {{ toYaml $.Values.controllerplugin.provisioner.resources | indent 12 }}
         - name: {{ .protocolSelector | lower }}-snapshotter
@@ -54,14 +54,14 @@ spec:
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
-              value: "unix:///var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}/csi-controllerplugin.sock"
+              value: "unix://{{ $.Values.kubeletDir }}/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}/csi-controllerplugin.sock"
             {{- if $.Values.controllerplugin.snapshotter.extraEnv }}
               {{- toYaml $.Values.controllerplugin.snapshotter.extraEnv | nindent 12 }}
             {{- end }}
           imagePullPolicy: {{ $.Values.controllerplugin.snapshotter.image.pullPolicy }}
           volumeMounts:
             - name: {{ .protocolSelector | lower }}-plugin-dir
-              mountPath: /var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}
+              mountPath: {{ $.Values.kubeletDir }}/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}
           resources:
 {{ toYaml $.Values.controllerplugin.snapshotter.resources | indent 12 }}
         - name: {{ .protocolSelector | lower }}-resizer
@@ -74,14 +74,14 @@ spec:
             - "--handle-volume-inuse-error=false"
           env:
             - name: ADDRESS
-              value: "unix:///var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}/csi-controllerplugin.sock"
+              value: "unix://{{ $.Values.kubeletDir }}/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}/csi-controllerplugin.sock"
             {{- if $.Values.controllerplugin.resizer.extraEnv }}
               {{- toYaml $.Values.controllerplugin.resizer.extraEnv | nindent 12 }}
             {{- end }}
           imagePullPolicy: {{ $.Values.controllerplugin.resizer.image.pullPolicy }}
           volumeMounts:
             - name: {{ .protocolSelector | lower }}-plugin-dir
-              mountPath: /var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}
+              mountPath: {{ $.Values.kubeletDir }}/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}
           resources:
 {{ toYaml $.Values.controllerplugin.resizer.resources | indent 12 }}
         - name: {{ .protocolSelector | lower }}-nodeplugin
@@ -114,7 +114,7 @@ spec:
             - name: DRIVER_NAME
               value: {{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}
             - name: CSI_ENDPOINT
-              value: "unix:///var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}/csi-controllerplugin.sock"
+              value: "unix://{{ $.Values.kubeletDir }}/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}/csi-controllerplugin.sock"
             - name: FWD_CSI_ENDPOINT
               value: "unix://{{ .fwdNodePluginEndpoint.dir }}/{{ .fwdNodePluginEndpoint.sockFile }}"
             - name: MANILA_SHARE_PROTO
@@ -133,11 +133,11 @@ spec:
           imagePullPolicy: {{ $.Values.csimanila.image.pullPolicy }}
           volumeMounts:
             - name: {{ .protocolSelector | lower }}-plugin-dir
-              mountPath: /var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}
+              mountPath: {{ $.Values.kubeletDir }}/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}
             - name: {{ .protocolSelector | lower }}-fwd-plugin-dir
               mountPath: {{ .fwdNodePluginEndpoint.dir }}
             - name: pod-mounts
-              mountPath: /var/lib/kubelet/pods
+              mountPath: {{ $.Values.kubeletDir }}/pods
               mountPropagation: Bidirectional
             {{- if $.Values.csimanila.runtimeConfig.enabled }}
             - name: {{ .protocolSelector | lower }}-runtime-config-dir
@@ -154,7 +154,7 @@ spec:
         {{- range .Values.shareProtocols }}
         - name: {{ .protocolSelector | lower }}-plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}
+            path: {{ $.Values.kubeletDir }}/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}
             type: DirectoryOrCreate
         - name: {{ .protocolSelector | lower }}-fwd-plugin-dir
           hostPath:
@@ -168,7 +168,7 @@ spec:
         {{- end }}
         - name: pod-mounts
           hostPath:
-            path: /var/lib/kubelet/pods
+            path: {{ .Values.kubeletDir }}/pods
             type: Directory
         {{- with .Values.controllerplugin.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -30,7 +30,7 @@ spec:
           args:
             - "-v={{ $.Values.logVerbosityLevel }}"
             - "--csi-address=/csi/csi.sock"
-            - "--kubelet-registration-path=/var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}/csi.sock"
+            - "--kubelet-registration-path={{ $.Values.kubeletDir }}/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}/csi.sock"
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -74,7 +74,7 @@ spec:
             - name: DRIVER_NAME
               value: {{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}
             - name: CSI_ENDPOINT
-              value: "unix:///var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}/csi.sock"
+              value: "unix://{{ $.Values.kubeletDir }}/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}/csi.sock"
             - name: FWD_CSI_ENDPOINT
               value: "unix://{{ .fwdNodePluginEndpoint.dir }}/{{ .fwdNodePluginEndpoint.sockFile }}"
             - name: MANILA_SHARE_PROTO
@@ -89,7 +89,7 @@ spec:
           imagePullPolicy: {{ $.Values.csimanila.image.pullPolicy }}
           volumeMounts:
             - name: {{ .protocolSelector | lower }}-plugin-dir
-              mountPath: /var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}
+              mountPath: {{ $.Values.kubeletDir }}/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}
             - name: {{ .protocolSelector | lower }}-fwd-plugin-dir
               mountPath: {{ .fwdNodePluginEndpoint.dir }}
             {{- if $.Values.csimanila.runtimeConfig.enabled }}
@@ -109,12 +109,12 @@ spec:
       volumes:
         - name: registration-dir
           hostPath:
-            path: /var/lib/kubelet/plugins_registry
+            path: {{ .Values.kubeletDir }}/plugins_registry
             type: Directory
         {{- range .Values.shareProtocols }}
         - name: {{ .protocolSelector | lower }}-plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}
+            path: {{ $.Values.kubeletDir }}/plugins/{{ printf "%s.%s" .protocolSelector $.Values.driverName | lower }}
             type: DirectoryOrCreate
         - name: {{ .protocolSelector | lower }}-fwd-plugin-dir
           hostPath:

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -4,6 +4,15 @@ fullNameOverride: ""
 # Base name of the CSI Manila driver
 driverName: manila.csi.openstack.org
 
+# Base directory of kubelet's on-node state. Only the plugin/registration
+# paths this chart itself creates (csi.sock, plugin registration dir,
+# mounted pods dir) are derived from this value - shareProtocols[].
+# fwdNodePluginEndpoint.dir below is independent and defaults to a path
+# under the same directory, so update both together if you override this on
+# a distribution that relocates kubelet's data dir (e.g. k0s defaults to
+# /var/lib/k0s/kubelet instead of /var/lib/kubelet).
+kubeletDir: /var/lib/kubelet
+
 # Enabled Manila share protocols
 shareProtocols:
   - protocolSelector: NFS


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the possibility to configure the kubelet dir to allow the use of the manila-csi-plugin with kubernetes distribution like k0s.

**Test**
```
helm template test . > /tmp/manila-default.yaml
helm template test . --set kubeletDir=/var/lib/k0s/kubelet > /tmp/manila-k0s.yaml
diff /tmp/manila-default.yaml /tmp/manila-k0s.yaml
296c296
<             - "--kubelet-registration-path=/var/lib/kubelet/plugins/nfs.manila.csi.openstack.org/csi.sock"
---
>             - "--kubelet-registration-path=/var/lib/k0s/kubelet/plugins/nfs.manila.csi.openstack.org/csi.sock"
328c328
<               value: "unix:///var/lib/kubelet/plugins/nfs.manila.csi.openstack.org/csi.sock"
---
>               value: "unix:///var/lib/k0s/kubelet/plugins/nfs.manila.csi.openstack.org/csi.sock"
336c336
<               mountPath: /var/lib/kubelet/plugins/nfs.manila.csi.openstack.org
---
>               mountPath: /var/lib/k0s/kubelet/plugins/nfs.manila.csi.openstack.org
347c347
<             path: /var/lib/kubelet/plugins_registry
---
>             path: /var/lib/k0s/kubelet/plugins_registry
351c351
<             path: /var/lib/kubelet/plugins/nfs.manila.csi.openstack.org
---
>             path: /var/lib/k0s/kubelet/plugins/nfs.manila.csi.openstack.org
408c408
<               value: "unix:///var/lib/kubelet/plugins/nfs.manila.csi.openstack.org/csi-controllerplugin.sock"
---
>               value: "unix:///var/lib/k0s/kubelet/plugins/nfs.manila.csi.openstack.org/csi-controllerplugin.sock"
412c412
<               mountPath: /var/lib/kubelet/plugins/nfs.manila.csi.openstack.org
---
>               mountPath: /var/lib/k0s/kubelet/plugins/nfs.manila.csi.openstack.org
426c426
<               value: "unix:///var/lib/kubelet/plugins/nfs.manila.csi.openstack.org/csi-controllerplugin.sock"
---
>               value: "unix:///var/lib/k0s/kubelet/plugins/nfs.manila.csi.openstack.org/csi-controllerplugin.sock"
430c430
<               mountPath: /var/lib/kubelet/plugins/nfs.manila.csi.openstack.org
---
>               mountPath: /var/lib/k0s/kubelet/plugins/nfs.manila.csi.openstack.org
445c445
<               value: "unix:///var/lib/kubelet/plugins/nfs.manila.csi.openstack.org/csi-controllerplugin.sock"
---
>               value: "unix:///var/lib/k0s/kubelet/plugins/nfs.manila.csi.openstack.org/csi-controllerplugin.sock"
449c449
<               mountPath: /var/lib/kubelet/plugins/nfs.manila.csi.openstack.org
---
>               mountPath: /var/lib/k0s/kubelet/plugins/nfs.manila.csi.openstack.org
470c470
<               value: "unix:///var/lib/kubelet/plugins/nfs.manila.csi.openstack.org/csi-controllerplugin.sock"
---
>               value: "unix:///var/lib/k0s/kubelet/plugins/nfs.manila.csi.openstack.org/csi-controllerplugin.sock"
478c478
<               mountPath: /var/lib/kubelet/plugins/nfs.manila.csi.openstack.org
---
>               mountPath: /var/lib/k0s/kubelet/plugins/nfs.manila.csi.openstack.org
482c482
<               mountPath: /var/lib/kubelet/pods
---
>               mountPath: /var/lib/k0s/kubelet/pods
489c489
<             path: /var/lib/kubelet/plugins/nfs.manila.csi.openstack.org
---
>             path: /var/lib/k0s/kubelet/plugins/nfs.manila.csi.openstack.org
497c497
<             path: /var/lib/kubelet/pods
---
>             path: /var/lib/k0s/kubelet/pods
```