### PR TITLE
[manila-csi-plugin] drop rules from aggregated ClusterRoles for Helm 4 SSA

### DIFF
--- a/charts/manila-csi-plugin/templates/controllerplugin-clusterrole.yaml
+++ b/charts/manila-csi-plugin/templates/controllerplugin-clusterrole.yaml
@@ -8,4 +8,4 @@ aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
         rbac.manila.csi.openstack.org/aggregate-to-controller-{{ include "openstack-manila-csi.name" . }}: "true"
-rules: []
+{{- /* do not set rules: clusterrole-aggregation-controller owns that field; Helm SSA applying rules: [] conflicts on upgrade */}}

--- a/charts/manila-csi-plugin/templates/nodeplugin-clusterrole.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-clusterrole.yaml
@@ -8,4 +8,4 @@ aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
         rbac.manila.csi.openstack.org/aggregate-to-nodeplugin-{{ include "openstack-manila-csi.name" . }}: "true"
-rules: []
+{{- /* do not set rules: clusterrole-aggregation-controller owns that field; Helm SSA applying rules: [] conflicts on upgrade */}}


### PR DESCRIPTION
**What this PR does / why we need it**:

Helm 4 applies with server-side apply. The manila chart's aggregated controller/node ClusterRoles set `rules: []`, so Helm takes ownership of `.rules`. After install, `clusterrole-aggregation-controller` fills that field, and the next `helm upgrade` dies with a conflict on `.rules`.

Drop `rules` from those two templates. The aggregator still writes the real rules; Helm just stops claiming the field.

**Which issue this PR fixes**:

fixes #3119

**Special notes for reviewers**:

`helm lint` is clean. `helm template` no longer emits `rules` on the aggregated ClusterRoles. Static manifests are unchanged.

**Release note**:

```release-note
[manila-csi-plugin] Helm chart aggregated ClusterRoles no longer set rules: [], so Helm 4 upgrades do not conflict with clusterrole-aggregation-controller.
```